### PR TITLE
accommodate referents in presentation proposal preview attribute spec…

### DIFF
--- a/aries_cloudagent/protocols/present_proof/v1_0/messages/inner/presentation_preview.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/messages/inner/presentation_preview.py
@@ -98,6 +98,7 @@ class PresAttrSpec(BaseModel):
         cred_def_id: str = None,
         mime_type: str = None,
         value: str = None,
+        referent: str = None,
         **kwargs,
     ):
         """
@@ -110,6 +111,7 @@ class PresAttrSpec(BaseModel):
             mime_type: MIME type
             value: attribute value as credential stores it
                 (None for unrevealed attribute)
+            referent: credential referent
 
         """
         super().__init__(**kwargs)
@@ -117,22 +119,29 @@ class PresAttrSpec(BaseModel):
         self.cred_def_id = cred_def_id
         self.mime_type = mime_type.lower() if mime_type else None
         self.value = value
+        self.referent = referent
 
     @staticmethod
-    def list_plain(plain: dict, cred_def_id: str):
+    def list_plain(plain: dict, cred_def_id: str, referent: str = None):
         """
         Return a list of `PresAttrSpec` on input cred def id.
 
         Args:
             plain: dict mapping names to values
-
+            cred_def_id: credential definition identifier to specify
+            referent: single referent to use, omit for none
 
         Returns:
             List of PresAttrSpec on input cred def id with no MIME types
 
         """
         return [
-            PresAttrSpec(name=k, cred_def_id=cred_def_id, value=plain[k]) for k in plain
+            PresAttrSpec(
+                name=k,
+                cred_def_id=cred_def_id,
+                value=plain[k],
+                referent=referent
+            ) for k in plain
         ]
 
     @property
@@ -178,6 +187,9 @@ class PresAttrSpec(BaseModel):
         if self.mime_type != other.mime_type:
             return False  # distinct MIME types
 
+        if self.referent != other.referent:
+            return False  # distinct credential referents
+
         return self.b64_decoded_value() == other.b64_decoded_value()
 
 
@@ -200,6 +212,11 @@ class PresAttrSpecSchema(BaseModelSchema):
         example="image/jpeg",
     )
     value = fields.Str(description="Attribute value", required=False, example="martini")
+    referent = fields.Str(
+        description="Credential referent",
+        required=False,
+        example="0"
+    )
 
 
 class PresentationPreview(BaseModel):
@@ -304,6 +321,7 @@ class PresentationPreview(BaseModel):
             "requested_predicates": {},
         }
 
+        attr_specs_names = {}
         for attr_spec in self.attributes:
             if attr_spec.posture == PresAttrSpec.Posture.SELF_ATTESTED:
                 proof_req["requested_attributes"][
@@ -321,19 +339,44 @@ class PresentationPreview(BaseModel):
                 )
 
                 timestamp = non_revo(attr_spec.cred_def_id)
-                proof_req["requested_attributes"][
-                    "{}_{}_uuid".format(
-                        len(proof_req["requested_attributes"]),
-                        canon(attr_spec.name))
-                ] = {
-                    "name": canon(attr_spec.name),
-                    "restrictions": [{"cred_def_id": cd_id}],
-                    **{
-                        "non_revoked": {"from": timestamp, "to": timestamp}
-                        for _ in [""]
-                        if revo_support
-                    },
-                }
+
+                if attr_spec.referent:
+                    if attr_spec.referent in attr_specs_names:
+                        attr_specs_names[attr_spec.referent]["names"].append(
+                            canon(attr_spec.name)
+                        )
+                    else:
+                        attr_specs_names[attr_spec.referent] = {
+                            "names": [canon(attr_spec.name)],
+                            "restrictions": [{"cred_def_id": cd_id}],
+                            **{
+                                "non_revoked": {"from": timestamp, "to": timestamp}
+                                for _ in [""]
+                                if revo_support
+                            },
+                        }
+                else:
+                    proof_req["requested_attributes"][
+                        "{}_{}_uuid".format(
+                            len(proof_req["requested_attributes"]),
+                            canon(attr_spec.name)
+                        )
+                    ] = {
+                        "name": canon(attr_spec.name),
+                        "restrictions": [{"cred_def_id": cd_id}],
+                        **{
+                            "non_revoked": {"from": timestamp, "to": timestamp}
+                            for _ in [""]
+                            if revo_support
+                        },
+                    }
+        for (reft, attr_spec) in attr_specs_names.items():
+            proof_req["requested_attributes"][
+                "{}_{}_uuid".format(
+                    len(proof_req["requested_attributes"]),
+                    canon(attr_spec["names"][0])
+                )
+            ] = attr_spec
 
         for pred_spec in self.predicates:
             cd_id = pred_spec.cred_def_id

