### PR TITLE
Allow querying credentials for proof request with multiple referents

### DIFF
--- a/aries_cloudagent/holder/indy.py
+++ b/aries_cloudagent/holder/indy.py
@@ -76,7 +76,8 @@ class IndyHolder(BaseHolder):
         credential_definition,
         credential_data,
         credential_request_metadata,
-        credential_attr_mime_types=None
+        credential_attr_mime_types=None,
+        credential_id=None
     ):
         """
         Store a credential in the wallet.
@@ -92,7 +93,7 @@ class IndyHolder(BaseHolder):
         """
         credential_id = await indy.anoncreds.prover_store_credential(
             self.wallet.handle,
-            None,  # Always let indy set the id for now
+            credential_id,
             json.dumps(credential_request_metadata),
             json.dumps(credential_data),
             json.dumps(credential_definition),

--- a/aries_cloudagent/messaging/credentials/manager.py
+++ b/aries_cloudagent/messaging/credentials/manager.py
@@ -465,12 +465,15 @@ class CredentialManager:
 
         return credential_exchange_record
 
-    async def store_credential(self, credential_exchange_record: CredentialExchange):
+    async def store_credential(
+        self, credential_exchange_record: CredentialExchange, credential_id: str
+    ):
         """
         Store a credential in the wallet.
 
         Args:
             credential_message: credential to store
+            credential_id: string to use as id for record in wallet
 
         """
 
@@ -487,6 +490,7 @@ class CredentialManager:
             credential_definition,
             raw_credential,
             credential_exchange_record.credential_request_metadata,
+            credential_id=credential_id
         )
 
         credential = await holder.get_credential(credential_id)

--- a/aries_cloudagent/messaging/credentials/routes.py
+++ b/aries_cloudagent/messaging/credentials/routes.py
@@ -457,6 +457,9 @@ async def credential_exchange_store(request: web.BaseRequest):
     context = request.app["request_context"]
     outbound_handler = request.app["outbound_message_router"]
 
+    body = await request.json()
+    credential_id = body.get("credential_id")
+
     credential_exchange_id = request.match_info["id"]
     credential_exchange_record = await CredentialExchange.retrieve_by_id(
         context, credential_exchange_id
@@ -482,7 +485,9 @@ async def credential_exchange_store(request: web.BaseRequest):
     (
         credential_exchange_record,
         credential_stored_message,
-    ) = await credential_manager.store_credential(credential_exchange_record)
+    ) = await credential_manager.store_credential(
+        credential_exchange_record, credential_id
+    )
 
     await outbound_handler(credential_stored_message, connection_id=connection_id)
     return web.json_response(credential_exchange_record.serialize())

--- a/aries_cloudagent/messaging/presentations/routes.py
+++ b/aries_cloudagent/messaging/presentations/routes.py
@@ -148,7 +148,7 @@ async def presentation_exchange_credentials_list(request: web.BaseRequest):
     context = request.app["request_context"]
 
     presentation_exchange_id = request.match_info["id"]
-    presentation_referent = request.match_info.get("referent")
+    presentation_referents = request.match_info.get("referent").split(",")
 
     try:
         presentation_exchange_record = await PresentationExchange.retrieve_by_id(
@@ -171,7 +171,7 @@ async def presentation_exchange_credentials_list(request: web.BaseRequest):
     holder: BaseHolder = await context.inject(BaseHolder)
     credentials = await holder.get_credentials_for_presentation_request_by_referent(
         presentation_exchange_record.presentation_request,
-        (presentation_referent,) if presentation_referent else (),
+        presentation_referents,
         start,
         count,
         extra_query,
@@ -182,7 +182,7 @@ async def presentation_exchange_credentials_list(request: web.BaseRequest):
         "Retrieved presentation credentials",
         {
             "presentation_exchange_id": presentation_exchange_id,
-            "referent": presentation_referent,
+            "referents": presentation_referents,
             "extra_query": extra_query,
             "credentials": credentials,
         },

--- a/docker/Dockerfile.run
+++ b/docker/Dockerfile.run
@@ -1,4 +1,4 @@
-FROM bcgovimages/von-image:py36-1.11-0
+FROM bcgovimages/von-image:py36-1.11-1
 
 ENV ENABLE_PTVSD 0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-aiohttp~=3.5.4
-aiohttp-apispec~=1.1.2
+aiohttp==3.5.4
+aiohttp-apispec==1.1.2
+apispec==2.0.2
 aiohttp-cors~=0.7.0
 base58~=1.0.3
 Markdown~=3.1.1
-marshmallow==3.0.0rc9
+marshmallow==3.0.0
 msgpack~=0.6.1
 prompt_toolkit~=2.0.9
 pynacl~=1.3.0


### PR DESCRIPTION
This pull request allows the controller to query for credentials for a proof request for multiple referents at once:

"/presentation_exchange/{id}/credentials/{referent}"

can also be called as

"/presentation_exchange/{id}/credentials/{referent_1},{referent_2},{referent_3}"

Multiple referents should be passed as a comma delimited string.

Existing behaviour does not change for a single referent