### PR TITLE
OpenAPI demo remove automation

### DIFF
--- a/demo/AriesOpenAPIDemo.md
+++ b/demo/AriesOpenAPIDemo.md
@@ -132,15 +132,31 @@ Enough with the preliminaries, let’s get started!
 
 We’ll start the demo by establishing a connection between the Alice and Faber agents. We’re starting there to demonstrate that you can use agents without having a ledger. We won’t be using the Indy public ledger at all for this step. Since the agents communicate using DIDcomm messaging and connect by exchanging pairwise DIDs and DIDDocs based on the `did:peer` DID method, a public ledger is not needed.
 
-In the Faber browser tab, execute the **`POST /connections/create-invitation`**. No input data is needed to be added for this call. If successful, you should see a connection ID, an invitation, and the invitation URL. The IDs will be different on each run.
+In the Faber browser tab, execute the **`POST /connections/create-invitation`** endpoint. No input data is needed to be added for this call. If successful, you should see a connection ID, an invitation, and the invitation URL. The IDs will be different on each run.
 
 Copy the entire block of the `invitation` object, from the curly brackets `{}`, excluding the trailing comma.
 
-Switch to the Alice browser tab and get ready to execute the **`POST /connections/receive-invitation`** section. Select all of the pre-populated text and replace it with the invitation object from the Faber tab. When you click `Execute` a you should get back a connection ID, an invitation key, and the state of the connection, which should be `requested`.
+Before switching over to the Alice browser tab, scroll to and execute  the **`GET /connections`** endpoint to see the list of Faber's connections. You should see a connection with a `connection_id` that is identical to the invitation you just created, and that its state is `invitation`.
 
-Scroll to and execute **`GET /connections`** to see a list of Alice's connections, and the information tracked about each connection. You should see the one connection Alice’s agent has, that it is with the Faber agent, and that its status is `active`.
+Switch to the Alice browser tab and get ready to execute the **`POST /connections/receive-invitation`** endpoint. Select all of the pre-populated text and replace it with the invitation object from the Faber tab. When you click `Execute` you should get back a connection response with a connection ID, an invitation key, and the state of the connection, which should be `request`.
 
-You are connected! Switch to the Faber agent browser tab and run the same **`GET /connections`** endpoint to see Faber view of the connection.  Hint - note the `connection_id`. You’ll need it later in the tutorial.
+> **Establishing connections with `--no-auto`**
+
+> If you started agents with the `--no-auto` option there are few more steps required to complete the connection between Alice and Faber. _If you started agents with the default options, skip this section, these intermediate steps are automated (see the [notes](#notes) below for what is actually happening behind the scenes)._
+
+> The connection response returned from the previous **`POST /connections/receive-invitation`** endpoint call will currently show a connection state of `invitation` rather than `request`.
+
+> At this point Alice has simply stored the invitation in her wallet. To complete a connection with Faber, she must accept the invitation and send a corresponding connection request to Faber. Find the `connection_id` in the connection response from the previous **`POST /connections/receive-invitation`** endpoint call. Scroll to the **`POST /connections/{id}/accept-invitation`** endpoint and paste the `connection_id` in the `id` parameter field (you will have to click the `Try it out` button to see the available URL parameters). The response from clicking `Execute` should show that the connection has a state of `request`.
+
+> Switch over to the Faber broswer tab, scroll to and execute the **`GET /connections`** endpoint. Note the connection that was previously created. It's state is now `request`, which indicates that Alice has accepted the invitation and has sent a corresponding connection request to Faber. Copy the `connection_id` for the next step.
+
+> To complete the connection process, Faber will respond to the connection request from Alice. Scroll to the **`POST /connections/{id}/accept-request`** endpint and paste the `connection_id` you previously copied into the `id` parameter field (you will have to click the `Try it out` button to see the available URL parameters). The response from clicking the `Execute` button should show that the connection has a state of `response`, which indicates that Faber has accepted Alice's connection request.
+
+> Switch over the the Alice browser tab.
+
+Scroll to and execute **`GET /connections`** to see a list of Alice's connections, and the information tracked about each connection. You should see the one connection Alice’s agent has, that it is with the Faber agent, and that its state is `active`.
+
+You are connected! Switch to the Faber browser tab and run the same **`GET /connections`** endpoint to see Faber's view of the connection. Its state is also `active`. Note the `connection_id`, you’ll need it later in the tutorial.
 
 ### Notes
 

--- a/demo/run_demo
+++ b/demo/run_demo
@@ -4,8 +4,19 @@ shopt -s nocasematch
 
 cd $(dirname $0)
 
-AGENT="$1"
-shift
+for i in "$@"
+do
+	case $i in
+	-e|--events)
+		EVENTS=1
+		shift
+	;;
+	*)
+		AGENT="$i"
+		shift
+	;;
+	esac
+done
 
 case "$@" in *--timing*)
 	if [ ! -d "../logs" ]; then
