### PR TITLE
Support direct response for connection response message

### DIFF
--- a/aries_cloudagent/messaging/connections/handlers/connection_request_handler.py
+++ b/aries_cloudagent/messaging/connections/handlers/connection_request_handler.py
@@ -28,6 +28,7 @@ class ConnectionRequestHandler(BaseHandler):
         except ConnectionManagerError as e:
             self._logger.exception("Error receiving connection request")
             if e.error_code:
+                target = None
                 if context.message.connection and context.message.connection.did_doc:
                     try:
                         target = mgr.diddoc_connection_target(
@@ -38,12 +39,7 @@ class ConnectionRequestHandler(BaseHandler):
                         self._logger.exception(
                             "Error parsing DIDDoc for problem report"
                         )
-                    else:
-                        await responder.send(
-                            ProblemReport(problem_code=e.error_code, explain=str(e)),
-                            target=target,
-                        )
-                        return
                 await responder.send_reply(
-                    ProblemReport(problem_code=e.error_code, explain=str(e))
+                    ProblemReport(problem_code=e.error_code, explain=str(e)),
+                    target=target,
                 )

--- a/aries_cloudagent/messaging/connections/handlers/connection_response_handler.py
+++ b/aries_cloudagent/messaging/connections/handlers/connection_response_handler.py
@@ -30,6 +30,7 @@ class ConnectionResponseHandler(BaseHandler):
         except ConnectionManagerError as e:
             self._logger.exception("Error receiving connection response")
             if e.error_code:
+                target = None
                 if context.message.connection and context.message.connection.did_doc:
                     try:
                         target = mgr.diddoc_connection_target(
@@ -40,14 +41,9 @@ class ConnectionResponseHandler(BaseHandler):
                         self._logger.exception(
                             "Error parsing DIDDoc for problem report"
                         )
-                    else:
-                        await responder.send(
-                            ProblemReport(problem_code=e.error_code, explain=str(e)),
-                            target=target,
-                        )
-                        return
                 await responder.send_reply(
-                    ProblemReport(problem_code=e.error_code, explain=str(e))
+                    ProblemReport(problem_code=e.error_code, explain=str(e)),
+                    target=target,
                 )
             return
 

--- a/aries_cloudagent/messaging/connections/handlers/tests/test_request_handler.py
+++ b/aries_cloudagent/messaging/connections/handlers/tests/test_request_handler.py
@@ -53,4 +53,4 @@ class TestRequestHandler:
             isinstance(result, ProblemReport)
             and result.problem_code == ProblemReportReason.REQUEST_NOT_ACCEPTED
         )
-        assert not target
+        assert target == {"target": None}

--- a/aries_cloudagent/messaging/connections/handlers/tests/test_response_handler.py
+++ b/aries_cloudagent/messaging/connections/handlers/tests/test_response_handler.py
@@ -53,4 +53,4 @@ class TestResponseHandler:
             isinstance(result, ProblemReport)
             and result.problem_code == ProblemReportReason.RESPONSE_NOT_ACCEPTED
         )
-        assert not target
+        assert target == {"target": None}

--- a/aries_cloudagent/messaging/connections/manager.py
+++ b/aries_cloudagent/messaging/connections/manager.py
@@ -396,7 +396,9 @@ class ConnectionManager:
                 BaseResponder, required=False
             )
             if responder:
-                await responder.send(response, connection_id=connection.connection_id)
+                await responder.send_reply(
+                    response, connection_id=connection.connection_id
+                )
                 # refetch connection for accurate state
                 connection = await ConnectionRecord.retrieve_by_id(
                     self._context, connection.connection_id

--- a/aries_cloudagent/messaging/discovery/handlers/tests/test_query_handler.py
+++ b/aries_cloudagent/messaging/discovery/handlers/tests/test_query_handler.py
@@ -34,4 +34,4 @@ class TestQueryHandler:
         result, target = messages[0]
         assert isinstance(result, Disclose) and result.protocols
         assert result.protocols[0]["pid"] == TEST_MESSAGE_FAMILY
-        assert target is None
+        assert not target

--- a/aries_cloudagent/messaging/responder.py
+++ b/aries_cloudagent/messaging/responder.py
@@ -69,7 +69,11 @@ class BaseResponder(ABC):
         await self.send_outbound(outbound)
 
     async def send_reply(
-        self, message: Union[AgentMessage, str, bytes], connection_id: str = None
+        self,
+        message: Union[AgentMessage, str, bytes],
+        *,
+        connection_id: str = None,
+        target: ConnectionTarget = None,
     ):
         """
         Send a reply to an incoming message.
@@ -77,6 +81,7 @@ class BaseResponder(ABC):
         Args:
             message: the `AgentMessage`, or pre-packed str or bytes to reply with
             connection_id: optionally override the target connection ID
+            target: optionally specify a `ConnectionTarget` to send to
 
         Raises:
             ResponderError: If there is no active connection
@@ -87,6 +92,7 @@ class BaseResponder(ABC):
             connection_id=connection_id or self.connection_id,
             reply_socket_id=self.reply_socket_id,
             reply_to_verkey=self.reply_to_verkey,
+            target=target,
         )
         await self.send_outbound(outbound)
 

--- a/aries_cloudagent/messaging/routing/handlers/tests/test_query_update_handlers.py
+++ b/aries_cloudagent/messaging/routing/handlers/tests/test_query_update_handlers.py
@@ -44,7 +44,7 @@ class TestQueryUpdateHandlers:
         assert len(messages) == 1
         result, target = messages[0]
         assert isinstance(result, RouteQueryResponse) and result.routes == []
-        assert target is None
+        assert not target
 
     @pytest.mark.asyncio
     async def test_no_connection(self, request_context):
@@ -79,7 +79,7 @@ class TestQueryUpdateHandlers:
         assert result.updated[0].recipient_key == TEST_VERKEY
         assert result.updated[0].action == RouteUpdate.ACTION_CREATE
         assert result.updated[0].result == RouteUpdated.RESULT_SUCCESS
-        assert target is None
+        assert not target
 
         request_context.message = RouteQueryRequest()
         query_handler = RouteQueryRequestHandler()
@@ -90,4 +90,4 @@ class TestQueryUpdateHandlers:
         result, target = messages[0]
         assert isinstance(result, RouteQueryResponse)
         assert result.routes[0].recipient_key == TEST_VERKEY
-        assert target is None
+        assert not target


### PR DESCRIPTION
These changes allow the initial connection response message (or problem report) sent after a connection request is received to be delivered by direct response, in cases where the sender has provided a transport decorator and is using a supported transport.