### PR TITLE
Connection record is_ready refactor

### DIFF
--- a/aries_cloudagent/dispatcher.py
+++ b/aries_cloudagent/dispatcher.py
@@ -75,7 +75,7 @@ class Dispatcher:
         context = RequestContext(base_context=self.context)
         context.message = message
         context.message_delivery = delivery
-        context.connection_active = connection and connection.is_active
+        context.connection_ready = connection and connection.is_ready
         context.connection_record = connection
 
         responder = DispatcherResponder(

--- a/aries_cloudagent/messaging/actionmenu/routes.py
+++ b/aries_cloudagent/messaging/actionmenu/routes.py
@@ -99,7 +99,7 @@ async def actionmenu_perform(request: web.BaseRequest):
     except StorageNotFoundError:
         raise web.HTTPNotFound()
 
-    if connection.is_active:
+    if connection.is_ready:
         msg = Perform(name=params["name"], params=params.get("params"))
         await outbound_handler(msg, connection_id=connection_id)
         return web.json_response({})
@@ -126,7 +126,7 @@ async def actionmenu_request(request: web.BaseRequest):
         LOGGER.debug("Connection not found for action menu request: %s", connection_id)
         raise web.HTTPNotFound()
 
-    if connection.is_active:
+    if connection.is_ready:
         msg = MenuRequest()
         await outbound_handler(msg, connection_id=connection_id)
         return web.json_response({})
@@ -163,7 +163,7 @@ async def actionmenu_send(request: web.BaseRequest):
         )
         raise web.HTTPNotFound()
 
-    if connection.is_active:
+    if connection.is_ready:
         await outbound_handler(msg, connection_id=connection_id)
         return web.json_response({})
 

