### PR TITLE
Add support for explicitly setting credential_id on storage

### DIFF
--- a/aries_cloudagent/messaging/credentials/routes.py
+++ b/aries_cloudagent/messaging/credentials/routes.py
@@ -466,7 +466,7 @@ async def credential_exchange_store(request: web.BaseRequest):
     outbound_handler = request.app["outbound_message_router"]
 
     try:
-        body = await request.json() or None 
+        body = await request.json() or {}
         credential_id = body.get("credential_id")
     except JSONDecodeError:
         credential_id = None

--- a/aries_cloudagent/messaging/credentials/routes.py
+++ b/aries_cloudagent/messaging/credentials/routes.py
@@ -448,6 +448,7 @@ async def credential_exchange_issue(request: web.BaseRequest):
 
 
 @docs(tags=["credential_exchange *DEPRECATED*"], summary="Stores a received credential")
+@request_schema(CredentialStoreRequestSchema()())
 @response_schema(CredentialRequestResultSchema(), 200)
 async def credential_exchange_store(request: web.BaseRequest):
     """

--- a/aries_cloudagent/messaging/credentials/routes.py
+++ b/aries_cloudagent/messaging/credentials/routes.py
@@ -448,7 +448,7 @@ async def credential_exchange_issue(request: web.BaseRequest):
 
 
 @docs(tags=["credential_exchange *DEPRECATED*"], summary="Stores a received credential")
-@request_schema(CredentialStoreRequestSchema()())
+@request_schema(CredentialStoreRequestSchema())
 @response_schema(CredentialRequestResultSchema(), 200)
 async def credential_exchange_store(request: web.BaseRequest):
     """

--- a/aries_cloudagent/messaging/credentials/routes.py
+++ b/aries_cloudagent/messaging/credentials/routes.py
@@ -73,7 +73,7 @@ class CredentialExchangeListSchema(Schema):
 class CredentialStoreRequestSchema(Schema):
     """Request schema for sending a credential store admin message."""
 
-    credential_id = fields.Str(required=True)
+    credential_id = fields.Str(required=False)
 
 
 class CredentialSchema(Schema):
@@ -466,7 +466,7 @@ async def credential_exchange_store(request: web.BaseRequest):
     outbound_handler = request.app["outbound_message_router"]
 
     try:
-        body = await request.json()
+        body = await request.json() or None 
         credential_id = body.get("credential_id")
     except JSONDecodeError:
         credential_id = None


### PR DESCRIPTION
This pull request adds the option of passing a "credential_id" parameter in the body of the request to instruct the wallet to use that id for storage.

Existing functionality is not changed if no value is passed.