### PR TITLE
Reduce impact of tags in non-secrets

### DIFF
--- a/aries_cloudagent/config/logging.py
+++ b/aries_cloudagent/config/logging.py
@@ -60,7 +60,8 @@ class LoggingConfigurator:
 
         log_config = load_resource(config_path, "utf-8")
         if log_config:
-            fileConfig(log_config, disable_existing_loggers=False)
+            with log_config:
+                fileConfig(log_config, disable_existing_loggers=False)
         else:
             logging.basicConfig(level=logging.WARNING)
             logging.root.warning(f"Logging config file not found: {config_path}")

--- a/aries_cloudagent/holder/tests/test_indy.py
+++ b/aries_cloudagent/holder/tests/test_indy.py
@@ -13,7 +13,7 @@ from aries_cloudagent.wallet.indy import IndyWallet
 import pytest
 
 from ...messaging.issue_credential.v1_0.messages.inner.credential_preview import (
-    CredentialPreview
+    CredentialPreview,
 )
 
 
@@ -73,7 +73,7 @@ class TestIndyHolder(AsyncTestCase):
             "type": IndyHolder.RECORD_TYPE_MIME_TYPES,
             "id": cred_id,
             "value": "value",
-            "tags": dummy_tags
+            "tags": dummy_tags,
         }
         mock_nonsec_get_wallet_record.return_value = json.dumps(dummy_rec)
 
@@ -88,12 +88,8 @@ class TestIndyHolder(AsyncTestCase):
             dummy_rec["type"],
             f"{IndyHolder.RECORD_TYPE_MIME_TYPES}::{dummy_rec['id']}",
             json.dumps(
-                {
-                    "retrieveType": True,
-                    "retrieveValue": True,
-                    "retrieveTags": True
-                }
-            )
+                {"retrieveType": False, "retrieveValue": True, "retrieveTags": True}
+            ),
         )
 
         assert mime_types == dummy_tags
@@ -106,7 +102,7 @@ class TestIndyHolder(AsyncTestCase):
             "type": IndyHolder.RECORD_TYPE_MIME_TYPES,
             "id": cred_id,
             "value": "value",
-            "tags": dummy_tags
+            "tags": dummy_tags,
         }
         mock_nonsec_get_wallet_record.return_value = json.dumps(dummy_rec)
 
@@ -121,12 +117,8 @@ class TestIndyHolder(AsyncTestCase):
             dummy_rec["type"],
             f"{IndyHolder.RECORD_TYPE_MIME_TYPES}::{dummy_rec['id']}",
             json.dumps(
-                {
-                    "retrieveType": True,
-                    "retrieveValue": True,
-                    "retrieveTags": True
-                }
-            )
+                {"retrieveType": False, "retrieveValue": True, "retrieveTags": True}
+            ),
         )
 
         assert a_mime_type == dummy_tags["a"]
@@ -233,7 +225,7 @@ class TestIndyHolder(AsyncTestCase):
         self,
         mock_nonsec_del_wallet_record,
         mock_nonsec_get_wallet_record,
-        mock_prover_del_cred
+        mock_prover_del_cred,
     ):
         mock_wallet = async_mock.MagicMock()
         holder = IndyHolder(mock_wallet)
@@ -242,18 +234,14 @@ class TestIndyHolder(AsyncTestCase):
                 "type": "typ",
                 "id": "ident",
                 "value": "value",
-                "tags": {
-                    "a": json.dumps("1"),
-                    "b": json.dumps("2")
-                }
+                "tags": {"a": json.dumps("1"), "b": json.dumps("2")},
             }
         )
 
         credential = await holder.delete_credential("credential_id")
 
         mock_prover_del_cred.assert_called_once_with(
-            mock_wallet.handle,
-            "credential_id"
+            mock_wallet.handle, "credential_id"
         )
 
     @async_mock.patch("indy.anoncreds.prover_create_proof")

--- a/aries_cloudagent/messaging/connections/models/connection_record.py
+++ b/aries_cloudagent/messaging/connections/models/connection_record.py
@@ -33,12 +33,10 @@ class ConnectionRecord(BaseRecord):  # lgtm[py/missing-equals]
     LOG_STATE_FLAG = "debug.connections"
     CACHE_ENABLED = True
     TAG_NAMES = {
-        "initiator",
         "my_did",
         "their_did",
         "request_id",
         "invitation_key",
-        "state",
     }
 
     RECORD_TYPE = "connection"
@@ -119,6 +117,7 @@ class ConnectionRecord(BaseRecord):  # lgtm[py/missing-equals]
         return {
             prop: getattr(self, prop)
             for prop in (
+                "initiator",
                 "their_role",
                 "inbound_connection_id",
                 "routing_state",
@@ -127,6 +126,7 @@ class ConnectionRecord(BaseRecord):  # lgtm[py/missing-equals]
                 "alias",
                 "error_msg",
                 "their_label",
+                "state",
             )
         }
 
@@ -151,9 +151,10 @@ class ConnectionRecord(BaseRecord):  # lgtm[py/missing-equals]
             tag_filter["their_did"] = their_did
         if my_did:
             tag_filter["my_did"] = my_did
+        post_filter = {}
         if initiator:
