### PR TITLE
broaden aries-rfc-36 cred proposal to underspecify cred def, allow is…

### DIFF
--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -10,17 +10,7 @@ from marshmallow import fields, Schema
 from ...ledger.base import BaseLedger
 from ...storage.base import BaseStorage
 from ..valid import INDY_CRED_DEF_ID, INDY_SCHEMA_ID, INDY_VERSION
-from .util import CRED_DEF_SENT_RECORD_TYPE
-
-
-CRED_DEF_SENT_PARMS = [
-    "schema_id",
-    "schema_issuer_did",
-    "schema_name",
-    "schema_version",
-    "issuer_did",
-    "cred_def_id",
-]
+from .util import CRED_DEF_TAGS, CRED_DEF_SENT_RECORD_TYPE
 
 
 class CredentialDefinitionSendRequestSchema(Schema):
@@ -136,7 +126,7 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
             "in": "query",
             "schema": {"type": "string"},
             "required": False,
-        } for p in CRED_DEF_SENT_PARMS
+        } for p in CRED_DEF_TAGS
     ],
     summary="Search for matching credential definitions that agent originated",
 )
@@ -158,7 +148,7 @@ async def credential_definitions_created(request: web.BaseRequest):
     found = await storage.search_records(
         type_filter=CRED_DEF_SENT_RECORD_TYPE,
         tag_query={
-            p: request.query[p] for p in CRED_DEF_SENT_PARMS if p in request.query
+            p: request.query[p] for p in CRED_DEF_TAGS if p in request.query
         }
     ).fetch_all()
 

--- a/aries_cloudagent/messaging/credential_definitions/util.py
+++ b/aries_cloudagent/messaging/credential_definitions/util.py
@@ -1,3 +1,11 @@
 """Credential definition utilities."""
 
+CRED_DEF_TAGS = [
+    "schema_id",
+    "schema_issuer_did",
+    "schema_name",
+    "schema_version",
+    "issuer_did",
+    "cred_def_id",
+]
 CRED_DEF_SENT_RECORD_TYPE = "cred_def_sent"

--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -10,10 +10,7 @@ from marshmallow import fields, Schema
 from ...ledger.base import BaseLedger
 from ...storage.base import BaseStorage
 from ..valid import INDY_SCHEMA_ID, INDY_VERSION
-from .util import SCHEMA_SENT_RECORD_TYPE
-
-
-SCHEMA_SENT_PARMS = ["schema_id", "schema_issuer_did", "schema_name", "schema_version"]
+from .util import SCHEMA_SENT_RECORD_TYPE, SCHEMA_TAGS
 
 
 class SchemaSendRequestSchema(Schema):
@@ -137,7 +134,7 @@ async def schemas_send_schema(request: web.BaseRequest):
             "in": "query",
             "schema": {"type": "string"},
             "required": False,
-        } for p in SCHEMA_SENT_PARMS
+        } for p in SCHEMA_TAGS
     ],
     summary="Search for matching schema that agent originated",
 )
@@ -159,7 +156,7 @@ async def schemas_created(request: web.BaseRequest):
     found = await storage.search_records(
         type_filter=SCHEMA_SENT_RECORD_TYPE,
         tag_query={
-            p: request.query[p] for p in SCHEMA_SENT_PARMS if p in request.query
+            p: request.query[p] for p in SCHEMA_TAGS if p in request.query
         }
     ).fetch_all()
 

--- a/aries_cloudagent/messaging/schemas/util.py
+++ b/aries_cloudagent/messaging/schemas/util.py
@@ -1,3 +1,4 @@
 """Schema utilities."""
 
+SCHEMA_TAGS = ["schema_id", "schema_issuer_did", "schema_name", "schema_version"]
 SCHEMA_SENT_RECORD_TYPE = "schema_sent"

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_proposal.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_proposal.py
@@ -3,6 +3,12 @@
 from marshmallow import fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.valid import (
+    INDY_CRED_DEF_ID,
+    INDY_DID,
+    INDY_SCHEMA_ID,
+    INDY_VERSION,
+)
 
 from ..message_types import CREDENTIAL_PROPOSAL, PROTOCOL_PACKAGE
 
@@ -32,7 +38,11 @@ class CredentialProposal(AgentMessage):
         comment: str = None,
         credential_proposal: CredentialPreview = None,
         schema_id: str = None,
+        schema_issuer_did: str = None,
+        schema_name: str = None,
+        schema_version: str = None,
         cred_def_id: str = None,
+        issuer_did: str = None,
         **kwargs,
     ):
         """
@@ -42,7 +52,11 @@ class CredentialProposal(AgentMessage):
             comment: optional human-readable comment
             credential_proposal: proposed credential preview
             schema_id: schema identifier
+            schema_issuer_did: schema issuer DID
+            schema_name: schema name
+            schema_version: schema version
             cred_def_id: credential definition identifier
+            issuer_did: credential issuer DID
         """
         super().__init__(_id, **kwargs)
         self.comment = comment
