### PR TITLE
Alias connection

### DIFF
--- a/aries_cloudagent/messaging/connections/manager.py
+++ b/aries_cloudagent/messaging/connections/manager.py
@@ -68,6 +68,7 @@ class ConnectionManager:
         accept: str = None,
         public: bool = False,
         multi_use: bool = False,
+        alias: str = None
     ) -> Tuple[ConnectionRecord, ConnectionInvitation]:
         """
         Generate new connection invitation.
@@ -109,6 +110,7 @@ class ConnectionManager:
             accept: set to 'auto' to auto-accept a corresponding connection request
             public: set to True to create an invitation from the public DID
             multi_use: set to True to create an invitation for multiple use
+            alias: optional alias to apply to connection for later use
 
         Returns:
             A tuple of the new `ConnectionRecord` and `ConnectionInvitation` instances
@@ -158,7 +160,8 @@ class ConnectionManager:
             their_role=their_role,
             state=ConnectionRecord.STATE_INVITATION,
             accept=accept,
-            invitation_mode=invitation_mode
+            invitation_mode=invitation_mode,
+            alias=alias
         )
 
         await connection.save(self.context, reason="Created new invitation")
@@ -182,6 +185,7 @@ class ConnectionManager:
         invitation: ConnectionInvitation,
         their_role: str = None,
         accept: str = None,
+        alias: str = None,
     ) -> ConnectionRecord:
         """
         Create a new connection record to track a received invitation.
@@ -190,6 +194,7 @@ class ConnectionManager:
             invitation: The `ConnectionInvitation` to store
             their_role: The role assigned to this connection
             accept: set to 'auto' to auto-accept the invitation
+            alias: optional alias to set on the record
 
         Returns:
             The new `ConnectionRecord` instance
@@ -212,6 +217,7 @@ class ConnectionManager:
             their_role=their_role,
             state=ConnectionRecord.STATE_INVITATION,
             accept=accept,
+            alias=alias
         )
 
         await connection.save(

--- a/aries_cloudagent/messaging/connections/models/connection_record.py
+++ b/aries_cloudagent/messaging/connections/models/connection_record.py
@@ -79,6 +79,7 @@ class ConnectionRecord(BaseRecord):
         routing_state: str = None,
         accept: str = None,
         invitation_mode: str = None,
+        alias: str = None,
         **kwargs,
     ):
         """Initialize a new ConnectionRecord."""
@@ -95,6 +96,7 @@ class ConnectionRecord(BaseRecord):
         self.routing_state = routing_state or self.ROUTING_STATE_NONE
         self.accept = accept or self.ACCEPT_MANUAL
         self.invitation_mode = invitation_mode or self.INVITATION_MODE_ONCE
+        self.alias = alias
 
     @property
     def connection_id(self) -> str:
@@ -122,7 +124,8 @@ class ConnectionRecord(BaseRecord):
                 "state",
                 "routing_state",
                 "accept",
-                "invitation_mode"
+                "invitation_mode",
+                "alias"
             )
         }
 
@@ -385,3 +388,4 @@ class ConnectionRecordSchema(BaseRecordSchema):
     accept = fields.Str(required=False)
     error_msg = fields.Str(required=False)
     invitation_mode = fields.Str(required=False)
+    alias = fields.Str(required=False)

--- a/aries_cloudagent/messaging/connections/routes.py
+++ b/aries_cloudagent/messaging/connections/routes.py
@@ -44,6 +44,12 @@ def connection_sort_key(conn):
     summary="Query agent-to-agent connections",
     parameters=[
         {
+            "name": "alias",
+            "in": "query",
+            "schema": {"type": "string"},
+            "required": False,
+        },
+        {
             "name": "initiator",
             "in": "query",
             "schema": {"type": "string", "enum": ["self", "external"]},
@@ -107,6 +113,7 @@ async def connections_list(request: web.BaseRequest):
     context = request.app["request_context"]
     tag_filter = {}
     for param_name in (
+        "alias",
         "initiator",
         "invitation_id",
         "my_did",

--- a/aries_cloudagent/messaging/connections/routes.py
+++ b/aries_cloudagent/messaging/connections/routes.py
@@ -153,6 +153,12 @@ async def connections_retrieve(request: web.BaseRequest):
     summary="Create a new connection invitation",
     parameters=[
         {
+            "name": "alias",
+            "in": "query",
+            "schema": {"type": "string"},
+            "required": False,
+        },
+        {
             "name": "accept",
             "in": "query",
             "schema": {"type": "string", "enum": ["none", "auto"]},
@@ -175,6 +181,7 @@ async def connections_create_invitation(request: web.BaseRequest):
     """
     context = request.app["request_context"]
     accept = request.query.get("accept")
+    alias = request.query.get("alias")
     public = request.query.get("public")
     multi_use = request.query.get("multi_use")
 
@@ -183,13 +190,17 @@ async def connections_create_invitation(request: web.BaseRequest):
 
     connection_mgr = ConnectionManager(context)
     connection, invitation = await connection_mgr.create_invitation(
-        accept=accept, public=bool(public), multi_use=bool(multi_use)
+        accept=accept, public=bool(public), multi_use=bool(multi_use), alias=alias
     )
     result = {
         "connection_id": connection and connection.connection_id,
         "invitation": invitation.serialize(),
         "invitation_url": invitation.to_url(),
     }
+
+    if connection and connection.alias:
+        result["alias"] = connection.alias
+
     return web.json_response(result)
 
 
@@ -198,11 +209,17 @@ async def connections_create_invitation(request: web.BaseRequest):
     summary="Receive a new connection invitation",
     parameters=[
         {
+            "name": "alias",
+            "in": "query",
+            "schema": {"type": "string"},
+            "required": False,
+        },
+        {
             "name": "accept",
             "in": "query",
             "schema": {"type": "string", "enum": ["none", "auto"]},
             "required": False,
-        }
+        },
     ],
 )
 @request_schema(ConnectionInvitationSchema())
@@ -225,7 +242,10 @@ async def connections_receive_invitation(request: web.BaseRequest):
     invitation_json = await request.json()
     invitation = ConnectionInvitation.deserialize(invitation_json)
     accept = request.query.get("accept")
-    connection = await connection_mgr.receive_invitation(invitation, accept=accept)
+    alias = request.query.get("alias")
+    connection = await connection_mgr.receive_invitation(
+        invitation, accept=accept, alias=alias
+    )
     return web.json_response(connection.serialize())
 
 


### PR DESCRIPTION
This pull request adds an optional alias parameter on the `create` and `receive` connection invitation endpoints.

It also adds the ability to query for connections by alias.