--- a/aries_cloudagent/protocols/present_proof/v1_0/messages/inner/tests/test_presentation_preview.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/messages/inner/tests/test_presentation_preview.py
@@ -24,18 +24,23 @@ from ..presentation_preview import (
 
 NOW_8601 = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(" ", "seconds")
 NOW_EPOCH = str_to_epoch(NOW_8601)
-S_ID = "NcYxiDXkpYi6ov5FcYDi1e:2:vidya:1.0"
-CD_ID = f"NcYxiDXkpYi6ov5FcYDi1e:3:CL:{S_ID}:tag1"
+S_ID = {
+    "score": "NcYxiDXkpYi6ov5FcYDi1e:2:score:1.0",
+    "membership": "NcYxiDXkpYi6ov5FcYDi1e:2:membership:1.0"
+}
+CD_ID = {
+    name: f"NcYxiDXkpYi6ov5FcYDi1e:3:CL:{S_ID[name]}:tag1" for name in S_ID
+}
 PRES_PREVIEW = PresentationPreview(
     attributes=[
         PresAttrSpec(
             name="player",
-            cred_def_id=CD_ID,
+            cred_def_id=CD_ID['score'],
             value="Richie Knucklez"
         ),
         PresAttrSpec(
             name="screenCapture",
-            cred_def_id=CD_ID,
+            cred_def_id=CD_ID['score'],
             mime_type="image/png",
             value="aW1hZ2luZSBhIHNjcmVlbiBjYXB0dXJl"
         )
@@ -43,9 +48,38 @@ PRES_PREVIEW = PresentationPreview(
     predicates=[
         PresPredSpec(
             name="highScore",
-            cred_def_id=CD_ID,
+            cred_def_id=CD_ID['score'],
             predicate=">=",
             threshold=1000000
+        )
+    ]
+)
+PRES_PREVIEW_ATTR_NAMES = PresentationPreview(
+    attributes=[
+        PresAttrSpec(
+            name="player",
+            cred_def_id=CD_ID['score'],
+            value="Richie Knucklez",
+            referent="reft-0"
+        ),
+        PresAttrSpec(
+            name="screenCapture",
+            cred_def_id=CD_ID['score'],
+            mime_type="image/png",
+            value="aW1hZ2luZSBhIHNjcmVlbiBjYXB0dXJl",
+            referent="reft-0"
+        ),
+        PresAttrSpec(
+            name="member",
+            cred_def_id=CD_ID['membership'],
+            value="Richard Hand",
+            referent="reft-1"
+        ),
+        PresAttrSpec(
+            name="since",
+            cred_def_id=CD_ID['membership'],
+            value="2020-01-01",
+            referent="reft-1"
         )
     ]
 )
@@ -58,7 +92,7 @@ INDY_PROOF_REQ = json.loads(f"""{{
             "name": "player",
             "restrictions": [
                 {{
-                    "cred_def_id": "{CD_ID}"
+                    "cred_def_id": "{CD_ID['score']}"
                 }}
             ]
         }},
@@ -66,7 +100,7 @@ INDY_PROOF_REQ = json.loads(f"""{{
             "name": "screenCapture",
             "restrictions": [
                 {{
-                    "cred_def_id": "{CD_ID}"
+                    "cred_def_id": "{CD_ID['score']}"
                 }}
             ]
         }}
@@ -78,11 +112,35 @@ INDY_PROOF_REQ = json.loads(f"""{{
             "p_value": 1000000,
             "restrictions": [
                 {{
-                    "cred_def_id": "{CD_ID}"
+                    "cred_def_id": "{CD_ID['score']}"
                 }}
             ]
         }}
     }}
+}}""")
+INDY_PROOF_REQ_ATTR_NAMES = json.loads(f"""{{
+    "name": "proof-req",
+    "version": "1.0",
+    "nonce": "12345",
+    "requested_attributes": {{
+        "0_player_uuid": {{
+            "names": ["player", "screenCapture"],
+            "restrictions": [
+                {{
+                    "cred_def_id": "{CD_ID['score']}"
+                }}
+            ]
+        }},
+        "1_member_uuid": {{
+            "names": ["member", "since"],
+            "restrictions": [
+                {{
+                    "cred_def_id": "{CD_ID['membership']}"
+                }}
+            ]
+        }}
+    }},
+    "requested_predicates": {{}}
 }}""")
 
 
@@ -99,14 +157,14 @@ class TestPresAttrSpec(TestCase):
 
         revealed = PresAttrSpec(
             name="ident",
-            cred_def_id=CD_ID,
+            cred_def_id=CD_ID["score"],
             value="655321"
         )
         assert revealed.posture == PresAttrSpec.Posture.REVEALED_CLAIM
 
         unrevealed = PresAttrSpec(
             name="ident",
-            cred_def_id=CD_ID
+            cred_def_id=CD_ID["score"]
         )
         assert unrevealed.posture == PresAttrSpec.Posture.UNREVEALED_CLAIM
 
@@ -119,18 +177,47 @@ class TestPresAttrSpec(TestCase):
                 "ident": "655321",
                 " Given Name ": "Alexander DeLarge"
             },
-            cred_def_id=CD_ID
+            cred_def_id=CD_ID["score"]
         )
         explicit = [
             PresAttrSpec(
                 name="ident",
-                cred_def_id=CD_ID,
+                cred_def_id=CD_ID["score"],
                 value="655321"
             ),
             PresAttrSpec(
                 name="givenname",
-                cred_def_id=CD_ID,
+                cred_def_id=CD_ID["score"],
                 value="Alexander DeLarge"
+            )
+        ]
+
+        # order could be askew
+        for listp in by_list:
+            assert any(xp == listp for xp in explicit)
+        assert len(explicit) == len(by_list)
+
+    def test_list_plain_share_referent(self):
+        by_list = PresAttrSpec.list_plain(
+            plain={
+                "ident": "655321",
+                " Given Name ": "Alexander DeLarge"
+            },
+            cred_def_id=CD_ID["score"],
+            referent="dummy"
+        )
+        explicit = [
+            PresAttrSpec(
+                name="ident",
+                cred_def_id=CD_ID["score"],
+                value="655321",
+                referent="dummy"
+            ),
+            PresAttrSpec(
+                name="givenname",
+                cred_def_id=CD_ID["score"],
+                value="Alexander DeLarge",
+                referent="dummy"
             )
         ]
 
@@ -181,7 +268,19 @@ class TestPresAttrSpec(TestCase):
                 value="dmFsdWU=",
                 mime_type=None
             ),
-            PresAttrSpec(name="name")
+            PresAttrSpec(name="name"),
+            PresAttrSpec(
+                name="name",
+                value="value",
+                cred_def_id="cred_def_id",
+                referent="reft-0"
+            ),
+            PresAttrSpec(
+                name="name",
+                value="value",
+                cred_def_id="cred_def_id",
+                referent="reft-1"
+            )
         ]
 
         for lhs in attr_specs_none_plain:
@@ -200,8 +299,19 @@ class TestPresAttrSpec(TestCase):
         """Test deserialization."""
         dump = json.dumps({
             "name": "PLAYER",
-            "cred_def_id": CD_ID,
+            "cred_def_id": CD_ID["score"],
             "value": "Richie Knucklez"
+        })
+
+        attr_spec = PresAttrSpec.deserialize(dump)
+        assert type(attr_spec) == PresAttrSpec
+        assert attr_spec.name == "player"
+
+        dump = json.dumps({
+            "name": "PLAYER",
+            "cred_def_id": CD_ID["score"],
+            "value": "Richie Knucklez",
+            "referent": "0"
         })
 
         attr_spec = PresAttrSpec.deserialize(dump)
@@ -214,8 +324,16 @@ class TestPresAttrSpec(TestCase):
         attr_spec_dict = PRES_PREVIEW.attributes[0].serialize()
         assert attr_spec_dict == {
             "name": "player",
-            "cred_def_id": CD_ID,
+            "cred_def_id": CD_ID["score"],
             "value": "Richie Knucklez"
+        }
+
+        attr_spec_dict = PRES_PREVIEW_ATTR_NAMES.attributes[0].serialize()
+        assert attr_spec_dict == {
+            "name": "player",
+            "cred_def_id": CD_ID["score"],
+            "value": "Richie Knucklez",
+            "referent": "reft-0"
         }
 
 
@@ -268,7 +386,7 @@ class TestPresPredSpec(TestCase):
         """Test deserialization."""
         dump = json.dumps({
             "name": "HIGH SCORE",
-            "cred_def_id": CD_ID,
+            "cred_def_id": CD_ID["score"],
             "predicate": ">=",
             "threshold": 1000000
         })
@@ -283,7 +401,7 @@ class TestPresPredSpec(TestCase):
         pred_spec_dict = PRES_PREVIEW.predicates[0].serialize()
         assert pred_spec_dict == {
             "name": "highscore",
-            "cred_def_id": CD_ID,
+            "cred_def_id": CD_ID["score"],
             "predicate": ">=",
             "threshold": 1000000
         }