--- a/aries_cloudagent/messaging/actionmenu/tests/test_routes.py
+++ b/aries_cloudagent/messaging/actionmenu/tests/test_routes.py
@@ -1,0 +1,235 @@
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
+
+from .. import routes as test_module
+
+from ....storage.error import StorageNotFoundError
+
+
+class TestActionMenuRoutes(AsyncTestCase):
+    async def test_actionmenu_perform(self):
+        mock_request = async_mock.MagicMock()
+        mock_request.json = async_mock.CoroutineMock()
+
+        mock_request.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "Perform", autospec=True
+        ) as mock_perform:
+
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock()
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            res = await test_module.actionmenu_perform(mock_request)
+            test_module.web.json_response.assert_called_once_with({})
+            mock_request.app["outbound_message_router"].assert_called_once_with(
+                mock_perform.return_value, connection_id=mock_request.match_info["id"]
+            )
+
+    async def test_actionmenu_perform_no_conn_record(self):
+        mock_request = async_mock.MagicMock()
+        mock_request.json = async_mock.CoroutineMock()
+
+        mock_request.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "Perform", autospec=True
+        ) as mock_perform:
+
+            # Emulate storage not found (bad connection id)
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock(
+                side_effect=StorageNotFoundError
+            )
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            with self.assertRaises(test_module.web.HTTPNotFound):
+                await test_module.actionmenu_perform(mock_request)
+
+    async def test_actionmenu_perform_conn_not_ready(self):
+        mock_request = async_mock.MagicMock()
+        mock_request.json = async_mock.CoroutineMock()
+
+        mock_request.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "Perform", autospec=True
+        ) as mock_perform:
+
+            # Emulate connection not ready
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock()
+            mock_connection_record.retrieve_by_id.return_value.is_ready = False
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            with self.assertRaises(test_module.web.HTTPForbidden):
+                await test_module.actionmenu_perform(mock_request)
+
+    async def test_actionmenu_request(self):
+        mock_request = async_mock.MagicMock()
+        mock_request.json = async_mock.CoroutineMock()
+
+        mock_request.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "MenuRequest", autospec=True
+        ) as menu_request:
+
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock()
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            res = await test_module.actionmenu_request(mock_request)
+            test_module.web.json_response.assert_called_once_with({})
+            mock_request.app["outbound_message_router"].assert_called_once_with(
+                menu_request.return_value, connection_id=mock_request.match_info["id"]
+            )
+
+    async def test_actionmenu_request_no_conn_record(self):
+        mock_request = async_mock.MagicMock()
+        mock_request.json = async_mock.CoroutineMock()
+
+        mock_request.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "Perform", autospec=True
+        ) as mock_perform:
+
+            # Emulate storage not found (bad connection id)
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock(
+                side_effect=StorageNotFoundError
+            )
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            with self.assertRaises(test_module.web.HTTPNotFound):
+                await test_module.actionmenu_request(mock_request)
+
+    async def test_actionmenu_request_conn_not_ready(self):
+        mock_request = async_mock.MagicMock()
+        mock_request.json = async_mock.CoroutineMock()
+
+        mock_request.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "Perform", autospec=True
+        ) as mock_perform:
+
+            # Emulate connection not ready
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock()
+            mock_connection_record.retrieve_by_id.return_value.is_ready = False
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            with self.assertRaises(test_module.web.HTTPForbidden):
+                await test_module.actionmenu_request(mock_request)
+
+    async def test_actionmenu_send(self):
+        mock_request = async_mock.MagicMock()
+        mock_request.json = async_mock.CoroutineMock()
+
+        mock_request.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "Menu", autospec=True
+        ) as mock_menu:
+
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock()
+            test_module.web.json_response = async_mock.CoroutineMock()
+            mock_menu.deserialize = async_mock.MagicMock()
+
+            res = await test_module.actionmenu_send(mock_request)
+            test_module.web.json_response.assert_called_once_with({})
+            mock_request.app["outbound_message_router"].assert_called_once_with(
+                mock_menu.deserialize.return_value, connection_id=mock_request.match_info["id"]
+            )
+
+    async def test_actionmenu_send_no_conn_record(self):
+        mock_request = async_mock.MagicMock()
+        mock_request.json = async_mock.CoroutineMock()
+
+        mock_request.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "Menu", autospec=True
+        ) as mock_menu:
+
+            mock_menu.deserialize = async_mock.MagicMock()
+
+            # Emulate storage not found (bad connection id)
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock(
+                side_effect=StorageNotFoundError
+            )
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            with self.assertRaises(test_module.web.HTTPNotFound):
+                await test_module.actionmenu_send(mock_request)
+
+    async def test_actionmenu_send_conn_not_ready(self):
+        mock_request = async_mock.MagicMock()
+        mock_request.json = async_mock.CoroutineMock()
+
+        mock_request.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "Menu", autospec=True
+        ) as mock_menu:
+
+            mock_menu.deserialize = async_mock.MagicMock()
+
+            # Emulate connection not ready
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock()
+            mock_connection_record.retrieve_by_id.return_value.is_ready = False
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            with self.assertRaises(test_module.web.HTTPForbidden):
+                await test_module.actionmenu_send(mock_request)
+

--- a/aries_cloudagent/messaging/basicmessage/routes.py
+++ b/aries_cloudagent/messaging/basicmessage/routes.py
@@ -39,7 +39,7 @@ async def connections_send_message(request: web.BaseRequest):
     except StorageNotFoundError:
         raise web.HTTPNotFound()
 
-    if connection.is_active:
+    if connection.is_ready:
         msg = BasicMessage(content=params["content"])
         await outbound_handler(msg, connection_id=connection_id)
 

