### PR TITLE
Align DID and DIDDoc fileds with RFC 0160: must be did and did_doc

### DIFF
--- a/aries_cloudagent/messaging/connections/models/connection_detail.py
+++ b/aries_cloudagent/messaging/connections/models/connection_detail.py
@@ -96,13 +96,13 @@ class ConnectionDetailSchema(BaseModelSchema):
         model_class = "ConnectionDetail"
 
     did = fields.Str(
-        data_key="DID",
+        data_key="did",
         required=False,
         description="DID for connection detail",
         **INDY_DID
     )
     did_doc = DIDDocWrapper(
-        data_key="DIDDoc",
+        data_key="did_doc",
         required=False,
         description="DID document for connection detail",
     )


### PR DESCRIPTION
As defined in the RFC these fields must be `did` and `did_doc`.

https://github.com/hyperledger/aries-rfcs/tree/master/features/0160-connection-protocol#attributes