### PR TITLE
Propose new plugin interface

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -497,6 +497,16 @@ class ProtocolGroup(ArgumentGroup):
             instances of this parameter can be specified.",
         )
         parser.add_argument(
+            "--plugin",
+            dest="external_plugins",
+            type=str,
+            action="append",
+            required=False,
+            metavar="<module>",
+            help="Load <module> as a plugin. Multiple instances of this\
+            parameter can be specified.",
+        )
+        parser.add_argument(
             "--auto-ping-connection",
             action="store_true",
             help="Automatically send a trust ping immediately after a\
@@ -526,6 +536,8 @@ class ProtocolGroup(ArgumentGroup):
         settings = {}
         if args.external_protocols:
             settings["external_protocols"] = args.external_protocols
+        if args.external_plugins:
+            settings["external_plugins"] = args.external_plugins
         if args.auto_ping_connection:
             settings["auto_ping_connection"] = True
         if args.invite_base_url:

--- a/aries_cloudagent/config/default_context.py
+++ b/aries_cloudagent/config/default_context.py
@@ -160,3 +160,16 @@ class DefaultContextBuilder(ContextBuilder):
         context.injector.bind_instance(
             BaseIntroductionService, DemoIntroductionService(context)
         )
+
+        # Load Plugins
+        for plugin_path in self.settings.get('external_plugins', []):
+            try:
+                external_plugin = ClassLoader.load_module(
+                    plugin_path
+                )
+                await external_plugin.setup(context)
+            except Exception as e:
+                raise ConfigError(
+                    "Failed to load external protocol module "
+                    + f"'{plugin_path}'"
+                ) from e


### PR DESCRIPTION
I'd like to propose a slightly different mechanism for loading protocol handlers as well as other features. Rather than specifically looking for message types inside of a loaded module, I propose that we attempt to load and execute an asynchronous `setup` method, with the context passed as the first argument. This would allow side loaded modules to not only add protocol handlers but also potentially define new ledgers, admin servers, admin server routes, etc. without having to fork the ACA-Py code base. The changes I've included here are mostly just a proof of concept of what this might look like and other changes are likely necessary to fully support side loading something like a ledger.

More than open to thoughts and feedback, why this approach is a bad idea, ideas for a better approach etc.