### PR TITLE
Fix relative imports so can run as main entry point when debugging

### DIFF
--- a/demo/runners/acme.py
+++ b/demo/runners/acme.py
@@ -4,8 +4,23 @@ import logging
 import os
 import sys
 
-from .support.agent import DemoAgent, default_genesis_txns
-from .support.utils import (
+"""
+From python docs:
+   modules intended for use as the main module of a Python application
+   must always use absolute imports.
+
+In order to use a debugger with this agent we want to invoke it as a
+main entry point but the relative import of .support then breaks.
+
+A fix is to add  the path to the runners directory to the python path
+so that we may use it with an absolute import instead.
+e.g. from runners.support.
+
+"""
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from runners.support.agent import DemoAgent, default_genesis_txns
+from runners.support.utils import (
     log_json,
     log_msg,
     log_status,

--- a/demo/runners/alice.py
+++ b/demo/runners/alice.py
@@ -4,8 +4,23 @@ import logging
 import os
 import sys
 
-from .support.agent import DemoAgent, default_genesis_txns
-from .support.utils import (
+"""
+From python docs:
+   modules intended for use as the main module of a Python application
+   must always use absolute imports.
+
+In order to use a debugger with this agent we want to invoke it as a
+main entry point but the relative import of .support then breaks.
+
+A fix is to add  the path to the runners directory to the python path
+so that we may use it with an absolute import instead.
+e.g. from runners.support.
+
+"""
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from runners.support.agent import DemoAgent, default_genesis_txns
+from runners.support.utils import (
     log_json,
     log_msg,
     log_status,

--- a/demo/runners/faber.py
+++ b/demo/runners/faber.py
@@ -5,8 +5,23 @@ import os
 import random
 import sys
 
-from .support.agent import DemoAgent, default_genesis_txns
-from .support.utils import (
+"""
+From python docs:
+   modules intended for use as the main module of a Python application
+   must always use absolute imports.
+
+In order to use a debugger with this agent we want to invoke it as a
+main entry point but the relative import of .support then breaks.
+
+A fix is to add  the path to the runners directory to the python path
+so that we may use it with an absolute import instead.
+e.g. from runners.support.
+
+"""
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from runners.support.agent import DemoAgent, default_genesis_txns
+from runners.support.utils import (
     log_json,
     log_msg,
     log_status,


### PR DESCRIPTION
From python docs:
   modules intended for use as the main module of a Python application
   must always use absolute imports.

In order to use a debugger with this agent we want to invoke it as a
main entry point but the relative import of .support then breaks.

A fix is to add  the path to the runners directory to the python path
so that we may use it with an absolute import instead.
e.g. from runners.support.

I cleaned up my branch to get rid of spurious commits that were reversed.