### PR TITLE
Reuse credential offers and requests when possible

### DIFF
--- a/aries_cloudagent/messaging/issue_credential/v1_0/handlers/credential_offer_handler.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/handlers/credential_offer_handler.py
@@ -1,7 +1,5 @@
 """Basic message handler."""
 
-
-from .....storage.error import StorageNotFoundError
 from ....base_handler import (
     BaseHandler,
     BaseResponder,
@@ -10,8 +8,6 @@ from ....base_handler import (
 )
 from ..manager import CredentialManager
 from ..messages.credential_offer import CredentialOffer
-from ..messages.credential_proposal import CredentialProposal
-from ..models.credential_exchange import V10CredentialExchange
 
 
 class CredentialOfferHandler(BaseHandler):
@@ -38,43 +34,7 @@ class CredentialOfferHandler(BaseHandler):
 
         credential_manager = CredentialManager(context)
 
-        indy_offer = context.message.indy_offer(0)
-        credential_proposal_dict = CredentialProposal(
-            comment=context.message.comment,
-            credential_proposal=context.message.credential_preview,
-            cred_def_id=indy_offer["cred_def_id"],
-            schema_id=indy_offer["schema_id"],
-        ).serialize()
-
-        # Get credential exchange record (holder sent proposal first)
-        # or create it (issuer sent offer first)
-        try:
-            (
-                credential_exchange_record
-            ) = await V10CredentialExchange.retrieve_by_tag_filter(
-                context,
-                {"thread_id": context.message._thread_id},
-                {"connection_id": context.connection_record.connection_id},
-            )
-            credential_exchange_record.credential_proposal_dict = (
-                credential_proposal_dict
-            )
-        except StorageNotFoundError:  # issuer sent this offer free of any proposal
-            credential_exchange_record = V10CredentialExchange(
-                connection_id=context.connection_record.connection_id,
-                thread_id=context.message._thread_id,
-                initiator=V10CredentialExchange.INITIATOR_EXTERNAL,
-                role=V10CredentialExchange.ROLE_HOLDER,
-                credential_definition_id=indy_offer["cred_def_id"],
-                schema_id=indy_offer["schema_id"],
-                credential_proposal_dict=credential_proposal_dict,
-            )
-
-        credential_exchange_record.credential_offer = indy_offer
-
-        credential_exchange_record = await credential_manager.receive_offer(
-            credential_exchange_record
-        )
+        credential_exchange_record = await credential_manager.receive_offer()
 
         # If auto respond is turned on, automatically reply with credential request
         if context.settings.get("debug.auto_respond_credential_offer"):

--- a/aries_cloudagent/messaging/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/manager.py
@@ -304,7 +304,7 @@ class CredentialManager:
 
     async def create_request(
         self, credential_exchange_record: V10CredentialExchange, holder_did: str
-    ):
+    ) -> Tuple[V10CredentialExchange, CredentialRequest]:
         """
         Create a credential request.
 
@@ -326,6 +326,8 @@ class CredentialManager:
                 credential_exchange_record.credential_exchange_id,
             )
         else:
+            if "nonce" not in credential_offer:
+                raise CredentialManagerError("Missing nonce in credential offer")
             nonce = credential_offer["nonce"]
             cache_key = (
                 f"credential_request::{credential_definition_id}::{holder_did}::{nonce}"

--- a/aries_cloudagent/messaging/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/manager.py
@@ -419,7 +419,7 @@ class CredentialManager:
         *,
         comment: str = None,
         credential_values: dict,
-    ):
+    ) -> Tuple[V10CredentialExchange, CredentialIssue]:
         """
         Issue a credential.
 

--- a/aries_cloudagent/messaging/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/manager.py
@@ -91,7 +91,7 @@ class CredentialManager:
         comment: str = None,
         credential_preview: CredentialPreview = None,
         credential_definition_id: str,
-    ):
+    ) -> V10CredentialExchange:
         """
         Create a credential proposal.
 
@@ -146,7 +146,7 @@ class CredentialManager:
         )
         return credential_exchange_record
 
-    async def receive_proposal(self,):
+    async def receive_proposal(self) -> V10CredentialExchange:
         """
         Receive a credential proposal from message in context on manager creation.
 
@@ -247,7 +247,7 @@ class CredentialManager:
 
         return (credential_exchange_record, credential_offer_message)
 