@@ -293,13 +411,13 @@ class TestPresPredSpec(TestCase):
 
         pred_spec_a = PresPredSpec(
             name="a",
-            cred_def_id=CD_ID,
+            cred_def_id=CD_ID["score"],
             predicate=Predicate.GE.value.math,
             threshold=0,
         )
         pred_spec_b = PresPredSpec(
             name="b",
-            cred_def_id=CD_ID,
+            cred_def_id=CD_ID["score"],
             predicate=Predicate.GE.value.math,
             threshold=0,
         )
@@ -340,6 +458,22 @@ class TestPresentationPreviewAsync(AsyncTestCase):
 
         assert indy_proof_req == CANON_INDY_PROOF_REQ
 
+    @pytest.mark.asyncio
+    async def test_to_indy_proof_request_attr_names(self):
+        """Test presentation preview to indy proof request."""
+
+        CANON_INDY_PROOF_REQ_ATTR_NAMES = deepcopy(INDY_PROOF_REQ_ATTR_NAMES)
+        for spec in CANON_INDY_PROOF_REQ_ATTR_NAMES["requested_attributes"].values():
+            spec["names"] = [canon(name) for name in spec["names"]]
+
+        pres_preview = deepcopy(PRES_PREVIEW_ATTR_NAMES)
+
+        indy_proof_req = await pres_preview.indy_proof_request(
+            **{k: INDY_PROOF_REQ_ATTR_NAMES[k] for k in ("name", "version", "nonce")}
+        )
+
+        assert indy_proof_req == CANON_INDY_PROOF_REQ_ATTR_NAMES
+
     async def test_to_indy_proof_request_self_attested(self):
         """Test presentation preview to inty proof request with self-attested values."""
 
@@ -362,20 +496,20 @@ class TestPresentationPreviewAsync(AsyncTestCase):
 
         pred_spec = PresPredSpec(
             name="highScore",
-            cred_def_id=CD_ID,
+            cred_def_id=CD_ID["score"],
             predicate=Predicate.GE.value.math,
             threshold=1000000
         )
         attr_spec = PresAttrSpec(
             name="HIGHSCORE",
-            cred_def_id=CD_ID,
+            cred_def_id=CD_ID["score"],
             value=1234567
         )
         assert attr_spec.satisfies(pred_spec)
 
         attr_spec = PresAttrSpec(
             name="HIGHSCORE",
-            cred_def_id=CD_ID,
+            cred_def_id=CD_ID["score"],
             value=985260
         )
         assert not attr_spec.satisfies(pred_spec)
@@ -401,12 +535,12 @@ class TestPresentationPreview(TestCase):
             "attributes": [
                 {
                     "name": "player",
-                    "cred_def_id": CD_ID,
+                    "cred_def_id": CD_ID["score"],
                     "value": "Richie Knucklez"
                 },
                 {
                     "name": "screencapture",
-                    "cred_def_id": CD_ID,
+                    "cred_def_id": CD_ID["score"],
                     "mime-type": "image/png",
                     "value": "aW1hZ2luZSBhIHNjcmVlbiBjYXB0dXJl"
                 }
@@ -414,7 +548,7 @@ class TestPresentationPreview(TestCase):
             "predicates": [
                 {
                     "name": "highscore",
-                    "cred_def_id": CD_ID,
+                    "cred_def_id": CD_ID["score"],
                     "predicate": ">=",
                     "threshold": 1000000
                 }
@@ -433,12 +567,12 @@ class TestPresentationPreview(TestCase):
             "attributes": [
                 {
                     "name": "player",
-                    "cred_def_id": CD_ID,
+                    "cred_def_id": CD_ID["score"],
                     "value": "Richie Knucklez"
                 },
                 {
                     "name": "screencapture",
-                    "cred_def_id": CD_ID,
+                    "cred_def_id": CD_ID["score"],
                     "mime-type": "image/png",
                     "value": "aW1hZ2luZSBhIHNjcmVlbiBjYXB0dXJl"
                 }
@@ -446,7 +580,7 @@ class TestPresentationPreview(TestCase):
             "predicates": [
                 {
                     "name": "highscore",
-                    "cred_def_id": CD_ID,
+                    "cred_def_id": CD_ID["score"],
                     "predicate": ">=",
                     "threshold": 1000000
                 }


### PR DESCRIPTION
…ifications.

Note that nothing here breaks v1.0 of RFC 37. It only anticipates the forthcoming tweak (+referent in attribute specification): the code will subsequently understand the corresponding proof request (with `names`) once the von-image uplift moves to 1.13 or higher.

Signed-off-by: sklump <srklump@hotmail.com>