### PR TITLE
Add `to_session_only` option

### DIFF
--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -300,7 +300,8 @@ class Conductor:
             if self.inbound_transport_manager.return_to_session(outbound):
                 return
 
-        await self.queue_outbound(context, outbound, inbound)
+        if not outbound.to_session_only:
+            await self.queue_outbound(context, outbound, inbound)
 
     def handle_not_returned(self, context: InjectionContext, outbound: OutboundMessage):
         """Handle a message that failed delivery via an inbound session."""

--- a/aries_cloudagent/messaging/responder.py
+++ b/aries_cloudagent/messaging/responder.py
@@ -44,6 +44,7 @@ class BaseResponder(ABC):
         reply_to_verkey: str = None,
         target: ConnectionTarget = None,
         target_list: Sequence[ConnectionTarget] = None,
+        to_session_only: bool = False
     ) -> OutboundMessage:
         """Create an OutboundMessage from a message payload."""
         if isinstance(message, AgentMessage):
@@ -63,6 +64,7 @@ class BaseResponder(ABC):
             reply_to_verkey=reply_to_verkey,
             target=target,
             target_list=target_list,
+            to_session_only=to_session_only
         )
 
     async def send(self, message: Union[AgentMessage, str, bytes], **kwargs):

--- a/aries_cloudagent/transport/outbound/message.py
+++ b/aries_cloudagent/transport/outbound/message.py
@@ -21,6 +21,7 @@ class OutboundMessage:
         reply_from_verkey: str = None,
         target: ConnectionTarget = None,
         target_list: Sequence[ConnectionTarget] = None,
+        to_session_only: bool = False,
     ):
         """Initialize an outgoing message."""
         self.connection_id = connection_id
@@ -33,6 +34,7 @@ class OutboundMessage:
         self.reply_from_verkey = reply_from_verkey
         self.target = target
         self.target_list = list(target_list) if target_list else []
+        self.to_session_only = to_session_only
 
     def __repr__(self) -> str:
         """


### PR DESCRIPTION
This makes it possible to send a message to a connection only if they have a live session open.

We found this useful for instances where one message handler triggers a chatty/non-essential notification to another agent.