### PR TITLE
Attachment decorator ident

### DIFF
--- a/aries_cloudagent/messaging/decorators/attach_decorator.py
+++ b/aries_cloudagent/messaging/decorators/attach_decorator.py
@@ -7,13 +7,14 @@ An attach decorator embeds content or specifies appended content.
 
 import base64
 import json
+import uuid
 
 from typing import Union
 
 from marshmallow import fields
 
 from ..models.base import BaseModel, BaseModelSchema
-from ..valid import BASE64, INDY_ISO8601_DATETIME, SHA256
+from ..valid import BASE64, INDY_ISO8601_DATETIME, SHA256, UUIDFour
 
 
 class AttachDecoratorData(BaseModel):
@@ -136,7 +137,7 @@ class AttachDecorator(BaseModel):
     def __init__(
         self,
         *,
-        append_id: str = None,
+        ident: str = None,
         description: str = None,
         filename: str = None,
         mime_type: str = None,
@@ -152,8 +153,7 @@ class AttachDecorator(BaseModel):
         content to a message.
 
         Args:
-            append_id ("@id" in serialization): if appending,
-                identifier for the appendage
+            ident ("@id" in serialization): identifier for the appendage
             mime_type ("mime-type" in serialization): MIME type for attachment
             filename: file name
             lastmod_time: last modification time, "%Y-%m-%d %H:%M:%SZ"
@@ -162,7 +162,7 @@ class AttachDecorator(BaseModel):
 
         """
         super().__init__(**kwargs)
-        self.append_id = append_id
+        self.ident = ident
         self.description = description
         self.filename = filename
         self.mime_type = mime_type
@@ -182,7 +182,16 @@ class AttachDecorator(BaseModel):
         return json.loads(base64.b64decode(self.data.base64_.encode()).decode())
 
     @classmethod
-    def from_indy_dict(cls, indy_dict: dict):
+    def from_indy_dict(
+        cls,
+        indy_dict: dict,
+        *,
+        ident: str = None,
+        description: str = None,
+        filename: str = None,
+        lastmod_time: str = None,
+        byte_count: int = None,
+    ):
         """
         Create `AttachDecorator` instance from indy object (dict).
 
@@ -191,9 +200,20 @@ class AttachDecorator(BaseModel):
 
         Args:
             indy_dict: indy (dict) data structure
+            ident: optional attachment identifier (default random UUID4)
+            description: optional attachment description
+            filename: optional attachment filename
+            lastmod_time: optional attachment last modification time
+            byte_count: optional attachment byte count
+
         """
         return AttachDecorator(
+            ident=ident or str(uuid.uuid4()),
+            description=description,
+            filename=filename,
             mime_type="application/json",
+            lastmod_time=lastmod_time,
+            byte_count=byte_count,
             data=AttachDecoratorData(
                 base64_=base64.b64encode(json.dumps(indy_dict).encode()).decode()
             )
@@ -208,12 +228,11 @@ class AttachDecoratorSchema(BaseModelSchema):
 
         model_class = AttachDecorator
 
-    append_id = fields.Str(
+    ident = fields.Str(
         description="Attachment identifier",
-        example="view-1",
+        example=UUIDFour.EXAMPLE,
         required=False,
         allow_none=False,
-        attribute="append_id",
         data_key="@id"
     )
     mime_type = fields.Str(

--- a/aries_cloudagent/messaging/decorators/tests/test_attach_decorator.py
+++ b/aries_cloudagent/messaging/decorators/tests/test_attach_decorator.py
@@ -3,17 +3,18 @@ from unittest import TestCase
 
 import base64
 import json
+import uuid
 
 from ..attach_decorator import AttachDecorator, AttachDecoratorData
 
 
 class TestAttachDecorator(TestCase):
-    append_id = 'image-0'
-    mime_type = 'image/png'
-    filename = 'potato.png'
-    byte_count = 123456
-    lastmod_time = datetime.now().replace(tzinfo=timezone.utc).isoformat(" ", "seconds")
+    ident = str(uuid.uuid4())
     description = 'To one trained by "Bob," Truth can be found in a potato'
+    filename = 'potato.png'
+    mime_type = 'image/png'
+    lastmod_time = datetime.now().replace(tzinfo=timezone.utc).isoformat(" ", "seconds")
+    byte_count = 123456
     data_b64 = AttachDecoratorData(
         base64_=base64.b64encode('sample image with padding'.encode()).decode()
     )
@@ -89,7 +90,7 @@ class TestAttachDecorator(TestCase):
 
     def test_init_appended_b64(self):
         decorator = AttachDecorator(
-            append_id=self.append_id,
+            ident=self.ident,
             mime_type=self.mime_type,
             filename=self.filename,
             lastmod_time=self.lastmod_time,
@@ -97,7 +98,7 @@ class TestAttachDecorator(TestCase):
             data=self.data_b64
         )
 
-        assert decorator.append_id == self.append_id
+        assert decorator.ident == self.ident
         assert decorator.mime_type == self.mime_type
         assert decorator.filename == self.filename
         assert decorator.lastmod_time == self.lastmod_time
@@ -106,7 +107,7 @@ class TestAttachDecorator(TestCase):
 
     def test_serialize_load_appended_b64(self):
         decorator = AttachDecorator(
-            append_id=self.append_id,
+            ident=self.ident,
             mime_type=self.mime_type,
             filename=self.filename,
             lastmod_time=self.lastmod_time,
@@ -117,7 +118,7 @@ class TestAttachDecorator(TestCase):
         dumped = decorator.serialize()
         loaded = AttachDecorator.deserialize(dumped)
 
-        assert loaded.append_id == self.append_id
+        assert loaded.ident == self.ident
         assert loaded.mime_type == self.mime_type
         assert loaded.filename == self.filename
         assert loaded.lastmod_time == self.lastmod_time
@@ -126,7 +127,7 @@ class TestAttachDecorator(TestCase):
 
     def test_init_appended_links(self):
         decorator = AttachDecorator(
-            append_id=self.append_id,
+            ident=self.ident,
             mime_type=self.mime_type,
             filename=self.filename,
             byte_count=self.byte_count,
@@ -134,7 +135,7 @@ class TestAttachDecorator(TestCase):
             description=self.description,
             data=self.data_links
         )
-        assert decorator.append_id == self.append_id
+        assert decorator.ident == self.ident
         assert decorator.mime_type == self.mime_type
         assert decorator.filename == self.filename
         assert decorator.byte_count == self.byte_count
@@ -144,7 +145,7 @@ class TestAttachDecorator(TestCase):
 
     def test_serialize_load_appended_links(self):
         decorator = AttachDecorator(
-            append_id=self.append_id,
+            ident=self.ident,
             mime_type=self.mime_type,
             filename=self.filename,
             byte_count=self.byte_count,
@@ -156,7 +157,7 @@ class TestAttachDecorator(TestCase):
         dumped = decorator.serialize()
         loaded = AttachDecorator.deserialize(dumped)
 
-        assert loaded.append_id == self.append_id
+        assert loaded.ident == self.ident
         assert loaded.mime_type == self.mime_type
         assert loaded.filename == self.filename
         assert loaded.byte_count == self.byte_count
@@ -165,7 +166,22 @@ class TestAttachDecorator(TestCase):
         assert loaded.data == self.data_links
 
     def test_indy_dict(self):
-        deco_indy = AttachDecorator.from_indy_dict(self.indy_cred)
+        deco_indy = AttachDecorator.from_indy_dict(
+            indy_dict=self.indy_cred,
+            ident=self.ident,
+            description=self.description,
+            filename=self.filename,
+            lastmod_time=self.lastmod_time,
+            byte_count=self.byte_count
+        )
         assert deco_indy.mime_type == 'application/json'
         assert hasattr(deco_indy.data, 'base64_')
         assert deco_indy.indy_dict == self.indy_cred
+        assert deco_indy.ident == self.ident
+        assert deco_indy.description == self.description
+        assert deco_indy.filename == self.filename
+        assert deco_indy.lastmod_time == self.lastmod_time
+        assert deco_indy.byte_count == self.byte_count
+
+        deco_indy_auto_id = AttachDecorator.from_indy_dict(indy_dict=self.indy_cred)
+        assert deco_indy_auto_id.ident

--- a/aries_cloudagent/messaging/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/manager.py
@@ -20,6 +20,12 @@ from .messages.credential_proposal import CredentialProposal
 from .messages.credential_request import CredentialRequest
 from .messages.credential_stored import CredentialStored
 from .messages.inner.credential_preview import CredentialPreview
+from .message_types import (
+    ATTACH_DECO_IDS,
+    CREDENTIAL_ISSUE,
+    CREDENTIAL_OFFER,
+    CREDENTIAL_REQUEST,
+)
 from .models.credential_exchange import V10CredentialExchange
 
 
@@ -331,7 +337,12 @@ class CredentialManager:
         credential_offer_message = CredentialOffer(
             comment=comment,
             credential_preview=cred_preview,
-            offers_attach=[AttachDecorator.from_indy_dict(credential_offer)],
+            offers_attach=[
+                AttachDecorator.from_indy_dict(
+                    indy_dict=credential_offer,
+                    ident=ATTACH_DECO_IDS[CREDENTIAL_OFFER],
+                )
+            ],
         )
 
         credential_offer_message._thread = {
@@ -410,7 +421,8 @@ class CredentialManager:
         credential_request_message = CredentialRequest(
             requests_attach=[
                 AttachDecorator.from_indy_dict(
-                    credential_exchange_record.credential_request
+                    indy_dict=credential_exchange_record.credential_request,
+                    ident=ATTACH_DECO_IDS[CREDENTIAL_REQUEST],
                 )
             ]
         )
@@ -505,7 +517,10 @@ class CredentialManager:
         credential_message = CredentialIssue(
             comment=comment,
             credentials_attach=[
-                AttachDecorator.from_indy_dict(credential_exchange_record.credential)
+                AttachDecorator.from_indy_dict(
+                    indy_dict=credential_exchange_record.credential,
+                    ident=ATTACH_DECO_IDS[CREDENTIAL_ISSUE]
+                )
             ],
         )
         credential_message._thread = {

--- a/aries_cloudagent/messaging/issue_credential/v1_0/message_types.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/message_types.py
@@ -21,3 +21,10 @@ MESSAGE_TYPES = {
 
 # Inner object types
 CREDENTIAL_PREVIEW = f"{MESSAGE_FAMILY}credential-preview"
+
+# Identifiers to use in attachment decorators
+ATTACH_DECO_IDS = {
+    CREDENTIAL_OFFER: "libindy-cred-offer-0",
+    CREDENTIAL_REQUEST: "libindy-cred-request-0",
+    CREDENTIAL_ISSUE: "libindy-cred-0"
+}

--- a/aries_cloudagent/messaging/issue_credential/v1_0/messages/tests/test_credential_issue.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/messages/tests/test_credential_issue.py
@@ -1,5 +1,5 @@
 from .....decorators.attach_decorator import AttachDecorator
-from ...message_types import CREDENTIAL_ISSUE
+from ...message_types import ATTACH_DECO_IDS, CREDENTIAL_ISSUE
 from ..credential_issue import CredentialIssue
 
 from unittest import mock, TestCase
@@ -76,14 +76,24 @@ class TestCredentialIssue(TestCase):
 
     cred_issue = CredentialIssue(
         comment="Test",
-        credentials_attach=[AttachDecorator.from_indy_dict(indy_cred)]
+        credentials_attach=[
+            AttachDecorator.from_indy_dict(
+                indy_dict=indy_cred,
+                ident=ATTACH_DECO_IDS[CREDENTIAL_ISSUE],
+            )
+        ]
     )
 
     def test_init(self):
         """Test initializer"""
         credential_issue = CredentialIssue(
             comment="Test",
-            credentials_attach=[AttachDecorator.from_indy_dict(self.indy_cred)]
+            credentials_attach=[
+                AttachDecorator.from_indy_dict(
+                    indy_dict=self.indy_cred,
+                    ident=ATTACH_DECO_IDS[CREDENTIAL_ISSUE],
+                )
+            ]
         )
         assert credential_issue.credentials_attach[0].indy_dict == self.indy_cred
         assert credential_issue.credentials_attach[0].ident  # auto-generates UUID4
@@ -93,7 +103,12 @@ class TestCredentialIssue(TestCase):
         """Test type"""
         credential_issue = CredentialIssue(
             comment="Test",
-            credentials_attach=[AttachDecorator.from_indy_dict(self.indy_cred)]
+            credentials_attach=[
+                AttachDecorator.from_indy_dict(
+                    indy_dict=self.indy_cred,
+                    ident=ATTACH_DECO_IDS[CREDENTIAL_ISSUE],
+                )
+            ]
         )
 
         assert credential_issue._type == CREDENTIAL_ISSUE
@@ -134,7 +149,6 @@ class TestCredentialIssueSchema(TestCase):
 
     credential_issue = CredentialIssue(
         comment="Test",
-        # credentials_attach=[AttachDecorator.from_indy_dict(TestCredentialIssue.indy_cred)]
         credentials_attach=[AttachDecorator.from_indy_dict({'hello': 'world'})]
     )
 

--- a/aries_cloudagent/messaging/issue_credential/v1_0/messages/tests/test_credential_issue.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/messages/tests/test_credential_issue.py
@@ -4,7 +4,6 @@ from ..credential_issue import CredentialIssue
 
 from unittest import mock, TestCase
 
-
 class TestCredentialIssue(TestCase):
     """Credential issue tests"""
 
@@ -87,6 +86,7 @@ class TestCredentialIssue(TestCase):
             credentials_attach=[AttachDecorator.from_indy_dict(self.indy_cred)]
         )
         assert credential_issue.credentials_attach[0].indy_dict == self.indy_cred
+        assert credential_issue.credentials_attach[0].ident  # auto-generates UUID4
         assert credential_issue.indy_credential(0) == self.indy_cred
 
     def test_type(self):

--- a/aries_cloudagent/messaging/issue_credential/v1_0/messages/tests/test_credential_offer.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/messages/tests/test_credential_offer.py
@@ -1,5 +1,5 @@
 from .....decorators.attach_decorator import AttachDecorator
-from ...message_types import CREDENTIAL_OFFER
+from ...message_types import ATTACH_DECO_IDS, CREDENTIAL_OFFER
 from ..credential_offer import CredentialOffer
 from ..inner.credential_preview import CredAttrSpec, CredentialPreview
 
@@ -40,7 +40,12 @@ class TestCredentialOffer(TestCase):
     offer = CredentialOffer(
         comment="shaken, not stirred",
         credential_preview=preview,
-        offers_attach=[AttachDecorator.from_indy_dict(indy_offer)]
+        offers_attach=[
+            AttachDecorator.from_indy_dict(
+                indy_dict=indy_offer,
+                ident=ATTACH_DECO_IDS[CREDENTIAL_OFFER],
+            )
+        ]
     )
 
     def test_init(self):
@@ -48,7 +53,12 @@ class TestCredentialOffer(TestCase):
         credential_offer = CredentialOffer(
             comment="shaken, not stirred",
             credential_preview=self.preview,
-            offers_attach=[AttachDecorator.from_indy_dict(self.indy_offer)]
+            offers_attach=[
+                AttachDecorator.from_indy_dict(
+                    indy_dict=self.indy_offer,
+                    ident=ATTACH_DECO_IDS[CREDENTIAL_OFFER],
+                )
+            ]
         )
         assert credential_offer.credential_preview == self.preview
         assert credential_offer.offers_attach[0].indy_dict == self.indy_offer
@@ -59,7 +69,12 @@ class TestCredentialOffer(TestCase):
         credential_offer = CredentialOffer(
             comment="shaken, not stirred",
             credential_preview=self.preview,
-            offers_attach=[AttachDecorator.from_indy_dict(self.indy_offer)]
+            offers_attach=[
+                AttachDecorator.from_indy_dict(
+                    indy_dict=self.indy_offer,
+                    ident=ATTACH_DECO_IDS[CREDENTIAL_OFFER],
+                )
+            ]
         )
 
         assert credential_offer._type == CREDENTIAL_OFFER
@@ -90,7 +105,12 @@ class TestCredentialOffer(TestCase):
         credential_offer = CredentialOffer(
             comment="shaken, not stirred",
             credential_preview=self.preview,
-            offers_attach=[AttachDecorator.from_indy_dict(self.indy_offer)]
+            offers_attach=[
+                AttachDecorator.from_indy_dict(
+                    indy_dict=self.indy_offer,
+                    ident=ATTACH_DECO_IDS[CREDENTIAL_OFFER],
+                )
+            ]
         )
 
         credential_offer_dict = credential_offer.serialize()

--- a/aries_cloudagent/messaging/issue_credential/v1_0/messages/tests/test_credential_request.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/messages/tests/test_credential_request.py
@@ -1,5 +1,5 @@
 from .....decorators.attach_decorator import AttachDecorator
-from ...message_types import CREDENTIAL_REQUEST
+from ...message_types import ATTACH_DECO_IDS, CREDENTIAL_REQUEST
 from ..credential_request import CredentialRequest
 
 from unittest import mock, TestCase
@@ -32,14 +32,24 @@ class TestCredentialRequest(TestCase):
 
     cred_req = CredentialRequest(
         comment="Test",
-        requests_attach=[AttachDecorator.from_indy_dict(indy_cred_req)]
+        requests_attach=[
+            AttachDecorator.from_indy_dict(
+                indy_dict=indy_cred_req,
+                ident=ATTACH_DECO_IDS[CREDENTIAL_REQUEST],
+            )
+        ]
     )
 
     def test_init(self):
         """Test initializer"""
         credential_request = CredentialRequest(
             comment="Test",
-            requests_attach=[AttachDecorator.from_indy_dict(self.indy_cred_req)]
+            requests_attach=[
+                AttachDecorator.from_indy_dict(
+                    indy_dict=self.indy_cred_req,
+                    ident=ATTACH_DECO_IDS[CREDENTIAL_REQUEST],
+                )
+            ]
         )
         assert credential_request.requests_attach[0].indy_dict == self.indy_cred_req
         assert credential_request.indy_cred_req(0) == self.indy_cred_req
@@ -48,7 +58,12 @@ class TestCredentialRequest(TestCase):
         """Test type"""
         credential_request = CredentialRequest(
             comment="Test",
-            requests_attach=[AttachDecorator.from_indy_dict(self.indy_cred_req)]
+            requests_attach=[
+                AttachDecorator.from_indy_dict(
+                    indy_dict=self.indy_cred_req,
+                    ident=ATTACH_DECO_IDS[CREDENTIAL_REQUEST],
+                )
+            ]
         )
 
         assert credential_request._type == CREDENTIAL_REQUEST
@@ -78,7 +93,12 @@ class TestCredentialRequest(TestCase):
         """
         credential_request = CredentialRequest(
             comment="Test",
-            requests_attach=[AttachDecorator.from_indy_dict(self.indy_cred_req)]
+            requests_attach=[
+                AttachDecorator.from_indy_dict(
+                    indy_dict=self.indy_cred_req,
+                    ident=ATTACH_DECO_IDS[CREDENTIAL_REQUEST],
+                )
+            ]
         )
 
         credential_request_dict = credential_request.serialize()
@@ -92,7 +112,9 @@ class TestCredentialRequestSchema(TestCase):
 
     credential_request = CredentialRequest(
         comment="Test",
-        requests_attach=[AttachDecorator.from_indy_dict(TestCredentialRequest.indy_cred_req)]
+        requests_attach=[
+            AttachDecorator.from_indy_dict(TestCredentialRequest.indy_cred_req)
+        ]
     )
 
     def test_make_model(self):

--- a/aries_cloudagent/messaging/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/messaging/present_proof/v1_0/manager.py
@@ -14,6 +14,7 @@ from .models.presentation_exchange import V10PresentationExchange
 from .messages.presentation_proposal import PresentationProposal
 from .messages.presentation_request import PresentationRequest
 from .messages.presentation import Presentation
+from .message_types import ATTACH_DECO_IDS, PRESENTATION, PRESENTATION_REQUEST
 
 
 class PresentationManagerError(BaseError):
@@ -138,7 +139,10 @@ class PresentationManager:
         presentation_request_message = PresentationRequest(
             comment=comment,
             request_presentations_attach=[
-                AttachDecorator.from_indy_dict(indy_proof_request)
+                AttachDecorator.from_indy_dict(
+                    indy_dict=indy_proof_request,
+                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+                )
             ],
         )
         presentation_request_message._thread = {
@@ -300,7 +304,12 @@ class PresentationManager:
 
         presentation_message = Presentation(
             comment=comment,
-            presentations_attach=[AttachDecorator.from_indy_dict(indy_proof)],
+            presentations_attach=[
+                AttachDecorator.from_indy_dict(
+                    indy_dict=indy_proof,
+                    ident=ATTACH_DECO_IDS[PRESENTATION],
+                )
+            ],
         )
 
         presentation_message._thread = {"thid": presentation_exchange_record.thread_id}

--- a/aries_cloudagent/messaging/present_proof/v1_0/message_types.py
+++ b/aries_cloudagent/messaging/present_proof/v1_0/message_types.py
@@ -17,3 +17,9 @@ MESSAGE_TYPES = {
 
 # Inner object types
 PRESENTATION_PREVIEW = f"{MESSAGE_FAMILY}presentation-preview"
+
+# Identifiers to use in attachment decorators
+ATTACH_DECO_IDS = {
+    PRESENTATION_REQUEST: "libindy-request-presentation-0",
+    PRESENTATION: "libindy-presentation-0"
+}

--- a/aries_cloudagent/messaging/present_proof/v1_0/messages/tests/test_presentation.py
+++ b/aries_cloudagent/messaging/present_proof/v1_0/messages/tests/test_presentation.py
@@ -5,7 +5,7 @@ import json
 
 from ......messaging.util import str_to_datetime, str_to_epoch
 from ......messaging.decorators.attach_decorator import AttachDecorator
-from ...message_types import PRESENTATION_PREVIEW, PRESENTATION
+from ...message_types import ATTACH_DECO_IDS, PRESENTATION_PREVIEW, PRESENTATION
 from ..presentation import Presentation, PresentationSchema
 
 
@@ -1654,11 +1654,13 @@ INDY_PROOF = json.loads("""{
     ]
 }""")
 
-PRES_IDENT = "presentation-0"
 PRES = Presentation(
     comment="Test",
     presentations_attach=[
-        AttachDecorator.from_indy_dict(indy_dict=INDY_PROOF, ident=PRES_IDENT)
+        AttachDecorator.from_indy_dict(
+            indy_dict=INDY_PROOF,
+            ident=ATTACH_DECO_IDS[PRESENTATION],
+        )
     ]
 )
 
@@ -1682,7 +1684,7 @@ class TestPresentation(TestCase):
             "presentations~attach": [
                 AttachDecorator.from_indy_dict(
                     indy_dict=INDY_PROOF,
-                    ident=PRES_IDENT,
+                    ident=ATTACH_DECO_IDS[PRESENTATION],
                 ).serialize()
             ]
         })
@@ -1700,7 +1702,7 @@ class TestPresentation(TestCase):
             "presentations~attach": [
                 AttachDecorator.from_indy_dict(
                     indy_dict=INDY_PROOF,
-                    ident=PRES_IDENT,
+                    ident=ATTACH_DECO_IDS[PRESENTATION],
                 ).serialize()
             ],
             "comment": "Test"

--- a/aries_cloudagent/messaging/present_proof/v1_0/messages/tests/test_presentation.py
+++ b/aries_cloudagent/messaging/present_proof/v1_0/messages/tests/test_presentation.py
@@ -1654,10 +1654,11 @@ INDY_PROOF = json.loads("""{
     ]
 }""")
 
+PRES_IDENT = "presentation-0"
 PRES = Presentation(
     comment="Test",
     presentations_attach=[
-        AttachDecorator.from_indy_dict(INDY_PROOF)
+        AttachDecorator.from_indy_dict(indy_dict=INDY_PROOF, ident=PRES_IDENT)
     ]
 )
 
@@ -1679,7 +1680,10 @@ class TestPresentation(TestCase):
             "@type": PRESENTATION,
             "comment": "Hello World",
             "presentations~attach": [
-                AttachDecorator.from_indy_dict(INDY_PROOF).serialize()
+                AttachDecorator.from_indy_dict(
+                    indy_dict=INDY_PROOF,
+                    ident=PRES_IDENT,
+                ).serialize()
             ]
         })
 