--- a/aries_cloudagent/messaging/basicmessage/tests/test_routes.py
+++ b/aries_cloudagent/messaging/basicmessage/tests/test_routes.py
@@ -1,0 +1,98 @@
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
+
+from .. import routes as test_module
+
+from ....storage.error import StorageNotFoundError
+
+
+class TestBasicMessageRoutes(AsyncTestCase):
+    async def test_connections_send_message(self):
+        mock_request = async_mock.MagicMock()
+        mock_request.json = async_mock.CoroutineMock()
+
+        mock_request.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "BasicMessage", autospec=True
+        ) as mock_basic_message, async_mock.patch.object(
+            test_module, "ConnectionManager", autospec=True
+        ) as mock_conn_manager:
+
+            mock_conn_manager.return_value.log_activity = async_mock.CoroutineMock()
+
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock()
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            res = await test_module.connections_send_message(mock_request)
+            test_module.web.json_response.assert_called_once_with({})
+            mock_conn_manager.return_value.log_activity.assert_called_once_with(
+                mock_connection_record.retrieve_by_id.return_value,
+                "message",
+                mock_connection_record.retrieve_by_id.return_value.DIRECTION_SENT,
+                {"content": mock_request.json.return_value["content"]},
+            )
+            mock_basic_message.assert_called_once()
+
+    async def test_connections_send_message_no_conn_record(self):
+        mock_request = async_mock.MagicMock()
+        mock_request.json = async_mock.CoroutineMock()
+
+        mock_request.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "BasicMessage", autospec=True
+        ) as mock_basic_message, async_mock.patch.object(
+            test_module, "ConnectionManager", autospec=True
+        ) as mock_conn_manager:
+
+            # Emulate storage not found (bad connection id)
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock(
+                side_effect=StorageNotFoundError
+            )
+
+            mock_conn_manager.return_value.log_activity = async_mock.CoroutineMock()
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            with self.assertRaises(test_module.web.HTTPNotFound):
+                await test_module.connections_send_message(mock_request)
+
+    async def test_connections_send_message_not_ready(self):
+        mock_request = async_mock.MagicMock()
+        mock_request.json = async_mock.CoroutineMock()
+
+        mock_request.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "BasicMessage", autospec=True
+        ) as mock_basic_message, async_mock.patch.object(
+            test_module, "ConnectionManager", autospec=True
+        ) as mock_conn_manager:
+
+            # Emulate connection not ready
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock()
+            mock_connection_record.retrieve_by_id.return_value.is_ready = False
+
+            mock_conn_manager.return_value.log_activity = async_mock.CoroutineMock()
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            await test_module.connections_send_message(mock_request)
+            mock_basic_message.assert_not_called()

--- a/aries_cloudagent/messaging/connections/manager.py
+++ b/aries_cloudagent/messaging/connections/manager.py
@@ -885,9 +885,9 @@ class ConnectionManager:
             raise ConnectionManagerError(
                 f"Routing connection not found: {inbound_connection_id}"
             )
-        if not router.is_active:
+        if not router.is_ready:
             raise ConnectionManagerError(
-                f"Routing connection is not active: {inbound_connection_id}"
+                f"Routing connection is not ready: {inbound_connection_id}"
             )
         connection.inbound_connection_id = inbound_connection_id
 

--- a/aries_cloudagent/messaging/connections/models/connection_record.py
+++ b/aries_cloudagent/messaging/connections/models/connection_record.py
@@ -440,11 +440,6 @@ class ConnectionRecord(BaseModel):
         await storage.update_record_value(record, json.dumps(value))
 
     @property
-    def is_active(self) -> bool:
-        """Accessor to check if the connection is active."""
-        return self.state == self.STATE_ACTIVE
-
-    @property
     def is_ready(self) -> str:
         """Accessor for connection readiness."""
         return self.state == self.STATE_ACTIVE or self.state == self.STATE_RESPONSE

--- a/aries_cloudagent/messaging/credentials/handlers/credential_issue_handler.py
+++ b/aries_cloudagent/messaging/credentials/handlers/credential_issue_handler.py
@@ -21,7 +21,7 @@ class CredentialIssueHandler(BaseHandler):
         assert isinstance(context.message, CredentialIssue)
         self._logger.info(f"Received credential: {context.message.issue}")
 
-        if not context.connection_active:
+        if not context.connection_ready:
             raise HandlerException("No connection established for credential request")
 
         credential_manager = CredentialManager(context)

