### PR TITLE
Fix signing when not needed

### DIFF
--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -552,7 +552,7 @@ class IndyLedger(BaseLedger):
         request_json = await indy.ledger.build_get_txn_request(
             None, None, seq_no=seq_no
         )
-        response = json.loads(await self._submit(request_json))
+        response = json.loads(await self._submit(request_json, sign=False))
 
         # transaction data format assumes node protocol >= 1.4 (circa 2018-07)
         data_txn = (response["result"].get("data", {}) or {}).get("txn", {})


### PR DESCRIPTION
Avoid signing ledger requests in cred_def_id2schema_id method. This makes it so potential holders are not required to have a public DID to send a proposal to an issuer.