-    async def receive_offer(self):
+    async def receive_offer(self) -> V10CredentialExchange:
         """
         Receive a credential offer.
 
@@ -472,7 +472,7 @@ class CredentialManager:
 
         return (credential_exchange_record, credential_message)
 
-    async def receive_credential(self):
+    async def receive_credential(self) -> V10CredentialExchange:
         """
         Receive a credential from an issuer.
 
@@ -502,7 +502,9 @@ class CredentialManager:
         await credential_exchange_record.save(self.context, reason="receive credential")
         return credential_exchange_record
 
-    async def store_credential(self, credential_exchange_record: V10CredentialExchange):
+    async def store_credential(
+        self, credential_exchange_record: V10CredentialExchange
+    ) -> Tuple[V10CredentialExchange, CredentialStored]:
         """
         Store a credential in the wallet.
 
@@ -549,7 +551,7 @@ class CredentialManager:
 
         return credential_exchange_record, credential_stored_message
 
-    async def credential_stored(self):
+    async def credential_stored(self) -> V10CredentialExchange:
         """
         Receive confirmation that holder stored credential.
 
@@ -571,3 +573,5 @@ class CredentialManager:
 
         # We're done with the exchange so delete
         await credential_exchange_record.delete_record(self.context)
+
+        return credential_exchange_record

--- a/aries_cloudagent/messaging/issue_credential/v1_0/messages/credential_issue.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/messages/credential_issue.py
@@ -7,7 +7,7 @@ from marshmallow import fields
 
 from ....agent_message import AgentMessage, AgentMessageSchema
 from ....decorators.attach_decorator import AttachDecorator, AttachDecoratorSchema