--- a/aries_cloudagent/messaging/credentials/handlers/credential_offer_handler.py
+++ b/aries_cloudagent/messaging/credentials/handlers/credential_offer_handler.py
@@ -23,7 +23,7 @@ class CredentialOfferHandler(BaseHandler):
 
         self._logger.info("Received credential offer: %s", context.message.offer_json)
 
-        if not context.connection_active:
+        if not context.connection_ready:
             raise HandlerException("No connection established for credential offer")
 
         credential_manager = CredentialManager(context)

--- a/aries_cloudagent/messaging/credentials/handlers/credential_request_handler.py
+++ b/aries_cloudagent/messaging/credentials/handlers/credential_request_handler.py
@@ -25,7 +25,7 @@ class CredentialRequestHandler(BaseHandler):
             "Received credential request: %s", context.message.serialize(as_string=True)
         )
 
-        if not context.connection_active:
+        if not context.connection_ready:
             raise HandlerException("No connection established for credential request")
 
         credential_manager = CredentialManager(context)

--- a/aries_cloudagent/messaging/credentials/tests/test_routes.py
+++ b/aries_cloudagent/messaging/credentials/tests/test_routes.py
@@ -7,6 +7,117 @@ from ....storage.error import StorageNotFoundError
 
 
 class TestCredentialRoutes(AsyncTestCase):
