### PR TITLE
Add issuer stored state

### DIFF
--- a/aries_cloudagent/conductor.py
+++ b/aries_cloudagent/conductor.py
@@ -220,7 +220,7 @@ class Conductor:
             except Exception:
                 self.logger.exception("Error creating invitation")
 
-    async def stop(self, timeout=1.0):
+    async def stop(self, timeout=0.1):
         """Stop the agent."""
         tasks = []
         if self.admin_server:

--- a/aries_cloudagent/conductor.py
+++ b/aries_cloudagent/conductor.py
@@ -220,7 +220,7 @@ class Conductor:
             except Exception:
                 self.logger.exception("Error creating invitation")
 
-    async def stop(self, timeout=0.1):
+    async def stop(self, timeout=1.0):
         """Stop the agent."""
         tasks = []
         if self.admin_server:

--- a/aries_cloudagent/messaging/credentials/handlers/credential_issue_handler.py
+++ b/aries_cloudagent/messaging/credentials/handlers/credential_issue_handler.py
@@ -32,4 +32,10 @@ class CredentialIssueHandler(BaseHandler):
 
         # Automatically move to next state if flag is set
         if context.settings.get("debug.auto_store_credential"):
-            await credential_manager.store_credential(credential_exchange_record)
+            (
+                credential_exchange_record,
+                credential_stored_message,
+            ) = await credential_manager.store_credential(credential_exchange_record)
+            
+            # Notify issuer that credential was stored
+            await responder.send_reply(credential_stored_message)

--- a/aries_cloudagent/messaging/credentials/handlers/credential_issue_handler.py
+++ b/aries_cloudagent/messaging/credentials/handlers/credential_issue_handler.py
@@ -36,6 +36,6 @@ class CredentialIssueHandler(BaseHandler):
                 credential_exchange_record,
                 credential_stored_message,
             ) = await credential_manager.store_credential(credential_exchange_record)
-            
+
             # Notify issuer that credential was stored
             await responder.send_reply(credential_stored_message)

--- a/aries_cloudagent/messaging/credentials/handlers/credential_stored_handler.py
+++ b/aries_cloudagent/messaging/credentials/handlers/credential_stored_handler.py
@@ -1,0 +1,29 @@
+"""Credential stored message handler."""
+
+from ...base_handler import BaseHandler, BaseResponder, HandlerException, RequestContext
+
+from ..manager import CredentialManager
+from ..messages.credential_stored import CredentialStored
+
+
+class CredentialStoredHandler(BaseHandler):
+    """Message handler class for credential offers."""
+
+    async def handle(self, context: RequestContext, responder: BaseResponder):
+        """
+        Message handler logic for credential stored messages.
+
+        Args:
+            context: request context
+            responder: responder callback
+        """
+        self._logger.debug(f"CredentialStoredHandler called with context {context}")
+        assert isinstance(context.message, CredentialStored)
+        self._logger.info(f"Received credential stored message: {context.message}")
+
+        if not context.connection_ready:
+            raise HandlerException("No connection established for credential_exchange")
+
+        credential_manager = CredentialManager(context)
+
+        await credential_manager.credential_stored(context.message)

--- a/aries_cloudagent/messaging/credentials/manager.py
+++ b/aries_cloudagent/messaging/credentials/manager.py
@@ -399,6 +399,11 @@ class CredentialManager:
                 thid=new_thread_id, pthid=credential_exchange_record.parent_thread_id
             )
             credential_exchange_record.thread_id = new_thread_id
+        else:
+            raise CredentialManagerError(
+                "The credential exchange object must have a parent thread id"
+                + " OR thread id in order to issue a credential."
+            )
 
         await credential_exchange_record.save(self.context, reason="Issue credential")
         return credential_exchange_record, credential_message

--- a/aries_cloudagent/messaging/credentials/message_types.py
+++ b/aries_cloudagent/messaging/credentials/message_types.py
@@ -5,6 +5,7 @@ MESSAGE_FAMILY = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/credential-issuance/0.1"
 CREDENTIAL_OFFER = f"{MESSAGE_FAMILY}/credential-offer"
 CREDENTIAL_REQUEST = f"{MESSAGE_FAMILY}/credential-request"
 CREDENTIAL_ISSUE = f"{MESSAGE_FAMILY}/credential-issue"
