### PR TITLE
allow self-connected agent to issue credentials, present proof

### DIFF
--- a/aries_cloudagent/messaging/issue_credential/v1_0/handlers/credential_issue_handler.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/handlers/credential_issue_handler.py
@@ -32,9 +32,7 @@ class CredentialIssueHandler(BaseHandler):
 
         credential_manager = CredentialManager(context)
 
-        credential_exchange_record = await credential_manager.receive_credential(
-            context.message
-        )
+        credential_exchange_record = await credential_manager.receive_credential()
 
         # Automatically move to next state if flag is set
         if context.settings.get("debug.auto_store_credential"):

--- a/aries_cloudagent/messaging/issue_credential/v1_0/handlers/credential_offer_handler.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/handlers/credential_offer_handler.py
@@ -54,7 +54,8 @@ class CredentialOfferHandler(BaseHandler):
                 await V10CredentialExchange.retrieve_by_tag_filter(
                     context,
                     {
-                        "thread_id": context.message._thread_id
+                        "thread_id": context.message._thread_id,
+                        "connection_id": context.connection_record.connection_id
                     }
                 )
             )
@@ -81,6 +82,6 @@ class CredentialOfferHandler(BaseHandler):
         if context.settings.get("debug.auto_respond_credential_offer"):
             (_, credential_request_message) = await credential_manager.create_request(
                 credential_exchange_record=credential_exchange_record,
-                connection_record=context.connection_record
+                holder_did=context.connection_record.my_did,
             )
             await responder.send_reply(credential_request_message)

--- a/aries_cloudagent/messaging/issue_credential/v1_0/handlers/credential_proposal_handler.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/handlers/credential_proposal_handler.py
@@ -36,10 +36,7 @@ class CredentialProposalHandler(BaseHandler):
             raise HandlerException("No connection established for credential proposal")
 
         credential_manager = CredentialManager(context)
-        credential_exchange_record = await credential_manager.receive_proposal(
-            credential_proposal_message=context.message,
-            connection_id=context.connection_record.connection_id
-        )
+        credential_exchange_record = await credential_manager.receive_proposal()
 
         # If auto_offer is enabled, respond immediately with offer
         if credential_exchange_record.auto_offer:

--- a/aries_cloudagent/messaging/issue_credential/v1_0/handlers/credential_request_handler.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/handlers/credential_request_handler.py
@@ -36,9 +36,7 @@ class CredentialRequestHandler(BaseHandler):
             raise HandlerException("No connection established for credential request")
 
         credential_manager = CredentialManager(context)
-        cred_exchange_rec = await credential_manager.receive_request(
-            credential_request_message=context.message
-        )
+        cred_exchange_rec = await credential_manager.receive_request()
 
         # If auto_issue is enabled, respond immediately
         if cred_exchange_rec.auto_issue:

--- a/aries_cloudagent/messaging/issue_credential/v1_0/handlers/credential_stored_handler.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/handlers/credential_stored_handler.py
@@ -34,4 +34,4 @@ class CredentialStoredHandler(BaseHandler):
 
         credential_manager = CredentialManager(context)
 
-        await credential_manager.credential_stored(context.message)
+        await credential_manager.credential_stored()

--- a/aries_cloudagent/messaging/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/routes.py
@@ -515,7 +515,7 @@ async def credential_exchange_send_request(request: web.BaseRequest):
         credential_request_message,
     ) = await credential_manager.create_request(
         credential_exchange_record,
-        connection_record
+        connection_record.my_did
     )
 
     await outbound_handler(credential_request_message, connection_id=connection_id)

--- a/aries_cloudagent/messaging/present_proof/v1_0/handlers/presentation_handler.py
+++ b/aries_cloudagent/messaging/present_proof/v1_0/handlers/presentation_handler.py
@@ -34,10 +34,7 @@ class PresentationHandler(BaseHandler):
 
         presentation_manager = PresentationManager(context)
 
-        presentation_exchange_record = await presentation_manager.receive_presentation(
-            context.message.indy_proof(),
-            context.message._thread_id
-        )
+        presentation_exchange_record = await presentation_manager.receive_presentation()
 
         if context.settings.get("debug.auto_verify_presentation"):
             await presentation_manager.verify_presentation(presentation_exchange_record)

--- a/aries_cloudagent/messaging/present_proof/v1_0/handlers/presentation_proposal_handler.py
+++ b/aries_cloudagent/messaging/present_proof/v1_0/handlers/presentation_proposal_handler.py
@@ -1,6 +1,5 @@
 """Aries0037 v1.0 presentation proposal handler."""
 
-
 from ....base_handler import (
     BaseHandler,
     BaseResponder,
@@ -38,10 +37,7 @@ class PresentationProposalHandler(BaseHandler):
             )
 
         presentation_manager = PresentationManager(context)
-        presentation_exchange_record = await presentation_manager.receive_proposal(
-            connection_id=context.connection_record.connection_id,
-            presentation_proposal_message=context.message
-        )
+        presentation_exchange_record = await presentation_manager.receive_proposal()
 
         # If auto_respond_presentation_proposal is set, reply with proof req
         if context.settings.get("debug.auto_respond_presentation_proposal"):

--- a/aries_cloudagent/messaging/present_proof/v1_0/handlers/presentation_request_handler.py
+++ b/aries_cloudagent/messaging/present_proof/v1_0/handlers/presentation_request_handler.py
@@ -51,7 +51,8 @@ class PresentationRequestHandler(BaseHandler):
                 await V10PresentationExchange.retrieve_by_tag_filter(
                     context,
                     {
-                        "thread_id": context.message._thread_id
+                        "thread_id": context.message._thread_id,
+                        "connection_id": context.connection_record.connection_id
                     }
                 )
             )  # holder initiated via proposal

--- a/aries_cloudagent/storage/base.py
+++ b/aries_cloudagent/storage/base.py
@@ -6,6 +6,7 @@ from typing import Mapping, Sequence
 from .error import StorageDuplicateError, StorageNotFoundError
 from .record import StorageRecord
 
+
 DEFAULT_PAGE_SIZE = 100
 
 


### PR DESCRIPTION
The v0.1 approach of selecting model record by initiator tag (filter) would not fly for v1.0 (issue-credential, present-proof) protocols: either side may initiate. Instead, select by connection identifier, available from the request context.

While altering manager.py for both, get message data from context where possible (i.e., unless routes.py instantiates and calls manager without the request context that corresponding handlers have).

Signed-off-by: sklump <srklump@hotmail.com>