### PR TITLE
unit tests for introduction protocol

### DIFF
--- a/aries_cloudagent/protocols/introduction/demo_service.py
+++ b/aries_cloudagent/protocols/introduction/demo_service.py
@@ -59,7 +59,7 @@ class DemoIntroductionService(BaseIntroductionService):
         msg = InvitationRequest(responder=init_connection.their_label, message=message)
 
         record = StorageRecord(
-            type=self.RECORD_TYPE,
+            type=DemoIntroductionService.RECORD_TYPE,
             value=json.dumps({"thread_id": msg._id, "state": "pending"}),
             tags={
                 "init_connection_id": init_connection_id,
@@ -87,7 +87,10 @@ class DemoIntroductionService(BaseIntroductionService):
 
         tag_filter = {"target_connection_id": target_connection_id}
         storage: BaseStorage = await self._context.inject(BaseStorage)
-        records = await storage.search_records(self.RECORD_TYPE, tag_filter).fetch_all()
+        records = await storage.search_records(
+            DemoIntroductionService.RECORD_TYPE,
+            tag_filter,
+        ).fetch_all()
 
         found = False
         for row in records:

--- a/aries_cloudagent/protocols/introduction/handlers/invitation_request_handler.py
+++ b/aries_cloudagent/protocols/introduction/handlers/invitation_request_handler.py
@@ -1,6 +1,11 @@
 """Handler for incoming invitation request messages."""
 
-from ...base_handler import BaseHandler, BaseResponder, HandlerException, RequestContext
+from ....messaging.base_handler import (
+    BaseHandler,
+    BaseResponder,
+    HandlerException,
+    RequestContext,
+)
 from ...connections.manager import ConnectionManager
 from ..messages.invitation_request import InvitationRequest
 from ..messages.invitation import Invitation

--- a/aries_cloudagent/protocols/introduction/handlers/tests/test_forward_invitation_handler.py
+++ b/aries_cloudagent/protocols/introduction/handlers/tests/test_forward_invitation_handler.py
@@ -1,0 +1,90 @@
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
+
+from .....config.injection_context import InjectionContext
+from .....connections.models.connection_record import ConnectionRecord
+from .....messaging.base_handler import HandlerException
+from .....messaging.request_context import RequestContext
+from .....messaging.responder import MockResponder
+
+from ....connections.messages.connection_invitation import ConnectionInvitation
+
+from ...messages.forward_invitation import ForwardInvitation
+
+from .. import forward_invitation_handler as test_module
+
+TEST_DID = "55GkHamhTU1ZbTbV2ab9DE"
+TEST_VERKEY = "3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"
+TEST_ROUTE_VERKEY = "9WCgWKUaAJj3VWxxtzvvMQN3AoFxoBtBDo9ntwJnVVCC"
+TEST_LABEL = "Label"
+TEST_ENDPOINT = "http://localhost"
+TEST_IMAGE_URL = "http://aries.ca/images/sample.png"
+
+
+class TestForwardInvitationHandler(AsyncTestCase):
+    async def setUp(self):
+        self.context = RequestContext(
+            base_context=InjectionContext(enforce_typing=False)
+        )
+
+        self.context.connection_ready = True
+        self.context.message = ForwardInvitation(
+            invitation=ConnectionInvitation(
+                label=TEST_LABEL,
+                did=TEST_DID,
+                recipient_keys=[TEST_VERKEY],
+                endpoint=TEST_ENDPOINT,
+                routing_keys=[TEST_ROUTE_VERKEY],
+                image_url=TEST_IMAGE_URL,
+            ),
+            message="Hello World"
+        )
+        self.context.update_settings({"accept_invites": False})
+
+    async def test_handle(self):
+        handler = test_module.ForwardInvitationHandler()
+
+        responder = MockResponder()
+        with async_mock.patch.object(
+            test_module, "ConnectionManager", autospec=True
+        ) as mock_mgr:
+            mock_mgr.return_value.receive_invitation = async_mock.CoroutineMock(
+                return_value=ConnectionRecord(connection_id="dummy")
+            )
+
+            await handler.handle(self.context, responder)
+            assert not(responder.messages)
+
+    async def test_handle_auto_accept(self):
+        handler = test_module.ForwardInvitationHandler()
+        self.context.update_settings({"accept_invites": True})
+
+        mock_conn_rec = async_mock.MagicMock(connection_id="dummy")
+        mock_conn_req = async_mock.MagicMock(label="test")
+
+        responder = MockResponder()
+        with async_mock.patch.object(
+            test_module, "ConnectionManager", autospec=True
+        ) as mock_mgr:
+            mock_mgr.return_value.receive_invitation = async_mock.CoroutineMock(
+                return_value=mock_conn_rec
+            )
+            mock_mgr.return_value.create_request = async_mock.CoroutineMock(
+                return_value=mock_conn_req
+            )
+
+            await handler.handle(self.context, responder)
+            assert mock_mgr.return_value.create_request.called_once_with(mock_conn_rec)
+
+            messages = responder.messages
+            assert len(messages) == 1
+            (result, target) = messages[0]
+            assert result == mock_conn_req
+            assert target["connection_id"] == "dummy"
+
+    async def test_handle_not_ready(self):
+        handler = test_module.ForwardInvitationHandler()
+        self.context.connection_ready = False
+
+        with self.assertRaises(HandlerException):
+            await handler.handle(self.context, None)

--- a/aries_cloudagent/protocols/introduction/handlers/tests/test_invitation_handler.py
+++ b/aries_cloudagent/protocols/introduction/handlers/tests/test_invitation_handler.py
@@ -1,0 +1,82 @@
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
+
+from .....config.injection_context import InjectionContext
+from .....connections.models.connection_record import ConnectionRecord
+from .....messaging.base_handler import HandlerException
+from .....messaging.request_context import RequestContext
+from .....messaging.responder import MockResponder
+from .....storage.base import BaseStorage
+from .....storage.basic import BasicStorage
+
+from ....connections.messages.connection_invitation import ConnectionInvitation
+
+from ...messages.invitation import Invitation
+from ...messages.invitation_request import InvitationRequest
+
+from .. import invitation_handler as test_module
+
+TEST_DID = "55GkHamhTU1ZbTbV2ab9DE"
+TEST_VERKEY = "3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"
+TEST_ROUTE_VERKEY = "9WCgWKUaAJj3VWxxtzvvMQN3AoFxoBtBDo9ntwJnVVCC"
+TEST_LABEL = "Label"
+TEST_ENDPOINT = "http://localhost"
+TEST_IMAGE_URL = "http://aries.ca/images/sample.png"
+
+
+class TestInvitationHandler(AsyncTestCase):
+    async def setUp(self):
+        self.storage = BasicStorage()
+
+        self.context = RequestContext(
+            base_context=InjectionContext(enforce_typing=False)
+        )
+        self.context.injector.bind_instance(BaseStorage, self.storage)
+
+        self.context.connection_ready = True
+        self.context.message = Invitation(
+            invitation=ConnectionInvitation(
+                label=TEST_LABEL,
+                did=TEST_DID,
+                recipient_keys=[TEST_VERKEY],
+                endpoint=TEST_ENDPOINT,
+                routing_keys=[TEST_ROUTE_VERKEY],
+                image_url=TEST_IMAGE_URL,
+            ),
+            message="Hello World",
+        )
+        self.context.connection_record = async_mock.MagicMock(connection_id="dummy")
+
+    async def test_handle(self):
+        handler = test_module.InvitationHandler()
+
+        mock_conn_rec = async_mock.MagicMock(connection_id="dummy")
+
+        responder = MockResponder()
+        with async_mock.patch.object(
+            self.context, "inject", async_mock.CoroutineMock()
+        ) as mock_ctx_inject:
+            mock_ctx_inject.return_value = async_mock.MagicMock(
+                return_invitation=async_mock.CoroutineMock()
+            )
+
+            await handler.handle(self.context, responder)
+
+            assert mock_ctx_inject.return_value.return_invitation.called_once_with(
+                self.context.connection_record.connection_id,
+                self.context.message,
+                responder.send
+            )
+
+    async def test_handle_no_service(self):
+        handler = test_module.InvitationHandler()
+
+        with self.assertRaises(HandlerException):
+            await handler.handle(self.context, None)
+
+    async def test_handle_not_ready(self):
+        handler = test_module.InvitationHandler()
+        self.context.connection_ready = False
+
+        with self.assertRaises(HandlerException):
+            await handler.handle(self.context, None)

--- a/aries_cloudagent/protocols/introduction/handlers/tests/test_invitation_request_handler.py
+++ b/aries_cloudagent/protocols/introduction/handlers/tests/test_invitation_request_handler.py
@@ -1,0 +1,85 @@
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
+
+from .....config.injection_context import InjectionContext
+from .....connections.models.connection_record import ConnectionRecord
+from .....messaging.base_handler import HandlerException
+from .....messaging.request_context import RequestContext
+from .....messaging.responder import MockResponder
+
+from ....connections.messages.connection_invitation import ConnectionInvitation
+
+from ...messages.invitation import Invitation
+from ...messages.invitation_request import InvitationRequest
+
+from .. import invitation_request_handler as test_module
+
+TEST_DID = "55GkHamhTU1ZbTbV2ab9DE"
+TEST_VERKEY = "3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"
+TEST_ROUTE_VERKEY = "9WCgWKUaAJj3VWxxtzvvMQN3AoFxoBtBDo9ntwJnVVCC"
+TEST_LABEL = "Label"
+TEST_ENDPOINT = "http://localhost"
+TEST_IMAGE_URL = "http://aries.ca/images/sample.png"
+
+
+class TestInvitationRequestHandler(AsyncTestCase):
+    async def setUp(self):
+        self.context = RequestContext(
+            base_context=InjectionContext(enforce_typing=False)
+        )
+
+        self.context.connection_ready = True
+        self.context.message = InvitationRequest(
+            responder="test-agent",
+            message="Hello World",
+        )
+        self.context.update_settings({"accept_requests": False})
+
+    async def test_handle(self):
+        handler = test_module.InvitationRequestHandler()
+
+        responder = MockResponder()
+        inv_req = InvitationRequest(responder=responder, message="Hello")
+
+        with async_mock.patch.object(
+            test_module, "ConnectionManager", autospec=True
+        ) as mock_mgr:
+            await handler.handle(self.context, responder)
+
+    async def test_handle_auto_accept(self):
+        handler = test_module.InvitationRequestHandler()
+        self.context.update_settings({"accept_requests": True})
+
+        conn_invitation=ConnectionInvitation(
+            label=TEST_LABEL,
+            did=TEST_DID,
+            recipient_keys=[TEST_VERKEY],
+            endpoint=TEST_ENDPOINT,
+            routing_keys=[TEST_ROUTE_VERKEY],
+            image_url=TEST_IMAGE_URL,
+        )
+        mock_conn_rec = async_mock.MagicMock(connection_id="dummy")
+
+        responder = MockResponder()
+        with async_mock.patch.object(
+            test_module, "ConnectionManager", autospec=True
+        ) as mock_mgr:
+            mock_mgr.return_value.create_invitation = async_mock.CoroutineMock(
+                return_value=(mock_conn_rec, conn_invitation)
+            )
+
+            await handler.handle(self.context, responder)
+            assert mock_mgr.return_value.create_invitation.called_once_with()
+
+            messages = responder.messages
+            assert len(messages) == 1
+            (result, _) = messages[0]
+            assert type(result) == Invitation
+            assert result._thread._thid == self.context.message._message_id
+
+    async def test_handle_not_ready(self):
+        handler = test_module.InvitationRequestHandler()
+        self.context.connection_ready = False
+
+        with self.assertRaises(HandlerException):
+            await handler.handle(self.context, None)

--- a/aries_cloudagent/protocols/introduction/tests/test_routes.py
+++ b/aries_cloudagent/protocols/introduction/tests/test_routes.py
@@ -1,0 +1,99 @@
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
+
+from aiohttp import web as aio_web
+
+from ....config.injection_context import InjectionContext
+from ....connections.models.connection_record import ConnectionRecord
+from ....messaging.request_context import RequestContext
+
+from .. import routes as test_module
+
+
+class TestIntroductionRoutes(AsyncTestCase):
+    async def test_introduction_start_no_service(self):
+        context = RequestContext(
+            base_context=InjectionContext(enforce_typing=False)
+        )
+
+        mock_req = async_mock.MagicMock()
+        mock_req.app = {
+            "request_context": context,
+            "outbound_message_router": None
+        }
+        mock_req.json = async_mock.CoroutineMock(
+            return_value={
+                "my_seed": "my_seed",
+                "my_did": "my_did",
+                "their_seed": "their_seed",
+                "their_did": "their_did",
+                "their_verkey": "their_verkey",
+                "their_endpoint": "their_endpoint",
+                "their_role": "their_role",
+                "alias": "alias",
+            }
+        )
+        mock_req.match_info = {"id": "dummy"}
+        mock_req.query = {
+            "target_connection_id": "dummy",
+            "message": "Hello",
+        }
+
+        with self.assertRaises(test_module.web.HTTPForbidden):
+            await test_module.introduction_start(mock_req)
+
+    async def test_introduction_start(self):
+        context = RequestContext(
+            base_context=InjectionContext(enforce_typing=False)
+        )
+
+        mock_req = async_mock.MagicMock()
+        mock_req.app = {
+            "request_context": context,
+            "outbound_message_router": None
+        }
+        mock_req.json = async_mock.CoroutineMock(
+            return_value={
+                "my_seed": "my_seed",
+                "my_did": "my_did",
+                "their_seed": "their_seed",
+                "their_did": "their_did",
+                "their_verkey": "their_verkey",
+                "their_endpoint": "their_endpoint",
+                "their_role": "their_role",
+                "alias": "alias",
+            }
+        )
+        mock_req.match_info = {"id": "dummy"}
+        mock_req.query = {
+            "target_connection_id": "dummy",
+            "message": "Hello",
+        }
+
+        mock_conn_rec = async_mock.MagicMock()
+        mock_conn_rec.serialize = async_mock.MagicMock()
+
+        test_module.web.json_response = async_mock.CoroutineMock()
+
+        with async_mock.patch.object(
+            context, "inject", async_mock.CoroutineMock()
+        ) as mock_ctx_inject:
+            mock_ctx_inject.return_value = async_mock.MagicMock(
+                start_introduction=async_mock.CoroutineMock()
+            )
+
+            await test_module.introduction_start(mock_req)
+            mock_ctx_inject.return_value.start_introduction.assert_called_once_with(
+                mock_req.match_info["id"],
+                mock_req.query["target_connection_id"],
+                mock_req.query["message"],
+                mock_req.app["outbound_message_router"],
+            )
+            test_module.web.json_response.assert_called_once_with({})
+
+    async def test_register(self):
+        mock_app = async_mock.MagicMock()
+        mock_app.add_routes = async_mock.MagicMock()
+
+        await test_module.register(mock_app)
+        mock_app.add_routes.assert_called_once()

--- a/aries_cloudagent/protocols/introduction/tests/test_service.py
+++ b/aries_cloudagent/protocols/introduction/tests/test_service.py
@@ -1,0 +1,198 @@
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
+
+from ....config.injection_context import InjectionContext
+from ....connections.models.connection_record import ConnectionRecord
+from ....messaging.request_context import RequestContext
+from ....messaging.responder import MockResponder
+from ....storage.base import BaseStorage
+from ....storage.basic import BasicStorage
+from ....storage.error import StorageNotFoundError
+
+from ...connections.messages.connection_invitation import ConnectionInvitation
+
+from .. import base_service, demo_service
+
+TEST_DID = "55GkHamhTU1ZbTbV2ab9DE"
+TEST_VERKEY = "3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"
+TEST_ROUTE_VERKEY = "9WCgWKUaAJj3VWxxtzvvMQN3AoFxoBtBDo9ntwJnVVCC"
+TEST_LABEL = "Label"
+TEST_ENDPOINT = "http://localhost"
+TEST_IMAGE_URL = "http://aries.ca/images/sample.png"
+
+
+class TestIntroductionRoutes(AsyncTestCase):
+    def setUp(self):
+        self.storage = BasicStorage()
+        self.context = InjectionContext(enforce_typing=False)
+        self.context.injector.bind_instance(BaseStorage, self.storage)
+
+    async def test_service_start_introduction_no_init_conn_rec(self):
+        service = await demo_service.DemoIntroductionService.service_handler()(
+            self.context
+        )
+
+        with self.assertRaises(base_service.IntroductionError):
+            await service.start_introduction(
+                init_connection_id="init-id",
+                target_connection_id=None,
+                message="Hello",
+                outbound_handler=None
+            )
+
+    async def test_service_start_introduction_init_conn_rec_not_active(self):
+        service = await demo_service.DemoIntroductionService.service_handler()(
+            self.context
+        )
+
+        conn_rec_init = ConnectionRecord(
+            connection_id=None,
+            state=ConnectionRecord.STATE_INACTIVE,
+        )
+        await conn_rec_init.save(self.context)
+        assert conn_rec_init._id
+
+        with self.assertRaises(base_service.IntroductionError):
+            await service.start_introduction(
+                init_connection_id=conn_rec_init._id,
+                target_connection_id=None,
+                message="Hello",
+                outbound_handler=None
+            )
+
+    async def test_service_start_introduction_no_target_conn_rec(self):
+        service = await demo_service.DemoIntroductionService.service_handler()(
+            self.context
+        )
+
+        conn_rec_init = ConnectionRecord(
+            connection_id=None,
+            state=ConnectionRecord.STATE_ACTIVE,
+        )
+        await conn_rec_init.save(self.context)
+        assert conn_rec_init._id
+        
+        with self.assertRaises(base_service.IntroductionError):
+            await service.start_introduction(
+                init_connection_id=conn_rec_init._id,
+                target_connection_id="target-id",
+                message="Hello",
+                outbound_handler=None
+            )
+
+    async def test_service_start_introduction_target_conn_rec_not_active(self):
+        service = await demo_service.DemoIntroductionService.service_handler()(
+            self.context
+        )
+
+        conn_rec_init = ConnectionRecord(
+            connection_id=None,
+            state=ConnectionRecord.STATE_ACTIVE,
+        )
+        await conn_rec_init.save(self.context)
+        assert conn_rec_init._id
+        
+
+        conn_rec_target = ConnectionRecord(
+            connection_id=None,
+            state=ConnectionRecord.STATE_INACTIVE,
+        )
+        await conn_rec_target.save(self.context)
+        assert conn_rec_target._id
+
+        with self.assertRaises(base_service.IntroductionError):
+            await service.start_introduction(
+                init_connection_id=conn_rec_init._id,
+                target_connection_id=conn_rec_target._id,
+                message="Hello",
+                outbound_handler=None
+            )
+
+    async def test_service_start_and_return_introduction(self):
+        service = await demo_service.DemoIntroductionService.service_handler()(
+            self.context
+        )
+        start_responder = MockResponder()
+
+        conn_rec_init = ConnectionRecord(
+            connection_id=None,
+            state=ConnectionRecord.STATE_ACTIVE,
+        )
+        await conn_rec_init.save(self.context)
+        assert conn_rec_init._id
+
+        conn_rec_target = ConnectionRecord(
+            connection_id=None,
+            state=ConnectionRecord.STATE_ACTIVE,
+        )
+        await conn_rec_target.save(self.context)
+        assert conn_rec_target._id
+
+        await service.start_introduction(
+            init_connection_id=conn_rec_init._id,
+            target_connection_id=conn_rec_target._id,
+            message="Hello Start",
+            outbound_handler=start_responder.send
+        )
+        messages = start_responder.messages
+        assert len(messages) == 1
+        (result, target) = messages[0]
+        assert isinstance(result, demo_service.InvitationRequest)
+        assert result.message == "Hello Start"
+        assert target["connection_id"] == conn_rec_target._id
+
+        invite = demo_service.Invitation(
+            invitation=ConnectionInvitation(
+                label=TEST_LABEL,
+                did=TEST_DID,
+                recipient_keys=[TEST_VERKEY],
+                endpoint=TEST_ENDPOINT,
+                routing_keys=[TEST_ROUTE_VERKEY],
+                image_url=TEST_IMAGE_URL,
+            ),
+            message="Hello Invite",
+            _id=result._id
+        ) 
+        return_responder = MockResponder()
+
+        await service.return_invitation(
+            target_connection_id=conn_rec_target._id,
+            invitation=invite,
+            outbound_handler=return_responder.send
+        )
+        messages = return_responder.messages
+        assert len(messages) == 1
+        (result, target) = messages[0]
+        assert isinstance(result, demo_service.ForwardInvitation)
+        assert result.message == "Hello Invite"
+        assert target["connection_id"] == conn_rec_init._id
+
+    async def test_service_return_invitation_not_found(self):
+        invite = demo_service.Invitation(
+            invitation=ConnectionInvitation(
+                label=TEST_LABEL,
+                did=TEST_DID,
+                recipient_keys=[TEST_VERKEY],
+                endpoint=TEST_ENDPOINT,
+                routing_keys=[TEST_ROUTE_VERKEY],
+                image_url=TEST_IMAGE_URL,
+            ),
+            message="Hello World",
+        ) 
+
+        service = await demo_service.DemoIntroductionService.service_handler()(
+            self.context
+        )
+
+        conn_rec_target = ConnectionRecord(
+            connection_id=None,
+            state=ConnectionRecord.STATE_ACTIVE,
+        )
+        await conn_rec_target.save(self.context)
+        assert conn_rec_target._id
+
+        await service.return_invitation(
+            target_connection_id=conn_rec_target._id,
+            invitation=invite,
+            outbound_handler=None
+        )


### PR DESCRIPTION
+ note enum-like fields are class, not instance variables: python allows slack here but mock framework raises fewer surprises in unit testing when specified class-wise
Signed-off-by: sklump <srklump@hotmail.com>