### PR TITLE
issuer includes please-ack on cred storage at issue; holder acks storage

### DIFF
--- a/aries_cloudagent/messaging/decorators/please_ack_decorator.py
+++ b/aries_cloudagent/messaging/decorators/please_ack_decorator.py
@@ -1,4 +1,4 @@
-"""The please-ack decorator to request acknowledgement."""
+"""The please-ack decorator (~please_ack) to request acknowledgement."""
 
 from typing import Sequence
 
@@ -32,6 +32,15 @@ class PleaseAckDecorator(BaseModel):
         super().__init__()
         self.message_id = message_id
         self.on = list(on) if on else None
+
+    def __eq__(self, other):
+        """Equality comparator."""
+
+        return (
+            type(self) == type(other) and
+            self.message_id == other.message_id and
+            (set(self.on or []) == set(other.on or []))
+        )
 
 
 class PleaseAckDecoratorSchema(BaseModelSchema):

--- a/aries_cloudagent/messaging/decorators/tests/test_please_ack_decorator.py
+++ b/aries_cloudagent/messaging/decorators/tests/test_please_ack_decorator.py
@@ -65,3 +65,15 @@ class TestPleaseAckDecorator(TestCase):
         assert type(loaded) == PleaseAckDecorator
         assert loaded.message_id == MESSAGE_ID
         assert loaded.on == list(ON)
+
+    def test_eq(self):
+        a = PleaseAckDecorator()
+        b = PleaseAckDecorator()
+        c = PleaseAckDecorator(on=[])
+        d = PleaseAckDecorator(message_id=MESSAGE_ID)
+        e = PleaseAckDecorator(message_id=MESSAGE_ID, on=ON)
+        assert a == b == c
+        assert a != d
+        assert a != e
+        assert d != e
+

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_issue_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_issue_handler.py
@@ -46,4 +46,5 @@ class CredentialIssueHandler(BaseHandler):
             ) = await credential_manager.store_credential(credential_exchange_record)
 
             # Ack issuer that holder stored credential
-            await responder.send_reply(credential_ack_message)
+            if credential_ack_message:
+                await responder.send_reply(credential_ack_message)

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -13,10 +13,11 @@ from ....messaging.credential_definitions.util import (
     CRED_DEF_TAGS,
     CRED_DEF_SENT_RECORD_TYPE
 )
+from ....messaging.decorators.please_ack_decorator import PleaseAckDecorator
 from ....storage.base import BaseStorage
 from ....storage.error import StorageNotFoundError
 
-from .messages.credential_issue import CredentialIssue, PLEASE_ACK_ON_STORE
+from .messages.credential_issue import CredentialIssue
 from .messages.credential_offer import CredentialOffer
 from .messages.credential_proposal import CredentialProposal
 from .messages.credential_request import CredentialRequest
@@ -482,7 +483,7 @@ class CredentialManager:
                     credential_exchange_record.credential
                 )
             ],
-            please_ack=PLEASE_ACK_ON_STORE,
+            please_ack=PleaseAckDecorator(),
         )
         credential_issue_message._thread = {
             "thid": credential_exchange_record.thread_id
@@ -516,9 +517,7 @@ class CredentialManager:
         credential_exchange_record.state = (
             V10CredentialExchange.STATE_CREDENTIAL_RECEIVED
         )
-        if V10CredentialExchange.STATE_CREDENTIAL_STORED in (
-            credential_issue_message.please_ack.on or []
-        ):
+        if credential_issue_message.please_ack is not None:
             credential_exchange_record.ack_on_store = True
 
         await credential_exchange_record.save(self.context, reason="receive credential")

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_issue.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_issue.py
@@ -1,7 +1,6 @@
 """A credential content message."""
 
-from copy import deepcopy
-from typing import Mapping, Sequence
+from typing import Sequence
 
 from marshmallow import fields
 
@@ -16,14 +15,10 @@ from .....messaging.decorators.please_ack_decorator import (
 )
 
 from ..message_types import ATTACH_DECO_IDS, CREDENTIAL_ISSUE, PROTOCOL_PACKAGE
-from ..models.credential_exchange import V10CredentialExchange
 
 
 HANDLER_CLASS = (
     f"{PROTOCOL_PACKAGE}.handlers.credential_issue_handler.CredentialIssueHandler"
-)
-PLEASE_ACK_ON_STORE = PleaseAckDecorator(
-    on=[V10CredentialExchange.STATE_CREDENTIAL_STORED]
 )
 
 
@@ -43,7 +38,7 @@ class CredentialIssue(AgentMessage):
         *,
         comment: str = None,
         credentials_attach: Sequence[AttachDecorator] = None,
-        please_ack: Mapping = None,
+        please_ack: PleaseAckDecorator = None,
         **kwargs,
     ):
         """
@@ -57,7 +52,7 @@ class CredentialIssue(AgentMessage):
         super().__init__(_id=_id, **kwargs)
         self.comment = comment
         self.credentials_attach = list(credentials_attach) if credentials_attach else []
-        self.please_ack = deepcopy(please_ack)
+        self.please_ack = please_ack
 
     def indy_credential(self, index: int = 0):
         """
