### PR TITLE
Use a common base class for storage-based data records

### DIFF
--- a/aries_cloudagent/conductor.py
+++ b/aries_cloudagent/conductor.py
@@ -139,7 +139,6 @@ class Conductor:
                     "get_connection_target",
                     "fetch_did_document",
                     "find_connection",
-                    "updated_record",
                 ),
             )
 

--- a/aries_cloudagent/config/injection_context.py
+++ b/aries_cloudagent/config/injection_context.py
@@ -20,9 +20,11 @@ class InjectionContext(BaseInjector):
 
     ROOT_SCOPE = "application"
 
-    def __init__(self, *, settings: Mapping[str, object] = None):
+    def __init__(
+        self, *, settings: Mapping[str, object] = None, enforce_typing: bool = True
+    ):
         """Initialize a `ServiceConfig`."""
-        self._injector = Injector(settings)
+        self._injector = Injector(settings, enforce_typing=enforce_typing)
         self._scope_name = self.ROOT_SCOPE
         self._scopes = []
 

--- a/aries_cloudagent/config/injector.py
+++ b/aries_cloudagent/config/injector.py
@@ -10,9 +10,11 @@ from .settings import Settings
 class Injector(BaseInjector):
     """Injector implementation with static and dynamic bindings."""
 
-    def __init__(self, settings: Mapping[str, object] = None):
+    def __init__(
+        self, settings: Mapping[str, object] = None, enforce_typing: bool = True
+    ):
         """Initialize an `Injector`."""
-        self.enforce_typing = True
+        self.enforce_typing = enforce_typing
         self._providers = {}
         self._settings = Settings(settings)
 

--- a/aries_cloudagent/messaging/connections/manager.py
+++ b/aries_cloudagent/messaging/connections/manager.py
@@ -1,7 +1,6 @@
 """Classes to manage connections."""
 
 import logging
-import sys
 
 from typing import Tuple
 
@@ -49,15 +48,6 @@ class ConnectionManager:
         """
         self._context = context
         self._logger = logging.getLogger(__name__)
-
-    def _log_state(self, msg: str, params: dict = None):
-        """Print a message with increased visibility (for testing)."""
-        if self._context.settings.get("debug.connections"):
-            print(msg, file=sys.stderr)
-            if params:
-                for k, v in params.items():
-                    print(f"    {k}: {v}", file=sys.stderr)
-            print(file=sys.stderr)
 
     @property
     def context(self) -> InjectionContext:
@@ -154,13 +144,7 @@ class ConnectionManager:
             accept=accept,
         )
 
-        await connection.save(self.context)
-        await self.updated_record(connection)
-
-        self._log_state(
-            "Created new connection record",
-            {"id": connection.connection_id, "state": connection.state},
-        )
+        await connection.save(self.context, reason="Created new invitation")
 
         # Create connection invitation message
         # Note: Need to split this into two stages to support inbound routing of invites
@@ -217,12 +201,10 @@ class ConnectionManager:
             accept=accept,
         )
 
-        await connection.save(self.context)
-        await self.updated_record(connection)
-
-        self._log_state(
-            "Created new connection record",
-            {"id": connection.connection_id, "state": connection.state},
+        await connection.save(
+            self.context,
+            reason="Created new connection record from invitation",
+            log_params={"invitation": invitation, "role": their_role},
         )
 
         # Save the invitation for later processing
@@ -289,9 +271,7 @@ class ConnectionManager:
         connection.request_id = request._id
         connection.state = ConnectionRecord.STATE_REQUEST
 
-        await connection.save(self.context)
-        await self.updated_record(connection)
-        self._log_state("Updated connection state", {"connection": connection})
+        await connection.save(self.context, reason="Created connection request")
 
         await connection.log_activity(
             self.context, "request", connection.DIRECTION_SENT
@@ -313,7 +293,9 @@ class ConnectionManager:
             The new or updated `ConnectionRecord` instance
 
         """
-        self._log_state("Receiving connection request", {"request": request})
+        ConnectionRecord.log_state(
+            self.context, "Receiving connection request", {"request": request}
+        )
 
         connection = None
         connection_key = None
@@ -338,7 +320,9 @@ class ConnectionManager:
         if connection:
             invitation = await connection.retrieve_invitation(self.context)
             connection_key = connection.invitation_key
-            self._log_state("Found invitation", {"invitation": invitation})
+            ConnectionRecord.log_state(
+                self.context, "Found invitation", {"invitation": invitation}
+            )
 
         conn_did_doc = request.connection.did_doc
         if not conn_did_doc:
@@ -356,10 +340,9 @@ class ConnectionManager:
             connection.their_label = request.label
             connection.their_did = request.connection.did
             connection.state = ConnectionRecord.STATE_REQUEST
-
-            await connection.save(self.context)
-            await self.updated_record(connection)
-            self._log_state("Updated connection state", {"connection": connection})
+            await connection.save(
+                self.context, reason="Received connection request from invitation"
+            )
         elif not self.context.settings.get("public_invites"):
             raise ConnectionManagerError("Public invitations are not enabled")
         else:
