### PR TITLE
Add credential received state transition

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -220,6 +220,12 @@ PARSER.add_argument(
 )
 
 PARSER.add_argument(
+    "--auto-store-credential",
+    action="store_true",
+    help="Automatically store a credential upon receipt.",
+)
+
+PARSER.add_argument(
     "--auto-respond-presentation-request",
     action="store_true",
     help="Auto-respond to presentation requests with a presentation "
@@ -360,6 +366,8 @@ def get_settings(args):
 
     if args.auto_respond_credential_offer:
         settings["debug.auto_respond_credential_offer"] = True
+    if args.auto_store_credential:
+        settings["debug.auto_store_credential"] = True
     if args.auto_respond_presentation_request:
         settings["debug.auto_respond_presentation_request"] = True
     if args.auto_verify_presentation:

--- a/aries_cloudagent/messaging/credentials/handlers/credential_issue_handler.py
+++ b/aries_cloudagent/messaging/credentials/handlers/credential_issue_handler.py
@@ -26,4 +26,8 @@ class CredentialIssueHandler(BaseHandler):
 
         credential_manager = CredentialManager(context)
 
-        await credential_manager.store_credential(context.message)
+        await credential_manager.receive_credential(context.message)
+
+        # Automatically move to next state if flag is set
+        if context.settings.get("debug.auto_store_credential"):
+            await credential_manager.store_credential(context.message)

--- a/aries_cloudagent/messaging/credentials/handlers/credential_issue_handler.py
+++ b/aries_cloudagent/messaging/credentials/handlers/credential_issue_handler.py
@@ -26,8 +26,10 @@ class CredentialIssueHandler(BaseHandler):
 
         credential_manager = CredentialManager(context)
 
-        await credential_manager.receive_credential(context.message)
+        credential_exchange_record = await credential_manager.receive_credential(
+            context.message
+        )
 
         # Automatically move to next state if flag is set
         if context.settings.get("debug.auto_store_credential"):
-            await credential_manager.store_credential(context.message)
+            await credential_manager.store_credential(credential_exchange_record)

--- a/aries_cloudagent/messaging/credentials/manager.py
+++ b/aries_cloudagent/messaging/credentials/manager.py
@@ -385,15 +385,17 @@ class CredentialManager:
 
         return credential_exchange_record, credential_message
 
-    async def store_credential(self, credential_message: CredentialIssue):
+    async def receive_credential(self, credential_message: CredentialIssue):
         """
-        Store a credential in the wallet.
+        Receive a credential a credential from an issuer.
+
+        Hold in storage to be potentially processed by controller before storing.
 
         Args:
             credential_message: credential to store
 
         """
-        credential = json.loads(credential_message.issue)
+        raw_credential = json.loads(credential_message.issue)
 
         try:
             (
@@ -422,22 +424,42 @@ class CredentialManager:
             credential_exchange_record.credential_id = None
             credential_exchange_record.credential = None
 
+        credential_exchange_record.raw_credential = raw_credential
+
+        await credential_exchange_record.save(self.context, reason="Receive credential")
+
+        return credential_exchange_record
+
+    async def store_credential(self, credential_message: CredentialIssue):
+        """
+        Store a credential in the wallet.
+
+        Args:
+            credential_message: credential to store
+
+        """
+        (credential_exchange_record) = await CredentialExchange.retrieve_by_tag_filter(
+            self.context, tag_filter={"thread_id": credential_message._thread_id}
+        )
+
+        raw_credential = credential_exchange_record.raw_credential
+
         ledger: BaseLedger = await self.context.inject(BaseLedger)
         async with ledger:
             credential_definition = await ledger.get_credential_definition(
-                credential["cred_def_id"]
+                raw_credential["cred_def_id"]
             )
 
         holder: BaseHolder = await self.context.inject(BaseHolder)
         credential_id = await holder.store_credential(
             credential_definition,
-            credential,
+            raw_credential,
             credential_exchange_record.credential_request_metadata,
         )
 
-        wallet_credential = await holder.get_credential(credential_id)
+        credential = await holder.get_credential(credential_id)
 
         credential_exchange_record.state = CredentialExchange.STATE_STORED
         credential_exchange_record.credential_id = credential_id
-        credential_exchange_record.credential = wallet_credential
+        credential_exchange_record.credential = credential
         await credential_exchange_record.save(self.context, reason="Store credential")

--- a/aries_cloudagent/messaging/credentials/manager.py
+++ b/aries_cloudagent/messaging/credentials/manager.py
@@ -425,12 +425,13 @@ class CredentialManager:
             credential_exchange_record.credential = None
 
         credential_exchange_record.raw_credential = raw_credential
+        credential_exchange_record.state = CredentialExchange.STATE_CREDENTIAL_RECEIVED
 
         await credential_exchange_record.save(self.context, reason="Receive credential")
 
         return credential_exchange_record
 
-    async def store_credential(self, credential_message: CredentialIssue):
+    async def store_credential(self, credential_exchange_record: CredentialExchange):
         """
         Store a credential in the wallet.
 
@@ -438,9 +439,6 @@ class CredentialManager:
             credential_message: credential to store
 
         """
-        (credential_exchange_record) = await CredentialExchange.retrieve_by_tag_filter(
-            self.context, tag_filter={"thread_id": credential_message._thread_id}
-        )
 
         raw_credential = credential_exchange_record.raw_credential
 
@@ -463,3 +461,4 @@ class CredentialManager:
         credential_exchange_record.credential_id = credential_id
         credential_exchange_record.credential = credential
         await credential_exchange_record.save(self.context, reason="Store credential")
+        return credential_exchange_record

--- a/aries_cloudagent/messaging/credentials/models/credential_exchange.py
+++ b/aries_cloudagent/messaging/credentials/models/credential_exchange.py
@@ -25,6 +25,7 @@ class CredentialExchange(BaseRecord):
     STATE_REQUEST_SENT = "request_sent"
     STATE_REQUEST_RECEIVED = "request_received"
     STATE_ISSUED = "issued"
+    STATE_CREDENTIAL_RECEIVED = "credential_received"
     STATE_STORED = "stored"
 
     def __init__(

--- a/aries_cloudagent/messaging/credentials/models/credential_exchange.py
+++ b/aries_cloudagent/messaging/credentials/models/credential_exchange.py
@@ -42,6 +42,7 @@ class CredentialExchange(BaseRecord):
         credential_request: dict = None,
         credential_request_metadata: dict = None,
         credential_id: str = None,
+        raw_credential: dict = None,
         credential: dict = None,
         credential_values: dict = None,
         auto_issue: bool = False,
@@ -62,6 +63,7 @@ class CredentialExchange(BaseRecord):
         self.credential_request_metadata = credential_request_metadata
         self.credential_id = credential_id
         self.credential = credential
+        self.raw_credential = raw_credential
         self.credential_values = credential_values
         self.auto_issue = auto_issue
         self.error_msg = error_msg
@@ -84,6 +86,7 @@ class CredentialExchange(BaseRecord):
                 "auto_issue",
                 "credential_values",
                 "credential",
+                "raw_credential",
                 "parent_thread_id",
             )
         }
@@ -126,6 +129,7 @@ class CredentialExchangeSchema(BaseRecordSchema):
     credential_request_metadata = fields.Dict(required=False)
     credential_id = fields.Str(required=False)
     credential = fields.Dict(required=False)
+    raw_credential = fields.Dict(required=False)
     auto_issue = fields.Bool(required=False)
     credential_values = fields.Dict(required=False)
     error_msg = fields.Str(required=False)

--- a/aries_cloudagent/messaging/credentials/routes.py
+++ b/aries_cloudagent/messaging/credentials/routes.py
@@ -241,7 +241,7 @@ async def credential_exchange_retrieve(request: web.BaseRequest):
 @response_schema(CredentialSendResultSchema(), 200)
 async def credential_exchange_send(request: web.BaseRequest):
     """
-    Request handler for sending a credential offer.
+    Request handler for sending a credential.
 
     Args:
         request: aiohttp request object
@@ -424,6 +424,51 @@ async def credential_exchange_issue(request: web.BaseRequest):
     ) = await credential_manager.issue_credential(credential_exchange_record)
 
     await outbound_handler(credential_issue_message, connection_id=connection_id)
+    return web.json_response(credential_exchange_record.serialize())
+
+
+@docs(tags=["credential_exchange"], summary="Stores a received credential")
+@response_schema(CredentialRequestResultSchema(), 200)
+async def credential_exchange_store(request: web.BaseRequest):
+    """
+    Request handler for storing a credential request.
+
+    Args:
+        request: aiohttp request object
+
+    Returns:
+        The credential request details.
+
+    """
+
+    context = request.app["request_context"]
+
+    credential_exchange_id = request.match_info["id"]
+    credential_exchange_record = await CredentialExchange.retrieve_by_id(
+        context, credential_exchange_id
+    )
+    connection_id = credential_exchange_record.connection_id
+
+    assert (
+        credential_exchange_record.state == CredentialExchange.STATE_CREDENTIAL_RECEIVED
+    )
+
+    credential_manager = CredentialManager(context)
+
+    try:
+        connection_record = await ConnectionRecord.retrieve_by_id(
+            context, connection_id
+        )
+    except StorageNotFoundError:
+        raise web.HTTPBadRequest()
+
+    if not connection_record.is_ready:
+        raise web.HTTPForbidden()
+
+    credential_exchange_record = await credential_manager.store_credential(
+        credential_exchange_record
+    )
+
     return web.json_response(credential_exchange_record.serialize())
 
 

--- a/aries_cloudagent/messaging/credentials/routes.py
+++ b/aries_cloudagent/messaging/credentials/routes.py
@@ -513,6 +513,7 @@ async def register(app: web.Application):
                 credential_exchange_send_request,
             ),
             web.post("/credential_exchange/{id}/issue", credential_exchange_issue),
+            web.post("/credential_exchange/{id}/store", credential_exchange_store),
             web.post("/credential_exchange/{id}/remove", credential_exchange_remove),
         ]
     )

--- a/aries_cloudagent/messaging/credentials/tests/test_routes.py
+++ b/aries_cloudagent/messaging/credentials/tests/test_routes.py
@@ -247,7 +247,9 @@ class TestCredentialRoutes(AsyncTestCase):
         ) as mock_cred_ex:
 
             mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
-            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_OFFER_RECEIVED
+            mock_cred_ex.retrieve_by_id.return_value.state = (
+                mock_cred_ex.STATE_OFFER_RECEIVED
+            )
 
             test_module.web.json_response = async_mock.CoroutineMock()
 
@@ -284,8 +286,9 @@ class TestCredentialRoutes(AsyncTestCase):
             test_module.web.json_response = async_mock.CoroutineMock()
 
             mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
-            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_OFFER_RECEIVED
-            
+            mock_cred_ex.retrieve_by_id.return_value.state = (
+                mock_cred_ex.STATE_OFFER_RECEIVED
+            )
 
             # Emulate storage not found (bad connection id)
             mock_connection_record.retrieve_by_id = async_mock.CoroutineMock(
@@ -325,7 +328,9 @@ class TestCredentialRoutes(AsyncTestCase):
         ) as mock_cred_ex:
 
             mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
-            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_OFFER_RECEIVED
+            mock_cred_ex.retrieve_by_id.return_value.state = (
+                mock_cred_ex.STATE_OFFER_RECEIVED
+            )
 
             test_module.web.json_response = async_mock.CoroutineMock()
 
@@ -348,20 +353,11 @@ class TestCredentialRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPForbidden):
                 await test_module.credential_exchange_send_request(mock)
 
-
-
-
-
-
-
-
     async def test_credential_exchange_store(self):
         mock = async_mock.MagicMock()
         mock.json = async_mock.CoroutineMock()
 
-        mock.app = {
-            "request_context": "context",
-        }
+        mock.app = {"request_context": "context"}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -372,7 +368,9 @@ class TestCredentialRoutes(AsyncTestCase):
         ) as mock_cred_ex:
 
             mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
-            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_CREDENTIAL_RECEIVED
+            mock_cred_ex.retrieve_by_id.return_value.state = (
+                mock_cred_ex.STATE_CREDENTIAL_RECEIVED
+            )
 
             test_module.web.json_response = async_mock.CoroutineMock()
 
@@ -392,9 +390,7 @@ class TestCredentialRoutes(AsyncTestCase):
         mock = async_mock.MagicMock()
         mock.json = async_mock.CoroutineMock()
 
-        mock.app = {
-            "request_context": "context",
-        }
+        mock.app = {"request_context": "context"}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -407,8 +403,9 @@ class TestCredentialRoutes(AsyncTestCase):
             test_module.web.json_response = async_mock.CoroutineMock()
 
             mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
-            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_CREDENTIAL_RECEIVED
-            
+            mock_cred_ex.retrieve_by_id.return_value.state = (
+                mock_cred_ex.STATE_CREDENTIAL_RECEIVED
+            )
 
             # Emulate storage not found (bad connection id)
             mock_connection_record.retrieve_by_id = async_mock.CoroutineMock(
@@ -426,9 +423,7 @@ class TestCredentialRoutes(AsyncTestCase):
         mock = async_mock.MagicMock()
         mock.json = async_mock.CoroutineMock()
 
-        mock.app = {
-            "request_context": "context",
-        }
+        mock.app = {"request_context": "context"}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -439,7 +434,9 @@ class TestCredentialRoutes(AsyncTestCase):
         ) as mock_cred_ex:
 
             mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
-            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_CREDENTIAL_RECEIVED
+            mock_cred_ex.retrieve_by_id.return_value.state = (
+                mock_cred_ex.STATE_CREDENTIAL_RECEIVED
+            )
 
             test_module.web.json_response = async_mock.CoroutineMock()
 
@@ -453,18 +450,6 @@ class TestCredentialRoutes(AsyncTestCase):
 
             with self.assertRaises(test_module.web.HTTPForbidden):
                 await test_module.credential_exchange_store(mock)
-
-
-
-
-
-
-
-
-
-
-
-
 
     async def test_credential_exchange_issue(self):
         mock = async_mock.MagicMock()
@@ -484,7 +469,9 @@ class TestCredentialRoutes(AsyncTestCase):
         ) as mock_cred_ex:
 
             mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
-            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_REQUEST_RECEIVED
+            mock_cred_ex.retrieve_by_id.return_value.state = (
+                mock_cred_ex.STATE_REQUEST_RECEIVED
+            )
 
             test_module.web.json_response = async_mock.CoroutineMock()
 
@@ -521,8 +508,9 @@ class TestCredentialRoutes(AsyncTestCase):
             test_module.web.json_response = async_mock.CoroutineMock()
 
             mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
-            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_REQUEST_RECEIVED
-            
+            mock_cred_ex.retrieve_by_id.return_value.state = (
+                mock_cred_ex.STATE_REQUEST_RECEIVED
+            )
 
             # Emulate storage not found (bad connection id)
             mock_connection_record.retrieve_by_id = async_mock.CoroutineMock(
@@ -562,7 +550,9 @@ class TestCredentialRoutes(AsyncTestCase):
         ) as mock_cred_ex:
 
             mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
-            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_REQUEST_RECEIVED
+            mock_cred_ex.retrieve_by_id.return_value.state = (
+                mock_cred_ex.STATE_REQUEST_RECEIVED
+            )
 
             test_module.web.json_response = async_mock.CoroutineMock()
 
@@ -584,9 +574,4 @@ class TestCredentialRoutes(AsyncTestCase):
 
             with self.assertRaises(test_module.web.HTTPForbidden):
                 await test_module.credential_exchange_issue(mock)
-
-
-
-
-
 

--- a/aries_cloudagent/messaging/credentials/tests/test_routes.py
+++ b/aries_cloudagent/messaging/credentials/tests/test_routes.py
@@ -355,6 +355,113 @@ class TestCredentialRoutes(AsyncTestCase):
 
 
 
+    async def test_credential_exchange_store(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_connection_manager, async_mock.patch.object(
+            test_module, "CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_CREDENTIAL_RECEIVED
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            mock_cred_ex_record = async_mock.MagicMock()
+
+            mock_connection_manager.return_value.store_credential.return_value = (
+                mock_cred_ex_record
+            )
+
+            await test_module.credential_exchange_store(mock)
+
+            test_module.web.json_response.assert_called_once_with(
+                mock_cred_ex_record.serialize.return_value
+            )
+
+    async def test_credential_exchange_store_no_conn_record(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_connection_manager, async_mock.patch.object(
+            test_module, "CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_CREDENTIAL_RECEIVED
+            
+
+            # Emulate storage not found (bad connection id)
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock(
+                side_effect=StorageNotFoundError
+            )
+
+            mock_connection_manager.return_value.store_credential.return_value = (
+                async_mock.MagicMock(),
+            )
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.credential_exchange_store(mock)
+
+    async def test_credential_exchange_store_not_ready(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "request_context": "context",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_connection_manager, async_mock.patch.object(
+            test_module, "CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_CREDENTIAL_RECEIVED
+
+            test_module.web.json_response = async_mock.CoroutineMock()
+
+            # Emulate connection not ready
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock()
+            mock_connection_record.retrieve_by_id.return_value.is_ready = False
+
+            mock_connection_manager.return_value.store_credential.return_value = (
+                async_mock.MagicMock(),
+            )
+
+            with self.assertRaises(test_module.web.HTTPForbidden):
+                await test_module.credential_exchange_store(mock)
+
+
+
+
+
+
+
+
+
 
 
 


### PR DESCRIPTION
This pull request adds an additional state transition for the credential exchange protocol.

When a holder receives a credential, instead of storing it immediately, the protocol enters a "received" state. The controller can then operate on the credential if it wants before storing it.

When the controller is ready for the credential to be stored in the wallet, it calls `/credential_exchange/{id}/store` which will carry it along to the next and (currently) state. This state is the same as it was previously.

The agent can be started with the flag `--auto-store-credential` to automate this step. With this flag passed, the agent behaviour is the same as before.

closes #95