@@ -1694,7 +1698,10 @@ class TestPresentation(TestCase):
         assert pres_dict == {
             "@type": PRESENTATION,
             "presentations~attach": [
-                AttachDecorator.from_indy_dict(INDY_PROOF).serialize()
+                AttachDecorator.from_indy_dict(
+                    indy_dict=INDY_PROOF,
+                    ident=PRES_IDENT,
+                ).serialize()
             ],
             "comment": "Test"
         }

--- a/aries_cloudagent/messaging/present_proof/v1_0/messages/tests/test_presentation_request.py
+++ b/aries_cloudagent/messaging/present_proof/v1_0/messages/tests/test_presentation_request.py
@@ -5,7 +5,7 @@ import json
 
 from ......messaging.util import str_to_datetime, str_to_epoch
 from ......messaging.decorators.attach_decorator import AttachDecorator
-from ...message_types import PRESENTATION_PREVIEW, PRESENTATION_REQUEST
+from ...message_types import ATTACH_DECO_IDS, PRESENTATION_PREVIEW, PRESENTATION_REQUEST
 from ..presentation_request import PresentationRequest, PresentationRequestSchema
 
 
@@ -59,11 +59,14 @@ INDY_PROOF_REQ = json.loads(f"""{{
         }}
     }}
 }}""")