+CREDENTIAL_STORED = f"{MESSAGE_FAMILY}/credential-stored"
 
 MESSAGE_TYPES = {
     CREDENTIAL_OFFER: (
@@ -18,5 +19,9 @@ MESSAGE_TYPES = {
     CREDENTIAL_ISSUE: (
         "aries_cloudagent.messaging.credentials.messages."
         + "credential_issue.CredentialIssue"
+    ),
+    CREDENTIAL_STORED: (
+        "aries_cloudagent.messaging.credentials.messages."
+        + "credential_stored.CredentialStored"
     ),
 }

--- a/aries_cloudagent/messaging/credentials/messages/credential_stored.py
+++ b/aries_cloudagent/messaging/credentials/messages/credential_stored.py
@@ -1,0 +1,35 @@
+"""A credential stored message."""
+
+# from marshmallow import fields
+
+from ...agent_message import AgentMessage, AgentMessageSchema
+from ..message_types import CREDENTIAL_STORED
+
+HANDLER_CLASS = (
+    "aries_cloudagent.messaging.credentials.handlers."
+    + "credential_stored_handler.CredentialStoredHandler"
+)
+
+
+class CredentialStored(AgentMessage):
+    """Class representing a credential stored message."""
+
+    class Meta:
+        """Credential metadata."""
+
+        handler_class = HANDLER_CLASS
+        schema_class = "CredentialStoredSchema"
+        message_type = CREDENTIAL_STORED
+
+    def __init__(self, **kwargs):
+        """Initialize credential object."""
+        super(CredentialStored, self).__init__(**kwargs)
+
+
+class CredentialStoredSchema(AgentMessageSchema):
+    """Credential stored schema."""
+
+    class Meta:
+        """Schema metadata."""
+
+        model_class = CredentialStored

--- a/aries_cloudagent/messaging/credentials/tests/test_routes.py
+++ b/aries_cloudagent/messaging/credentials/tests/test_routes.py
@@ -357,7 +357,10 @@ class TestCredentialRoutes(AsyncTestCase):
         mock = async_mock.MagicMock()
         mock.json = async_mock.CoroutineMock()
 
-        mock.app = {"request_context": "context"}
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -377,7 +380,8 @@ class TestCredentialRoutes(AsyncTestCase):
             mock_cred_ex_record = async_mock.MagicMock()
 
             mock_connection_manager.return_value.store_credential.return_value = (
-                mock_cred_ex_record
+                mock_cred_ex_record,
+                async_mock.MagicMock()
             )
 
             await test_module.credential_exchange_store(mock)
@@ -390,7 +394,10 @@ class TestCredentialRoutes(AsyncTestCase):
         mock = async_mock.MagicMock()
         mock.json = async_mock.CoroutineMock()
 
-        mock.app = {"request_context": "context"}
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -423,7 +430,10 @@ class TestCredentialRoutes(AsyncTestCase):
         mock = async_mock.MagicMock()
         mock.json = async_mock.CoroutineMock()
 
-        mock.app = {"request_context": "context"}
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True

--- a/demo/runners/performance.py
+++ b/demo/runners/performance.py
@@ -96,8 +96,27 @@ class AliceAgent(BaseAgent):
 class FaberAgent(BaseAgent):
     def __init__(self, port: int, **kwargs):
         super().__init__("Faber", port, **kwargs)
+        self.credential_state = {}
+        self.credential_event = asyncio.Event()
         self.schema_id = None
         self.credential_definition_id = None
+
+    async def handle_credentials(self, payload):
+        cred_id = payload["credential_exchange_id"]
+        self.credential_state[cred_id] = payload["state"]
+        self.credential_event.set()
+
+    def check_received_creds(self) -> (int, int):
+        self.credential_event.clear()
+        pending = 0
+        total = len(self.credential_state)
+        for result in self.credential_state.values():
+            if result != "stored":
+                pending += 1
+        return pending, total
+
+    async def update_creds(self):
+        await self.credential_event.wait()
 
     async def publish_defs(self):
         # create a schema
@@ -246,17 +265,21 @@ async def main(start_port: int, show_timing: bool = False, routing: bool = False
             try:
                 issue_pg = pb(range(issue_count), label="Issuing credentials")
                 receive_pg = pb(range(issue_count), label="Receiving credentials")
+                issue_task = asyncio.ensure_future(
+                    check_received(faber, issue_count, issue_pg)
+                )
                 receive_task = asyncio.ensure_future(
                     check_received(alice, issue_count, receive_pg)
                 )
                 with faber.log_timer(
                     f"Done starting {issue_count} credential exchanges in "
                 ):
-                    for idx in issue_pg:
+                    for idx in range(0, issue_count):
                         await send()
                         if not (idx + 1) % batch_size and idx < issue_count - 1:
                             batch_timer.reset()
 
+                await issue_task
                 await receive_task
             except KeyboardInterrupt:
                 if receive_task:


### PR DESCRIPTION
This pull request adds a new `stored` state to the issuer credential exchange object.

The holder agent can send a new message type back to the issuer agent to inform them that the credential was successfully stored.

This change breaks compatibility with our provisional 0.1 credential exchange protocol: https://hackmd.io/oWSw18DLTYCmHi_ty_gYvg?view

However, worst case scenario, the issuer agent will receive a "credential_stored" message it doesn't understand or no message at all.

The new message type is `did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/credential-issuance/0.1/credential-stored`. The message body is empty except for other information such as threads, etc.

This pull request also updates the performance demo to wait for this message before considering a credential issue "complete".

@andrewwhitehead do you mind looking extra close at the changes to the performance demo to make sure what I've done makes sense? Thanks!

cc: @swcurran just a heads up regarding a change to the protocol.