-            tag_filter["initiator"] = initiator
-        return await cls.retrieve_by_tag_filter(context, tag_filter)
+            post_filter["initiator"] = initiator
+        return await cls.retrieve_by_tag_filter(context, tag_filter, post_filter)
 
     @classmethod
     async def retrieve_by_invitation_key(
@@ -166,10 +167,11 @@ class ConnectionRecord(BaseRecord):  # lgtm[py/missing-equals]
             invitation_key: The key on the originating invitation
             initiator: Filter by the initiator value
         """
-        tag_filter = {"invitation_key": invitation_key, "state": cls.STATE_INVITATION}
+        tag_filter = {"invitation_key": invitation_key}
+        post_filter = {"state": cls.STATE_INVITATION}
         if initiator:
-            tag_filter["initiator"] = initiator
-        return await cls.retrieve_by_tag_filter(context, tag_filter)
+            post_filter["initiator"] = initiator
+        return await cls.retrieve_by_tag_filter(context, tag_filter, post_filter)
 
     @classmethod
     async def retrieve_by_request_id(

--- a/aries_cloudagent/messaging/connections/models/connection_record.py
+++ b/aries_cloudagent/messaging/connections/models/connection_record.py
@@ -32,6 +32,14 @@ class ConnectionRecord(BaseRecord):  # lgtm[py/missing-equals]
     WEBHOOK_TOPIC_ACTIVITY = "connections_activity"
     LOG_STATE_FLAG = "debug.connections"
     CACHE_ENABLED = True
+    TAG_NAMES = {
+        "initiator",
+        "my_did",
+        "their_did",
+        "request_id",
+        "invitation_key",
+        "state",
+    }
 
     RECORD_TYPE = "connection"
     RECORD_TYPE_ACTIVITY = "connection_activity"
@@ -108,26 +116,17 @@ class ConnectionRecord(BaseRecord):  # lgtm[py/missing-equals]
     @property
     def record_value(self) -> dict:
         """Accessor to for the JSON record value properties for this connection."""
-        return {"error_msg": self.error_msg, "their_label": self.their_label}
-
-    @property
-    def record_tags(self) -> dict:
-        """Accessor for the record tags generated for this connection."""
         return {
             prop: getattr(self, prop)
             for prop in (
-                "my_did",
-                "their_did",
                 "their_role",
                 "inbound_connection_id",
-                "initiator",
-                "invitation_key",
-                "request_id",
-                "state",
                 "routing_state",
                 "accept",
                 "invitation_mode",
                 "alias",
+                "error_msg",
+                "their_label",
             )
         }
 
@@ -378,29 +377,21 @@ class ConnectionRecordSchema(BaseRecordSchema):
         model_class = ConnectionRecord
 
     connection_id = fields.Str(
-        required=False,
-        description="Connection identifier",
-        example=UUIDFour.EXAMPLE,
+        required=False, description="Connection identifier", example=UUIDFour.EXAMPLE
     )
     my_did = fields.Str(
-        required=False,
-        description="Our DID for connection",
-        **INDY_DID
+        required=False, description="Our DID for connection", **INDY_DID
     )
     their_did = fields.Str(
-        required=False,
-        description="Their DID for connection",
-        **INDY_DID
+        required=False, description="Their DID for connection", **INDY_DID
     )
     their_label = fields.Str(
-        required=False,
-        description="Their label for connection",
-        example="Bob"
+        required=False, description="Their label for connection", example="Bob"
     )
     their_role = fields.Str(
         required=False,
         description="Their assigned role for connection",
-        example="Point of contact"
+        example="Point of contact",
     )
     inbound_connection_id = fields.Str(
         required=False,
@@ -414,9 +405,7 @@ class ConnectionRecordSchema(BaseRecordSchema):
         validate=OneOf(["self", "external", "multiuse"]),
     )
     invitation_key = fields.Str(
-        required=False,
-        description="Public key for connection",
-        **INDY_RAW_PUBLIC_KEY
+        required=False, description="Public key for connection", **INDY_RAW_PUBLIC_KEY
     )
     request_id = fields.Str(
         required=False,
@@ -443,7 +432,7 @@ class ConnectionRecordSchema(BaseRecordSchema):
         required=False,
         description="Invitation mode: once or multi",
         example=ConnectionRecord.INVITATION_MODE_ONCE,
-        validate=OneOf(["once", "multi"])
+        validate=OneOf(["once", "multi"]),
     )
     alias = fields.Str(
         required=False,

--- a/aries_cloudagent/messaging/connections/routes.py
+++ b/aries_cloudagent/messaging/connections/routes.py
@@ -125,17 +125,23 @@ async def connections_list(request: web.BaseRequest):
     context = request.app["request_context"]
     tag_filter = {}
     for param_name in (
-        "alias",
-        "initiator",
         "invitation_id",
         "my_did",
-        "state",
         "their_did",
-        "their_role",
+        "request_id",
     ):
         if param_name in request.query and request.query[param_name] != "":
             tag_filter[param_name] = request.query[param_name]
-    records = await ConnectionRecord.query(context, tag_filter)
+    post_filter = {}
+    for param_name in (
+        "alias",
+        "initiator",
+        "state",
+        "their_role",
+    ):
+        if param_name in request.query and request.query[param_name] != "":
+            post_filter[param_name] = request.query[param_name]
+    records = await ConnectionRecord.query(context, tag_filter, post_filter)
     results = []
     for record in records:
         row = record.serialize()

--- a/aries_cloudagent/messaging/credentials/manager.py
+++ b/aries_cloudagent/messaging/credentials/manager.py
@@ -342,8 +342,10 @@ class CredentialManager:
 
         credential_exchange_record = await CredentialExchange.retrieve_by_tag_filter(
             self.context,
-            tag_filter={
+            {
                 "thread_id": credential_request_message._thread_id,
+            },
+            {
                 "initiator": "self",
             },
         )
@@ -443,8 +445,10 @@ class CredentialManager:
                 credential_exchange_record
             ) = await CredentialExchange.retrieve_by_tag_filter(
                 self.context,
-                tag_filter={
+                {
                     "thread_id": credential_message._thread_id,
+                },
+                {
                     "initiator": "external",
                 },
             )
@@ -462,8 +466,10 @@ class CredentialManager:
                 credential_exchange_record
             ) = await CredentialExchange.retrieve_by_tag_filter(
                 self.context,
-                tag_filter={
+                {
                     "thread_id": credential_message._thread.pthid,
+                },
+                {
                     "initiator": "external",
                 },
             )
@@ -583,8 +589,10 @@ class CredentialManager:
         # Get current exchange record by thread id
         credential_exchange_record = await CredentialExchange.retrieve_by_tag_filter(
             self.context,
-            tag_filter={
+            {
                 "thread_id": credential_stored_message._thread_id,
+            },
+            {
                 "initiator": "self",
             },
         )

--- a/aries_cloudagent/messaging/credentials/manager.py
+++ b/aries_cloudagent/messaging/credentials/manager.py
@@ -340,14 +340,10 @@ class CredentialManager:
 
         credential_request = json.loads(credential_request_message.request)
 
-        credential_exchange_record = await CredentialExchange.retrieve_by_tag_filter(
-            self.context,
-            {
-                "thread_id": credential_request_message._thread_id,
-            },
-            {
-                "initiator": "self",
-            },
+        (
+            credential_exchange_record
+        ) = await CredentialExchange.retrieve_by_thread_and_initiator(
+            self.context, credential_request_message._thread_id, "self"
         )
         credential_exchange_record.credential_request = credential_request
         credential_exchange_record.state = CredentialExchange.STATE_REQUEST_RECEIVED
@@ -443,14 +439,8 @@ class CredentialManager:
         try:
             (
                 credential_exchange_record
-            ) = await CredentialExchange.retrieve_by_tag_filter(
-                self.context,
-                {
-                    "thread_id": credential_message._thread_id,
-                },
-                {
-                    "initiator": "external",
-                },
+            ) = await CredentialExchange.retrieve_by_thread_and_initiator(
+                self.context, credential_message._thread_id, "external"
             )
         except StorageNotFoundError:
 
@@ -464,14 +454,8 @@ class CredentialManager:
             # credential_request_metadata
             (
                 credential_exchange_record
-            ) = await CredentialExchange.retrieve_by_tag_filter(
-                self.context,
-                {
-                    "thread_id": credential_message._thread.pthid,
-                },
-                {
-                    "initiator": "external",
-                },
+            ) = await CredentialExchange.retrieve_by_thread_and_initiator(
+                self.context, credential_message._thread.pthid, "external"
             )
 
             # Copy values from parent but create new record on save (no id)
@@ -587,14 +571,10 @@ class CredentialManager:
         """
 
         # Get current exchange record by thread id
-        credential_exchange_record = await CredentialExchange.retrieve_by_tag_filter(
-            self.context,
-            {
-                "thread_id": credential_stored_message._thread_id,
-            },
-            {
-                "initiator": "self",
-            },
+        (
+            credential_exchange_record
+        ) = await CredentialExchange.retrieve_by_thread_and_initiator(
+            self.context, credential_stored_message._thread_id, "self"
         )
 
         credential_exchange_record.state = CredentialExchange.STATE_STORED

--- a/aries_cloudagent/messaging/credentials/models/credential_exchange.py
+++ b/aries_cloudagent/messaging/credentials/models/credential_exchange.py
@@ -17,6 +17,7 @@ class CredentialExchange(BaseRecord):
     RECORD_ID_NAME = "credential_exchange_id"
     WEBHOOK_TOPIC = "credentials"
     LOG_STATE_FLAG = "debug.credentials"
+    TAG_NAMES = {"connection_id", "thread_id", "initiator", "state"}
 
     INITIATOR_SELF = "self"
     INITIATOR_EXTERNAL = "external"
@@ -90,19 +91,6 @@ class CredentialExchange(BaseRecord):
                 "credential",
                 "raw_credential",
                 "parent_thread_id",
-            )
-        }
-
-    @property
-    def record_tags(self) -> dict:
-        """Accessor for the record tags generated for this credential exchange."""
-        return {
-            prop: getattr(self, prop)
-            for prop in (
-                "connection_id",
-                "thread_id",
-                "initiator",
-                "state",
                 "credential_definition_id",
                 "schema_id",
                 "credential_id",

--- a/aries_cloudagent/messaging/credentials/models/credential_exchange.py
+++ b/aries_cloudagent/messaging/credentials/models/credential_exchange.py
@@ -17,7 +17,7 @@ class CredentialExchange(BaseRecord):
     RECORD_ID_NAME = "credential_exchange_id"
     WEBHOOK_TOPIC = "credentials"
     LOG_STATE_FLAG = "debug.credentials"
-    TAG_NAMES = {"connection_id", "thread_id", "initiator", "state"}
+    TAG_NAMES = {"thread_id"}
 
     INITIATOR_SELF = "self"
     INITIATOR_EXTERNAL = "external"
@@ -82,6 +82,8 @@ class CredentialExchange(BaseRecord):
         return {
             prop: getattr(self, prop)
             for prop in (
+                "connection_id",
+                "initiator",
                 "credential_offer",
                 "credential_request",
                 "credential_request_metadata",
@@ -94,6 +96,7 @@ class CredentialExchange(BaseRecord):
                 "credential_definition_id",
                 "schema_id",
                 "credential_id",
+                "state",
             )
         }
 

--- a/aries_cloudagent/messaging/credentials/routes.py
+++ b/aries_cloudagent/messaging/credentials/routes.py
@@ -264,6 +264,9 @@ async def credential_exchange_list(request: web.BaseRequest):
     """
     context = request.app["request_context"]
     tag_filter = {}
+    if "thread_id" in request.query and request.query["thread_id"] != "":
+        tag_filter["thread_id"] = request.query["thread_id"]
+    post_filter = {}
     for param_name in (
         "connection_id",
         "initiator",
@@ -272,8 +275,8 @@ async def credential_exchange_list(request: web.BaseRequest):
         "schema_id",
     ):
         if param_name in request.query and request.query[param_name] != "":
-            tag_filter[param_name] = request.query[param_name]
-    records = await CredentialExchange.query(context, tag_filter)
+            post_filter[param_name] = request.query[param_name]
+    records = await CredentialExchange.query(context, tag_filter, post_filter)
     return web.json_response({"results": [record.serialize() for record in records]})
 
 

--- a/aries_cloudagent/messaging/credentials/tests/test_manager.py
+++ b/aries_cloudagent/messaging/credentials/tests/test_manager.py
@@ -33,7 +33,7 @@ class TestCredentialManager(AsyncTestCase):
             mock_json.loads.return_value = async_mock.MagicMock()
 
             mock_credential_exchange_instance = (
-                mock_credential_exchange.retrieve_by_tag_filter.return_value
+                mock_credential_exchange.retrieve_by_thread_and_initiator.return_value
             ) = async_mock.CoroutineMock()
 
             mock_credential_exchange_instance.save = async_mock.CoroutineMock()
@@ -75,7 +75,7 @@ class TestCredentialManager(AsyncTestCase):
             mock_json.loads.return_value = async_mock.MagicMock()
 
             mock_credential_exchange_instance = (
-                mock_credential_exchange.retrieve_by_tag_filter.return_value
+                mock_credential_exchange.retrieve_by_thread_and_initiator.return_value
             ) = async_mock.CoroutineMock()
 
             mock_credential_exchange_instance.save = async_mock.CoroutineMock()
@@ -116,7 +116,7 @@ class TestCredentialManager(AsyncTestCase):
             mock_json.loads.return_value = async_mock.MagicMock()
 
             mock_credential_exchange_instance = (
-                mock_credential_exchange.retrieve_by_tag_filter.return_value
+                mock_credential_exchange.retrieve_by_thread_and_initiator.return_value
             ) = async_mock.CoroutineMock()
 
             mock_credential_exchange_instance.save = async_mock.CoroutineMock()
@@ -171,7 +171,7 @@ class TestCredentialManager(AsyncTestCase):
             mock_json.loads.return_value = async_mock.MagicMock()
 
             mock_credential_exchange_instance = (
-                mock_credential_exchange.retrieve_by_tag_filter.return_value
+                mock_credential_exchange.retrieve_by_thread_and_initiator.return_value
             ) = async_mock.CoroutineMock()
 
             mock_credential_exchange_instance.save = async_mock.CoroutineMock()
@@ -226,7 +226,7 @@ class TestCredentialManager(AsyncTestCase):
             mock_json.loads.return_value = async_mock.MagicMock()
 
             mock_credential_exchange_instance = (
-                mock_credential_exchange.retrieve_by_tag_filter.return_value
+                mock_credential_exchange.retrieve_by_thread_and_initiator.return_value
             ) = async_mock.CoroutineMock()
 
             mock_credential_exchange_instance.save = async_mock.CoroutineMock()

--- a/aries_cloudagent/messaging/issue_credential/v1_0/handlers/credential_offer_handler.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/handlers/credential_offer_handler.py
@@ -6,7 +6,7 @@ from ....base_handler import (
     BaseHandler,
     BaseResponder,
     HandlerException,
-    RequestContext
+    RequestContext,
 )
 from ..manager import CredentialManager
 from ..messages.credential_offer import CredentialOffer
@@ -30,8 +30,7 @@ class CredentialOfferHandler(BaseHandler):
         assert isinstance(context.message, CredentialOffer)
 
         self._logger.info(
-            "Received credential offer: %s",
-            context.message.serialize(as_string=True)
+            "Received credential offer: %s", context.message.serialize(as_string=True)
         )
 
         if not context.connection_ready:
@@ -44,20 +43,18 @@ class CredentialOfferHandler(BaseHandler):
             comment=context.message.comment,
             credential_proposal=context.message.credential_preview,
             cred_def_id=indy_offer["cred_def_id"],
-            schema_id=indy_offer["schema_id"]
+            schema_id=indy_offer["schema_id"],
         ).serialize()
 
         # Get credential exchange record (holder sent proposal first)
         # or create it (issuer sent offer first)
         try:
-            credential_exchange_record = (
-                await V10CredentialExchange.retrieve_by_tag_filter(
-                    context,
-                    {
-                        "thread_id": context.message._thread_id,
-                        "connection_id": context.connection_record.connection_id
-                    }
-                )
+            (
+                credential_exchange_record
+            ) = await V10CredentialExchange.retrieve_by_tag_filter(
+                context,
+                {"thread_id": context.message._thread_id},
+                {"connection_id": context.connection_record.connection_id},
             )
             credential_exchange_record.credential_proposal_dict = (
                 credential_proposal_dict
@@ -70,7 +67,7 @@ class CredentialOfferHandler(BaseHandler):
                 role=V10CredentialExchange.ROLE_HOLDER,
                 credential_definition_id=indy_offer["cred_def_id"],
                 schema_id=indy_offer["schema_id"],
-                credential_proposal_dict=credential_proposal_dict
+                credential_proposal_dict=credential_proposal_dict,
             )
 
         credential_exchange_record.credential_offer = indy_offer

--- a/aries_cloudagent/messaging/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/manager.py
@@ -474,10 +474,8 @@ class CredentialManager:
 
         credential_exchange_record = await V10CredentialExchange.retrieve_by_tag_filter(
             self.context,
-            tag_filter={
-                "thread_id": credential_request_message._thread_id,
-                "connection_id": self.context.connection_record.connection_id,
-            },
+            {"thread_id": credential_request_message._thread_id},
+            {"connection_id": self.context.connection_record.connection_id},
         )
         credential_exchange_record.credential_request = credential_request
         credential_exchange_record.state = V10CredentialExchange.STATE_REQUEST_RECEIVED
@@ -568,10 +566,8 @@ class CredentialManager:
             credential_exchange_record = await (
                 V10CredentialExchange.retrieve_by_tag_filter(
                     self.context,
-                    tag_filter={
-                        "thread_id": credential_message._thread_id,
-                        "connection_id": self.context.connection_record.connection_id,
-                    },
+                    {"thread_id": credential_message._thread_id},
+                    {"connection_id": self.context.connection_record.connection_id},
                 )
             )
         except StorageNotFoundError:
@@ -586,10 +582,8 @@ class CredentialManager:
             credential_exchange_record = await (
                 V10CredentialExchange.retrieve_by_tag_filter(
                     self.context,
-                    tag_filter={
-                        "thread_id": credential_message._thread.pthid,
-                        "connection_id": self.context.connection_record.connection_id,
-                    },
+                    {"thread_id": credential_message._thread.pthid},
+                    {"connection_id": self.context.connection_record.connection_id},
                 )
             )
 
@@ -708,10 +702,8 @@ class CredentialManager:
         credential_stored_message = self.context.message
         credential_exchange_record = await V10CredentialExchange.retrieve_by_tag_filter(
             self.context,
-            tag_filter={
-                "thread_id": credential_stored_message._thread_id,
-                "connection_id": self.context.connection_record.connection_id,
-            },
+            {"thread_id": credential_stored_message._thread_id},
+            {"connection_id": self.context.connection_record.connection_id},
         )
 
         credential_exchange_record.state = V10CredentialExchange.STATE_STORED

--- a/aries_cloudagent/messaging/issue_credential/v1_0/models/credential_exchange.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/models/credential_exchange.py
@@ -18,7 +18,7 @@ class V10CredentialExchange(BaseRecord):
     RECORD_TYPE = "credential_exchange_v10"
     RECORD_ID_NAME = "credential_exchange_id"
     WEBHOOK_TOPIC = "issue_credential"
-    TAG_NAMES = {"connection_id", "thread_id", "role", "state"}
+    TAG_NAMES = {"thread_id"}
 
     INITIATOR_SELF = "self"
     INITIATOR_EXTERNAL = "external"
@@ -92,6 +92,7 @@ class V10CredentialExchange(BaseRecord):
         return {
             prop: getattr(self, prop)
             for prop in (
+                "connection_id",
                 "credential_proposal_dict",
                 "credential_offer",
                 "credential_request",
@@ -106,6 +107,8 @@ class V10CredentialExchange(BaseRecord):
                 "credential_definition_id",
                 "schema_id",
                 "credential_id",
+                "role",
+                "state",
             )
         }
 

--- a/aries_cloudagent/messaging/issue_credential/v1_0/models/credential_exchange.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/models/credential_exchange.py
@@ -18,6 +18,7 @@ class V10CredentialExchange(BaseRecord):
     RECORD_TYPE = "credential_exchange_v10"
     RECORD_ID_NAME = "credential_exchange_id"
     WEBHOOK_TOPIC = "issue_credential"
+    TAG_NAMES = {"connection_id", "thread_id", "role", "state"}
 
     INITIATOR_SELF = "self"
     INITIATOR_EXTERNAL = "external"
@@ -88,42 +89,25 @@ class V10CredentialExchange(BaseRecord):
     @property
     def record_value(self) -> dict:
         """Accessor for the JSON record value generated for this credential exchange."""
-        result = self.tags
-        for prop in (
-            "credential_proposal_dict",
-            "credential_offer",
-            "credential_request",
-            "credential_request_metadata",
-            "error_msg",
-            "auto_offer",
-            "auto_issue",
-            "raw_credential",
-            "credential",
-            "parent_thread_id",
-        ):
-            val = getattr(self, prop)
-            if val:
-                result[prop] = val
-        return result
-
-    @property
-    def record_tags(self) -> dict:
-        """Accessor for the record tags generated for this credential exchange."""
-        result = {}
-        for prop in (
-            "connection_id",
-            "thread_id",
-            "initiator",
-            "role",
-            "state",
-            "credential_definition_id",
-            "schema_id",
-            "credential_id",
-        ):
-            val = getattr(self, prop)
-            if val:
-                result[prop] = val
-        return result
+        return {
+            prop: getattr(self, prop)
+            for prop in (
+                "credential_proposal_dict",
+                "credential_offer",
+                "credential_request",
+                "credential_request_metadata",
+                "error_msg",
+                "auto_offer",
+                "auto_issue",
+                "raw_credential",
+                "credential",
+                "parent_thread_id",
+                "initiator",
+                "credential_definition_id",
+                "schema_id",
+                "credential_id",
+            )
+        }
 
 
 class V10CredentialExchangeSchema(BaseRecordSchema):
@@ -140,19 +124,13 @@ class V10CredentialExchangeSchema(BaseRecordSchema):
         example=UUIDFour.EXAMPLE,
     )
     connection_id = fields.Str(
-        required=False,
-        description="Connection identifier",
-        example=UUIDFour.EXAMPLE,
+        required=False, description="Connection identifier", example=UUIDFour.EXAMPLE
     )
     thread_id = fields.Str(
-        required=False,
-        description="Thread identifier",
-        example=UUIDFour.EXAMPLE,
+        required=False, description="Thread identifier", example=UUIDFour.EXAMPLE
     )
     parent_thread_id = fields.Str(
-        required=False,
-        description="Parent thread identifier",
-        example=UUIDFour.EXAMPLE,
+        required=False, description="Parent thread identifier", example=UUIDFour.EXAMPLE
     )
     initiator = fields.Str(
         required=False,
@@ -177,39 +155,28 @@ class V10CredentialExchangeSchema(BaseRecordSchema):
         **INDY_CRED_DEF_ID
     )
     schema_id = fields.Str(
-        required=False,
-        description="Schema identifier",
-        **INDY_SCHEMA_ID
+        required=False, description="Schema identifier", **INDY_SCHEMA_ID
     )
     credential_proposal_dict = fields.Dict(
-        required=False,
-        description="Serialized credential proposal message"
+        required=False, description="Serialized credential proposal message"
     )
     credential_offer = fields.Dict(
-        required=False,
-        description="(Indy) credential offer",
+        required=False, description="(Indy) credential offer"
     )
     credential_request = fields.Dict(
-        required=False,
-        description="(Indy) credential request",
+        required=False, description="(Indy) credential request"
     )
     credential_request_metadata = fields.Dict(
-        required=False,
-        description="(Indy) credential request metadata",
+        required=False, description="(Indy) credential request metadata"
     )
     credential_id = fields.Str(
-        required=False,
-        description="Credential identifier",
-        example=UUIDFour.EXAMPLE,
+        required=False, description="Credential identifier", example=UUIDFour.EXAMPLE
     )
     raw_credential = fields.Dict(
         required=False,
-        description="Credential as received, prior to storage in holder wallet"
+        description="Credential as received, prior to storage in holder wallet",
     )
-    credential = fields.Dict(
-        required=False,
-        description="Credential as stored",
-    )
+    credential = fields.Dict(required=False, description="Credential as stored")
     auto_offer = fields.Bool(
         required=False,
         description="Holder choice to accept offer in this credential exchange",

--- a/aries_cloudagent/messaging/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/routes.py
@@ -144,15 +144,17 @@ async def credential_exchange_list(request: web.BaseRequest):
     """
     context = request.app["request_context"]
     tag_filter = {}
+    if "thread_id" in request.query and request.query["thread_id"] != "":
+        tag_filter["thread_id"] = request.query["thread_id"]
+    post_filter = {}
     for param_name in (
         "connection_id",
         "role",
         "state",
-        "thread_id",
     ):
         if param_name in request.query and request.query[param_name] != "":
-            tag_filter[param_name] = request.query[param_name]
-    records = await V10CredentialExchange.query(context, tag_filter)
+            post_filter[param_name] = request.query[param_name]
+    records = await V10CredentialExchange.query(context, tag_filter, post_filter)
     return web.json_response({"results": [record.serialize() for record in records]})
 
 

--- a/aries_cloudagent/messaging/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/routes.py
@@ -146,10 +146,9 @@ async def credential_exchange_list(request: web.BaseRequest):
     tag_filter = {}
     for param_name in (
         "connection_id",
-        "initiator",
+        "role",
         "state",
-        "credential_definition_id",
-        "schema_id",
+        "thread_id",
     ):
         if param_name in request.query and request.query[param_name] != "":
             tag_filter[param_name] = request.query[param_name]

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -222,14 +222,14 @@ class BaseRecord(BaseModel):
             post_filter: Additional value filters to apply after retrieval
         """
         storage: BaseStorage = await context.inject(BaseStorage)
-        result = storage.search_records(
+        query = storage.search_records(
             cls.RECORD_TYPE,
             cls.prefix_tag_filter(tag_filter),
             None,
             {"retrieveTags": False},
         )
         found = None
-        async for record in result:
+        async for record in query:
             vals = json.loads(record.value)
             if not post_filter or match_post_filter(vals, post_filter):
                 if found:
@@ -254,14 +254,14 @@ class BaseRecord(BaseModel):
             post_filter: Additional value filters to apply
         """
         storage: BaseStorage = await context.inject(BaseStorage)
-        result = storage.search_records(
+        query = storage.search_records(
             cls.RECORD_TYPE,
             cls.prefix_tag_filter(tag_filter),
             None,
             {"retrieveTags": False},
         )
         result = []
-        async for record in result:
+        async for record in query:
             vals = json.loads(record.value)
             if not post_filter or match_post_filter(vals, post_filter):
                 result.append(cls.from_storage(record.id, vals))

--- a/aries_cloudagent/messaging/models/tests/test_base_record.py
+++ b/aries_cloudagent/messaging/models/tests/test_base_record.py
@@ -26,7 +26,7 @@ class BaseRecordImplSchema(BaseRecordSchema):
 
 
 class UnencTestImpl(BaseRecord):
-    UNENCRYPTED_TAGS = {"a", "b"}
+    TAG_NAMES = {"~a", "~b", "c"}
 
 
 class TestBaseRecord(AsyncTestCase):

--- a/aries_cloudagent/messaging/models/tests/test_base_record.py
+++ b/aries_cloudagent/messaging/models/tests/test_base_record.py
@@ -126,7 +126,7 @@ class TestBaseRecord(AsyncTestCase):
             mock_storage.get_record.return_value = stored
             result = await BaseRecordImpl.retrieve_by_id(context, record_id, False)
             mock_storage.get_record.assert_awaited_once_with(
-                BaseRecordImpl.RECORD_TYPE, record_id
+                BaseRecordImpl.RECORD_TYPE, record_id, {"retrieveTags": False}
             )
             set_cached_key.assert_awaited_once_with(
                 context, cache_key.return_value, record_value
@@ -146,12 +146,10 @@ class TestBaseRecord(AsyncTestCase):
             BaseRecordImpl.RECORD_TYPE, json.dumps(record_value), {}, record_id
         )
 
-        mock_storage.search_records.return_value.fetch_all = async_mock.CoroutineMock(
-            return_value=[stored]
-        )
+        mock_storage.search_records.return_value.__aiter__.return_value = [stored]
         result = await BaseRecordImpl.query(context, tag_filter)
         mock_storage.search_records.assert_called_once_with(
-            BaseRecordImpl.RECORD_TYPE, tag_filter
+            BaseRecordImpl.RECORD_TYPE, tag_filter, None, {"retrieveTags": False}
         )
         assert result and isinstance(result[0], BaseRecordImpl)
         assert result[0]._id == record_id

--- a/aries_cloudagent/messaging/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/messaging/present_proof/v1_0/manager.py
@@ -76,8 +76,7 @@ class PresentationManager:
             auto_present=auto_present,
         )
         await presentation_exchange_record.save(
-            self.context,
-            reason="create presentation proposal"
+            self.context, reason="create presentation proposal"
         )
 
         return presentation_exchange_record
@@ -128,14 +127,12 @@ class PresentationManager:
             A tuple (updated presentation exchange record, presentation request message)
 
         """
-        indy_proof_request = (
-            await (
-                PresentationProposal.deserialize(
-                    presentation_exchange_record.presentation_proposal_dict
-                )
-            ).presentation_proposal.indy_proof_request(
-                name=name, version=version, nonce=nonce
+        indy_proof_request = await (
+            PresentationProposal.deserialize(
+                presentation_exchange_record.presentation_proposal_dict
             )
+        ).presentation_proposal.indy_proof_request(
+            name=name, version=version, nonce=nonce
         )
 
         presentation_request_message = PresentationRequest(
@@ -155,8 +152,7 @@ class PresentationManager:
         presentation_exchange_record.state = V10PresentationExchange.STATE_REQUEST_SENT
         presentation_exchange_record.presentation_request = indy_proof_request
         await presentation_exchange_record.save(
-            self.context,
-            reason="create (bound) presentation request"
+            self.context, reason="create (bound) presentation request"
         )
 
         return presentation_exchange_record, presentation_request_message
@@ -185,8 +181,7 @@ class PresentationManager:
             presentation_request=presentation_request_message.indy_proof_request(),
         )
         await presentation_exchange_record.save(
-            self.context,
-            reason="create (free) presentation request"
+            self.context, reason="create (free) presentation request"
         )
 
         return presentation_exchange_record
@@ -309,8 +304,7 @@ class PresentationManager:
             comment=comment,
             presentations_attach=[
                 AttachDecorator.from_indy_dict(
-                    indy_dict=indy_proof,
-                    ident=ATTACH_DECO_IDS[PRESENTATION],
+                    indy_dict=indy_proof, ident=ATTACH_DECO_IDS[PRESENTATION]
                 )
             ],
         )
@@ -342,10 +336,8 @@ class PresentationManager:
             presentation_exchange_record
         ) = await V10PresentationExchange.retrieve_by_tag_filter(
             self.context,
-            tag_filter={
-                "thread_id": thread_id,
-                "connection_id": self.context.connection_record.connection_id
-            },
+            {"thread_id": thread_id},
+            {"connection_id": self.context.connection_record.connection_id},
         )
 
         presentation_exchange_record.presentation = presentation
@@ -354,8 +346,7 @@ class PresentationManager:
         )
 
         await presentation_exchange_record.save(
-            self.context,
-            reason="receive presentation"
+            self.context, reason="receive presentation"
         )
 
         return presentation_exchange_record
@@ -412,8 +403,7 @@ class PresentationManager:
         presentation_exchange_record.state = V10PresentationExchange.STATE_VERIFIED
 
         await presentation_exchange_record.save(
-            self.context,
-            reason="verify presentation"
+            self.context, reason="verify presentation"
         )
 
         return presentation_exchange_record

--- a/aries_cloudagent/messaging/present_proof/v1_0/models/presentation_exchange.py
+++ b/aries_cloudagent/messaging/present_proof/v1_0/models/presentation_exchange.py
@@ -18,12 +18,13 @@ class V10PresentationExchange(BaseRecord):
     RECORD_TYPE = "presentation_exchange_v10"
     RECORD_ID_NAME = "presentation_exchange_id"
     WEBHOOK_TOPIC = "present_proof"
+    TAG_NAMES = {"connection_id", "thread_id", "role", "state"}
 
     INITIATOR_SELF = "self"
     INITIATOR_EXTERNAL = "external"
 
-    ROLE_PROVER = 'prover'
-    ROLE_VERIFIER = 'verifier'
+    ROLE_PROVER = "prover"
+    ROLE_VERIFIER = "verifier"
 
     STATE_PROPOSAL_SENT = "proposal_sent"
     STATE_PROPOSAL_RECEIVED = "proposal_received"
@@ -72,34 +73,18 @@ class V10PresentationExchange(BaseRecord):
     @property
     def record_value(self) -> dict:
         """Accessor for JSON record value generated for this presentation exchange."""
-        result = self.tags
-        for prop in (
-            "presentation_proposal_dict",
-            "presentation_request",
-            "presentation",
-            "auto_present",
-            "error_msg",
-        ):
-            val = getattr(self, prop)
-            if val:
-                result[prop] = val
-        return result
-
-    @property
-    def record_tags(self) -> dict:
-        """Accessor for the record tags generated for this presentation exchange."""
-        result = {}
-        for prop in (
-                "connection_id",
-                "thread_id",
+        return {
+            prop: getattr(self, prop)
+            for prop in (
                 "initiator",
-                "role",
-                "state",
-                "verified"):
-            val = getattr(self, prop)
-            if val:
-                result[prop] = val
-        return result
+                "presentation_proposal_dict",
+                "presentation_request",
+                "presentation",
+                "auto_present",
+                "error_msg",
+                "verified",
+            )
+        }
 
 
 class V10PresentationExchangeSchema(BaseRecordSchema):
@@ -143,16 +128,14 @@ class V10PresentationExchangeSchema(BaseRecordSchema):
         example=V10PresentationExchange.STATE_VERIFIED,
     )
     presentation_proposal_dict = fields.Dict(
-        required=False,
-        description="Serialized presentation proposal message",
+        required=False, description="Serialized presentation proposal message"
     )
     presentation_request = fields.Dict(
         required=False,
         description="(Indy) presentation request (also known as proof request)",
     )
     presentation = fields.Dict(
-        required=False,
-        description="(Indy) presentation (also known as proof)"
+        required=False, description="(Indy) presentation (also known as proof)"
     )
     verified = fields.Str(  # tag: must be a string
         required=False,
@@ -166,7 +149,5 @@ class V10PresentationExchangeSchema(BaseRecordSchema):
         example=False,
     )
     error_msg = fields.Str(
-        required=False,
-        description="Error message",
-        example="Invalid structure"
+        required=False, description="Error message", example="Invalid structure"
     )

--- a/aries_cloudagent/messaging/present_proof/v1_0/models/presentation_exchange.py
+++ b/aries_cloudagent/messaging/present_proof/v1_0/models/presentation_exchange.py
@@ -18,7 +18,7 @@ class V10PresentationExchange(BaseRecord):
     RECORD_TYPE = "presentation_exchange_v10"
     RECORD_ID_NAME = "presentation_exchange_id"
     WEBHOOK_TOPIC = "present_proof"
-    TAG_NAMES = {"connection_id", "thread_id", "role", "state"}
+    TAG_NAMES = {"thread_id"}
 
     INITIATOR_SELF = "self"
     INITIATOR_EXTERNAL = "external"
@@ -76,10 +76,13 @@ class V10PresentationExchange(BaseRecord):
         return {
             prop: getattr(self, prop)
             for prop in (
+                "connection_id",
                 "initiator",
                 "presentation_proposal_dict",
                 "presentation_request",
                 "presentation",
+                "role",
+                "state",
                 "auto_present",
                 "error_msg",
                 "verified",

--- a/aries_cloudagent/messaging/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/messaging/present_proof/v1_0/routes.py
@@ -282,9 +282,8 @@ async def presentation_exchange_list(request: web.BaseRequest):
     for param_name in (
         "connection_id",
         "thread_id",
-        "initiator",
+        "role",
         "state",
-        "verified"
     ):
         if param_name in request.query and request.query[param_name] != "":
             tag_filter[param_name] = request.query[param_name]

--- a/aries_cloudagent/messaging/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/messaging/present_proof/v1_0/routes.py
@@ -279,15 +279,17 @@ async def presentation_exchange_list(request: web.BaseRequest):
     """
     context = request.app["request_context"]
     tag_filter = {}
+    if "thread_id" in request.query and request.query["thread_id"] != "":
+        tag_filter["thread_id"] = request.query["thread_id"]
+    post_filter = {}
     for param_name in (
         "connection_id",
-        "thread_id",
         "role",
         "state",
     ):
         if param_name in request.query and request.query[param_name] != "":
-            tag_filter[param_name] = request.query[param_name]
-    records = await V10PresentationExchange.query(context, tag_filter)
+            post_filter[param_name] = request.query[param_name]
+    records = await V10PresentationExchange.query(context, tag_filter, post_filter)
     return web.json_response({"results": [record.serialize() for record in records]})
 
 

--- a/aries_cloudagent/messaging/presentations/manager.py
+++ b/aries_cloudagent/messaging/presentations/manager.py
@@ -224,7 +224,7 @@ class PresentationManager:
         (
             presentation_exchange_record
         ) = await PresentationExchange.retrieve_by_tag_filter(
-            self.context, tag_filter={"thread_id": thread_id, "initiator": "self"}
+            self.context, {"thread_id": thread_id}, {"initiator": "self"}
         )
 
         presentation_exchange_record.presentation = presentation

--- a/aries_cloudagent/messaging/presentations/models/presentation_exchange.py
+++ b/aries_cloudagent/messaging/presentations/models/presentation_exchange.py
@@ -17,7 +17,7 @@ class PresentationExchange(BaseRecord):
     RECORD_ID_NAME = "presentation_exchange_id"
     WEBHOOK_TOPIC = "presentations"
     LOG_STATE_FLAG = "debug.presentations"
-    TAG_NAMES = ("connection_id", "initiator", "thread_id", "state")
+    TAG_NAMES = {"thread_id"}
 
     INITIATOR_SELF = "self"
     INITIATOR_EXTERNAL = "external"
@@ -64,10 +64,13 @@ class PresentationExchange(BaseRecord):
         return {
             prop: getattr(self, prop)
             for prop in (
+                "connection_id",
+                "initiator",
                 "presentation_request",
                 "presentation",
                 "error_msg",
                 "verified",
+                "state",
             )
         }
 

--- a/aries_cloudagent/messaging/presentations/models/presentation_exchange.py
+++ b/aries_cloudagent/messaging/presentations/models/presentation_exchange.py
@@ -17,6 +17,7 @@ class PresentationExchange(BaseRecord):
     RECORD_ID_NAME = "presentation_exchange_id"
     WEBHOOK_TOPIC = "presentations"
     LOG_STATE_FLAG = "debug.presentations"
+    TAG_NAMES = ("connection_id", "initiator", "thread_id", "state")
 
     INITIATOR_SELF = "self"
     INITIATOR_EXTERNAL = "external"
@@ -60,22 +61,15 @@ class PresentationExchange(BaseRecord):
     @property
     def record_value(self) -> dict:
         """Accessor for JSON record value generated for this presentation exchange."""
-        result = self.tags
-        for prop in ("presentation_request", "presentation", "error_msg"):
-            val = getattr(self, prop)
-            if val:
-                result[prop] = val
-        return result
-
-    @property
-    def record_tags(self) -> dict:
-        """Accessor for the record tags generated for this presentation exchange."""
-        result = {}
-        for prop in ("connection_id", "thread_id", "initiator", "state", "verified"):
-            val = getattr(self, prop)
-            if val:
-                result[prop] = val
-        return result
+        return {
+            prop: getattr(self, prop)
+            for prop in (
+                "presentation_request",
+                "presentation",
+                "error_msg",
+                "verified",
+            )
+        }
 
 
 class PresentationExchangeSchema(BaseRecordSchema):

--- a/aries_cloudagent/messaging/presentations/routes.py
+++ b/aries_cloudagent/messaging/presentations/routes.py
@@ -76,8 +76,6 @@ async def presentation_exchange_list(request: web.BaseRequest):
         "connection_id",
         "initiator",
         "state",
-        "credential_definition_id",
-        "schema_id",
     ):
         if param_name in request.query and request.query[param_name] != "":
             tag_filter[param_name] = request.query[param_name]

--- a/aries_cloudagent/messaging/presentations/routes.py
+++ b/aries_cloudagent/messaging/presentations/routes.py
@@ -72,14 +72,17 @@ async def presentation_exchange_list(request: web.BaseRequest):
     """
     context = request.app["request_context"]
     tag_filter = {}
+    if "thread_id" in request.query and request.query["thread_id"] != "":
+        tag_filter["thread_id"] = request.query["thread_id"]
+    post_filter = {}
     for param_name in (
         "connection_id",
         "initiator",
         "state",
     ):
         if param_name in request.query and request.query[param_name] != "":
-            tag_filter[param_name] = request.query[param_name]
-    records = await PresentationExchange.query(context, tag_filter)
+            post_filter[param_name] = request.query[param_name]
+    records = await PresentationExchange.query(context, tag_filter, post_filter)
     return web.json_response({"results": [record.serialize() for record in records]})
 
 

--- a/aries_cloudagent/storage/base.py
+++ b/aries_cloudagent/storage/base.py
@@ -24,13 +24,16 @@ class BaseStorage(ABC):
         """
 
     @abstractmethod
-    async def get_record(self, record_type: str, record_id: str) -> StorageRecord:
+    async def get_record(
+        self, record_type: str, record_id: str, options: Mapping = None
+    ) -> StorageRecord:
         """
         Fetch a record from the store by type and ID.
 
         Args:
             record_type: The record type
             record_id: The record id
+            options: A dictionary of backend-specific options
 
         Returns:
             A `StorageRecord` instance
@@ -84,7 +87,11 @@ class BaseStorage(ABC):
 
     @abstractmethod
     def search_records(
-        self, type_filter: str, tag_query: Mapping = None, page_size: int = None
+        self,
+        type_filter: str,
+        tag_query: Mapping = None,
+        page_size: int = None,
+        options: Mapping = None,
     ) -> "BaseStorageRecordSearch":
         """
         Create a new record query.
@@ -93,6 +100,7 @@ class BaseStorage(ABC):
             type_filter: Filter string
             tag_query: Tags to query
             page_size: Page size
+            options: Dictionary of backend-specific options
 
         Returns:
             An instance of `BaseStorageRecordSearch`
@@ -113,6 +121,7 @@ class BaseStorageRecordSearch(ABC):
         type_filter: str,
         tag_query: Mapping,
         page_size: int = None,
+        options: Mapping = None,
     ):
         """
         Initialize a `BaseStorageRecordSearch` instance.
@@ -122,6 +131,7 @@ class BaseStorageRecordSearch(ABC):
             type_filter: Filter string
             tag_query: Tags to search
             page_size: Size of page to return
+            options: Dictionary of backend-specific options
 
         """
         self._buffer = None