@@ -97,7 +92,5 @@ class CredentialIssueSchema(AgentMessageSchema):
         PleaseAckDecoratorSchema,
         required=False,
         data_key="~please_ack",
-        comment=f"Specify {PLEASE_ACK_ON_STORE.serialize(as_string=True)}",
-        example=PLEASE_ACK_ON_STORE,
-        validate=lambda p: p == PLEASE_ACK_ON_STORE
+        validate=lambda p: not p.on
     )

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/tests/test_credential_issue.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/tests/test_credential_issue.py
@@ -4,7 +4,7 @@ from ......messaging.decorators.attach_decorator import AttachDecorator
 from ......messaging.decorators.please_ack_decorator import PleaseAckDecorator
 from ......messaging.models.base import BaseModelError
 from ...message_types import ATTACH_DECO_IDS, CREDENTIAL_ISSUE, PROTOCOL_PACKAGE
-from ..credential_issue import CredentialIssue, PLEASE_ACK_ON_STORE
+from ..credential_issue import CredentialIssue
 
 
 class TestCredentialIssue(TestCase):
@@ -94,12 +94,12 @@ class TestCredentialIssue(TestCase):
                     indy_dict=self.indy_cred, ident=ATTACH_DECO_IDS[CREDENTIAL_ISSUE],
                 )
             ],
-            please_ack=PLEASE_ACK_ON_STORE
+            please_ack=PleaseAckDecorator()
         )
         assert credential_issue.credentials_attach[0].indy_dict == self.indy_cred
         assert credential_issue.credentials_attach[0].ident  # auto-generates UUID4
         assert credential_issue.indy_credential(0) == self.indy_cred
-        assert credential_issue.please_ack == PLEASE_ACK_ON_STORE
+        assert credential_issue.please_ack == PleaseAckDecorator()
 
     def test_type(self):
         """Test type"""
@@ -161,10 +161,10 @@ class TestCredentialIssueSchema(TestCase):
         credential_issue = CredentialIssue(
             comment="Test",
             credentials_attach=[AttachDecorator.from_indy_dict({"hello": "world"})],
-            please_ack=PLEASE_ACK_ON_STORE
+            please_ack=PleaseAckDecorator()
         )
         data = credential_issue.serialize()
-        assert data.get("~please_ack", None) == PLEASE_ACK_ON_STORE.serialize()
+        assert data.get("~please_ack", None) == PleaseAckDecorator().serialize()
         model_instance = CredentialIssue.deserialize(data)
         assert isinstance(model_instance, CredentialIssue)
 
@@ -173,7 +173,7 @@ class TestCredentialIssueSchema(TestCase):
         credential_issue = CredentialIssue(
             comment="Test",
             credentials_attach=[AttachDecorator.from_indy_dict({"hello": "world"})],
-            please_ack=PleaseAckDecorator()
+            please_ack=PleaseAckDecorator(on=["not-supported"])
         )
         data = credential_issue.serialize()
         with self.assertRaises(BaseModelError):

--- a/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
@@ -34,6 +34,7 @@ class V10CredentialExchange(BaseRecord):
     STATE_REQUEST_RECEIVED = "request_received"
     STATE_ISSUED = "credential_issued"
     STATE_CREDENTIAL_RECEIVED = "credential_received"
+    STATE_CREDENTIAL_STORED = "credential_stored"
     STATE_ACKED = "credential_acked"
 
     def __init__(
@@ -57,6 +58,7 @@ class V10CredentialExchange(BaseRecord):
         credential: dict = None,  # indy credential as stored
         auto_offer: bool = False,
         auto_issue: bool = False,
+        ack_on_store: bool = False,
         error_msg: str = None,
         **kwargs,
     ):
@@ -80,6 +82,7 @@ class V10CredentialExchange(BaseRecord):
         self.credential = credential
         self.auto_offer = auto_offer
         self.auto_issue = auto_issue
+        self.ack_on_store = ack_on_store
         self.error_msg = error_msg
 
     @property
@@ -101,6 +104,7 @@ class V10CredentialExchange(BaseRecord):
                 "error_msg",
                 "auto_offer",
                 "auto_issue",
