### PR TITLE
Activate create-static REST API

### DIFF
--- a/aries_cloudagent/protocols/connections/manager.py
+++ b/aries_cloudagent/protocols/connections/manager.py
@@ -561,6 +561,7 @@ class ConnectionManager:
         their_verkey: str = None,
         their_endpoint: str = None,
         their_role: str = None,
+        their_label: str = None,
         alias: str = None,
     ) -> ConnectionRecord:
         """
@@ -604,6 +605,7 @@ class ConnectionManager:
             my_did=my_info.did,
             their_did=their_info.did,
             their_role=their_role,
+            their_label=their_label,
             state=ConnectionRecord.STATE_ACTIVE,
             alias=alias,
         )

--- a/aries_cloudagent/protocols/connections/manager.py
+++ b/aries_cloudagent/protocols/connections/manager.py
@@ -563,7 +563,7 @@ class ConnectionManager:
         their_role: str = None,
         their_label: str = None,
         alias: str = None,
-    ) -> ConnectionRecord:
+    ) -> (DIDInfo, DIDInfo, ConnectionRecord):
         """
         Register a new static connection (for use by the test suite).
 
@@ -615,7 +615,7 @@ class ConnectionManager:
         did_doc = await self.create_did_document(their_info, None, [their_endpoint])
         await self.store_did_document(did_doc)
 
-        return connection
+        return my_info, their_info, connection
 
     async def find_connection(
         self,

--- a/aries_cloudagent/protocols/connections/routes.py
+++ b/aries_cloudagent/protocols/connections/routes.py
@@ -63,6 +63,9 @@ class ConnectionStaticRequestSchema(Schema):
     their_role = fields.Str(
         description="Role to assign to this connection", required=False
     )
+    their_label = fields.Str(
+        description="Label to assign to this connection", required=False
+    )
     alias = fields.Str(description="Alias to assign to this connection", required=False)
 
 
@@ -460,6 +463,7 @@ async def connections_create_static(request: web.BaseRequest):
         their_verkey=body.get("their_verkey") or None,
         their_endpoint=body.get("their_endpoint") or None,
         their_role=body.get("their_role") or None,
+        their_label=body.get("their_label") or None,
         alias=body.get("alias") or None,
     )
     result = connection.serialize()

--- a/aries_cloudagent/protocols/connections/routes.py
+++ b/aries_cloudagent/protocols/connections/routes.py
@@ -71,6 +71,7 @@ class ConnectionStaticRequestSchema(Schema):
 
 class ConnectionStaticResultSchema(Schema):
     """Result schema for new static connection."""
+
     my_did = fields.Str(
         description="Local DID", required=True, example=IndyDID.EXAMPLE
     )

--- a/aries_cloudagent/protocols/connections/routes.py
+++ b/aries_cloudagent/protocols/connections/routes.py
@@ -474,6 +474,7 @@ async def register(app: web.Application):
         [
             web.get("/connections", connections_list),
             web.get("/connections/{id}", connections_retrieve),
+            web.post("/connections/create-static", connections_create_static),
             web.post("/connections/create-invitation", connections_create_invitation),
             web.post("/connections/receive-invitation", connections_receive_invitation),
             web.post(

--- a/aries_cloudagent/protocols/connections/routes.py
+++ b/aries_cloudagent/protocols/connections/routes.py
@@ -69,6 +69,20 @@ class ConnectionStaticRequestSchema(Schema):
     alias = fields.Str(description="Alias to assign to this connection", required=False)
 
 
+class ConnectionStaticResultSchema(Schema):
+    """Result schema for new static connection."""
+    my_did = fields.Str(
+        description="Local DID", required=True, example=IndyDID.EXAMPLE
+    )
+    mv_verkey = fields.Str(description="My verification key", required=True)
+    my_endpoint = fields.Str(description="My endpoint", required=True)
+    their_did = fields.Str(
+        description="Remote DID", required=True, example=IndyDID.EXAMPLE
+    )
+    their_verkey = fields.Str(description="Remote verification key", required=True)
+    record = fields.Nested(ConnectionRecordSchema, required=True)
+
+
 def connection_sort_key(conn):
     """Get the sorting key for a particular connection."""
     if conn["state"] == ConnectionRecord.STATE_INACTIVE:

--- a/aries_cloudagent/protocols/connections/tests/test_manager.py
+++ b/aries_cloudagent/protocols/connections/tests/test_manager.py
@@ -599,7 +599,7 @@ class TestConnectionManager(AsyncTestCase, TestConfig):
             ConnectionRecord, "save", autospec=True
         ) as mock_conn_rec_save:
 
-            conn_rec = await self.manager.create_static_connection(
+            _my, _their, conn_rec = await self.manager.create_static_connection(
                 my_did=self.test_did,
                 their_did=self.test_target_did,
                 their_verkey=self.test_target_verkey,
@@ -626,7 +626,7 @@ class TestConnectionManager(AsyncTestCase, TestConfig):
             ConnectionRecord, "save", autospec=True
         ) as mock_conn_rec_save:
 
-            conn_rec = await self.manager.create_static_connection(
+            _my, _their, conn_rec = await self.manager.create_static_connection(
                 my_did=self.test_did,
                 their_seed=self.test_seed,
                 their_endpoint=self.test_endpoint,

--- a/aries_cloudagent/protocols/connections/tests/test_routes.py
+++ b/aries_cloudagent/protocols/connections/tests/test_routes.py
@@ -409,6 +409,12 @@ class TestConnectionRoutes(AsyncTestCase):
 
         mock_conn_rec = async_mock.MagicMock()
         mock_conn_rec.serialize = async_mock.MagicMock()
+        mock_my_info = async_mock.MagicMock()
+        mock_my_info.did = "my_did"
+        mock_my_info.verkey = "my_verkey"
+        mock_their_info = async_mock.MagicMock()
+        mock_their_info.did = "their_did"
+        mock_their_info.verkey = "their_verkey"
 
         with async_mock.patch.object(
             test_module, "ConnectionManager", autospec=True
@@ -417,11 +423,18 @@ class TestConnectionRoutes(AsyncTestCase):
         ) as mock_response:
 
             mock_conn_mgr.return_value.create_static_connection = async_mock.CoroutineMock(
-                return_value=mock_conn_rec
+                return_value=(mock_my_info, mock_their_info, mock_conn_rec)
             )
 
             await test_module.connections_create_static(mock_req)
-            mock_response.assert_called_once_with(mock_conn_rec.serialize.return_value)
+            mock_response.assert_called_once_with({
+                "my_did": mock_my_info.did,
+                "my_verkey": mock_my_info.verkey,
+                "their_did": mock_their_info.did,
+                "their_verkey": mock_their_info.verkey,
+                "my_endpoint": context.settings.get("default_endpoint"),
+                "record": mock_conn_rec.serialize.return_value
+            })
 
     async def test_register(self):
         mock_app = async_mock.MagicMock()


### PR DESCRIPTION
This change will be useful when creating a backchannel for ACA-Py for testing with the protocol test suite. Also helpful for general connecting of static agents, of course.