@@ -129,6 +139,7 @@ class BaseStorageRecordSearch(ABC):
         self._store = store
         self._tag_query = tag_query
         self._type_filter = type_filter
+        self._options = options or {}
 
     @property
     def handle(self):
@@ -148,7 +159,7 @@ class BaseStorageRecordSearch(ABC):
         return False
 
     @property
-    def page_size(self):
+    def page_size(self) -> int:
         """
         Accessor for page size.
 
@@ -170,7 +181,7 @@ class BaseStorageRecordSearch(ABC):
         return self._store
 
     @property
-    def tag_query(self):
+    def tag_query(self) -> Mapping:
         """
         Accessor for tag query.
 
@@ -181,7 +192,7 @@ class BaseStorageRecordSearch(ABC):
         return self._tag_query
 
     @property
-    def type_filter(self):
+    def type_filter(self) -> str:
         """
         Accessor for type filter.
 
@@ -190,6 +201,27 @@ class BaseStorageRecordSearch(ABC):
 
         """
         return self._type_filter
+
+    @property
+    def options(self) -> Mapping:
+        """
+        Accessor for the search options.
+
+        Returns:
+            The search options
+
+        """
+        return self._options
+
+    def option(self, name: str, default=None):
+        """
+        Fetch a named search option, if defined.
+
+        Return:
+            The option value or default
+
+        """
+        return self._options.get(name, default)
 
     @abstractmethod
     async def fetch(self, max_count: int) -> Sequence[StorageRecord]:

--- a/aries_cloudagent/storage/basic.py
+++ b/aries_cloudagent/storage/basic.py
@@ -47,13 +47,16 @@ class BasicStorage(BaseStorage):
             raise StorageDuplicateError("Duplicate record")
         self._records[record.id] = record
 
-    async def get_record(self, record_type: str, record_id: str) -> StorageRecord:
+    async def get_record(
+        self, record_type: str, record_id: str, options: Mapping = None
+    ) -> StorageRecord:
         """
         Fetch a record from the store by type and ID.
 
         Args:
             record_type: The record type
             record_id: The record id
+            options: A dictionary of backend-specific options
 
         Returns:
             A `StorageRecord` instance
@@ -142,7 +145,11 @@ class BasicStorage(BaseStorage):
         del self._records[record.id]
 
     def search_records(
-        self, type_filter: str, tag_query: Mapping = None, page_size: int = None
+        self,
+        type_filter: str,
+        tag_query: Mapping = None,
+        page_size: int = None,
+        options: Mapping = None,
     ) -> "BasicStorageRecordSearch":
         """
         Search stored records.
@@ -151,12 +158,15 @@ class BasicStorage(BaseStorage):
             type_filter: Filter string
             tag_query: Tags to query
             page_size: Page size
+            options: Dictionary of backend-specific options
 
         Returns:
             An instance of `BaseStorageRecordSearch`
 
         """
-        return BasicStorageRecordSearch(self, type_filter, tag_query, page_size)
+        return BasicStorageRecordSearch(
+            self, type_filter, tag_query, page_size, options
+        )
 
 
 def basic_tag_value_match(value: str, match: dict) -> bool:
@@ -237,6 +247,7 @@ class BasicStorageRecordSearch(BaseStorageRecordSearch):
         type_filter: str,
         tag_query: Mapping,
         page_size: int = None,
+        options: Mapping = None,
     ):
         """
         Initialize a `BasicStorageRecordSearch` instance.
@@ -246,10 +257,11 @@ class BasicStorageRecordSearch(BaseStorageRecordSearch):
             type_filter: Filter string
             tag_query: Tags to search
             page_size: Size of page to return
+            options: Dictionary of backend-specific options
 
         """
         super(BasicStorageRecordSearch, self).__init__(
-            store, type_filter, tag_query, page_size
+            store, type_filter, tag_query, page_size, options
         )
         self._cache = None
         self._iter = None


### PR DESCRIPTION
- Avoid fetching tags on BaseRecord models
- Reduce the tags applied to current BaseRecord models
- Add in-memory filtering for values that were previously tags
- Implement caching by thread ID in the (v0.1) CredentialManager