@@ -73,6 +84,10 @@ if ! [ -z "$LEDGER_URL" ]; then
 fi
 if ! [ -z "$GENESIS_URL" ]; then
 	DOCKER_ENV="${DOCKER_ENV} -e GENESIS_URL=${GENESIS_URL}"
+fi
+
+if ! [ -z "$EVENTS" ]; then
+	DOCKER_ENV="${DOCKER_ENV} -e EVENTS=1"
 fi
 
 # on Windows, docker run needs to be prefixed by winpty

--- a/demo/run_demo
+++ b/demo/run_demo
@@ -7,8 +7,12 @@ cd $(dirname $0)
 for i in "$@"
 do
 	case $i in
-	-e|--events)
+	--events)
 		EVENTS=1
+		shift
+	;;
+	--no-auto)
+		NO_AUTO=1
 		shift
 	;;
 	*)
@@ -88,6 +92,9 @@ fi
 
 if ! [ -z "$EVENTS" ]; then
 	DOCKER_ENV="${DOCKER_ENV} -e EVENTS=1"
+fi
+if ! [ -z "$NO_AUTO" ]; then
+	DOCKER_ENV="${DOCKER_ENV} -e NO_AUTO=1"
 fi
 
 # on Windows, docker run needs to be prefixed by winpty

--- a/demo/runners/alice.py
+++ b/demo/runners/alice.py
@@ -34,7 +34,7 @@ class AliceAgent(DemoAgent):
             extra_args=[
                 "--auto-accept-invites",
                 "--auto-accept-requests",
-                "--auto-store-credential",
+                "--auto-store-credential"
             ],
             seed=None,
             **kwargs,

--- a/demo/runners/alice.py
+++ b/demo/runners/alice.py
@@ -31,7 +31,7 @@ class AliceAgent(DemoAgent):
             http_port,
             admin_port,
             prefix="Alice",
