### PR TITLE
DIDDoc: Change authentication block to adhere to spec

### DIFF
--- a/aries_cloudagent/connections/tests/test_diddoc.py
+++ b/aries_cloudagent/connections/tests/test_diddoc.py
@@ -52,10 +52,7 @@ class TestDIDDoc(AsyncTestCase):
                 },
             ],
             "authentication": [
-                {
-                    "type": "RsaSignatureAuthentication2018",
-                    "publicKey": "did:sov:LjgpST2rjsoxYegQDRm7EL#4",
-                }
+                "did:sov:LjgpST2rjsoxYegQDRm7EL#4"
             ],
             "service": [
                 {
@@ -122,10 +119,7 @@ class TestDIDDoc(AsyncTestCase):
                 },
             ],
             "authentication": [
-                {
-                    "type": "RsaSignatureAuthentication2018",
-                    "publicKey": "did:sov:LjgpST2rjsoxYegQDRm7EL#4",
-                },
+                "did:sov:LjgpST2rjsoxYegQDRm7EL#4",
                 {
                     "id": "did:sov:LjgpST2rjsoxYegQDRm7EL#6",
                     "type": "RsaVerificationKey2018",
@@ -169,10 +163,7 @@ class TestDIDDoc(AsyncTestCase):
                 },
             ],
             "authentication": [
-                {
-                    "type": "RsaSignatureAuthentication2018",
-                    "publicKey": "did:sov:LjgpST2rjsoxYegQDRm7EL#4",
-                },
+                "did:sov:LjgpST2rjsoxYegQDRm7EL#4",
                 {
                     "id": "did:sov:LjgpST2rjsoxYegQDRm7EL#6",
                     "type": "RsaVerificationKey2018",


### PR DESCRIPTION
DID 1.0 spec assumes authentication block elements to be string references or embedded ones