-PRES_REQ_IDENT = "presentation-0"
+
 PRES_REQ = PresentationRequest(
     comment="Test",
     request_presentations_attach=[
-        AttachDecorator.from_indy_dict(indy_dict=INDY_PROOF_REQ, ident=PRES_REQ_IDENT)
+        AttachDecorator.from_indy_dict(
+            indy_dict=INDY_PROOF_REQ,
+            ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+        )
     ]
 )
 
@@ -87,7 +90,7 @@ class TestPresentationRequest(TestCase):
             "request_presentations~attach": [
                 AttachDecorator.from_indy_dict(
                     indy_dict=INDY_PROOF_REQ,
-                    ident=PRES_REQ_IDENT,
+                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
                 ).serialize()
             ]
         })
@@ -105,7 +108,7 @@ class TestPresentationRequest(TestCase):
             "request_presentations~attach": [
                 AttachDecorator.from_indy_dict(
                     indy_dict=INDY_PROOF_REQ,
-                    ident=PRES_REQ_IDENT,
+                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
                 ).serialize()
             ],
             "comment": "Test"

--- a/aries_cloudagent/messaging/present_proof/v1_0/messages/tests/test_presentation_request.py
+++ b/aries_cloudagent/messaging/present_proof/v1_0/messages/tests/test_presentation_request.py
@@ -59,10 +59,11 @@ INDY_PROOF_REQ = json.loads(f"""{{
         }}
     }}
 }}""")
