### PR TITLE
Add invitation mode "static" for static connections

### DIFF
--- a/aries_cloudagent/connections/models/connection_record.py
+++ b/aries_cloudagent/connections/models/connection_record.py
@@ -431,9 +431,9 @@ class ConnectionRecordSchema(BaseRecordSchema):
     )
     invitation_mode = fields.Str(
         required=False,
-        description="Invitation mode: once or multi",
+        description="Invitation mode: once, multi, or static",
         example=ConnectionRecord.INVITATION_MODE_ONCE,
-        validate=OneOf(["once", "multi"]),
+        validate=OneOf(["once", "multi", "static"]),
     )
     alias = fields.Str(
         required=False,

--- a/aries_cloudagent/connections/models/connection_record.py
+++ b/aries_cloudagent/connections/models/connection_record.py
@@ -59,6 +59,7 @@ class ConnectionRecord(BaseRecord):  # lgtm[py/missing-equals]
 
     INVITATION_MODE_ONCE = "once"
     INVITATION_MODE_MULTI = "multi"
+    INVITATION_MODE_STATIC = "static"
 
     ROUTING_STATE_NONE = "none"
     ROUTING_STATE_REQUEST = "request"

--- a/aries_cloudagent/protocols/connections/manager.py
+++ b/aries_cloudagent/protocols/connections/manager.py
@@ -621,6 +621,7 @@ class ConnectionManager:
         # Create connection record
         connection = ConnectionRecord(
             initiator=ConnectionRecord.INITIATOR_SELF,
+            invitation_mode=ConnectionRecord.INVITATION_MODE_STATIC,
             my_did=my_info.did,
             their_did=their_info.did,
             their_role=their_role,


### PR DESCRIPTION
This adds an invitation mode of "static" for connections created statically. The end goal is to be able to distinguish connection records for static connections from connections made through the connection protocol. Not sure if this is the best way but it works.