### PR TITLE
Fix passing custom endpoint while accepting invitation

### DIFF
--- a/aries_cloudagent/protocols/connections/manager.py
+++ b/aries_cloudagent/protocols/connections/manager.py
@@ -273,6 +273,8 @@ class ConnectionManager:
         if not my_endpoint:
             my_endpoints = [self.context.settings.get("default_endpoint")]
             my_endpoints.extend(self.context.settings.get("additional_endpoints"))
+        else:
+            my_endpoints = [my_endpoint]
         did_doc = await self.create_did_document(
             my_info, connection.inbound_connection_id, my_endpoints
         )

--- a/aries_cloudagent/protocols/connections/tests/test_manager.py
+++ b/aries_cloudagent/protocols/connections/tests/test_manager.py
@@ -236,6 +236,19 @@ class TestConnectionManager(AsyncTestCase, TestConfig):
         )
         assert conn_req
 
+    async def test_create_request_my_endpoint(self):
+        conn_req = await self.manager.create_request(
+            ConnectionRecord(
+                initiator=ConnectionRecord.INITIATOR_EXTERNAL,
+                invitation_key=self.test_verkey,
+                their_label="Hello",
+                their_role="Point of contact",
+                alias="Bob",
+            ),
+            my_endpoint="http://testendpoint.com/endpoint"
+        )
+        assert conn_req
+
     async def test_create_request_my_did(self):
         wallet = await self.context.inject(BaseWallet)
         await wallet.create_local_did(


### PR DESCRIPTION
`my_endpoints` is undefined if `my_endpoint` is passed to the method. The fix initializes `my_endpoints` in the else block