### PR TITLE
Add methods to get and set the credential tagging policy for a cred def ID

### DIFF
--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -50,12 +50,24 @@ class IndyErrorHandler:
     def __exit__(self, err_type, err_value, err_traceback):
         """Exit the context manager."""
         if err_type is IndyError:
-            err_msg = self.message or "Exception while performing ledger operation"
-            indy_message = hasattr(err_value, "message") and err_value.message
-            if indy_message:
-                err_msg += f": {indy_message}"
-            # TODO: may wish to attach backtrace when available
-            raise self.error_cls(err_msg) from err_value
+            raise self.wrap_error(
+                err_value, self.message, self.error_cls
+            ) from err_value
+
+    @classmethod
+    def wrap_error(
+        cls,
+        err_value: IndyError,
+        message: str = None,
+        error_cls: Type[LedgerError] = LedgerError,
+    ) -> LedgerError:
+        """Create an instance of LedgerError from an IndyError."""
+        err_msg = message or "Exception while performing ledger operation"
+        indy_message = hasattr(err_value, "message") and err_value.message
+        if indy_message:
+            err_msg += f": {indy_message}"
+        # TODO: may wish to attach backtrace when available
+        return error_cls(err_msg)
 
 
 class IndyLedger(BaseLedger):
@@ -391,9 +403,7 @@ class IndyLedger(BaseLedger):
 
         return parsed_response
 
-    async def send_credential_definition(
-        self, schema_id: str, tag: str = "default"
-    ):
+    async def send_credential_definition(self, schema_id: str, tag: str = "default"):
         """
         Send credential definition to ledger and store relevant key matter in wallet.
 
@@ -430,25 +440,41 @@ class IndyLedger(BaseLedger):
         except IndyError as error:
             if error.error_code == ErrorCode.AnoncredsCredDefAlreadyExistsError:
                 try:
-                    cred_def_id = re.search(
+                    credential_definition_id = re.search(
                         r"\w*:3:CL:(([1-9][0-9]*)|(.{21,22}:2:.+:[0-9.]+)):\w*",
                         error.message,
                     ).group(0)
-                    return cred_def_id
                 # The regex search failed so let the error bubble up
                 except AttributeError:
-                    raise error
+                    raise LedgerError(
+                        "Previous credential definition exists, but ID could "
+                        "not be extracted"
+                    )
             else:
-                raise
+                raise IndyErrorHandler.wrap_error(error) from error
 
-        with IndyErrorHandler("Exception when building cred def request"):
-            request_json = await indy.ledger.build_cred_def_request(
-                public_did.did, credential_definition_json
+        # check if the cred def already exists on the ledger
+        cred_def = json.loads(credential_definition_json)
+        exist_def = await self.fetch_credential_definition(credential_definition_id)
+        if exist_def:
+            if exist_def["value"] != cred_def["value"]:
+                self.logger.warning(
+                    "Ledger definition of cred def %s will be replaced",
+                    credential_definition_id,
+                )
+                exist_def = None
+
+        if not exist_def:
+            with IndyErrorHandler("Exception when building cred def request"):
+                request_json = await indy.ledger.build_cred_def_request(
+                    public_did.did, credential_definition_json
+                )
+            await self._submit(request_json, True, True)
+        else:
+            self.logger.warning(
+                "Ledger definition of cred def %s already exists",
+                credential_definition_id,
             )
-
-        await self._submit(request_json, True, True)
-
-        # TODO: validate response
 
         return credential_definition_id
 
@@ -487,11 +513,15 @@ class IndyLedger(BaseLedger):
         response_json = await self._submit(request_json, sign=bool(public_did))
 
         with IndyErrorHandler("Exception when parsing cred def response"):
-            (
-                _,
-                parsed_credential_definition_json,
-            ) = await indy.ledger.parse_get_cred_def_response(response_json)
-        parsed_response = json.loads(parsed_credential_definition_json)
+            try:
+                (
+                    _,
+                    parsed_credential_definition_json,
+                ) = await indy.ledger.parse_get_cred_def_response(response_json)
+                parsed_response = json.loads(parsed_credential_definition_json)
+            except IndyError as error:
+                if error.error_code == ErrorCode.LedgerNotFound:
+                    parsed_response = None
 
         if parsed_response and self.cache:
             await self.cache.set(
@@ -596,8 +626,9 @@ class IndyLedger(BaseLedger):
             return True
         return False
 
-    async def register_nym(self, did: str, verkey: str, alias: str = None,
-                           role: str = None):
+    async def register_nym(
+        self, did: str, verkey: str, alias: str = None, role: str = None
+    ):
         """
         Register a nym on the ledger.
 