-            extra_args=[
+            extra_args=[] if os.getenv("NO_AUTO") else [
                 "--auto-accept-invites",
                 "--auto-accept-requests",
                 "--auto-store-credential"

--- a/demo/runners/faber.py
+++ b/demo/runners/faber.py
@@ -34,7 +34,7 @@ class FaberAgent(DemoAgent):
             http_port,
             admin_port,
             prefix="Faber",
-            extra_args=[
+            extra_args=[] if os.getenv("NO_AUTO") else [
                 "--auto-accept-invites",
                 "--auto-accept-requests"
             ],

--- a/demo/runners/faber.py
+++ b/demo/runners/faber.py
@@ -34,7 +34,10 @@ class FaberAgent(DemoAgent):
             http_port,
             admin_port,
             prefix="Faber",
-            extra_args=["--auto-accept-invites", "--auto-accept-requests"],
+            extra_args=[
+                "--auto-accept-invites",
+                "--auto-accept-requests"
+            ],
             **kwargs,
         )
         self.connection_id = None

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -25,7 +25,7 @@ event_stream_handler = logging.StreamHandler()
 event_stream_handler.setFormatter(logging.Formatter("\nEVENT: %(message)s"))
 
 EVENT_LOGGER = logging.getLogger('event')
-EVENT_LOGGER.setLevel(logging.DEBUG)
+EVENT_LOGGER.setLevel(logging.DEBUG if os.getenv("EVENTS") else logging.NOTSET)
 EVENT_LOGGER.addHandler(event_stream_handler)
 EVENT_LOGGER.propagate = False
 

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -21,6 +21,14 @@ from .utils import flatten, log_json, log_msg, log_timer, output_reader
 
 LOGGER = logging.getLogger(__name__)
 
+event_stream_handler = logging.StreamHandler()
+event_stream_handler.setFormatter(logging.Formatter("\nEVENT: %(message)s"))
+
+EVENT_LOGGER = logging.getLogger('event')
+EVENT_LOGGER.setLevel(logging.DEBUG)
+EVENT_LOGGER.addHandler(event_stream_handler)
+EVENT_LOGGER.propagate = False
+
 DEFAULT_POSTGRES = bool(os.getenv("POSTGRES"))
 DEFAULT_INTERNAL_HOST = "127.0.0.1"
 DEFAULT_EXTERNAL_HOST = "localhost"
@@ -330,6 +338,7 @@ class DemoAgent:
             handler = f"handle_{topic}"
             method = getattr(self, handler, None)
             if method:
+                EVENT_LOGGER.debug(f"Agent called controller webhook: {handler}" + f" with payload: \n{json.dumps(payload, indent=4)}" if payload else "")
                 asyncio.get_event_loop().create_task(method(payload))
             else:
                 log_msg(
@@ -358,7 +367,9 @@ class DemoAgent:
 
     async def admin_GET(self, path, text=False, params=None) -> ClientResponse:
         try:
-            return await self.admin_request("GET", path, None, text, params)
+            EVENT_LOGGER.debug(f"Controller GET {path} request to Agent")
+            response = await self.admin_request("GET", path, None, text, params)
+            EVENT_LOGGER.debug(f"Response from GET {path} received: \n{json.dumps(response, indent=4)}")
         except ClientError as e:
             self.log(f"Error during GET {path}: {str(e)}")
             raise
@@ -367,7 +378,10 @@ class DemoAgent:
         self, path, data=None, text=False, params=None
     ) -> ClientResponse:
         try:
-            return await self.admin_request("POST", path, data, text, params)
+            EVENT_LOGGER.debug(f"Controller POST {path} request to Agent" + f" with data: \n{json.dumps(data, indent=4)}" if data else "");
+            response =  await self.admin_request("POST", path, data, text, params)
+            EVENT_LOGGER.debug(f"Response from POST {path} received: \n{json.dumps(response, indent=4)}");
+            return response
         except ClientError as e:
             self.log(f"Error during POST {path}: {str(e)}")
             raise

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -24,7 +24,7 @@ LOGGER = logging.getLogger(__name__)
 event_stream_handler = logging.StreamHandler()
 event_stream_handler.setFormatter(logging.Formatter("\nEVENT: %(message)s"))
 
-EVENT_LOGGER = logging.getLogger('event')
+EVENT_LOGGER = logging.getLogger("event")
 EVENT_LOGGER.setLevel(logging.DEBUG if os.getenv("EVENTS") else logging.NOTSET)
 EVENT_LOGGER.addHandler(event_stream_handler)
 EVENT_LOGGER.propagate = False


### PR DESCRIPTION
Adds event logger to `agent.py` that is activated when running `run_demo` with the `--events` option.

Adds a `--no-auto` option to `run_demo` that deactivates `--auto-...` arguments in agent.

Updates OpenAPI demo documentation for invitation scenarios when `--no-auto` option is set

PR for: https://github.com/hyperledger/aries-cloudagent-python/issues/361