+    async def test_credential_exchange_send(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_credential_manager:
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            mock_credential_manager.return_value.create_offer = (
+                async_mock.CoroutineMock()
+            )
+
+            mock_credential_manager.return_value.offer_credential = (
+                async_mock.CoroutineMock()
+            )
+
+            mock_cred_ex_record = async_mock.MagicMock()
+
+            mock_credential_manager.return_value.offer_credential.return_value = (
+                mock_cred_ex_record,
+                async_mock.MagicMock(),
+            )
+
+            await test_module.credential_exchange_send(mock)
+
+            test_module.web.json_response.assert_called_once_with(
+                mock_credential_manager.return_value.prepare_send.return_value.serialize.return_value
+            )
+
+    async def test_credential_exchange_send_no_conn_record(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_connection_manager:
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            # Emulate storage not found (bad connection id)
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock(
+                side_effect=StorageNotFoundError
+            )
+
+            mock_connection_manager.return_value.create_offer = (
+                async_mock.CoroutineMock()
+            )
+
+            mock_connection_manager.return_value.offer_credential = (
+                async_mock.CoroutineMock()
+            )
+            mock_connection_manager.return_value.offer_credential.return_value = (
+                async_mock.MagicMock(),
+                async_mock.MagicMock(),
+            )
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.credential_exchange_send(mock)
+
+    async def test_credential_exchange_send_not_ready(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_connection_manager:
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            # Emulate connection not ready
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock()
+            mock_connection_record.retrieve_by_id.return_value.is_ready = False
+
+            mock_connection_manager.return_value.create_offer = (
+                async_mock.CoroutineMock()
+            )
+
+            mock_connection_manager.return_value.offer_credential = (
+                async_mock.CoroutineMock()
+            )
+            mock_connection_manager.return_value.offer_credential.return_value = (
+                async_mock.MagicMock(),
+                async_mock.MagicMock(),
+            )
+
+            with self.assertRaises(test_module.web.HTTPForbidden):
+                await test_module.credential_exchange_send(mock)
+
     async def test_credential_exchange_send_offer(self):
         mock = async_mock.MagicMock()
         mock.json = async_mock.CoroutineMock()
@@ -117,3 +228,258 @@ class TestCredentialRoutes(AsyncTestCase):
 
             with self.assertRaises(test_module.web.HTTPForbidden):
                 await test_module.credential_exchange_send_offer(mock)
+
+    async def test_credential_exchange_send_request(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_connection_manager, async_mock.patch.object(
+            test_module, "CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_OFFER_RECEIVED
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            mock_cred_ex_record = async_mock.MagicMock()
+
+            mock_connection_manager.return_value.create_request.return_value = (
+                mock_cred_ex_record,
+                async_mock.MagicMock(),
+            )
+
+            await test_module.credential_exchange_send_request(mock)
+
+            test_module.web.json_response.assert_called_once_with(
+                mock_cred_ex_record.serialize.return_value
+            )
+
+    async def test_credential_exchange_send_request_no_conn_record(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_connection_manager, async_mock.patch.object(
+            test_module, "CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_OFFER_RECEIVED
+            
+
+            # Emulate storage not found (bad connection id)
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock(
+                side_effect=StorageNotFoundError
+            )
+
+            mock_connection_manager.return_value.create_offer = (
+                async_mock.CoroutineMock()
+            )
+
+            mock_connection_manager.return_value.offer_credential = (
+                async_mock.CoroutineMock()
+            )
+            mock_connection_manager.return_value.offer_credential.return_value = (
+                async_mock.MagicMock(),
+                async_mock.MagicMock(),
+            )
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.credential_exchange_send_request(mock)
+
+    async def test_credential_exchange_send_request_not_ready(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_connection_manager, async_mock.patch.object(
+            test_module, "CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_OFFER_RECEIVED
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            # Emulate connection not ready
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock()
+            mock_connection_record.retrieve_by_id.return_value.is_ready = False
+
+            mock_connection_manager.return_value.create_offer = (
+                async_mock.CoroutineMock()
+            )
+
+            mock_connection_manager.return_value.offer_credential = (
+                async_mock.CoroutineMock()
+            )
+            mock_connection_manager.return_value.offer_credential.return_value = (
+                async_mock.MagicMock(),
+                async_mock.MagicMock(),
+            )
+
+            with self.assertRaises(test_module.web.HTTPForbidden):
+                await test_module.credential_exchange_send_request(mock)
+
+
+
+
+
+
+
+
+
+
+
+
+    async def test_credential_exchange_issue(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_connection_manager, async_mock.patch.object(
+            test_module, "CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_REQUEST_RECEIVED
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            mock_cred_ex_record = async_mock.MagicMock()
+
+            mock_connection_manager.return_value.issue_credential.return_value = (
+                mock_cred_ex_record,
+                async_mock.MagicMock(),
+            )
+
+            await test_module.credential_exchange_issue(mock)
+
+            test_module.web.json_response.assert_called_once_with(
+                mock_cred_ex_record.serialize.return_value
+            )
+
+    async def test_credential_exchange_issue_no_conn_record(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_connection_manager, async_mock.patch.object(
+            test_module, "CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_REQUEST_RECEIVED
+            
+
+            # Emulate storage not found (bad connection id)
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock(
+                side_effect=StorageNotFoundError
+            )
+
+            mock_connection_manager.return_value.create_offer = (
+                async_mock.CoroutineMock()
+            )
+
+            mock_connection_manager.return_value.offer_credential = (
+                async_mock.CoroutineMock()
+            )
+            mock_connection_manager.return_value.issue_credential.return_value = (
+                async_mock.MagicMock(),
+                async_mock.MagicMock(),
+            )
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.credential_exchange_issue(mock)
+
+    async def test_credential_exchange_issue_not_ready(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_connection_manager, async_mock.patch.object(
+            test_module, "CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_REQUEST_RECEIVED
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            # Emulate connection not ready
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock()
+            mock_connection_record.retrieve_by_id.return_value.is_ready = False
+
+            mock_connection_manager.return_value.create_offer = (
+                async_mock.CoroutineMock()
+            )
+
+            mock_connection_manager.return_value.offer_credential = (
+                async_mock.CoroutineMock()
+            )
+            mock_connection_manager.return_value.issue_credential.return_value = (
+                async_mock.MagicMock(),
+                async_mock.MagicMock(),
+            )
+
+            with self.assertRaises(test_module.web.HTTPForbidden):
+                await test_module.credential_exchange_issue(mock)
+
+
+
+
+
+

--- a/aries_cloudagent/messaging/introduction/handlers/forward_invitation_handler.py
+++ b/aries_cloudagent/messaging/introduction/handlers/forward_invitation_handler.py
@@ -13,7 +13,7 @@ class ForwardInvitationHandler(BaseHandler):
         self._logger.debug("ForwardInvitationHandler called with context %s", context)
         assert isinstance(context.message, ForwardInvitation)
 
-        if not context.connection_active:
+        if not context.connection_ready:
             raise HandlerException(
                 "No connection established for forward invitation message"
             )

--- a/aries_cloudagent/messaging/introduction/handlers/invitation_handler.py
+++ b/aries_cloudagent/messaging/introduction/handlers/invitation_handler.py
@@ -13,7 +13,7 @@ class InvitationHandler(BaseHandler):
         self._logger.debug("InvitationHandler called with context %s", context)
         assert isinstance(context.message, Invitation)
 
-        if not context.connection_active:
+        if not context.connection_ready:
             raise HandlerException("No connection established for invitation message")
 
         service: BaseIntroductionService = await context.inject(

--- a/aries_cloudagent/messaging/introduction/handlers/invitation_request_handler.py
+++ b/aries_cloudagent/messaging/introduction/handlers/invitation_request_handler.py
@@ -14,7 +14,7 @@ class InvitationRequestHandler(BaseHandler):
         self._logger.debug("InvitationRequestHandler called with context %s", context)
         assert isinstance(context.message, InvitationRequest)
 
-        if not context.connection_active:
+        if not context.connection_ready:
             raise HandlerException(
                 "No connection established for invitation request message"
             )

--- a/aries_cloudagent/messaging/request_context.py
+++ b/aries_cloudagent/messaging/request_context.py
@@ -30,13 +30,13 @@ class RequestContext(InjectionContext):
             self._scope_name = base_context.scope_name
             self._scopes = base_context._scopes
             self.start_scope("request")
-        self._connection_active = False
+        self._connection_ready = False
         self._connection_record = None
         self._message = None
         self._message_delivery = None
 
     @property
-    def connection_active(self) -> bool:
+    def connection_ready(self) -> bool:
         """
         Accessor for the flag indicating an active connection with the sender.
 
@@ -44,10 +44,10 @@ class RequestContext(InjectionContext):
             True if the connection is active, else False
 
         """
-        return self._connection_active
+        return self._connection_ready
 
-    @connection_active.setter
-    def connection_active(self, active: bool):
+    @connection_ready.setter
+    def connection_ready(self, active: bool):
         """
         Setter for the flag indicating an active connection with the sender.
 
@@ -55,7 +55,7 @@ class RequestContext(InjectionContext):
             active: The new active value
 
         """
-        self._connection_active = active
+        self._connection_ready = active
 
     @property
     def connection_record(self) -> ConnectionRecord:

--- a/aries_cloudagent/messaging/routing/handlers/route_query_request_handler.py
+++ b/aries_cloudagent/messaging/routing/handlers/route_query_request_handler.py
@@ -16,7 +16,7 @@ class RouteQueryRequestHandler(BaseHandler):
         )
         assert isinstance(context.message, RouteQueryRequest)
 
-        if not context.connection_active:
+        if not context.connection_ready:
             raise HandlerException("Cannot query routes: no active connection")
 
         # TODO implement pagination

--- a/aries_cloudagent/messaging/routing/handlers/route_query_response_handler.py
+++ b/aries_cloudagent/messaging/routing/handlers/route_query_response_handler.py
@@ -14,7 +14,7 @@ class RouteQueryResponseHandler(BaseHandler):
         )
         assert isinstance(context.message, RouteQueryResponse)
 
-        if not context.connection_active:
+        if not context.connection_ready:
             raise HandlerException(
                 "Cannot handle route query response: no active connection"
             )

--- a/aries_cloudagent/messaging/routing/handlers/route_update_request_handler.py
+++ b/aries_cloudagent/messaging/routing/handlers/route_update_request_handler.py
@@ -16,7 +16,7 @@ class RouteUpdateRequestHandler(BaseHandler):
         )
         assert isinstance(context.message, RouteUpdateRequest)
 
-        if not context.connection_active:
+        if not context.connection_ready:
             raise HandlerException("Cannot update routes: no active connection")
 
         mgr = RoutingManager(context)

--- a/aries_cloudagent/messaging/routing/handlers/route_update_response_handler.py
+++ b/aries_cloudagent/messaging/routing/handlers/route_update_response_handler.py
@@ -19,7 +19,7 @@ class RouteUpdateResponseHandler(BaseHandler):
         )
         assert isinstance(context.message, RouteUpdateResponse)
 
-        if not context.connection_active:
+        if not context.connection_ready:
             raise HandlerException("Cannot handle updated routes: no active connection")
 
         conn_mgr = ConnectionManager(context)

--- a/aries_cloudagent/messaging/routing/handlers/tests/test_query_update_handlers.py
+++ b/aries_cloudagent/messaging/routing/handlers/tests/test_query_update_handlers.py
@@ -26,7 +26,7 @@ TEST_ROUTE_VERKEY = "9WCgWKUaAJj3VWxxtzvvMQN3AoFxoBtBDo9ntwJnVVCC"
 @pytest.fixture()
 def request_context() -> RequestContext:
     ctx = RequestContext()
-    ctx.connection_active = True
+    ctx.connection_ready = True
     ctx.connection_record = ConnectionRecord(connection_id="conn-id")
     ctx.message_delivery = MessageDelivery(sender_verkey=TEST_VERKEY)
     ctx.injector.bind_instance(BaseStorage, BasicStorage())
@@ -48,7 +48,7 @@ class TestQueryUpdateHandlers:
 
     @pytest.mark.asyncio
     async def test_no_connection(self, request_context):
-        request_context.connection_active = False
+        request_context.connection_ready = False
         request_context.message = RouteQueryRequest()
         handler = RouteQueryRequestHandler()
         responder = MockResponder()

--- a/aries_cloudagent/messaging/trustping/handlers/ping_handler.py
+++ b/aries_cloudagent/messaging/trustping/handlers/ping_handler.py
@@ -25,12 +25,7 @@ class PingHandler(BaseHandler):
             "Received trust ping from: %s", context.message_delivery.sender_did
         )
 
-        response_state = (
-            context.connection_record
-            and context.connection_record.state
-            == context.connection_record.STATE_RESPONSE
-        )
-        if not context.connection_active and not response_state:
+        if not context.connection_ready:
             self._logger.info(
                 "Connection not active, skipping ping response: %s",
                 context.message_delivery.sender_did,

--- a/aries_cloudagent/messaging/trustping/routes.py
+++ b/aries_cloudagent/messaging/trustping/routes.py
@@ -26,7 +26,7 @@ async def connections_send_ping(request: web.BaseRequest):
     except StorageNotFoundError:
         raise web.HTTPNotFound()
 
-    if connection.is_active or connection.state == connection.STATE_RESPONSE:
+    if connection.is_ready:
         msg = Ping()
         await outbound_handler(msg, connection_id=connection_id)
 

--- a/demo/acme.py
+++ b/demo/acme.py
@@ -19,23 +19,23 @@ class AcmeAgent(DemoAgent):
     def __init__(self, http_port: int, admin_port: int, **kwargs):
         super().__init__("Acme Agent", http_port, admin_port, prefix="Acme", **kwargs)
         self.connection_id = None
-        self._connection_active = asyncio.Future()
+        self._connection_ready = asyncio.Future()
         self.cred_state = {}
         # TODO define a dict to hold credential attributes based on credential_definition_id
         self.cred_attrs = {}
 
     async def detect_connection(self):
-        await self._connection_active
+        await self._connection_ready
 
     @property
-    def connection_active(self):
-        return self._connection_active.done() and self._connection_active.result()
+    def connection_ready(self):
+        return self._connection_ready.done() and self._connection_ready.result()
 
     async def handle_connections(self, message):
         if message["connection_id"] == self.connection_id:
-            if message["state"] == "active" and not self._connection_active.done():
+            if message["state"] == "active" and not self._connection_ready.done():
                 self.log("Connected")
-                self._connection_active.set_result(True)
+                self._connection_ready.set_result(True)
 
     async def handle_credentials(self, message):
         state = message["state"]

--- a/demo/alice.py
+++ b/demo/alice.py
@@ -18,21 +18,21 @@ class AliceAgent(DemoAgent):
     def __init__(self, http_port: int, admin_port: int, **kwargs):
         super().__init__("Alice Agent", http_port, admin_port, prefix="Alice", **kwargs)
         self.connection_id = None
-        self._connection_active = asyncio.Future()
+        self._connection_ready = asyncio.Future()
         self.cred_state = {}
 
     async def detect_connection(self):
-        await self._connection_active
+        await self._connection_ready
 
     @property
-    def connection_active(self):
-        return self._connection_active.done() and self._connection_active.result()
+    def connection_ready(self):
+        return self._connection_ready.done() and self._connection_ready.result()
 
     async def handle_connections(self, message):
         if message["connection_id"] == self.connection_id:
-            if message["state"] == "active" and not self._connection_active.done():
+            if message["state"] == "active" and not self._connection_ready.done():
                 self.log("Connected")
-                self._connection_active.set_result(True)
+                self._connection_ready.set_result(True)
 
     async def handle_credentials(self, message):
         state = message["state"]

--- a/demo/faber.py
+++ b/demo/faber.py
@@ -19,23 +19,23 @@ class FaberAgent(DemoAgent):
     def __init__(self, http_port: int, admin_port: int, **kwargs):
         super().__init__("Faber Agent", http_port, admin_port, prefix="Faber", **kwargs)
         self.connection_id = None
-        self._connection_active = asyncio.Future()
+        self._connection_ready = asyncio.Future()
         self.cred_state = {}
         # TODO define a dict to hold credential attributes based on credential_definition_id
         self.cred_attrs = {}
 
     async def detect_connection(self):
-        await self._connection_active
+        await self._connection_ready
 
     @property
-    def connection_active(self):
-        return self._connection_active.done() and self._connection_active.result()
+    def connection_ready(self):
+        return self._connection_ready.done() and self._connection_ready.result()
 
     async def handle_connections(self, message):
         if message["connection_id"] == self.connection_id:
-            if message["state"] == "active" and not self._connection_active.done():
+            if message["state"] == "active" and not self._connection_ready.done():
                 self.log("Connected")
-                self._connection_active.set_result(True)
+                self._connection_ready.set_result(True)
 
     async def handle_credentials(self, message):
         state = message["state"]

--- a/demo/performance.py
+++ b/demo/performance.py
@@ -22,16 +22,16 @@ class BaseAgent(DemoAgent):
             prefix = ident
         super().__init__(ident, port, port + 1, timing=timing, prefix=prefix, **kwargs)
         self.connection_id = None
-        self.connection_active = asyncio.Future()
+        self.connection_ready = asyncio.Future()
 
     async def detect_connection(self):
-        await self.connection_active
+        await self.connection_ready
 
     async def handle_connections(self, payload):
         if payload["connection_id"] == self.connection_id:
-            if payload["state"] == "active" and not self.connection_active.done():
+            if payload["state"] == "active" and not self.connection_ready.done():
                 self.log("Connected")
-                self.connection_active.set_result(True)
+                self.connection_ready.set_result(True)
 
 
 class AliceAgent(BaseAgent):


### PR DESCRIPTION
This pull request refactors the rest of `connection.is_active` references to use `is_ready` instead. It also removes the `is_ready` property on the connection record