### PR TITLE
Add CLI args for specifying more attrs of invite

### DIFF
--- a/aries_cloudagent/conductor.py
+++ b/aries_cloudagent/conductor.py
@@ -182,7 +182,14 @@ class Conductor:
         if context.settings.get("debug.print_invitation"):
             try:
                 mgr = ConnectionManager(self.context)
-                _connection, invitation = await mgr.create_invitation()
+                _connection, invitation = await mgr.create_invitation(
+                    their_role=context.settings.get("debug.invite_role"),
+                    my_label=context.settings.get("debug.invite_label"),
+                    multi_use=context.settings.get(
+                        "debug.invite_multi_use", False
+                    ),
+                    public=context.settings.get("debug.invite_public", False)
+                )
                 invite_url = invitation.to_url()
                 print("Invitation URL:")
                 print(invite_url)

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -209,6 +209,30 @@ class DebugGroup(ArgumentGroup):
             help="After startup, generate and print a new connection invitation\
             URL. Default: false.",
         )
+        parser.add_argument(
+            "--invite-role",
+            dest="invite_role",
+            type=str,
+            metavar="<role>",
+            help="Specify the role of the generated invitation."
+        )
+        parser.add_argument(
+            "--invite-label",
+            dest="invite_label",
+            type=str,
+            metavar="<label>",
+            help="Specify the label of the generated invitation."
+        )
+        parser.add_argument(
+            "--invite-multi-use",
+            action="store_true",
+            help="Flag specifying the generated invite should be multi-use."
+        )
+        parser.add_argument(
+            "--invite-public",
+            action="store_true",
+            help="Flag specifying the generated invite should be public."
+        )
 
         parser.add_argument(
             "--auto-accept-invites",
@@ -286,6 +310,14 @@ class DebugGroup(ArgumentGroup):
             settings["debug.seed"] = args.debug_seed
         if args.invite:
             settings["debug.print_invitation"] = True
+        if args.invite_role:
+            settings["debug.invite_role"] = args.invite_role
+        if args.invite_label:
+            settings["debug.invite_label"] = args.invite_label
+        if args.invite_multi_use:
+            settings["debug.invite_multi_use"] = True
+        if args.invite_public:
+            settings["debug.invite_public"] = True
 
         if args.auto_respond_credential_proposal:
             settings["debug.auto_respond_credential_proposal"] = True


### PR DESCRIPTION
More command line arguments for specifying role, label, multiuse, and public attributes of the invite generated at startup. Helpful for debugging.