### PR TITLE
Update scripts to run correctly in Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 *.json text eol=lf
 *.conf text eol=lf
 **/bin/* text eol=lf
+scripts/* text eol=lf

--- a/scripts/run_docker
+++ b/scripts/run_docker
@@ -19,5 +19,11 @@ if [ ! -z "${WEBHOOK_URL}" ]; then
 	ARGS="${ARGS} -e WEBHOOK_URL=\"${WEBHOOK_URL}\""
 fi
 
+if [ "$OSTYPE" == "msys" ]; then
+  DOCKER="winpty docker"
+else
+  DOCKER="docker"
+fi
+
 RAND_NAME=$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
-docker run --rm -ti --name "aries-cloudagent-runner_${RAND_NAME}" $ARGS aries-cloudagent-run "$@"
+$DOCKER run --rm -ti --name "aries-cloudagent-runner_${RAND_NAME}" $ARGS aries-cloudagent-run "$@"

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -14,5 +14,5 @@ else
 fi
 
 $DOCKER run --rm -ti --name aries-cloudagent-runner \
-	-v "$(pwd)/../test-reports:/usr/src/app/test-reports" \
+	-v "/$(pwd)/../test-reports:/usr/src/app/test-reports" \
 	aries-cloudagent-test "$@"

--- a/scripts/run_tests_indy
+++ b/scripts/run_tests_indy
@@ -24,6 +24,6 @@ if [ ! -z "$POSTGRES_URL" ]; then
 fi
 
 $DOCKER run --rm -ti --name aries-cloudagent-runner \
-  -v "$(pwd)/../test-reports:/home/indy/src/app/test-reports" \
+  -v "/$(pwd)/../test-reports:/home/indy/src/app/test-reports" \
   $DOCKER_ARGS \
   aries-cloudagent-test "$@"


### PR DESCRIPTION
The scripts under the `scripts` folder were updated to allow their execution in Windows (using Git bash). The changes include prefixing the `docker` executable with `winpty` and escaping the volume mount paths.

`.gitattributes` was also updated to prevent line endings in the scripts from being changed when checking out code in windows, since this would cause issues in UNIX/Linux machines if committed.

Changes were tested under Windows in Git Bash and using WSL (Ubuntu), to ensure correct execution under UNIX/Linux.