@@ -375,12 +358,8 @@ class ConnectionManager:
             if self.context.settings.get("debug.auto_accept_requests"):
                 connection.accept = ConnectionRecord.ACCEPT_AUTO
 
-            await connection.save(self.context)
-            await self.updated_record(connection)
-
-            self._log_state(
-                "Created new connection record",
-                {"id": connection.connection_id, "state": connection.state},
+            await connection.save(
+                self.context, reason="Received connection request from public DID"
             )
 
         # Attach the connection request so it can be found and responded to
@@ -422,8 +401,10 @@ class ConnectionManager:
             A tuple of the updated `ConnectionRecord` new `ConnectionResponse` message
 
         """
-        self._log_state(
-            "Creating connection response", {"connection_id": connection.connection_id}
+        ConnectionRecord.log_state(
+            self.context,
+            "Creating connection response",
+            {"connection_id": connection.connection_id},
         )
 
         if connection.state not in (
@@ -454,22 +435,15 @@ class ConnectionManager:
         # Sign connection field using the invitation key
         wallet: BaseWallet = await self.context.inject(BaseWallet)
         await response.sign_field("connection", connection.invitation_key, wallet)
-        self._log_state(
-            "Created connection response",
-            {
-                "my_did": my_info.did,
-                "their_did": connection.their_did,
-                "response": response,
-            },
-        )
 
         # Update connection state
         connection.state = ConnectionRecord.STATE_RESPONSE
 
-        await connection.save(self.context)
-        await self.updated_record(connection)
-        self._log_state("Updated connection state", {"connection": connection})
-
+        await connection.save(
+            self.context,
+            reason="Created connection response",
+            log_params={"response": response},
+        )
         await connection.log_activity(
             self.context, "response", connection.DIRECTION_SENT
         )
@@ -547,9 +521,7 @@ class ConnectionManager:
         connection.their_did = their_did
         connection.state = ConnectionRecord.STATE_RESPONSE
 
-        await connection.save(self.context)
-        await self.updated_record(connection)
-
+        await connection.save(self.context, reason="Accepted connection response")
         await connection.log_activity(
             self.context, "response", connection.DIRECTION_RECEIVED
         )
@@ -596,15 +568,10 @@ class ConnectionManager:
         ):
             connection.state = ConnectionRecord.STATE_ACTIVE
 
-            await connection.save(self.context)
-            await self.updated_record(connection)
-            self._log_state("Connection promoted to active", {"connection": connection})
+            await connection.save(self.context, reason="Connection promoted to active")
         elif connection and connection.state == ConnectionRecord.STATE_INACTIVE:
             connection.state = ConnectionRecord.STATE_ACTIVE
-            await connection.save(self.context)
-            await self.updated_record(connection)
-
-            self._log_state("Connection restored to active", {"connection": connection})
+            await connection.save(self.context, reason="Connection restored to active")
 
         if not connection and my_verkey:
             try:
@@ -959,7 +926,6 @@ class ConnectionManager:
         )
         connection.routing_state = ConnectionRecord.ROUTING_STATE_REQUEST
         await connection.save(self.context)
-        await self.updated_record(connection)
         return connection.routing_state
 
     async def update_inbound(
@@ -983,7 +949,6 @@ class ConnectionManager:
             if conn_info.verkey == recip_verkey:
                 connection.routing_state = routing_state
                 await connection.save(self.context)
-                await self.updated_record(connection)
 
     async def log_activity(
         self,
@@ -994,28 +959,3 @@ class ConnectionManager:
     ):
         """Log activity against a connection record and send webhook."""
         await connection.log_activity(self._context, activity_type, direction, meta)
-        await self.updated_activity(connection)
-
-    async def updated_record(self, connection: ConnectionRecord):
-        """Call webhook when the record is updated."""
-        responder: BaseResponder = await self._context.inject(
-            BaseResponder, required=False
-        )
-        if responder:
-            await responder.send_webhook("connections", connection.serialize())
-        cache: BaseCache = await self._context.inject(BaseCache, required=False)
-        cache_key = f"connection_target::{connection.connection_id}"
-        if cache:
-            await cache.clear(cache_key)
-
-    async def updated_activity(self, connection: ConnectionRecord):
-        """Call webhook when the record activity is updated."""
-        responder: BaseResponder = await self._context.inject(
-            BaseResponder, required=False
-        )
-        if responder:
-            activity = await connection.fetch_activity(self._context)
-            await responder.send_webhook(
-                "connections_activity",
-                {"connection_id": connection.connection_id, "activity": activity},
-            )

--- a/aries_cloudagent/messaging/connections/manager.py
+++ b/aries_cloudagent/messaging/connections/manager.py
@@ -106,8 +106,6 @@ class ConnectionManager:
             A tuple of the new `ConnectionRecord` and `ConnectionInvitation` instances
 
         """
-        self._log_state("Creating invitation")
-
         if not my_label:
             my_label = self.context.settings.get("default_label")
         wallet: BaseWallet = await self.context.inject(BaseWallet)
@@ -178,10 +176,6 @@ class ConnectionManager:
             The new `ConnectionRecord` instance
 
         """
-        self._log_state(
-            "Receiving invitation", {"invitation": invitation, "role": their_role}
-        )
-
         if not invitation.did:
             if not invitation.recipient_keys:
                 raise ConnectionManagerError("Invitation must contain recipient key(s)")

--- a/aries_cloudagent/messaging/connections/models/connection_record.py
+++ b/aries_cloudagent/messaging/connections/models/connection_record.py
@@ -95,32 +95,28 @@ class ConnectionRecord(BaseRecord):
         return self._id
 
     @property
-    def value(self) -> dict:
-        """Accessor for the JSON record value generated for this connection."""
-        value = super().value
-        value.update({"error_msg": self.error_msg, "their_label": self.their_label})
-        return value
+    def record_value(self) -> dict:
+        """Accessor to for the JSON record value properties for this connection."""
+        return {"error_msg": self.error_msg, "their_label": self.their_label}
 
     @property
-    def tags(self) -> dict:
+    def record_tags(self) -> dict:
         """Accessor for the record tags generated for this connection."""
-        result = super().tags
-        for prop in (
-            "my_did",
-            "their_did",
-            "their_role",
-            "inbound_connection_id",
-            "initiator",
-            "invitation_key",
-            "request_id",
-            "state",
-            "routing_state",
-            "accept",
-        ):
-            val = getattr(self, prop)
-            if val:
-                result[prop] = val
-        return result
+        return {
+            prop: getattr(self, prop)
+            for prop in (
+                "my_did",
+                "their_did",
+                "their_role",
+                "inbound_connection_id",
+                "initiator",
+                "invitation_key",
+                "request_id",
+                "state",
+                "routing_state",
+                "accept",
+            )
+        }
 
     @classmethod
     async def retrieve_by_did(

--- a/aries_cloudagent/messaging/connections/models/connection_record.py
+++ b/aries_cloudagent/messaging/connections/models/connection_record.py
@@ -29,6 +29,7 @@ class ConnectionRecord(BaseRecord):
     WEBHOOK_TOPIC = "connections"
     WEBHOOK_TOPIC_ACTIVITY = "connections_activity"
     LOG_STATE_FLAG = "debug.connections"
+    CACHE_ENABLED = True
 
     RECORD_TYPE = "connection"
     RECORD_TYPE_ACTIVITY = "connection_activity"

--- a/aries_cloudagent/messaging/credentials/models/credential_exchange.py
+++ b/aries_cloudagent/messaging/credentials/models/credential_exchange.py
@@ -15,6 +15,7 @@ class CredentialExchange(BaseRecord):
 
     RECORD_TYPE = "credential_exchange"
     RECORD_ID_NAME = "credential_exchange_id"
+    WEBHOOK_TOPIC = "credentials"
 
     INITIATOR_SELF = "self"
     INITIATOR_EXTERNAL = "external"

--- a/aries_cloudagent/messaging/credentials/models/credential_exchange.py
+++ b/aries_cloudagent/messaging/credentials/models/credential_exchange.py
@@ -1,21 +1,11 @@
 """Handle credential exchange information interface with non-secrets storage."""
 
-import json
-import uuid
-
-from typing import Sequence
-
 from marshmallow import fields
 
-from ....cache.base import BaseCache
-from ....config.injection_context import InjectionContext
-from ....storage.base import BaseStorage
-from ....storage.record import StorageRecord
-
-from ...models.base import BaseModel, BaseModelSchema
+from ...models.base_record import BaseRecord, BaseRecordSchema
 
 
-class CredentialExchange(BaseModel):
+class CredentialExchange(BaseRecord):
     """Represents a credential exchange."""
 
     class Meta:
@@ -24,6 +14,7 @@ class CredentialExchange(BaseModel):
         schema_class = "CredentialExchangeSchema"
 
     RECORD_TYPE = "credential_exchange"
+    RECORD_ID_NAME = "credential_exchange_id"
 
     INITIATOR_SELF = "self"
     INITIATOR_EXTERNAL = "external"
@@ -54,9 +45,10 @@ class CredentialExchange(BaseModel):
         credential_values: dict = None,
         auto_issue: bool = False,
         error_msg: str = None,
+        **kwargs,
     ):
         """Initialize a new CredentialExchange."""
-        self._id = credential_exchange_id
+        super().__init__(credential_exchange_id, state, **kwargs)
         self.connection_id = connection_id
         self.thread_id = thread_id
         self.parent_thread_id = parent_thread_id
@@ -79,152 +71,40 @@ class CredentialExchange(BaseModel):
         return self._id
 
     @property
-    def storage_record(self) -> StorageRecord:
-        """Accessor for a `StorageRecord` representing this credential exchange."""
-        return StorageRecord(
-            self.RECORD_TYPE,
-            json.dumps(self.value),
-            self.tags,
-            self.credential_exchange_id,
-        )
+    def record_value(self) -> dict:
+        """Accessor to for the JSON record value props for this credential exchange."""
+        return {
+            prop: getattr(self, prop)
+            for prop in (
+                "credential_offer",
+                "credential_request",
+                "credential_request_metadata",
+                "error_msg",
+                "auto_issue",
+                "credential_values",
+                "credential",
+                "parent_thread_id",
+            )
+        }
 
     @property
-    def value(self) -> dict:
-        """Accessor for the JSON record value generated for this credential exchange."""
-        result = self.tags
-        for prop in (
-            "credential_offer",
-            "credential_request",
-            "credential_request_metadata",
-            "error_msg",
-            "auto_issue",
-            "credential_values",
-            "credential",
-            "parent_thread_id",
-        ):
-            val = getattr(self, prop)
-            if val:
-                result[prop] = val
-        return result
-
-    @property
-    def tags(self) -> dict:
+    def record_tags(self) -> dict:
         """Accessor for the record tags generated for this credential exchange."""
-        result = {}
-        for prop in (
-            "connection_id",
-            "thread_id",
-            "initiator",
-            "state",
-            "credential_definition_id",
-            "schema_id",
-            "credential_id",
-        ):
-            val = getattr(self, prop)
-            if val:
-                result[prop] = val
-        return result
-
-    async def save(self, context: InjectionContext):
-        """Persist the credential exchange record to storage.
-
-        Args:
-            context: The `InjectionContext` instance to use
-        """
-        storage: BaseStorage = await context.inject(BaseStorage)
-        if not self._id:
-            self._id = str(uuid.uuid4())
-            await storage.add_record(self.storage_record)
-        else:
-            record = self.storage_record
-            await storage.update_record_value(record, record.value)
-            await storage.update_record_tags(record, record.tags)
-
-        cache_key = f"{self.RECORD_TYPE}::{self._id}"
-        cache: BaseCache = await context.inject(BaseCache, required=False)
-        if cache:
-            await cache.clear(cache_key)
-
-    @classmethod
-    async def retrieve_by_id(
-        cls, context: InjectionContext, credential_exchange_id: str, cached: bool = True
-    ):
-        """Retrieve a credential exchange record by ID.
-
-        Args:
-            context: The `InjectionContext` instance to use
-            credential_exchange_id: The ID of the credential exchange record to find
-            cached: Whether to check the cache for this record
-        """
-        cache = None
-        cache_key = f"{cls.RECORD_TYPE}::{credential_exchange_id}"
-        vals = None
-
-        if cached and credential_exchange_id:
-            cache: BaseCache = await context.inject(BaseCache, required=False)
-            if cache:
-                vals = await cache.get(cache_key)
-
-        if not vals:
-            storage: BaseStorage = await context.inject(BaseStorage)
-            result = await storage.get_record(cls.RECORD_TYPE, credential_exchange_id)
-            vals = json.loads(result.value)
-            if result.tags:
-                vals.update(result.tags)
-            if cache:
-                await cache.set(cache_key, vals, 60)
-
-        return CredentialExchange(credential_exchange_id=credential_exchange_id, **vals)
-
-    @classmethod
-    async def retrieve_by_tag_filter(
-        cls, context: InjectionContext, tag_filter: dict
-    ) -> "CredentialExchange":
-        """Retrieve a credential exchange record by tag filter.
-
-        Args:
-            context: The `InjectionContext` instance to use
-            tag_filter: The filter dictionary to apply
-        """
-        storage: BaseStorage = await context.inject(BaseStorage)
-        result = await storage.search_records(
-            cls.RECORD_TYPE, tag_filter
-        ).fetch_single()
-        vals = json.loads(result.value)
-        vals.update(result.tags)
-        return CredentialExchange(credential_exchange_id=result.id, **vals)
-
-    @classmethod
-    async def query(
-        cls, context: InjectionContext, tag_filter: dict = None
-    ) -> Sequence["CredentialExchange"]:
-        """Query existing credential exchange records.
-
-        Args:
-            context: The `InjectionContext` instance to use
-            tag_filter: An optional dictionary of tag filter clauses
-        """
-        storage: BaseStorage = await context.inject(BaseStorage)
-        found = await storage.search_records(cls.RECORD_TYPE, tag_filter).fetch_all()
-        result = []
-        for record in found:
-            vals = json.loads(record.value)
-            vals.update(record.tags)
-            result.append(CredentialExchange(credential_exchange_id=record.id, **vals))
-        return result
-
-    async def delete_record(self, context: InjectionContext):
-        """Remove the credential exchange record.
-
-        Args:
-            context: The `InjectionContext` instance to use
-        """
-        if self.credential_exchange_id:
-            storage: BaseStorage = await context.inject(BaseStorage)
-            await storage.delete_record(self.storage_record)
+        return {
+            prop: getattr(self, prop)
+            for prop in (
+                "connection_id",
+                "thread_id",
+                "initiator",
+                "state",
+                "credential_definition_id",
+                "schema_id",
+                "credential_id",
+            )
+        }
 
 
-class CredentialExchangeSchema(BaseModelSchema):
+class CredentialExchangeSchema(BaseRecordSchema):
     """Schema to allow serialization/deserialization of credential exchange records."""
 
     class Meta:

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -1,0 +1,367 @@
+"""Classes for BaseStorage-based record management."""
+
+import json
+import sys
+import uuid
+
+from datetime import datetime
+from typing import Any, Mapping, Sequence, Union
+
+from marshmallow import fields
+
+from ...cache.base import BaseCache
+from ...config.injection_context import InjectionContext
+from ...storage.base import BaseStorage
+from ...storage.record import StorageRecord
+
+from .base import BaseModel, BaseModelSchema
+from ..responder import BaseResponder
+from ..util import datetime_to_str, time_now
+
+
+class BaseRecord(BaseModel):
+    """Represents a single storage record."""
+
+    class Meta:
+        """BaseRecord metadata."""
+
+    RECORD_ID_NAME = "record_id"
+    RECORD_TYPE = None
+    WEBHOOK_TOPIC = None
+    LOG_STATE_FLAG = None
+
+    def __init__(
+        self,
+        record_id: str = None,
+        state: str = None,
+        *,
+        created_at: Union[str, datetime] = None,
+        updated_at: Union[str, datetime] = None,
+    ):
+        """Initialize a new BaseRecord."""
+        if not self.RECORD_TYPE:
+            raise TypeError(
+                "Can't instantiate abstract class {} with no RECORD_TYPE".format(
+                    self.__class__.__name__
+                )
+            )
+        self._id = record_id
+        self._last_state = state
+        self.state = state
+        self.created_at = datetime_to_str(created_at)
+        self.updated_at = datetime_to_str(updated_at)
+
+    @classmethod
+    def from_storage(cls, record_id: str, record: Mapping[str, Any]):
+        """Initialize a record from its stored representation.
+
+        Args:
+            record_id: The unique record identifier
+            record: The stored representation
+        """
+        record_id_name = cls.RECORD_ID_NAME
+        if record_id_name in record:
+            raise ValueError(f"Duplicate {record_id_name} inputs")
+        record[record_id_name] = record_id
+        return cls(**record)
+
+    @property
+    def storage_record(self) -> StorageRecord:
+        """Accessor for a `StorageRecord` representing this record."""
+        return StorageRecord(
+            self.RECORD_TYPE, json.dumps(self.value), self.tags, self._id
+        )
+
+    @property
+    def value(self) -> dict:
+        """Accessor for the JSON record value generated for this record."""
+        ret = self.tags
+        ret.update({"created_at": self.created_at, "updated_at": self.updated_at})
+        return ret
+
+    @property
+    def tags(self) -> dict:
+        """Accessor for the record tags generated for this record."""
+        result = {}
+        for prop in ("state",):
+            val = getattr(self, prop)
+            if val:
+                result[prop] = val
+        return result
+
+    @classmethod
+    def cache_key(cls, record_id: str, record_type: str = None):
+        """Assemble a cache key.
+
+        Args:
+            record_id: The record identifier
+            record_type The cache type identifier, defaulting to RECORD_TYPE
+        """
+        if not record_type:
+            record_type = cls.RECORD_TYPE
+        if record_id:
+            return f"{record_type}::{record_id}"
+
+    @classmethod
+    async def get_cached_key(cls, context: InjectionContext, cache_key: str):
+        """Shortcut method to fetch a cached key value.
+
+        Args:
+            context: The injection context to use
+            cache_key: The unique cache identifier
+        """
+        if not cache_key:
+            return
+        cache: BaseCache = await context.inject(BaseCache, required=False)
+        if cache:
+            return await cache.get(cache_key)
+
+    @classmethod
+    async def set_cached_key(
+        cls, context: InjectionContext, cache_key: str, value: Any, ttl=60
+    ):
+        """Shortcut method to set a cached key value.
+
+        Args:
+            context: The injection context to use
+            cache_key: The unique cache identifier
+            value: The value to cache
+            ttl: The cache ttl
+        """
+        if not cache_key:
+            return
+        cache: BaseCache = await context.inject(BaseCache, required=False)
+        if cache:
+            await cache.set(cache_key, value, 60)
+
+    @classmethod
+    async def clear_cached_key(cls, context: InjectionContext, cache_key: str):
+        """Shortcut method to clear a cached key value, if any.
+
+        Args:
+            context: The injection context to use
+            cache_key: The unique cache identifier
+        """
+        if not cache_key:
+            return
+        cache: BaseCache = await context.inject(BaseCache, required=False)
+        if cache:
+            await cache.clear(cache_key)
+
+    async def clear_cached(self, context: InjectionContext):
+        """Clear the cached value of this record, if any."""
+        await self.clear_cached_key(context, self.cache_key(self._id))
+
+    @classmethod
+    async def retrieve_by_id(
+        cls, context: InjectionContext, record_id: str, cached: bool = True
+    ) -> "BaseRecord":
+        """Retrieve a stored record by ID.
+
+        Args:
+            context: The injection context to use
+            record_id: The ID of the record to find
+            cached: Whether to check the cache for this record
+        """
+        cache = None
+        cache_key = cls.cache_key(record_id)
+        vals = None
+
+        if cached:
+            vals = await cls.get_cached_key(context, cache_key)
+
+        if not vals:
+            storage: BaseStorage = await context.inject(BaseStorage)
+            result = await storage.get_record(cls.RECORD_TYPE, record_id)
+            vals = json.loads(result.value)
+            if result.tags:
+                vals.update(result.tags)
+            if cache:
+                await cls.set_cached_key(context, cache_key, vals)
+
+        return cls.from_storage(record_id, vals)
+
+    @classmethod
+    async def retrieve_by_tag_filter(
+        cls, context: InjectionContext, tag_filter: dict
+    ) -> "BaseRecord":
+        """Retrieve a record by tag filter.
+
+        Args:
+            context: The injection context to use
+            tag_filter: The filter dictionary to apply
+        """
+        storage: BaseStorage = await context.inject(BaseStorage)
+        result = await storage.search_records(
+            cls.RECORD_TYPE, tag_filter
+        ).fetch_single()
+        vals = json.loads(result.value)
+        vals.update(result.tags)
+        return cls.from_storage(result.id, vals)
+
+    @classmethod
+    async def query(
+        cls, context: InjectionContext, tag_filter: dict = None
+    ) -> Sequence["BaseRecord"]:
+        """Query stored records.
+
+        Args:
+            context: The injection context to use
+            tag_filter: An optional dictionary of tag filter clauses
+        """
+        storage: BaseStorage = await context.inject(BaseStorage)
+        found = await storage.search_records(cls.RECORD_TYPE, tag_filter).fetch_all()
+        result = []
+        for record in found:
+            vals = json.loads(record.value)
+            vals.update(record.tags)
+            result.append(cls.from_storage(record.id, vals))
+        return result
+
+    async def save(
+        self,
+        context: InjectionContext,
+        *,
+        reason: str = None,
+        log_params: Mapping[str, Any] = None,
+        log_override: bool = False,
+        webhook: bool = None,
+    ) -> str:
+        """Persist the record to storage.
+
+        Args:
+            context: The injection context to use
+            reason: A reason to add to the log
+            log_params: Additional parameters to log
+            webhook: Flag to override whether the webhook is sent
+        """
+        new_record = None
+        log_reason = reason or ("Updated record" if self._id else "Created record")
+        try:
+            self.updated_at = time_now()
+            storage: BaseStorage = await context.inject(BaseStorage)
+            if not self._id:
+                self._id = str(uuid.uuid4())
+                self.created_at = self.updated_at
+                await storage.add_record(self.storage_record)
+                new_record = True
+            else:
+                record = self.storage_record
+                await storage.update_record_value(record, record.value)
+                await storage.update_record_tags(record, record.tags)
+                new_record = False
+        finally:
+            params = {self.RECORD_TYPE: self.serialize()}
+            if log_params:
+                params.update(log_params)
+            if new_record is None:
+                log_reason = f"FAILED: {log_reason}"
+            self.log_state(context, log_reason, params, override=log_override)
+
+        await self.post_save(context, new_record, self._last_state, webhook)
+        self._last_state = self.state
+
+        return self._id
+
+    async def post_save(
+        self,
+        context: InjectionContext,
+        new_record: bool,
+        last_state: str,
+        webhook: bool = None,
+    ):
+        """Perform post-save actions.
+
+        Args:
+            context: The injection context to use
+            new_record: Flag indicating if the record was just created
+            last_state: The previous state value
+            webhook: Adjust whether the webhook is called
+        """
+        await self.clear_cached(context)
+
+        webhook_topic = self.webhook_topic
+        if webhook is None:
+            webhook = bool(webhook_topic) and (
+                new_record or (last_state != self.state)
+            )
+        if webhook:
+            await self.send_webhook(
+                context, self.webhook_payload, topic=self.webhook_topic
+            )
+
+    async def delete_record(self, context: InjectionContext):
+        """Remove the stored record.
+
+        Args:
+            context: The injection context to use
+        """
+        if self._id:
+            storage: BaseStorage = await context.inject(BaseStorage)
+            await storage.delete_record(self.storage_record)
+        # FIXME - update state and send webhook?
+
+    @property
+    def webhook_payload(self):
+        """Return a JSON-serialized version of the record for the webhook."""
+        return self.serialize()
+
+    @property
+    def webhook_topic(self):
+        """Return the webhook topic value."""
+        return self.WEBHOOK_TOPIC
+
+    async def send_webhook(
+        self, context: InjectionContext, payload: Any, topic: str = None
+    ):
+        """Send a standard webhook.
+
+        Args:
+            context: The injection context to use
+            payload: The webhook payload
+            topic: The webhook topic, defaulting to WEBHOOK_TOPIC
+        """
+        if not payload:
+            return
+        if not topic:
+            topic = self.webhook_topic
+            if not topic:
+                return
+        responder: BaseResponder = await context.inject(BaseResponder, required=False)
+        if responder:
+            await responder.send_webhook(topic, payload)
+
+    @classmethod
+    def log_state(
+        cls,
+        context: InjectionContext,
+        msg: str,
+        params: dict = None,
+        override: bool = False,
+    ):
+        """Print a message with increased visibility (for testing)."""
+        if override or (
+            cls.LOG_STATE_FLAG and context.settings.get(cls.LOG_STATE_FLAG)
+        ):
+            out = msg + "\n"
+            if params:
+                for k, v in params.items():
+                    out += f"    {k}: {v}\n"
+            print(out, file=sys.stderr)
+
+    def __eq__(self, other: Any) -> bool:
+        """Comparison between records."""
+        if type(other) is type(self):
+            return self.value == other.value and self.tags == other.tags
+        return False
+
+
+class BaseRecordSchema(BaseModelSchema):
+    """Schema to allow serialization/deserialization of base records."""
+
+    class Meta:
+        """BaseRecordSchema metadata."""
+
+    state = fields.Str(required=False)
+    created_at = fields.Str(required=False)
+    updated_at = fields.Str(required=False)

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -30,7 +30,7 @@ class BaseRecord(BaseModel):
     WEBHOOK_TOPIC = None
     LOG_STATE_FLAG = None
     CACHE_TTL = 60
-    CACHE_DISABLED = False
+    CACHE_ENABLED = False
 
     def __init__(
         self,
@@ -178,7 +178,7 @@ class BaseRecord(BaseModel):
         cache_key = cls.cache_key(record_id)
         vals = None
 
-        if cached:
+        if cls.CACHE_ENABLED and cached:
             vals = await cls.get_cached_key(context, cache_key)
 
         if not vals:
@@ -187,7 +187,7 @@ class BaseRecord(BaseModel):
             vals = json.loads(result.value)
             if result.tags:
                 vals.update(result.tags)
-            if not cls.CACHE_DISABLED:
+            if cls.CACHE_ENABLED:
                 await cls.set_cached_key(context, cache_key, vals)
 
         return cls.from_storage(record_id, vals)

--- a/aries_cloudagent/messaging/models/tests/test_base_record.py
+++ b/aries_cloudagent/messaging/models/tests/test_base_record.py
@@ -1,0 +1,181 @@
+import json
+
+from asynctest import TestCase as AsyncTestCase, mock as async_mock
+
+from ....cache.base import BaseCache
+from ....config.injection_context import InjectionContext
+from ....storage.base import BaseStorage, StorageRecord
+
+from ...responder import BaseResponder, MockResponder
+from ...util import time_now
+
+from ..base_record import BaseRecord, BaseRecordSchema
+
+
+class BaseRecordImpl(BaseRecord):
+    class Meta:
+        schema_class = "BaseRecordImplSchema"
+
+    RECORD_TYPE = "record"
+
+
+class BaseRecordImplSchema(BaseRecordSchema):
+    class Meta:
+        model_class = BaseRecordImpl
+
+
+class TestBaseRecord(AsyncTestCase):
+    def test_init_undef(self):
+        with self.assertRaises(TypeError):
+            BaseRecord()
+
+    def test_from_storage_values(self):
+        record_id = "record_id"
+        stored = {"created_at": time_now(), "updated_at": time_now()}
+        inst = BaseRecordImpl.from_storage(record_id, stored)
+        assert isinstance(inst, BaseRecordImpl)
+        assert inst._id == record_id
+        assert inst.value == stored
+
+    async def test_post_save_new(self):
+        context = InjectionContext(enforce_typing=False)
+        mock_storage = async_mock.MagicMock()
+        mock_storage.add_record = async_mock.CoroutineMock()
+        context.injector.bind_instance(BaseStorage, mock_storage)
+        record = BaseRecordImpl()
+        with async_mock.patch.object(
+            record, "post_save", async_mock.CoroutineMock()
+        ) as post_save:
+            await record.save(context, reason="reason", webhook=True)
+            post_save.assert_called_once_with(context, True, None, True)
+        mock_storage.add_record.assert_called_once()
+
+    async def test_post_save_exist(self):
+        context = InjectionContext(enforce_typing=False)
+        mock_storage = async_mock.MagicMock()
+        mock_storage.update_record_value = async_mock.CoroutineMock()
+        mock_storage.update_record_tags = async_mock.CoroutineMock()
+        context.injector.bind_instance(BaseStorage, mock_storage)
+        record = BaseRecordImpl()
+        last_state = "last_state"
+        record._last_state = last_state
+        record._id = "id"
+        with async_mock.patch.object(
+            record, "post_save", async_mock.CoroutineMock()
+        ) as post_save:
+            await record.save(context, reason="reason", webhook=False)
+            post_save.assert_called_once_with(context, False, last_state, False)
+        mock_storage.update_record_value.assert_called_once()
+        mock_storage.update_record_tags.assert_called_once()
+
+    async def test_cache(self):
+        context = InjectionContext(enforce_typing=False)
+        mock_cache = async_mock.MagicMock(BaseCache, autospec=True)
+        context.injector.bind_instance(BaseCache, mock_cache)
+        record = BaseRecordImpl()
+        cache_key = "cache_key"
+        cache_result = await record.get_cached_key(context, cache_key)
+        mock_cache.get.assert_awaited_once_with(cache_key)
+        assert cache_result is mock_cache.get.return_value
+
+        await record.set_cached_key(context, cache_key, record)
+        mock_cache.set.assert_awaited_once_with(cache_key, record, record.CACHE_TTL)
+
+        await record.clear_cached_key(context, cache_key)
+        mock_cache.clear.assert_awaited_once_with(cache_key)
+
+    async def test_retrieve_cached_id(self):
+        context = InjectionContext(enforce_typing=False)
+        mock_storage = async_mock.MagicMock(BaseStorage, autospec=True)
+        context.injector.bind_instance(BaseStorage, mock_storage)
+        record_id = "record_id"
+        stored = {"created_at": time_now(), "updated_at": time_now()}
+        with async_mock.patch.object(
+            BaseRecordImpl, "get_cached_key"
+        ) as get_cached_key, async_mock.patch.object(
+            BaseRecordImpl, "cache_key"
+        ) as cache_key:
+            get_cached_key.return_value = stored
+            result = await BaseRecordImpl.retrieve_by_id(context, record_id, True)
+            cache_key.assert_called_once_with(record_id)
+            get_cached_key.assert_awaited_once_with(context, cache_key.return_value)
+            mock_storage.get_record.assert_not_called()
+            assert isinstance(result, BaseRecordImpl)
+            assert result._id == record_id
+            assert result.value == stored
+
+    async def test_retrieve_uncached_id(self):
+        context = InjectionContext(enforce_typing=False)
+        mock_storage = async_mock.MagicMock(BaseStorage, autospec=True)
+        context.injector.bind_instance(BaseStorage, mock_storage)
+        record_id = "record_id"
+        record_value = {"created_at": time_now(), "updated_at": time_now()}
+        stored = StorageRecord(
+            BaseRecordImpl.RECORD_TYPE, json.dumps(record_value), {}, record_id
+        )
+        with async_mock.patch.object(
+            BaseRecordImpl, "set_cached_key"
+        ) as set_cached_key, async_mock.patch.object(
+            BaseRecordImpl, "cache_key"
+        ) as cache_key:
+            mock_storage.get_record.return_value = stored
+            result = await BaseRecordImpl.retrieve_by_id(context, record_id, False)
+            mock_storage.get_record.assert_awaited_once_with(
+                BaseRecordImpl.RECORD_TYPE, record_id
+            )
+            set_cached_key.assert_awaited_once_with(
+                context, cache_key.return_value, record_value
+            )
+            assert isinstance(result, BaseRecordImpl)
+            assert result._id == record_id
+            assert result.value == record_value
+
+    async def test_query(self):
+        context = InjectionContext(enforce_typing=False)
+        mock_storage = async_mock.MagicMock(BaseStorage, autospec=True)
+        context.injector.bind_instance(BaseStorage, mock_storage)
+        record_id = "record_id"
+        record_value = {"created_at": time_now(), "updated_at": time_now()}
+        tag_filter = {"tag": "filter"}
+        stored = StorageRecord(
+            BaseRecordImpl.RECORD_TYPE, json.dumps(record_value), {}, record_id
+        )
+
+        mock_storage.search_records.return_value.fetch_all = async_mock.CoroutineMock(
+            return_value=[stored]
+        )
+        result = await BaseRecordImpl.query(context, tag_filter)
+        mock_storage.search_records.assert_called_once_with(
+            BaseRecordImpl.RECORD_TYPE, tag_filter
+        )
+        assert result and isinstance(result[0], BaseRecordImpl)
+        assert result[0]._id == record_id
+        assert result[0].value == record_value
+
+    @async_mock.patch("builtins.print")
+    def test_log_state(self, mock_print):
+        test_param = "test.log"
+        context = InjectionContext(settings={test_param: 1})
+        with async_mock.patch.object(
+            BaseRecordImpl, "LOG_STATE_FLAG", test_param
+        ) as cls:
+            record = BaseRecordImpl()
+            record.log_state(context, "state")
+        mock_print.assert_called_once()
+
+    @async_mock.patch("builtins.print")
+    def test_skip_log(self, mock_print):
+        context = InjectionContext()
+        record = BaseRecordImpl()
+        record.log_state(context, "state")
+        mock_print.assert_not_called()
+
+    async def test_webhook(self):
+        context = InjectionContext()
+        mock_responder = MockResponder()
+        context.injector.bind_instance(BaseResponder, mock_responder)
+        record = BaseRecordImpl()
+        payload = {"test": "payload"}
+        topic = "topic"
+        await record.send_webhook(context, payload, topic=topic)
+        assert mock_responder.webhooks == [(topic, payload)]

--- a/aries_cloudagent/messaging/models/tests/test_base_record.py
+++ b/aries_cloudagent/messaging/models/tests/test_base_record.py
@@ -17,6 +17,7 @@ class BaseRecordImpl(BaseRecord):
         schema_class = "BaseRecordImplSchema"
 
     RECORD_TYPE = "record"
+    CACHE_ENABLED = True
 
 
 class BaseRecordImplSchema(BaseRecordSchema):


### PR DESCRIPTION
This changeset adds the BaseRecord class with support for webhooks and logging of state changes. It removes duplicate code from the ConnectionRecord, CredentialExchange, and PresentationExchange classes and moves webhook handling out of the corresponding Manager classes.