@@ -50,7 +64,11 @@ class CredentialProposal(AgentMessage):
             credential_proposal if credential_proposal else CredentialPreview()
         )
         self.schema_id = schema_id
+        self.schema_issuer_did = schema_issuer_did
+        self.schema_name = schema_name
+        self.schema_version = schema_version
         self.cred_def_id = cred_def_id
+        self.issuer_did = issuer_did
 
 
 class CredentialProposalSchema(AgentMessageSchema):
@@ -63,5 +81,32 @@ class CredentialProposalSchema(AgentMessageSchema):
 
     comment = fields.Str(required=False, allow_none=False)
     credential_proposal = fields.Nested(CredentialPreviewSchema, required=True)
-    schema_id = fields.Str(required=False, allow_none=False)
-    cred_def_id = fields.Str(required=False, allow_none=False)
+    schema_id = fields.Str(
+        required=False,
+        allow_none=False,
+        **INDY_SCHEMA_ID
+    )
+    schema_issuer_did = fields.Str(
+        required=False,
+        allow_none=False,
+        **INDY_DID
+    )
+    schema_name = fields.Str(
+        required=False,
+        allow_none=False,
+    )
+    schema_version = fields.Str(
+        required=False,
+        allow_none=False,
+        **INDY_VERSION
+    )
+    cred_def_id = fields.Str(
+        required=False,
+        allow_none=False,
+        **INDY_CRED_DEF_ID
+    )
+    issuer_did = fields.Str(
+        required=False,
+        allow_none=False,
+        **INDY_DID
+    )

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/tests/test_credential_proposal.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/tests/test_credential_proposal.py
@@ -88,15 +88,37 @@ class TestCredentialProposal(TestCase):
 class TestCredentialProposalSchema(TestCase):
     """Test credential cred proposal schema."""
 
-    credential_proposal = CredentialProposal(
-        comment="Hello World",
-        credential_proposal=CRED_PREVIEW,
-        schema_id="GMm4vMw8LLrLJjp81kRRLp:2:ahoy:1560364003.0",
-        cred_def_id="GMm4vMw8LLrLJjp81kRRLp:3:CL:12:tag",
-    )
+    credential_proposals = [
+        CredentialProposal(
+            credential_proposal=CRED_PREVIEW,
+        ),
+        CredentialProposal(
+            comment="Hello World",
+            credential_proposal=CRED_PREVIEW,
+            cred_def_id="GMm4vMw8LLrLJjp81kRRLp:3:CL:12:tag"
+        ),
+        CredentialProposal(
+            comment="Hello World",
+            credential_proposal=CRED_PREVIEW,
+            schema_id="GMm4vMw8LLrLJjp81kRRLp:2:ahoy:1.0",
+        ),
+        CredentialProposal(
+            comment="Hello World",
+            credential_proposal=CRED_PREVIEW,
+            schema_issuer_did="GMm4vMw8LLrLJjp81kRRLp",
+        ),
+        CredentialProposal(
+            comment="Hello World",
+            credential_proposal=CRED_PREVIEW,
+            schema_name="ahoy",
+            schema_version="1.0",
+            issuer_did="GMm4vMw8LLrLJjp81kRRLp",
+        ),
+    ]
 
     def test_make_model(self):
         """Test making model."""
-        data = self.credential_proposal.serialize()
-        model_instance = CredentialProposal.deserialize(data)
-        assert isinstance(model_instance, CredentialProposal)
+        for credential_proposal in self.credential_proposals:
+            data = credential_proposal.serialize()
+            model_instance = CredentialProposal.deserialize(data)
+            assert isinstance(model_instance, CredentialProposal)

--- a/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
@@ -110,7 +110,7 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock = async_mock.MagicMock()
         mock.json = async_mock.CoroutineMock(
-            return_value={"connection_id": conn_id, "credential_preview": preview_spec}
+            return_value={"connection_id": conn_id, "credential_proposal": preview_spec}
         )
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
@@ -209,7 +209,7 @@ class TestCredentialRoutes(AsyncTestCase):
         mock.json = async_mock.CoroutineMock(
             return_value={
                 "auto_issue": False,
-                "credential_definition_id": "cred-def-id",
+                "cred_def_id": "cred-def-id",
             }
         )
 
@@ -251,7 +251,7 @@ class TestCredentialRoutes(AsyncTestCase):
         mock.json = async_mock.CoroutineMock(
             return_value={
                 "auto_issue": False,
-                "credential_definition_id": "cred-def-id",
+                "cred_def_id": "cred-def-id",
             }
         )
 


### PR DESCRIPTION
Allow for cred proposal underspecification of cred def id, only lock down cred def id at issuer on offer. Sync up api requests to Aries RFC-36 verbiage.