### PR TITLE
Changes to display Agent Label and Version on CLI and SwaggerUI

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -23,6 +23,8 @@ from ..transport.stats import StatsTracer
 from .base_server import BaseAdminServer
 from .error import AdminSetupError
 
+from ..version import __version__
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -209,9 +211,12 @@ class AdminServer(BaseAdminServer):
         )
         for route in app.router.routes():
             cors.add(route)
+        # get agent label
+        agent_label = self.context.settings.get("default_label"),
+        version_string = f"v{__version__}"
 
         setup_aiohttp_apispec(
-            app=app, title="Aries Cloud Agent", version="v1", swagger_path="/api/doc"
+            app=app, title=agent_label, version=version_string, swagger_path="/api/doc"
         )
         app.on_startup.append(self.on_startup)
         return app

--- a/aries_cloudagent/conductor.py
+++ b/aries_cloudagent/conductor.py
@@ -187,8 +187,12 @@ class Conductor:
             # for example
             context.injector.bind_instance(BaseResponder, self.admin_server.responder)
 
+        # Get agent label
+        default_label = context.settings.get("default_label")
+
         # Show some details about the configuration to the user
         LoggingConfigurator.print_banner(
+            default_label,
             self.inbound_transport_manager.registered_transports,
             self.outbound_transport_manager.registered_transports,
             public_did,

--- a/aries_cloudagent/config/logging.py
+++ b/aries_cloudagent/config/logging.py
@@ -79,6 +79,7 @@ class LoggingConfigurator:
     @classmethod
     def print_banner(
         cls,
+        agent_label,
         inbound_transports,
         outbound_transports,
         public_did,
@@ -90,6 +91,7 @@ class LoggingConfigurator:
         Print a startup banner describing the configuration.
 
         Args:
+            agent_label: Agent Label
             inbound_transports: Configured inbound transports
             outbound_transports: Configured outbound transports
             admin_server: Admin server info
@@ -111,7 +113,7 @@ class LoggingConfigurator:
                 + f" {content} {border_character}{border_character}"
             )
 
-        banner_title_string = "Aries Cloud Agent"
+        banner_title_string = agent_label or "ACA"
         banner_title_spacer = " " * (banner_length - len(banner_title_string))
 
         banner_border = border_character * (banner_length + 6)

--- a/aries_cloudagent/config/tests/test_logging.py
+++ b/aries_cloudagent/config/tests/test_logging.py
@@ -6,6 +6,7 @@ from .. import logging as test_module
 
 
 class TestLoggingConfigurator:
+    agent_label_arg_value = "Aries Cloud Agent"
     transport_arg_value = "transport"
     host_arg_value = "host"
     port_arg_value = "port"
@@ -36,7 +37,8 @@ class TestLoggingConfigurator:
     def test_banner(self):
         stdout = StringIO()
         with contextlib.redirect_stdout(stdout):
+            test_label = "Aries Cloud Agent"
             test_did = "55GkHamhTU1ZbTbV2ab9DE"
-            test_module.LoggingConfigurator.print_banner([], [], test_did)
+            test_module.LoggingConfigurator.print_banner(test_label, [], [], test_did)
         output = stdout.getvalue()
         assert test_did in output


### PR DESCRIPTION
- Adding agent label to CLI banner
- Adding agent label and version to SwaggerUI

Having this information displayed on CLI and UI helps to identify agents without keeping port number based notepads. 

Signed-off-by: Satish Mohan <54302767+smohan-dw@users.noreply.github.com>