### PR TITLE
Switch to PyNaCl instead of pysodium; update dependencies

### DIFF
--- a/aries_cloudagent/messaging/agent_message.py
+++ b/aries_cloudagent/messaging/agent_message.py
@@ -324,7 +324,7 @@ class AgentMessageSchema(BaseModelSchema):
         self._signatures = {}
 
     @pre_load
-    def extract_decorators(self, data):
+    def extract_decorators(self, data, **kwargs):
         """
         Pre-load hook to extract the decorators and check the signed fields.
 
@@ -364,7 +364,7 @@ class AgentMessageSchema(BaseModelSchema):
         return processed
 
     @post_load
-    def populate_decorators(self, obj):
+    def populate_decorators(self, obj, **kwargs):
         """
         Post-load hook to populate decorators on the message.
 
@@ -379,7 +379,7 @@ class AgentMessageSchema(BaseModelSchema):
         return obj
 
     @pre_dump
-    def check_dump_decorators(self, obj):
+    def check_dump_decorators(self, obj, **kwargs):
         """
         Pre-dump hook to validate and load the message decorators.
 
@@ -410,7 +410,7 @@ class AgentMessageSchema(BaseModelSchema):
         return obj
 
     @post_dump
-    def dump_decorators(self, data):
+    def dump_decorators(self, data, **kwargs):
         """
         Post-dump hook to write the decorators to the serialized output.
 
@@ -430,7 +430,7 @@ class AgentMessageSchema(BaseModelSchema):
         return result
 
     @post_dump
-    def replace_signatures(self, data):
+    def replace_signatures(self, data, **kwargs):
         """
         Post-dump hook to write the signatures to the serialized output.
 

--- a/aries_cloudagent/messaging/connections/messages/connection_invitation.py
+++ b/aries_cloudagent/messaging/connections/messages/connection_invitation.py
@@ -102,7 +102,7 @@ class ConnectionInvitationSchema(AgentMessageSchema):
     image_url = fields.Str(data_key="imageUrl", required=False, allow_none=True)
 
     @validates_schema
-    def validate_fields(self, data):
+    def validate_fields(self, data, **kwargs):
         """
         Validate schema fields.
 

--- a/aries_cloudagent/messaging/models/base.py
+++ b/aries_cloudagent/messaging/models/base.py
@@ -242,7 +242,7 @@ class BaseModelSchema(Schema):
         return self._get_model_class()
 
     @pre_load
-    def skip_dump_only(self, data):
+    def skip_dump_only(self, data, **kwargs):
         """
         Skip fields that are only expected during serialization.
 
@@ -265,7 +265,7 @@ class BaseModelSchema(Schema):
         return data
 
     @post_load
-    def make_model(self, data: dict):
+    def make_model(self, data: dict, **kwargs):
         """
         Return model instance after loading.
 
@@ -276,7 +276,7 @@ class BaseModelSchema(Schema):
         return self.Model(**data)
 
     @post_dump
-    def remove_skipped_values(self, data):
+    def remove_skipped_values(self, data, **kwargs):
         """
         Remove values that are are marked to skip.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ Markdown>=3.1.1
 marshmallow==3.0.0rc3
 msgpack>=0.6.1<0.7
 prompt_toolkit~=2.0.9
-pysodium>=0.7.1<0.8
+pynacl~=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 aiohttp~=3.5.4
 aiohttp-apispec~=1.1.2
 aiohttp-cors~=0.7.0
-base58
-Markdown>=3.1.1
-marshmallow==3.0.0rc3
-msgpack>=0.6.1<0.7
+base58~=1.0.3
+Markdown~=3.1.1
+marshmallow==3.0.0rc9
+msgpack~=0.6.1
 prompt_toolkit~=2.0.9
 pynacl~=1.3.0


### PR DESCRIPTION
PyNaCl publishes wheel packages with libsodium included, which helps to simplify installation.

Note: recent versions of marshmallow pass additional arguments to pre-load and post-load hooks.