+                "ack_on_store",
                 "raw_credential",
                 "credential",
                 "parent_thread_id",
@@ -206,6 +210,11 @@ class V10CredentialExchangeSchema(BaseRecordSchema):
         required=False,
         description="Issuer choice to issue to request in this credential exchange",
         example=False,
+    )
+    ack_on = fields.Bool(
+        required=False,
+        description="Whether holder promises to send ack to issuer on credential store",
+        example=True,
     )
     error_msg = fields.Str(
         required=False,

--- a/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
@@ -211,7 +211,7 @@ class V10CredentialExchangeSchema(BaseRecordSchema):
         description="Issuer choice to issue to request in this credential exchange",
         example=False,
     )
-    ack_on = fields.Bool(
+    ack_on_store = fields.Bool(
         required=False,
         description="Whether holder promises to send ack to issuer on credential store",
         example=True,

--- a/aries_cloudagent/protocols/issue_credential/v1_0/models/tests/test_retrieve.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/models/tests/test_retrieve.py
@@ -1,0 +1,42 @@
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
+
+from ......cache.base import BaseCache
+from ......cache.basic import BasicCache
+from ......config.injection_context import InjectionContext
+from ......messaging.request_context import RequestContext
+from ......storage.base import BaseStorage
+from ......storage.basic import BasicStorage
+
+from ..credential_exchange import V10CredentialExchange
+
+
+class TestCredentialExchange(AsyncTestCase):
+    async def setUp(self):
+        self.context = RequestContext(
+            base_context=InjectionContext(enforce_typing=False)
+        )
+
+        self.cache = BasicCache()
+        self.context.injector.bind_instance(BaseCache, self.cache)
+
+        self.storage = BasicStorage()
+        self.context.injector.bind_instance(BaseStorage, self.storage)
+
+    async def test_retrieve_by_connection_and_thread(self):
+        records = [
+            V10CredentialExchange(
+                connection_id=str(i),
+                thread_id=str(i),
+            ) for i in range(3)
+        ]
+        for record in records:
+            await record.save(self.context)
+
+        for i in range(2):  # cover cache code for both set() and get()
+            found = await V10CredentialExchange.retrieve_by_connection_and_thread(
+                context=self.context,
+                connection_id=str(1),
+                thread_id=str(1),
+            )
+            assert found.serialize() == records[1].serialize()

--- a/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
@@ -596,10 +596,12 @@ async def credential_exchange_store(request: web.BaseRequest):
 
     (
         credential_exchange_record,
-        credential_stored_message,
+        credential_ack_message,
     ) = await credential_manager.store_credential(credential_exchange_record)
 
-    await outbound_handler(credential_stored_message, connection_id=connection_id)
+    if credential_ack_message:
+        await outbound_handler(credential_ack_message, connection_id=connection_id)
+
     return web.json_response(credential_exchange_record.serialize())
 
 

--- a/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_manager.py
@@ -4,14 +4,14 @@ from asynctest import mock as async_mock
 from .....config.injection_context import InjectionContext
 from .....holder.base import BaseHolder
 from .....issuer.base import BaseIssuer
+from .....messaging.decorators.please_ack_decorator import PleaseAckDecorator
 from .....messaging.request_context import RequestContext
 from .....ledger.base import BaseLedger
 from .....storage.error import StorageNotFoundError
-from .....storage.base import BaseStorage, BaseStorageRecordSearch
 
 from ..manager import CredentialManager, CredentialManagerError
 from ..messages.credential_ack import CredentialAck
-from ..messages.credential_issue import CredentialIssue, PLEASE_ACK_ON_STORE
+from ..messages.credential_issue import CredentialIssue
 from ..messages.credential_offer import CredentialOffer
 from ..messages.credential_proposal import CredentialProposal
 from ..messages.credential_request import CredentialRequest
@@ -551,7 +551,7 @@ class TestCredentialManager(AsyncTestCase):
 
             assert ret_exchange.credential == cred
             assert ret_cred_issue.indy_credential() == cred
-            assert ret_cred_issue.please_ack == PLEASE_ACK_ON_STORE
+            assert ret_cred_issue.please_ack == PleaseAckDecorator()
             assert ret_exchange.state == V10CredentialExchange.STATE_ISSUED
             assert ret_cred_issue._thread_id == thread_id
 
@@ -569,7 +569,7 @@ class TestCredentialManager(AsyncTestCase):
 
         issue = CredentialIssue(
             credentials_attach=[CredentialIssue.wrap_indy_credential(indy_cred)],
-            please_ack=PLEASE_ACK_ON_STORE,
+            please_ack=PleaseAckDecorator(),
         )
         self.context.message = issue
         self.context.connection_record = async_mock.MagicMock()

--- a/aries_cloudagent/protocols/present_proof/v1_0/messages/tests/test_presentation_ack.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/messages/tests/test_presentation_ack.py
@@ -47,13 +47,13 @@ class TestPresentationAckSchema(TestCase):
     def test_make_model(self):
         """Test making model."""
         pres_ack_dict = PresentationAck().serialize()
-        '''
+        """
         Looks like: {
             "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/ack",
             "@id": "f49773e3-bd56-4868-a5f1-456d1e6d1a16",
             "status": "OK"
         }
-        '''
+        """
 
         model_instance = PresentationAck.deserialize(pres_ack_dict)
         assert isinstance(model_instance, PresentationAck)

--- a/demo/AriesOpenAPIDemo.md
+++ b/demo/AriesOpenAPIDemo.md
@@ -193,7 +193,7 @@ Now we need put into the JSON the data values for the credential. Copy and paste
 
 Ok, finally, you are ready to click `Execute`. The request should work, but if it doesn’t - check your JSON! Did you get all the quotes and commas right?
 
-To confirm the issuance worked, scroll up to the top of the `v1.0 issue-credential exchange` section and execute the **`GET /issue-credential/records`** endpoint. You should see a lot of information about the exchange, including the state - `credential_acked`.
+To confirm the issuance worked, scroll up to the top of the `v1.0 issue-credential exchange` section and execute the **`GET /issue-credential/records`** endpoint. You should see a lot of information about the exchange, including the state - `credential_stored`.
 
 Let’s look at it from Alice’s side. Switch to the Alice’s agent browser tab, find the `credentials` section and within that, execute the **`GET /credentials`** endpoint. There should be a list of credentials held by Alice, with just a single entry, the credential issued from the Faber agent. Note that the element `referent` is the value of the `credential_id` element used in other calls. `referent` is the name returned in the `indy-sdk` call to get the set of credentials for the wallet and ACA-Py code is not changing it in the response.
 

--- a/demo/runners/alice.py
+++ b/demo/runners/alice.py
@@ -91,11 +91,6 @@ class AliceAgent(DemoAgent):
             self.log("credential_definition_id", message["credential_definition_id"])
             self.log("schema_id", message["schema_id"])
 
-        elif state == "credential_acked":
-            cred_id = message["credential_id"]
-            self.log(f"Acked credential {cred_id} acceptance")
-            log_status(f"#18.2 Acked credential {cred_id} acceptance")
-
     async def handle_present_proof(self, message):
         state = message["state"]
         presentation_exchange_id = message["presentation_exchange_id"]

--- a/demo/runners/alice.py
+++ b/demo/runners/alice.py
@@ -77,9 +77,9 @@ class AliceAgent(DemoAgent):
                 "/issue-credential/records/" f"{credential_exchange_id}/send-request"
             )
 
-        elif state == "credential_acked":
-            self.log("Stored credential {cred_id} in wallet")
+        elif state == "credential_stored":
             cred_id = message["credential_id"]
+            self.log(f"Stored credential {cred_id} in wallet")
             log_status(f"#18.1 Stored credential {cred_id} in wallet")
             resp = await self.admin_GET(f"/credential/{cred_id}")
             log_json(resp, label="Credential details:")
@@ -90,6 +90,11 @@ class AliceAgent(DemoAgent):
             self.log("credential_id", message["credential_id"])
             self.log("credential_definition_id", message["credential_definition_id"])
             self.log("schema_id", message["schema_id"])
+
+        elif state == "credential_acked":
+            cred_id = message["credential_id"]
+            self.log(f"Acked credential {cred_id} acceptance")
+            log_status(f"#18.2 Acked credential {cred_id} acceptance")
 
     async def handle_present_proof(self, message):
         state = message["state"]


### PR DESCRIPTION
I've reintroduced credential_received, credential_acked and credential_stored as distinct states. Only the issuer gets credential_acked in an exchange record; the record is gone at the holder side at ack in any case; the holder's last web hook update is credential_saved.

The please-ack from the issuer side necessarily asks for ack on credential_stored (accepted) as per Aries RFC 0036 (issue-credential) state transition diagram (text disagrees for the moment - patience will provide convergence) and 0317 (please-ack) semantics (not the example - again, I hope to convince the example to converge with all germane Aries RFC pics and text).

For the moment this impl is a stake in the ground to show the concept working as I interpret the Aries RFC design intent.

Signed-off-by: sklump <srklump@hotmail.com>