@@ -608,8 +639,9 @@ class IndyLedger(BaseLedger):
             role: For permissioned ledgers, what role should the new DID have.
         """
         public_did = await self.wallet.get_public_did()
-        r = await indy.ledger.build_nym_request(public_did and public_did.did,
-                                                did, verkey, alias, role)
+        r = await indy.ledger.build_nym_request(
+            public_did and public_did.did, did, verkey, alias, role
+        )
         await self._submit(r, True, True)
 
     def nym_to_did(self, nym: str) -> str:

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -391,7 +391,9 @@ class IndyLedger(BaseLedger):
 
         return parsed_response
 
-    async def send_credential_definition(self, schema_id: str, tag: str = "default"):
+    async def send_credential_definition(
+        self, schema_id: str, tag: str = "default"
+    ):
         """
         Send credential definition to ledger and store relevant key matter in wallet.
 
@@ -430,7 +432,7 @@ class IndyLedger(BaseLedger):
                 try:
                     cred_def_id = re.search(
                         r"\w*:3:CL:(([1-9][0-9]*)|(.{21,22}:2:.+:[0-9.]+)):\w*",
-                        error.message
+                        error.message,
                     ).group(0)
                     return cred_def_id
                 # The regex search failed so let the error bubble up
@@ -518,9 +520,7 @@ class IndyLedger(BaseLedger):
 
         # get txn by sequence number, retrieve schema identifier components
         request_json = await indy.ledger.build_get_txn_request(
-            None,
-            None,
-            seq_no=seq_no
+            None, None, seq_no=seq_no
         )
         response = json.loads(await self._submit(request_json))
 
@@ -530,7 +530,7 @@ class IndyLedger(BaseLedger):
             (origin_did, name, version) = (
                 data_txn["metadata"]["from"],
                 data_txn["data"]["data"]["name"],
-                data_txn["data"]["data"]["version"]
+                data_txn["data"]["data"]["version"],
             )
             return f"{origin_did}:2:{name}:{version}"
 

--- a/aries_cloudagent/ledger/tests/test_indy.py
+++ b/aries_cloudagent/ledger/tests/test_indy.py
@@ -327,6 +327,7 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger.get_schema")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_open")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_close")
+    @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger.fetch_credential_definition")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._submit")
     @async_mock.patch("indy.anoncreds.issuer_create_and_store_credential_def")
     @async_mock.patch("indy.ledger.build_cred_def_request")
@@ -335,6 +336,7 @@ class TestIndyLedger(AsyncTestCase):
         mock_build_cred_def,
         mock_create_store_cred_def,
         mock_submit,
+        mock_fetch_cred_def,
         mock_close,
         mock_open,
         mock_get_schema,
@@ -346,6 +348,8 @@ class TestIndyLedger(AsyncTestCase):
         cred_id = "cred_id"
         cred_json = "[]"
         mock_create_store_cred_def.return_value = (cred_id, cred_json)
+
+        mock_fetch_cred_def.return_value = None
 
         ledger = IndyLedger("name", mock_wallet)
 

--- a/aries_cloudagent/messaging/credentials/manager.py
+++ b/aries_cloudagent/messaging/credentials/manager.py
@@ -466,7 +466,7 @@ class CredentialManager:
         return credential_exchange_record
 
     async def store_credential(
-        self, credential_exchange_record: CredentialExchange, credential_id: str
+        self, credential_exchange_record: CredentialExchange, credential_id: str = None
     ):
         """
         Store a credential in the wallet.

--- a/aries_cloudagent/wallet/indy.py
+++ b/aries_cloudagent/wallet/indy.py
@@ -818,3 +818,38 @@ class IndyWallet(BaseWallet):
         to_verkey = unpacked.get("recipient_verkey", None)
         from_verkey = unpacked.get("sender_verkey", None)
         return message, from_verkey, to_verkey
+
+    async def get_credential_definition_tag_policy(self, credential_definition_id: str):
+        """Return the tag policy for a given credential definition ID."""
+        policy_json = await indy.anoncreds.prover_get_credential_attr_tag_policy(
+            self.handle, credential_definition_id
+        )
+        return json.loads(policy_json) if policy_json else None
+
+    async def set_credential_definition_tag_policy(
+        self,
+        credential_definition_id: str,
+        taggables: Sequence[str] = None,
+        retroactive: bool = True,
+    ):
+        """
+        Set the tag policy for a given credential definition ID.
+
+        Args:
+            credential_definition_id: The ID of the credential definition
+            taggables: A sequence of string values representing attribute names
+            retroactive: Whether to apply the policy to previously-stored credentials
+        """
+
+        if taggables is not None:
+            self.logger.info(
+                "Set tagging policy: %s %s", credential_definition_id, taggables
+            )
+            await indy.anoncreds.prover_set_credential_attr_tag_policy(
+                self.handle,
+                credential_definition_id,
+                json.dumps(taggables),
+                retroactive,
+            )
+        else:
+            self.logger.info("Clear tagging policy: %s", credential_definition_id)


### PR DESCRIPTION
- Add `wallet/tag-policy/{cred_def_id}` GET and POST endpoints
- Avoid republishing a cred def that already exists on the ledger