+PRES_REQ_IDENT = "presentation-0"
 PRES_REQ = PresentationRequest(
     comment="Test",
     request_presentations_attach=[
-        AttachDecorator.from_indy_dict(INDY_PROOF_REQ)
+        AttachDecorator.from_indy_dict(indy_dict=INDY_PROOF_REQ, ident=PRES_REQ_IDENT)
     ]
 )
 
@@ -84,7 +85,10 @@ class TestPresentationRequest(TestCase):
             "@type": PRESENTATION_REQUEST,
             "comment": "Hello World",
             "request_presentations~attach": [
-                AttachDecorator.from_indy_dict(INDY_PROOF_REQ).serialize()
+                AttachDecorator.from_indy_dict(
+                    indy_dict=INDY_PROOF_REQ,
+                    ident=PRES_REQ_IDENT,
+                ).serialize()
             ]
         })
 
@@ -99,7 +103,10 @@ class TestPresentationRequest(TestCase):
         assert pres_req_dict == {
             "@type": PRESENTATION_REQUEST,
             "request_presentations~attach": [
-                AttachDecorator.from_indy_dict(INDY_PROOF_REQ).serialize()
+                AttachDecorator.from_indy_dict(
+                    indy_dict=INDY_PROOF_REQ,
+                    ident=PRES_REQ_IDENT,
+                ).serialize()
             ],
             "comment": "Test"
         }


### PR DESCRIPTION
Allow specification of all attach-deco attributes on init; auto-generate (uuid4) ident for attachment deco by default via from_indy_dict().