-from ..message_types import CREDENTIAL_ISSUE
+from ..message_types import ATTACH_DECO_IDS, CREDENTIAL_ISSUE
 
 
 HANDLER_CLASS = (
@@ -57,6 +57,13 @@ class CredentialIssue(AgentMessage):
         """
         return self.credentials_attach[index].indy_dict
 
+    @classmethod
+    def wrap_indy_credential(clss, indy_cred: dict) -> AttachDecorator:
+        """Convert an indy credential offer to an attachment decorator."""
+        return AttachDecorator.from_indy_dict(
+            indy_dict=indy_cred, ident=ATTACH_DECO_IDS[CREDENTIAL_ISSUE]
+        )
+
 
 class CredentialIssueSchema(AgentMessageSchema):
     """Credential schema."""
@@ -68,8 +75,5 @@ class CredentialIssueSchema(AgentMessageSchema):
 
     comment = fields.Str(comment="Human-readable comment", required=False)
     credentials_attach = fields.Nested(
-        AttachDecoratorSchema,
-        required=True,
-        many=True,
-        data_key="credentials~attach"
+        AttachDecoratorSchema, required=True, many=True, data_key="credentials~attach"
     )

--- a/aries_cloudagent/messaging/issue_credential/v1_0/messages/credential_issue.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/messages/credential_issue.py
@@ -58,7 +58,7 @@ class CredentialIssue(AgentMessage):
         return self.credentials_attach[index].indy_dict
 
     @classmethod
-    def wrap_indy_credential(clss, indy_cred: dict) -> AttachDecorator:
+    def wrap_indy_credential(cls, indy_cred: dict) -> AttachDecorator:
         """Convert an indy credential offer to an attachment decorator."""
         return AttachDecorator.from_indy_dict(
             indy_dict=indy_cred, ident=ATTACH_DECO_IDS[CREDENTIAL_ISSUE]

--- a/aries_cloudagent/messaging/issue_credential/v1_0/messages/credential_offer.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/messages/credential_offer.py
@@ -7,13 +7,13 @@ from marshmallow import fields
 
 from ....agent_message import AgentMessage, AgentMessageSchema
 from ....decorators.attach_decorator import AttachDecorator, AttachDecoratorSchema
-from ..message_types import CREDENTIAL_OFFER
+from ..message_types import ATTACH_DECO_IDS, CREDENTIAL_OFFER
 from .inner.credential_preview import CredentialPreview, CredentialPreviewSchema
 
 
 HANDLER_CLASS = (
     "aries_cloudagent.messaging.issue_credential.v1_0.handlers."
-    + "credential_offer_handler.CredentialOfferHandler"
+    "credential_offer_handler.CredentialOfferHandler"
 )
 
 
@@ -52,7 +52,7 @@ class CredentialOffer(AgentMessage):
         )
         self.offers_attach = list(offers_attach) if offers_attach else []
 
-    def indy_offer(self, index: int = 0):
+    def indy_offer(self, index: int = 0) -> dict:
         """
         Retrieve and decode indy offer from attachment.
 
@@ -62,6 +62,13 @@ class CredentialOffer(AgentMessage):
 
         """
         return self.offers_attach[index].indy_dict
+
+    @classmethod
+    def wrap_indy_offer(cls, indy_offer: dict) -> AttachDecorator:
+        """Convert an indy credential offer to an attachment decorator."""
+        return AttachDecorator.from_indy_dict(
+            indy_dict=indy_offer, ident=ATTACH_DECO_IDS[CREDENTIAL_OFFER]
+        )
 
 
 class CredentialOfferSchema(AgentMessageSchema):
@@ -75,8 +82,5 @@ class CredentialOfferSchema(AgentMessageSchema):
     comment = fields.Str(required=False, allow_none=False)
     credential_preview = fields.Nested(CredentialPreviewSchema, required=False)
     offers_attach = fields.Nested(
-        AttachDecoratorSchema,
-        required=True,
-        many=True,
-        data_key="offers~attach"
+        AttachDecoratorSchema, required=True, many=True, data_key="offers~attach"
     )

--- a/aries_cloudagent/messaging/issue_credential/v1_0/messages/credential_request.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/messages/credential_request.py
@@ -7,7 +7,7 @@ from marshmallow import fields
 
 from ....agent_message import AgentMessage, AgentMessageSchema
 from ....decorators.attach_decorator import AttachDecorator, AttachDecoratorSchema
-from ..message_types import CREDENTIAL_REQUEST
+from ..message_types import ATTACH_DECO_IDS, CREDENTIAL_REQUEST
 
 
 HANDLER_CLASS = (
@@ -57,6 +57,13 @@ class CredentialRequest(AgentMessage):
         """
         return self.requests_attach[index].indy_dict
 
+    @classmethod
+    def wrap_indy_cred_req(cls, indy_cred_req: dict) -> AttachDecorator:
+        """Convert an indy credential request to an attachment decorator."""
+        return AttachDecorator.from_indy_dict(
+            indy_dict=indy_cred_req, ident=ATTACH_DECO_IDS[CREDENTIAL_REQUEST]
+        )
+
 
 class CredentialRequestSchema(AgentMessageSchema):
     """Credential request schema."""
@@ -68,8 +75,5 @@ class CredentialRequestSchema(AgentMessageSchema):
 
     comment = fields.Str(required=False)
     requests_attach = fields.Nested(
-        AttachDecoratorSchema,
-        required=True,
-        many=True,
-        data_key="requests~attach"
+        AttachDecoratorSchema, required=True, many=True, data_key="requests~attach"
     )

--- a/aries_cloudagent/messaging/issue_credential/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/messaging/issue_credential/v1_0/tests/test_manager.py
@@ -1,0 +1,326 @@
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
+
+from .....config.injection_context import InjectionContext
+from .....issuer.base import BaseIssuer
+from .....messaging.request_context import RequestContext
+from .....ledger.base import BaseLedger
+from .....storage.error import StorageNotFoundError
+
+from ..manager import CredentialManager, CredentialManagerError
+from ..messages.credential_offer import CredentialOffer
+from ..messages.credential_proposal import CredentialProposal
+from ..messages.inner.credential_preview import CredentialPreview, CredAttrSpec
+from ..models.credential_exchange import V10CredentialExchange
+
+
+class TestCredentialManager(AsyncTestCase):
+    async def setUp(self):
+        self.context = RequestContext(
+            base_context=InjectionContext(enforce_typing=False)
+        )
+        Ledger = async_mock.MagicMock(BaseLedger, autospec=True)
+        self.ledger = Ledger()
+        self.context.injector.bind_instance(BaseLedger, self.ledger)
+        self.manager = CredentialManager(self.context)
+
+    async def test_prepare_send(self):
+        schema_id = "LjgpST2rjsoxYegQDRm7EL:2:bc-reg:1.0"
+        cred_def_id = "LjgpST2rjsoxYegQDRm7EL:3:CL:18:tag"
+        connection_id = "test_conn_id"
+        preview = CredentialPreview(
+            attributes=(CredAttrSpec(name="attr", value="value"),)
+        )
+        proposal = CredentialProposal(
+            credential_proposal=preview, cred_def_id=cred_def_id, schema_id=schema_id
+        )
+        with async_mock.patch.object(
+            self.manager, "create_offer", autospec=True
+        ) as create_offer:
+            create_offer.return_value = (object(), None)
+            ret_exchange = await self.manager.prepare_send(connection_id, proposal)
+            create_offer.assert_called_once()
+            assert ret_exchange is create_offer.return_value[0]
+            exchange: V10CredentialExchange = create_offer.call_args[1][
+                "credential_exchange_record"
+            ]
+            assert exchange.auto_issue
+            assert exchange.connection_id == connection_id
+            assert exchange.credential_definition_id == cred_def_id
+            assert exchange.role == exchange.ROLE_ISSUER
+            assert exchange.credential_proposal_dict == proposal.serialize()
+
+    async def test_create_proposal(self):
+        schema_id = "LjgpST2rjsoxYegQDRm7EL:2:bc-reg:1.0"
+        cred_def_id = "LjgpST2rjsoxYegQDRm7EL:3:CL:18:tag"
+        connection_id = "test_conn_id"
+        comment = "comment"
+        preview = CredentialPreview(
+            attributes=(CredAttrSpec(name="attr", value="value"),)
+        )
+
+        self.ledger.credential_definition_id2schema_id = async_mock.CoroutineMock(
+            return_value=schema_id
+        )
+
+        with self.assertRaises(CredentialManagerError):
+            await self.manager.create_proposal(
+                connection_id,
+                auto_offer=True,
+                comment=comment,
+                credential_preview=preview,
+                credential_definition_id=None,
+            )
+
+        with self.assertRaises(CredentialManagerError):
+            await self.manager.create_proposal(
+                connection_id,
+                auto_offer=True,
+                comment=comment,
+                credential_preview=None,
+                credential_definition_id=cred_def_id,
+            )
+
+        with async_mock.patch.object(
+            V10CredentialExchange, "save", autospec=True
+        ) as save_ex:
+            exchange: V10CredentialExchange = await self.manager.create_proposal(
+                connection_id,
+                auto_offer=True,
+                comment=comment,
+                credential_preview=preview,
+                credential_definition_id=cred_def_id,
+            )
+            save_ex.assert_called_once()
+        proposal = CredentialProposal.deserialize(exchange.credential_proposal_dict)
+
+        assert exchange.auto_offer
+        assert exchange.connection_id == connection_id
+        assert exchange.credential_definition_id == cred_def_id
+        assert exchange.schema_id == schema_id
+        assert exchange.thread_id == proposal._thread_id
+        assert exchange.role == exchange.ROLE_HOLDER
+        assert exchange.state == V10CredentialExchange.STATE_PROPOSAL_SENT
+
+    async def test_receive_proposal(self):
+        schema_id = "LjgpST2rjsoxYegQDRm7EL:2:bc-reg:1.0"
+        cred_def_id = "LjgpST2rjsoxYegQDRm7EL:3:CL:18:tag"
+        connection_id = "test_conn_id"
+        comment = "comment"
+
+        preview = CredentialPreview(
+            attributes=(CredAttrSpec(name="attr", value="value"),)
+        )
+        self.context.connection_record = async_mock.MagicMock()
+        self.context.connection_record.connection_id = connection_id
+
+        self.ledger.credential_definition_id2schema_id = async_mock.CoroutineMock(
+            return_value=schema_id
+        )
+
+        with self.assertRaises(CredentialManagerError):
+            self.context.message = CredentialProposal(
+                credential_proposal=preview, cred_def_id=None, schema_id=None
+            )
+            await self.manager.receive_proposal()
+
+        with async_mock.patch.object(
+            V10CredentialExchange, "save", autospec=True
+        ) as save_ex:
+            proposal = CredentialProposal(
+                credential_proposal=preview, cred_def_id=cred_def_id, schema_id=None
+            )
+            self.context.message = proposal
+
+            exchange = await self.manager.receive_proposal()
+            save_ex.assert_called_once()
+
+            assert exchange.connection_id == connection_id
+            assert exchange.credential_definition_id == cred_def_id
+            assert exchange.role == V10CredentialExchange.ROLE_ISSUER
+            assert exchange.state == V10CredentialExchange.STATE_PROPOSAL_RECEIVED
+            assert exchange.schema_id == schema_id
+            assert exchange.thread_id == proposal._thread_id
+
+            ret_proposal: CredentialProposal = CredentialProposal.deserialize(
+                exchange.credential_proposal_dict
+            )
+            attrs = ret_proposal.credential_proposal.attributes
+            assert attrs == preview.attributes
+
+    async def test_create_free_offer(self):
+        schema_id = "LjgpST2rjsoxYegQDRm7EL:2:bc-reg:1.0"
+        cred_def_id = "LjgpST2rjsoxYegQDRm7EL:3:CL:18:tag"
+        connection_id = "test_conn_id"
+        comment = "comment"
+
+        exchange = V10CredentialExchange(
+            credential_definition_id=cred_def_id, role=V10CredentialExchange.ROLE_ISSUER
+        )
+
+        with async_mock.patch.object(
+            V10CredentialExchange, "save", autospec=True
+        ) as save_ex, async_mock.patch.object(
+            V10CredentialExchange, "get_cached_key", autospec=True
+        ) as get_cached_key, async_mock.patch.object(
+            V10CredentialExchange, "set_cached_key", autospec=True
+        ) as set_cached_key:
+            get_cached_key.return_value = None
+            cred_offer = {"cred_def_id": cred_def_id, "schema_id": schema_id}
+            issuer = async_mock.MagicMock()
+            issuer.create_credential_offer = async_mock.CoroutineMock(
+                return_value=cred_offer
+            )
+            self.context.injector.bind_instance(BaseIssuer, issuer)
+
+            (ret_exchange, ret_offer) = await self.manager.create_offer(
+                credential_exchange_record=exchange, comment=comment
+            )
+            assert ret_exchange is exchange
+            save_ex.assert_called_once()
+
+            issuer.create_credential_offer.assert_called_once_with(cred_def_id)
+
+            assert exchange.thread_id == ret_offer._thread_id
+            assert exchange.credential_definition_id == cred_def_id
+            assert exchange.role == V10CredentialExchange.ROLE_ISSUER
+            assert exchange.schema_id == schema_id
+            assert exchange.state == V10CredentialExchange.STATE_OFFER_SENT
+            assert exchange.credential_offer == cred_offer
+
+    async def test_create_bound_offer(self):
+        schema_id = "LjgpST2rjsoxYegQDRm7EL:2:bc-reg:1.0"
+        cred_def_id = "LjgpST2rjsoxYegQDRm7EL:3:CL:18:tag"
+        connection_id = "test_conn_id"
+        comment = "comment"
+
+        preview = CredentialPreview(
+            attributes=(CredAttrSpec(name="attr", value="value"),)
+        )
+        proposal = CredentialProposal(credential_proposal=preview)
+        exchange = V10CredentialExchange(
+            credential_definition_id=cred_def_id,
+            credential_proposal_dict=proposal.serialize(),
+            role=V10CredentialExchange.ROLE_ISSUER,
+        )
+
+        with async_mock.patch.object(
+            V10CredentialExchange, "save", autospec=True
+        ) as save_ex, async_mock.patch.object(
+            V10CredentialExchange, "get_cached_key", autospec=True
+        ) as get_cached_key, async_mock.patch.object(
+            V10CredentialExchange, "set_cached_key", autospec=True
+        ) as set_cached_key:
+            get_cached_key.return_value = None
+            cred_offer = {"cred_def_id": cred_def_id, "schema_id": schema_id}
+            issuer = async_mock.MagicMock()
+            issuer.create_credential_offer = async_mock.CoroutineMock(
+                return_value=cred_offer
+            )
+            self.context.injector.bind_instance(BaseIssuer, issuer)
+
+            (ret_exchange, ret_offer) = await self.manager.create_offer(
+                credential_exchange_record=exchange, comment=comment
+            )
+            assert ret_exchange is exchange
+            save_ex.assert_called_once()
+
+            issuer.create_credential_offer.assert_called_once_with(cred_def_id)
+
+            assert exchange.thread_id == ret_offer._thread_id
+            assert exchange.schema_id == schema_id
+            assert exchange.credential_definition_id == cred_def_id
+            assert exchange.role == V10CredentialExchange.ROLE_ISSUER
+            assert exchange.state == V10CredentialExchange.STATE_OFFER_SENT
+            assert exchange.credential_offer == cred_offer
+
+            # additionally check that credential preview was passed through
+            assert ret_offer.credential_preview.attributes == preview.attributes
+
+    async def test_receive_offer_proposed(self):
+        schema_id = "LjgpST2rjsoxYegQDRm7EL:2:bc-reg:1.0"
+        cred_def_id = "LjgpST2rjsoxYegQDRm7EL:3:CL:18:tag"
+        connection_id = "test_conn_id"
+        indy_offer = {"schema_id": schema_id, "cred_def_id": cred_def_id}
+        thread_id = "thread-id"
+
+        preview = CredentialPreview(
+            attributes=(CredAttrSpec(name="attr", value="value"),)
+        )
+        proposal = CredentialProposal(credential_proposal=preview)
+
+        offer = CredentialOffer(
+            credential_preview=preview,
+            offers_attach=[CredentialOffer.wrap_indy_offer(indy_offer)],
+        )
+        offer.assign_thread_id(thread_id)
+
+        self.context.message = offer
+        self.context.connection_record = async_mock.MagicMock()
+        self.context.connection_record.connection_id = connection_id
+
+        stored_exchange = V10CredentialExchange(
+            connection_id=connection_id,
+            credential_definition_id=cred_def_id,
+            credential_proposal_dict=proposal.serialize(),
+            initiator=V10CredentialExchange.INITIATOR_EXTERNAL,
+            role=V10CredentialExchange.ROLE_HOLDER,
+            schema_id=schema_id,
+            thread_id=thread_id,
+        )
+
+        with async_mock.patch.object(
+            V10CredentialExchange, "save", autospec=True
+        ) as save_ex, async_mock.patch.object(
+            V10CredentialExchange,
+            "retrieve_by_connection_and_thread",
+            async_mock.CoroutineMock(return_value=stored_exchange),
+        ) as retrieve_ex:
+            exchange = await self.manager.receive_offer()
+
+            assert exchange.connection_id == connection_id
+            assert exchange.credential_definition_id == cred_def_id
+            assert exchange.schema_id == schema_id
+            assert exchange.thread_id == offer._thread_id
+            assert exchange.role == V10CredentialExchange.ROLE_HOLDER
+            assert exchange.state == V10CredentialExchange.STATE_OFFER_RECEIVED
+            assert exchange.credential_offer == indy_offer
+
+            proposal = CredentialProposal.deserialize(exchange.credential_proposal_dict)
+            assert proposal.credential_proposal.attributes == preview.attributes
+
+    async def test_receive_offer_non_proposed(self):
+        schema_id = "LjgpST2rjsoxYegQDRm7EL:2:bc-reg:1.0"
+        cred_def_id = "LjgpST2rjsoxYegQDRm7EL:3:CL:18:tag"
+        connection_id = "test_conn_id"
+        indy_offer = {"schema_id": schema_id, "cred_def_id": cred_def_id}
+        preview = CredentialPreview(
+            attributes=(CredAttrSpec(name="attr", value="value"),)
+        )
+        offer = CredentialOffer(
+            credential_preview=preview,
+            offers_attach=[CredentialOffer.wrap_indy_offer(indy_offer)],
+        )
+        self.context.message = offer
+        self.context.connection_record = async_mock.MagicMock()
+        self.context.connection_record.connection_id = connection_id
+
+        with async_mock.patch.object(
+            V10CredentialExchange, "save", autospec=True
+        ) as save_ex, async_mock.patch.object(
+            V10CredentialExchange,
+            "retrieve_by_connection_and_thread",
+            async_mock.CoroutineMock(side_effect=StorageNotFoundError),
+        ) as retrieve_ex:
+            exchange = await self.manager.receive_offer()
+
+            assert exchange.connection_id == connection_id
+            assert exchange.credential_definition_id == cred_def_id
+            assert exchange.schema_id == schema_id
+            assert exchange.thread_id == offer._thread_id
+            assert exchange.role == V10CredentialExchange.ROLE_HOLDER
+            assert exchange.state == V10CredentialExchange.STATE_OFFER_RECEIVED
+            assert exchange.credential_offer == indy_offer
+
+            proposal = CredentialProposal.deserialize(exchange.credential_proposal_dict)
+            assert proposal.credential_proposal.attributes == preview.attributes


### PR DESCRIPTION
Also adds tests and type info to the CredentialManager class, and allows create_offer to be called without a credential proposal.