### PR TITLE
Fix broken assignment in IndyProofReqPredSpecSchema

### DIFF
--- a/aries_cloudagent/protocols/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/routes.py
@@ -128,12 +128,12 @@ class IndyProofReqPredSpecSchema(Schema):
     """Schema for predicate specification in indy proof request."""
 
     name = fields.String(example="index", description="Attribute name", required=True)
-    p_type: fields.String(
+    p_type = fields.String(
         description="Predicate type (indy currently supports only '>=')",
         required=True,
         **INDY_PREDICATE
     )
-    p_value: fields.Integer(description="Threshold value", required=True)
+    p_value = fields.Integer(description="Threshold value", required=True)
     restrictions = fields.List(
         fields.Nested(IndyProofReqSpecRestrictionsSchema()),
         description="If present, credential must satisfy one of given restrictions",


### PR DESCRIPTION
Ran into this recently. Seems to be breaking requesting a presentation through a controller, resulting in a schema validation failure if `p_type` and `p_value` are specified.

Signed-off-by: Daniel Bluhm <daniel.bluhm@sovrin.org>