### PR TITLE
Isolate anoncreds usage in IndyIssuer and IndyHolder classes

### DIFF
--- a/aries_cloudagent/holder/base.py
+++ b/aries_cloudagent/holder/base.py
@@ -1,7 +1,7 @@
 """Base holder class."""
 
 from abc import ABC, ABCMeta, abstractmethod
-from typing import Union
+from typing import Tuple, Union
 
 from ..core.error import BaseError
 
@@ -24,7 +24,7 @@ class BaseHolder(ABC, metaclass=ABCMeta):
         return "<{}>".format(self.__class__.__name__)
 
     @abstractmethod
-    async def get_credential(self, credential_id: str):
+    async def get_credential(self, credential_id: str) -> str:
         """
         Get a credential stored in the wallet.
 
@@ -67,7 +67,7 @@ class BaseHolder(ABC, metaclass=ABCMeta):
         schemas: dict,
         credential_definitions: dict,
         rev_states_json: dict = None,
-    ):
+    ) -> str:
         """
         Get credentials stored in the wallet.
 
@@ -81,10 +81,10 @@ class BaseHolder(ABC, metaclass=ABCMeta):
 
     @abstractmethod
     async def create_credential_request(
-        self, credential_offer, credential_definition, holder_did: str
-    ):
+        self, credential_offer: dict, credential_definition: dict, holder_did: str
+    ) -> Tuple[str, str]:
         """
-        Create a credential offer for the given credential definition id.
+        Create a credential request for the given credential offer.
 
         Args:
             credential_offer: The credential offer to create request for
@@ -92,19 +92,19 @@ class BaseHolder(ABC, metaclass=ABCMeta):
             holder_did: the DID of the agent making the request
 
         Returns:
-            A credential request
+            A tuple of the credential request and credential request metadata
 
         """
 
     @abstractmethod
     async def store_credential(
         self,
-        credential_definition,
-        credential_data,
-        credential_request_metadata,
+        credential_definition: dict,
+        credential_data: dict,
+        credential_request_metadata: dict,
         credential_attr_mime_types=None,
-        credential_id=None,
-        rev_reg_def_json=None,
+        credential_id: str = None,
+        rev_reg_def: dict = None,
     ):
         """
         Store a credential in the wallet.
@@ -117,6 +117,9 @@ class BaseHolder(ABC, metaclass=ABCMeta):
             credential_attr_mime_types: dict mapping attribute names to (optional)
                 MIME types to store as non-secret record, if specified
             credential_id: optionally override the stored credential id
-            rev_reg_def_json: optional revocation registry definition in json
+            rev_reg_def: revocation registry definition in json
+
+        Returns:
+            the ID of the stored credential
 
         """

--- a/aries_cloudagent/holder/base.py
+++ b/aries_cloudagent/holder/base.py
@@ -3,6 +3,12 @@
 from abc import ABC, ABCMeta, abstractmethod
 from typing import Union
 
+from ..core.error import BaseError
+
+
+class HolderError(BaseError):
+    """Base class for holder exceptions."""
+
 
 class BaseHolder(ABC, metaclass=ABCMeta):
     """Base class for holder."""

--- a/aries_cloudagent/holder/base.py
+++ b/aries_cloudagent/holder/base.py
@@ -123,3 +123,26 @@ class BaseHolder(ABC, metaclass=ABCMeta):
             the ID of the stored credential
 
         """
+
+    @abstractmethod
+    async def create_revocation_state(
+        self,
+        cred_rev_id: str,
+        rev_reg_def: dict,
+        rev_reg_delta: dict,
+        timestamp: int,
+        tails_file_path: str,
+    ) -> str:
+        """
+        Get credentials stored in the wallet.
+
+        Args:
+            cred_rev_id: credential revocation id in revocation registry
+            rev_reg_def: revocation registry definition
+            rev_reg_delta: revocation delta
+            timestamp: delta timestamp
+
+        Returns:
+            the revocation state
+
+        """

--- a/aries_cloudagent/holder/indy.py
+++ b/aries_cloudagent/holder/indy.py
@@ -9,7 +9,7 @@ from typing import Sequence, Tuple, Union
 import indy.anoncreds
 from indy.error import ErrorCode, IndyError
 
-from ..indy.error import IndyErrorHandler
+from ..indy import IndyErrorHandler, create_tails_reader
 from ..storage.indy import IndyStorage
 from ..storage.error import StorageError, StorageNotFoundError
 from ..storage.record import StorageRecord
@@ -342,3 +342,36 @@ class IndyHolder(BaseHolder):
             )
 
         return presentation_json
+
+    async def create_revocation_state(
+        self,
+        cred_rev_id: str,
+        rev_reg_def: dict,
+        rev_reg_delta: dict,
+        timestamp: int,
+        tails_file_path: str,
+    ) -> str:
+        """
+        Get credentials stored in the wallet.
+
+        Args:
+            cred_rev_id: credential revocation id in revocation registry
+            rev_reg_def: revocation registry definition
+            rev_reg_delta: revocation delta
+            timestamp: delta timestamp
+
+        Returns:
+            the revocation state
+
+        """
+
+        tails_file_reader = await create_tails_reader(tails_file_path)
+        rev_state_json = await indy.anoncreds.create_revocation_state(
+            tails_file_reader,
+            rev_reg_def_json=json.dumps(rev_reg_def),
+            cred_rev_id=cred_rev_id,
+            rev_reg_delta_json=json.dumps(rev_reg_delta),
+            timestamp=timestamp,
+        )
+
+        return rev_state_json

--- a/aries_cloudagent/holder/indy.py
+++ b/aries_cloudagent/holder/indy.py
@@ -9,7 +9,8 @@ from typing import Sequence, Tuple, Union
 import indy.anoncreds
 from indy.error import ErrorCode, IndyError
 
-from ..indy import IndyErrorHandler, create_tails_reader
+from ..indy import create_tails_reader
+from ..indy.error import IndyErrorHandler
 from ..storage.indy import IndyStorage
 from ..storage.error import StorageError, StorageNotFoundError
 from ..storage.record import StorageRecord

--- a/aries_cloudagent/holder/tests/test_indy.py
+++ b/aries_cloudagent/holder/tests/test_indy.py
@@ -25,11 +25,11 @@ class TestIndyHolder(AsyncTestCase):
 
     @async_mock.patch("indy.anoncreds.prover_create_credential_req")
     async def test_create_credential_request(self, mock_create_credential_req):
-        mock_create_credential_req.return_value = ("{}", "{}")
+        mock_create_credential_req.return_value = ("{}", "[]")
         mock_wallet = async_mock.MagicMock()
 
         holder = IndyHolder(mock_wallet)
-        cred_req = await holder.create_credential_request(
+        cred_req_json, cred_req_meta_json = await holder.create_credential_request(
             "credential_offer", "credential_definition", "did"
         )
 
@@ -41,7 +41,7 @@ class TestIndyHolder(AsyncTestCase):
             mock_wallet.master_secret_id,
         )
 
-        assert cred_req == ({}, {})
+        assert (json.loads(cred_req_json), json.loads(cred_req_meta_json)) == ({}, [])
 
     @async_mock.patch("indy.anoncreds.prover_store_credential")
     async def test_store_credential(self, mock_store_cred):
@@ -60,7 +60,7 @@ class TestIndyHolder(AsyncTestCase):
             cred_req_metadata_json=json.dumps("credential_request_metadata"),
             cred_json=json.dumps("credential_data"),
             cred_def_json=json.dumps("credential_definition"),
-            rev_reg_def_json=None
+            rev_reg_def=None,
         )
 
         assert cred_id == "cred_id"
@@ -212,11 +212,11 @@ class TestIndyHolder(AsyncTestCase):
         mock_wallet = async_mock.MagicMock()
         holder = IndyHolder(mock_wallet)
 
-        credential = await holder.get_credential("credential_id")
+        credential_json = await holder.get_credential("credential_id")
 
         mock_get_cred.assert_called_once_with(mock_wallet.handle, "credential_id")
 
-        assert credential == json.loads("{}")
+        assert json.loads(credential_json) == {}
 
     @async_mock.patch("indy.anoncreds.prover_delete_credential")
     @async_mock.patch("indy.non_secrets.get_wallet_record")
@@ -251,7 +251,7 @@ class TestIndyHolder(AsyncTestCase):
         mock_wallet = async_mock.MagicMock()
         holder = IndyHolder(mock_wallet)
 
-        presentation = await holder.create_presentation(
+        presentation_json = await holder.create_presentation(
             "presentation_request",
             "requested_credentials",
             "schemas",
@@ -268,4 +268,4 @@ class TestIndyHolder(AsyncTestCase):
             json.dumps({}),
         )
 
-        assert presentation == json.loads("{}")
+        assert json.loads(presentation_json) == {}

--- a/aries_cloudagent/holder/tests/test_indy.py
+++ b/aries_cloudagent/holder/tests/test_indy.py
@@ -60,7 +60,7 @@ class TestIndyHolder(AsyncTestCase):
             cred_req_metadata_json=json.dumps("credential_request_metadata"),
             cred_json=json.dumps("credential_data"),
             cred_def_json=json.dumps("credential_definition"),
-            rev_reg_def=None,
+            rev_reg_def_json=None,
         )
 
         assert cred_id == "cred_id"

--- a/aries_cloudagent/indy/__init__.py
+++ b/aries_cloudagent/indy/__init__.py
@@ -6,10 +6,6 @@ from pathlib import Path
 
 import indy.blob_storage
 
-from .error import IndyErrorHandler
-
-__all__ = ["IndyErrorHandler", "create_tails_reader", "create_tails_writer"]
-
 
 async def create_tails_reader(tails_file_path: str) -> int:
     """Get a handle for the blob_storage file reader."""

--- a/aries_cloudagent/indy/__init__.py
+++ b/aries_cloudagent/indy/__init__.py
@@ -1,0 +1,33 @@
+"""Indy utilities."""
+
+import json
+
+from pathlib import Path
+
+import indy.blob_storage
+
+from .error import IndyErrorHandler
+
+__all__ = ["IndyErrorHandler", "create_tails_reader", "create_tails_writer"]
+
+
+async def create_tails_reader(tails_file_path: str) -> int:
+    """Get a handle for the blob_storage file reader."""
+    tails_file_path = Path(tails_file_path)
+
+    if not tails_file_path.exists():
+        raise FileNotFoundError("Tails file does not exist.")
+
+    tails_reader_config = json.dumps(
+        {
+            "base_dir": str(tails_file_path.parent.absolute()),
+            "file": str(tails_file_path.name),
+        }
+    )
+    return await indy.blob_storage.open_reader("default", tails_reader_config)
+
+
+async def create_tails_writer(tails_base_dir: str) -> int:
+    """Get a handle for the blob_storage file writer."""
+    tails_writer_config = json.dumps({"base_dir": tails_base_dir, "uri_pattern": ""})
+    return await indy.blob_storage.open_writer("default", tails_writer_config)

--- a/aries_cloudagent/indy/error.py
+++ b/aries_cloudagent/indy/error.py
@@ -1,0 +1,42 @@
+"""Indy error handling."""
+
+from typing import Type
+
+from indy.error import IndyError
+
+from ..core.error import BaseError
+
+
+class IndyErrorHandler:
+    """Trap IndyError and raise an appropriate LedgerError instead."""
+
+    def __init__(self, message: str = None, error_cls: Type[BaseError] = BaseError):
+        """Init the context manager."""
+        self.error_cls = error_cls
+        self.message = message
+
+    def __enter__(self):
+        """Enter the context manager."""
+        return self
+
+    def __exit__(self, err_type, err_value, err_traceback):
+        """Exit the context manager."""
+        if isinstance(err_value, IndyError):
+            raise self.wrap_error(
+                err_value, self.message, self.error_cls
+            ) from err_value
+
+    @classmethod
+    def wrap_error(
+        cls,
+        err_value: IndyError,
+        message: str = None,
+        error_cls: Type[BaseError] = BaseError,
+    ) -> BaseError:
+        """Create an instance of BaseError from an IndyError."""
+        err_msg = message or "Exception while performing ledger operation"
+        indy_message = hasattr(err_value, "message") and err_value.message
+        if indy_message:
+            err_msg += f": {indy_message}"
+        # TODO: may wish to attach backtrace when available
+        return error_cls(err_msg)

--- a/aries_cloudagent/indy/tests/test_utils.py
+++ b/aries_cloudagent/indy/tests/test_utils.py
@@ -1,0 +1,33 @@
+from os import makedirs
+from pathlib import Path
+from shutil import rmtree
+
+from asynctest import TestCase as AsyncTestCase, mock as async_mock
+
+import indy.blob_storage
+
+from .. import create_tails_reader
+
+TAILS_DIR = "/tmp/indy/revocation/tails_files"
+TAILS_HASH = "8UW1Sz5cqoUnK9hqQk7nvtKK65t7Chu3ui866J23sFyJ"
+TAILS_LOCAL = f"{TAILS_DIR}/{TAILS_HASH}"
+
+
+class TestIndyUtils(AsyncTestCase):
+    def tearDown(self):
+        rmtree(TAILS_DIR, ignore_errors=True)
+
+    async def test_tails_reader(self):
+        makedirs(TAILS_DIR, exist_ok=True)
+        with open(TAILS_LOCAL, "a") as f:
+            print("1234123412431234", file=f)
+
+        with async_mock.patch.object(
+            indy.blob_storage, "open_reader", async_mock.CoroutineMock()
+        ) as mock_blob_open_reader:
+            result = await create_tails_reader(TAILS_LOCAL)
+            assert result == mock_blob_open_reader.return_value
+
+        rmtree(TAILS_DIR, ignore_errors=True)
+        with self.assertRaises(FileNotFoundError):
+            await create_tails_reader(TAILS_LOCAL)

--- a/aries_cloudagent/issuer/base.py
+++ b/aries_cloudagent/issuer/base.py
@@ -1,6 +1,22 @@
 """Ledger issuer class."""
 
 from abc import ABC, ABCMeta, abstractmethod
+from typing import Sequence, Tuple
+
+from ..core.error import BaseError
+
+
+DEFAULT_CRED_DEF_TAG = "default"
+DEFAULT_ISSUANCE_TYPE = "ISSUANCE_BY_DEFAULT"
+DEFAULT_SIGNATURE_TYPE = "CL"
+
+
+class IssuerError(BaseError):
+    """Generic issuer error."""
+
+
+class IssuerRevocationRegistryFullError(IssuerError):
+    """Revocation registry is full when issuing a new credential."""
 
 
 class BaseIssuer(ABC, metaclass=ABCMeta):
@@ -17,6 +33,75 @@ class BaseIssuer(ABC, metaclass=ABCMeta):
         return "<{}>".format(self.__class__.__name__)
 
     @abstractmethod
+    def make_schema_id(
+        self, origin_did: str, schema_name: str, schema_version: str
+    ) -> str:
+        """Derive the ID for a schema."""
+
+    @abstractmethod
+    async def create_and_store_schema(
+        self,
+        origin_did: str,
+        schema_name: str,
+        schema_version: str,
+        attribute_names: Sequence[str],
+    ) -> Tuple[str, str]:
+        """
+        Create a new credential schema and store it in the wallet.
+
+        Args:
+            origin_did: the DID issuing the credential definition
+            schema_name: the schema name
+            schema_version: the schema version
+            attribute_names: a sequence of schema attribute names
+
+        Returns:
+            A tuple of the schema ID and JSON
+
+        """
+
+    @abstractmethod
+    def make_credential_definition_id(
+        self, origin_did: str, schema: dict, signature_type: str = None, tag: str = None
+    ) -> str:
+        """Derive the ID for a credential definition."""
+
+    @abstractmethod
+    async def credential_definition_in_wallet(
+        self, credential_definition_id: str
+    ) -> bool:
+        """
+        Check whether a given credential definition ID is present in the wallet.
+
+        Args:
+            credential_definition_id: The credential definition ID to check
+        """
+
+    @abstractmethod
+    async def create_and_store_credential_definition(
+        self,
+        origin_did: str,
+        schema: dict,
+        signature_type: str = None,
+        tag: str = None,
+        support_revocation: bool = False,
+    ) -> Tuple[str, str]:
+        """
+        Create a new credential definition and store it in the wallet.
+
+        Args:
+            origin_did: the DID issuing the credential definition
+            schema_json: the schema used as a basis
+            signature_type: the credential definition signature type (default 'CL')
+            tag: the credential definition tag
+            support_revocation: whether to enable revocation for this credential def
+
+        Returns:
+            A tuple of the credential definition ID and JSON
+
+        """
+
+    @abstractmethod
     def create_credential_offer(self, credential_definition_id):
         """
         Create a credential offer for the given credential definition id.
@@ -28,7 +113,6 @@ class BaseIssuer(ABC, metaclass=ABCMeta):
             A credential offer
 
         """
-        pass
 
     @abstractmethod
     async def create_credential(
@@ -55,7 +139,6 @@ class BaseIssuer(ABC, metaclass=ABCMeta):
             A tuple of created credential, revocation id
 
         """
-        pass
 
     @abstractmethod
     def revoke_credential(self, revoc_reg_id, tails_reader_handle, cred_revoc_id):
@@ -68,4 +151,31 @@ class BaseIssuer(ABC, metaclass=ABCMeta):
             cred_revoc_id: index of the credential in the revocation registry
 
         """
-        pass
+
+    @abstractmethod
+    async def create_and_store_revocation_registry(
+        self,
+        origin_did: str,
+        cred_def_id: str,
+        revoc_def_type: str,
+        tag: str,
+        max_cred_num: int,
+        tails_base_path: str,
+        issuance_type: str = None,
+    ) -> Tuple[str, str, str]:
+        """
+        Create a new revocation registry and store it in the wallet.
+
+        Args:
+            origin_did: the DID issuing the revocation registry
+            cred_def_id: the identifier of the related credential definition
+            revoc_def_type: the revocation registry type (default CL_ACCUM)
+            tag: the unique revocation registry tag
+            max_cred_num: the number of credentials supported in the registry
+            tails_base_path: where to store the tails file
+            issuance_type: optionally override the issuance type
+
+        Returns:
+            A tuple of the revocation registry ID, JSON, and entry JSON
+
+        """

--- a/aries_cloudagent/issuer/base.py
+++ b/aries_cloudagent/issuer/base.py
@@ -142,14 +142,14 @@ class BaseIssuer(ABC, metaclass=ABCMeta):
 
     @abstractmethod
     def revoke_credential(
-        self, revoc_reg_id, tails_reader_handle, cred_revoc_id
+        self, revoc_reg_id: str, tails_file_path: str, cred_revoc_id: str
     ) -> str:
         """
         Revoke a credential.
 
         Args:
             revoc_reg_id: ID of the revocation registry
-            tails_reader_handle: handle for the registry tails file
+            tails_file_path: path to the local tails file
             cred_revoc_id: index of the credential in the revocation registry
 
         Returns:

--- a/aries_cloudagent/issuer/base.py
+++ b/aries_cloudagent/issuer/base.py
@@ -102,7 +102,7 @@ class BaseIssuer(ABC, metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def create_credential_offer(self, credential_definition_id):
+    def create_credential_offer(self, credential_definition_id) -> str:
         """
         Create a credential offer for the given credential definition id.
 
@@ -110,20 +110,20 @@ class BaseIssuer(ABC, metaclass=ABCMeta):
             credential_definition_id: The credential definition to create an offer for
 
         Returns:
-            A credential offer
+            The created credential offer
 
         """
 
     @abstractmethod
     async def create_credential(
         self,
-        schema,
-        credential_offer,
-        credential_request,
-        credential_values,
+        schema: dict,
+        credential_offer: dict,
+        credential_request: dict,
+        credential_values: dict,
         revoc_reg_id: str = None,
         tails_reader_handle: int = None,
-    ):
+    ) -> Tuple[str, str]:
         """
         Create a credential.
 
@@ -136,19 +136,24 @@ class BaseIssuer(ABC, metaclass=ABCMeta):
             tails_reader_handle: Handle for the tails file blob reader
 
         Returns:
-            A tuple of created credential, revocation id
+            A tuple of created credential and revocation id
 
         """
 
     @abstractmethod
-    def revoke_credential(self, revoc_reg_id, tails_reader_handle, cred_revoc_id):
+    def revoke_credential(
+        self, revoc_reg_id, tails_reader_handle, cred_revoc_id
+    ) -> str:
         """
         Revoke a credential.
 
-        Args
+        Args:
             revoc_reg_id: ID of the revocation registry
             tails_reader_handle: handle for the registry tails file
             cred_revoc_id: index of the credential in the revocation registry
+
+        Returns:
+            the revocation delta
 
         """
 

--- a/aries_cloudagent/issuer/indy.py
+++ b/aries_cloudagent/issuer/indy.py
@@ -18,7 +18,8 @@ from .base import (
     DEFAULT_ISSUANCE_TYPE,
     DEFAULT_SIGNATURE_TYPE,
 )
-from ..indy import create_tails_reader, create_tails_writer, IndyErrorHandler
+from ..indy import create_tails_reader, create_tails_writer
+from ..indy.error import IndyErrorHandler
 
 
 class IndyIssuer(BaseIssuer):

--- a/aries_cloudagent/issuer/indy.py
+++ b/aries_cloudagent/issuer/indy.py
@@ -2,22 +2,23 @@
 
 import json
 import logging
+from typing import Sequence, Tuple
 
 import indy.anoncreds
-from indy.error import AnoncredsRevocationRegistryFullError
+import indy.blob_storage
+from indy.error import AnoncredsRevocationRegistryFullError, IndyError, ErrorCode
 
-from ..core.error import BaseError
 from ..messaging.util import encode
 
-from .base import BaseIssuer
-
-
-class IssuerError(BaseError):
-    """Generic issuer error."""
-
-
-class IssuerRevocationRegistryFullError(IssuerError):
-    """Revocation registry is full when issuing a new credential."""
+from .base import (
+    BaseIssuer,
+    IssuerError,
+    IssuerRevocationRegistryFullError,
+    DEFAULT_CRED_DEF_TAG,
+    DEFAULT_ISSUANCE_TYPE,
+    DEFAULT_SIGNATURE_TYPE,
+)
+from ..indy.error import IndyErrorHandler
 
 
 class IndyIssuer(BaseIssuer):
@@ -34,6 +35,111 @@ class IndyIssuer(BaseIssuer):
         self.logger = logging.getLogger(__name__)
         self.wallet = wallet
 
+    def make_schema_id(
+        self, origin_did: str, schema_name: str, schema_version: str
+    ) -> str:
+        """Derive the ID for a schema."""
+        return f"{origin_did}:2:{schema_name}:{schema_version}"
+
+    async def create_and_store_schema(
+        self,
+        origin_did: str,
+        schema_name: str,
+        schema_version: str,
+        attribute_names: Sequence[str],
+    ) -> Tuple[str, str]:
+        """
+        Create a new credential schema and store it in the wallet.
+
+        Args:
+            origin_did: the DID issuing the credential definition
+            schema_name: the schema name
+            schema_version: the schema version
+            attribute_names: a sequence of schema attribute names
+
+        Returns:
+            A tuple of the schema ID and JSON
+
+        """
+
+        with IndyErrorHandler("Error when creating schema", IssuerError):
+            schema_id, schema_json = await indy.anoncreds.issuer_create_schema(
+                origin_did, schema_name, schema_version, json.dumps(attribute_names),
+            )
+        return (schema_id, schema_json)
+
+    def make_credential_definition_id(
+        self, origin_did: str, schema: dict, signature_type: str = None, tag: str = None
+    ) -> str:
+        """Derive the ID for a credential definition."""
+        signature_type = signature_type or DEFAULT_SIGNATURE_TYPE
+        tag = tag or DEFAULT_CRED_DEF_TAG
+        return f"{origin_did}:3:{signature_type}:{str(schema['seqNo'])}:{tag}"
+
+    async def credential_definition_in_wallet(
+        self, credential_definition_id: str
+    ) -> bool:
+        """
+        Check whether a given credential definition ID is present in the wallet.
+
+        Args:
+            credential_definition_id: The credential definition ID to check
+        """
+        try:
+            await indy.anoncreds.issuer_create_credential_offer(
+                self.wallet.handle, credential_definition_id
+            )
+            return True
+        except IndyError as error:
+            if error.error_code not in (
+                ErrorCode.CommonInvalidStructure,
+                ErrorCode.WalletItemNotFound,
+            ):
+                raise IndyErrorHandler.wrap_error(
+                    error,
+                    "Error when checking wallet for credential definition",
+                    IssuerError,
+                ) from error
+            # recognized error signifies no such cred def in wallet: pass
+        return False
+
+    async def create_and_store_credential_definition(
+        self,
+        origin_did: str,
+        schema: dict,
+        signature_type: str = None,
+        tag: str = None,
+        support_revocation: bool = False,
+    ) -> Tuple[str, str]:
+        """
+        Create a new credential definition and store it in the wallet.
+
+        Args:
+            origin_did: the DID issuing the credential definition
+            schema_json: the schema used as a basis
+            signature_type: the credential definition signature type (default 'CL')
+            tag: the credential definition tag
+            support_revocation: whether to enable revocation for this credential def
+
+        Returns:
+            A tuple of the credential definition ID and JSON
+
+        """
+
+        with IndyErrorHandler("Error when creating credential definition", IssuerError):
+            (
+                credential_definition_id,
+                credential_definition_json,
+            ) = await indy.anoncreds.issuer_create_and_store_credential_def(
+                self.wallet.handle,
+                origin_did,
+                json.dumps(schema),
+                tag or DEFAULT_CRED_DEF_TAG,
+                signature_type or DEFAULT_SIGNATURE_TYPE,
+                json.dumps({"support_revocation": support_revocation}),
+            )
+        return (credential_definition_id, credential_definition_json)
+
     async def create_credential_offer(self, credential_definition_id: str):
         """
         Create a credential offer for the given credential definition id.
@@ -45,9 +151,10 @@ class IndyIssuer(BaseIssuer):
             A credential offer
 
         """
-        credential_offer_json = await indy.anoncreds.issuer_create_credential_offer(
-            self.wallet.handle, credential_definition_id
-        )
+        with IndyErrorHandler("Exception when creating credential offer", IssuerError):
+            credential_offer_json = await indy.anoncreds.issuer_create_credential_offer(
+                self.wallet.handle, credential_definition_id
+            )
 
         credential_offer = json.loads(credential_offer_json)
 
@@ -111,6 +218,10 @@ class IndyIssuer(BaseIssuer):
         except AnoncredsRevocationRegistryFullError:
             self.logger.error("Revocation registry is full when creating a credential.")
             raise IssuerRevocationRegistryFullError("Revocation registry full")
+        except IndyError as error:
+            raise IndyErrorHandler.wrap_error(
+                error, "Error when issuing credential", IssuerError
+            ) from error
 
         return json.loads(credential_json), credential_revocation_id
 
@@ -126,11 +237,69 @@ class IndyIssuer(BaseIssuer):
             cred_revoc_id: index of the credential in the revocation registry
 
         """
-        revoc_reg_delta_json = await indy.anoncreds.issuer_revoke_credential(
-            self.wallet.handle, tails_reader_handle, revoc_reg_id, cred_revoc_id
-        )
-        # may throw AnoncredsInvalidUserRevocId if using ISSUANCE_ON_DEMAND
+        with IndyErrorHandler("Exception when revoking credential", IssuerError):
+            revoc_reg_delta_json = await indy.anoncreds.issuer_revoke_credential(
+                self.wallet.handle, tails_reader_handle, revoc_reg_id, cred_revoc_id
+            )
+            # may throw AnoncredsInvalidUserRevocId if using ISSUANCE_ON_DEMAND
 
         delta = json.loads(revoc_reg_delta_json)
 
         return delta
+
+    async def create_and_store_revocation_registry(
+        self,
+        origin_did: str,
+        cred_def_id: str,
+        revoc_def_type: str,
+        tag: str,
+        max_cred_num: int,
+        tails_base_path: str,
+        issuance_type: str = None,
+    ) -> Tuple[str, str, str]:
+        """
+        Create a new revocation registry and store it in the wallet.
+
+        Args:
+            origin_did: the DID issuing the revocation registry
+            cred_def_id: the identifier of the related credential definition
+            revoc_def_type: the revocation registry type (default CL_ACCUM)
+            tag: the unique revocation registry tag
+            max_cred_num: the number of credentials supported in the registry
+            tails_base_path: where to store the tails file
+            issuance_type: optionally override the issuance type
+
+        Returns:
+            A tuple of the revocation registry ID, JSON, and entry JSON
+
+        """
+
+        tails_writer_config = json.dumps(
+            {"base_dir": tails_base_path, "uri_pattern": ""}
+        )
+        tails_writer = await indy.blob_storage.open_writer(
+            "default", tails_writer_config
+        )
+
+        with IndyErrorHandler(
+            "Exception when creating revocation registry", IssuerError
+        ):
+            (
+                revoc_reg_id,
+                revoc_reg_def_json,
+                revoc_reg_entry_json,
+            ) = await indy.anoncreds.issuer_create_and_store_revoc_reg(
+                self.wallet.handle,
+                origin_did,
+                revoc_def_type,
+                tag,
+                cred_def_id,
+                json.dumps(
+                    {
+                        "max_cred_num": max_cred_num,
+                        "issuance_type": issuance_type or DEFAULT_ISSUANCE_TYPE,
+                    }
+                ),
+                tails_writer,
+            )
+        return (revoc_reg_id, revoc_reg_def_json, revoc_reg_entry_json)

--- a/aries_cloudagent/issuer/indy.py
+++ b/aries_cloudagent/issuer/indy.py
@@ -140,7 +140,7 @@ class IndyIssuer(BaseIssuer):
             )
         return (credential_definition_id, credential_definition_json)
 
-    async def create_credential_offer(self, credential_definition_id: str):
+    async def create_credential_offer(self, credential_definition_id: str) -> str:
         """
         Create a credential offer for the given credential definition id.
 
@@ -148,7 +148,7 @@ class IndyIssuer(BaseIssuer):
             credential_definition_id: The credential definition to create an offer for
 
         Returns:
-            A credential offer
+            The created credential offer
 
         """
         with IndyErrorHandler("Exception when creating credential offer", IssuerError):
@@ -156,19 +156,17 @@ class IndyIssuer(BaseIssuer):
                 self.wallet.handle, credential_definition_id
             )
 
-        credential_offer = json.loads(credential_offer_json)
-
-        return credential_offer
+        return credential_offer_json
 
     async def create_credential(
         self,
-        schema,
-        credential_offer,
-        credential_request,
-        credential_values,
+        schema: dict,
+        credential_offer: dict,
+        credential_request: dict,
+        credential_values: dict,
         revoc_reg_id: str = None,
         tails_reader_handle: int = None,
-    ):
+    ) -> Tuple[str, str]:
         """
         Create a credential.
 
@@ -181,7 +179,7 @@ class IndyIssuer(BaseIssuer):
             tails_reader_handle: Handle for the tails file blob reader
 
         Returns:
-            A tuple of created credential, revocation id
+            A tuple of created credential and revocation id
 
         """
 
@@ -223,18 +221,21 @@ class IndyIssuer(BaseIssuer):
                 error, "Error when issuing credential", IssuerError
             ) from error
 
-        return json.loads(credential_json), credential_revocation_id
+        return credential_json, credential_revocation_id
 
     async def revoke_credential(
         self, revoc_reg_id: str, tails_reader_handle: int, cred_revoc_id: str
-    ) -> dict:
+    ) -> str:
         """
         Revoke a credential.
 
-        Args
+        Args:
             revoc_reg_id: ID of the revocation registry
             tails_reader_handle: handle for the registry tails file
             cred_revoc_id: index of the credential in the revocation registry
+
+        Returns:
+            the revocation delta
 
         """
         with IndyErrorHandler("Exception when revoking credential", IssuerError):
@@ -243,9 +244,7 @@ class IndyIssuer(BaseIssuer):
             )
             # may throw AnoncredsInvalidUserRevocId if using ISSUANCE_ON_DEMAND
 
-        delta = json.loads(revoc_reg_delta_json)
-
-        return delta
+        return revoc_reg_delta_json
 
     async def create_and_store_revocation_registry(
         self,

--- a/aries_cloudagent/issuer/tests/test_indy.py
+++ b/aries_cloudagent/issuer/tests/test_indy.py
@@ -25,8 +25,8 @@ class TestIndyIssuer(AsyncTestCase):
         mock_create_offer.return_value = json.dumps(test_offer)
         mock_wallet = async_mock.MagicMock()
         issuer = IndyIssuer(mock_wallet)
-        offer = await issuer.create_credential_offer(test_cred_def_id)
-        assert offer == test_offer
+        offer_json = await issuer.create_credential_offer(test_cred_def_id)
+        assert json.loads(offer_json) == test_offer
         mock_create_offer.assert_awaited_once_with(mock_wallet.handle, test_cred_def_id)
 
     @async_mock.patch("indy.anoncreds.issuer_create_credential")
@@ -46,10 +46,10 @@ class TestIndyIssuer(AsyncTestCase):
             None,
         )
 
-        cred, revoc_id = await issuer.create_credential(
+        cred_json, revoc_id = await issuer.create_credential(
             test_schema, test_offer, test_request, test_values
         )
-        assert cred == test_credential
+        assert json.loads(cred_json) == test_credential
         assert revoc_id == test_revoc_id
         mock_create_credential.assert_awaited_once()
         (
@@ -68,6 +68,6 @@ class TestIndyIssuer(AsyncTestCase):
 
         with self.assertRaises(IssuerError):
             # missing attribute
-            cred, revoc_id = await issuer.create_credential(
+            cred_json, revoc_id = await issuer.create_credential(
                 test_schema, test_offer, test_request, {}
             )

--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -122,13 +122,18 @@ class BaseLedger(ABC, metaclass=ABCMeta):
 
     @abstractmethod
     async def create_and_send_credential_definition(
-        self, schema_id: str, tag: str = None, support_revocation: bool = False
+        self,
+        schema_id: str,
+        signature_type: str = None,
+        tag: str = None,
+        support_revocation: bool = False,
     ) -> Tuple[str, dict]:
         """
         Send credential definition to ledger and store relevant key matter in wallet.
 
         Args:
             schema_id: The schema id of the schema to create cred def for
+            signature_type: The signature type to use on the credential definition
             tag: Optional tag to distinguish multiple credential definitions
             support_revocation: Optional flag to enable revocation for this cred def
 

--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod, ABCMeta
 import re
 from typing import Tuple, Sequence
 
+from ..issuer.base import BaseIssuer
+
 
 class BaseLedger(ABC, metaclass=ABCMeta):
     """Base class for ledger."""
@@ -90,12 +92,17 @@ class BaseLedger(ABC, metaclass=ABCMeta):
 
     @abstractmethod
     async def create_and_send_schema(
-        self, schema_name: str, schema_version: str, attribute_names: Sequence[str]
+        self,
+        issuer: BaseIssuer,
+        schema_name: str,
+        schema_version: str,
+        attribute_names: Sequence[str],
     ) -> Tuple[str, dict]:
         """
         Send schema to ledger.
 
         Args:
+            issuer: The issuer instance to use for schema creation
             schema_name: The schema name
             schema_version: The schema version
             attribute_names: A list of schema attributes
@@ -123,6 +130,7 @@ class BaseLedger(ABC, metaclass=ABCMeta):
     @abstractmethod
     async def create_and_send_credential_definition(
         self,
+        issuer: BaseIssuer,
         schema_id: str,
         signature_type: str = None,
         tag: str = None,
@@ -132,6 +140,7 @@ class BaseLedger(ABC, metaclass=ABCMeta):
         Send credential definition to ledger and store relevant key matter in wallet.
 
         Args:
+            issuer: The issuer instance to use for credential definition creation
             schema_id: The schema id of the schema to create cred def for
             signature_type: The signature type to use on the credential definition
             tag: Optional tag to distinguish multiple credential definitions

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -473,6 +473,7 @@ class IndyLedger(BaseLedger):
         Send credential definition to ledger and store relevant key matter in wallet.
 
         Args:
+            issuer: The issuer instance to use for credential definition creation
             schema_id: The schema id of the schema to create cred def for
             signature_type: The signature type to use on the credential definition
             tag: Optional tag to distinguish multiple credential definitions

--- a/aries_cloudagent/ledger/tests/test_indy.py
+++ b/aries_cloudagent/ledger/tests/test_indy.py
@@ -406,6 +406,10 @@ class TestIndyLedger(AsyncTestCase):
         mock_fetch_schema_by_id.return_value = None
         mock_fetch_schema_by_seq_no.return_value = None
 
+        mock_submit.return_value = (
+            r'{"op":"REPLY","result":{"txnMetadata":{"seqNo": 1}}}'
+        )
+
         async with ledger:
             mock_wallet.get_public_did = async_mock.CoroutineMock()
             mock_wallet.get_public_did.return_value = None

--- a/aries_cloudagent/ledger/tests/test_indy.py
+++ b/aries_cloudagent/ledger/tests/test_indy.py
@@ -7,6 +7,7 @@ from asynctest import mock as async_mock
 import pytest
 
 from aries_cloudagent.cache.basic import BasicCache
+from aries_cloudagent.issuer.base import BaseIssuer, IssuerError
 from aries_cloudagent.ledger.indy import (
     BadLedgerRequestError,
     ClosedPoolError,
@@ -27,7 +28,9 @@ from aries_cloudagent.wallet.base import DIDInfo
 
 @pytest.mark.indy
 class TestIndyLedger(AsyncTestCase):
-    test_did_info = DIDInfo("55GkHamhTU1ZbTbV2ab9DE", "3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx", None)
+    test_did_info = DIDInfo(
+        "55GkHamhTU1ZbTbV2ab9DE", "3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx", None
+    )
     test_did = "55GkHamhTU1ZbTbV2ab9DE"
     test_verkey = "3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"
 
@@ -58,10 +61,7 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("builtins.open")
     async def test_init_do_not_recreate(self, mock_open, mock_list_pools):
         mock_open.return_value = async_mock.MagicMock()
-        mock_list_pools.return_value = [
-            {"pool": "name"},
-            {"pool": "another"}
-        ]
+        mock_list_pools.return_value = [{"pool": "name"}, {"pool": "another"}]
 
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
@@ -80,17 +80,10 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("indy.pool.list_pools")
     @async_mock.patch("builtins.open")
     async def test_init_recreate(
-        self,
-        mock_open,
-        mock_list_pools,
-        mock_delete_config,
-        mock_create_config
+        self, mock_open, mock_list_pools, mock_delete_config, mock_create_config
     ):
         mock_open.return_value = async_mock.MagicMock()
-        mock_list_pools.return_value = [
-            {"pool": "name"},
-            {"pool": "another"}
-        ]
+        mock_list_pools.return_value = [{"pool": "name"}, {"pool": "another"}]
         mock_delete_config.return_value = None
 
         mock_wallet = async_mock.MagicMock()
@@ -245,7 +238,7 @@ class TestIndyLedger(AsyncTestCase):
                 "version": "0.0",
                 "digest": "digest",
                 "mechanism": "dummy",
-                "time": "now"
+                "time": "now",
             }
         )
 
@@ -258,22 +251,16 @@ class TestIndyLedger(AsyncTestCase):
                 request_json="{}",
                 sign=None,
                 taa_accept=True,
-                sign_did=self.test_did_info
+                sign_did=self.test_did_info,
             )
 
             mock_wallet.get_public_did.assert_not_called()
             mock_append_taa.assert_called_once_with(
-                "{}",
-                "sample",
-                "0.0",
-                "digest",
-                "dummy",
-                "now"
+                "{}", "sample", "0.0", "digest", "dummy", "now"
             )
             mock_sign_submit.assert_called_once_with(
                 ledger.pool_handle, ledger.wallet.handle, self.test_did, "{}"
             )
-
 
     @async_mock.patch("indy.pool.set_protocol_version")
     @async_mock.patch("indy.pool.create_pool_ledger_config")
@@ -395,12 +382,10 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger.fetch_schema_by_id")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger.fetch_schema_by_seq_no")
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.add_record")
-    @async_mock.patch("indy.anoncreds.issuer_create_schema")
     @async_mock.patch("indy.ledger.build_schema_request")
     async def test_send_schema(
         self,
         mock_build_schema_req,
-        mock_create_schema,
         mock_add_record,
         mock_fetch_schema_by_seq_no,
         mock_fetch_schema_by_id,
@@ -411,9 +396,13 @@ class TestIndyLedger(AsyncTestCase):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
 
+        issuer = async_mock.MagicMock(BaseIssuer)
         ledger = IndyLedger("name", mock_wallet)
 
-        mock_create_schema.return_value = ("schema_issuer_did:name:1.0", "{}")
+        issuer.create_and_store_schema.return_value = (
+            "schema_issuer_did:name:1.0",
+            "{}",
+        )
         mock_fetch_schema_by_id.return_value = None
         mock_fetch_schema_by_seq_no.return_value = None
 
@@ -423,7 +412,7 @@ class TestIndyLedger(AsyncTestCase):
 
             with self.assertRaises(BadLedgerRequestError):
                 schema_id, schema_def = await ledger.create_and_send_schema(
-                    "schema_name", "schema_version", [1, 2, 3]
+                    issuer, "schema_name", "schema_version", [1, 2, 3]
                 )
 
             mock_wallet.get_public_did = async_mock.CoroutineMock()
@@ -431,23 +420,25 @@ class TestIndyLedger(AsyncTestCase):
             mock_did.did = self.test_did
 
             schema_id, schema_def = await ledger.create_and_send_schema(
-                "schema_name", "schema_version", [1, 2, 3]
+                issuer, "schema_name", "schema_version", [1, 2, 3]
             )
 
             mock_wallet.get_public_did.assert_called_once_with()
-            mock_create_schema.assert_called_once_with(
-                mock_did.did, "schema_name", "schema_version", json.dumps([1, 2, 3])
+            issuer.create_and_store_schema.assert_called_once_with(
+                mock_did.did, "schema_name", "schema_version", [1, 2, 3]
             )
 
             mock_build_schema_req.assert_called_once_with(
-                mock_did.did, mock_create_schema.return_value[1]
+                mock_did.did, issuer.create_and_store_schema.return_value[1]
             )
 
             mock_submit.assert_called_once_with(
-                mock_build_schema_req.return_value, True, sign_did=mock_wallet.get_public_did.return_value
+                mock_build_schema_req.return_value,
+                True,
+                sign_did=mock_wallet.get_public_did.return_value,
             )
 
-            assert schema_id == mock_create_schema.return_value[0]
+            assert schema_id == issuer.create_and_store_schema.return_value[0]
 
     @async_mock.patch("indy.pool.set_protocol_version")
     @async_mock.patch("indy.pool.create_pool_ledger_config")
@@ -455,12 +446,10 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("indy.pool.close_pool_ledger")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger.check_existing_schema")
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.add_record")
-    @async_mock.patch("indy.anoncreds.issuer_create_schema")
     @async_mock.patch("indy.ledger.build_schema_request")
     async def test_send_schema_already_exists(
         self,
         mock_build_schema_req,
-        mock_create_schema,
         mock_add_record,
         mock_check_existing,
         mock_close_pool,
@@ -475,16 +464,16 @@ class TestIndyLedger(AsyncTestCase):
         mock_wallet.get_public_did = async_mock.CoroutineMock()
         mock_wallet.get_public_did.return_value.did = "abc"
 
-        mock_create_schema.return_value = (1, "{}")
-
         fetch_schema_id = f"{mock_wallet.get_public_did.return_value.did}:{2}:schema_name:schema_version"
         mock_check_existing.return_value = (fetch_schema_id, {})
 
+        issuer = async_mock.MagicMock(BaseIssuer)
+        issuer.create_and_store_schema.return_value = ("1", "{}")
         ledger = IndyLedger("name", mock_wallet)
 
         async with ledger:
             schema_id, schema_def = await ledger.create_and_send_schema(
-                "schema_name", "schema_version", [1, 2, 3]
+                issuer, "schema_name", "schema_version", [1, 2, 3]
             )
             assert schema_id == fetch_schema_id
             assert schema_def == {}
@@ -495,12 +484,10 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("indy.pool.close_pool_ledger")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger.check_existing_schema")
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.add_record")
-    @async_mock.patch("indy.anoncreds.issuer_create_schema")
     @async_mock.patch("indy.ledger.build_schema_request")
     async def test_send_schema_ledger_transaction_error_already_exists(
         self,
         mock_build_schema_req,
-        mock_create_schema,
         mock_add_record,
         mock_check_existing,
         mock_close_pool,
@@ -514,11 +501,11 @@ class TestIndyLedger(AsyncTestCase):
         mock_wallet.get_public_did = async_mock.CoroutineMock()
         mock_wallet.get_public_did.return_value.did = "abc"
 
-        mock_create_schema.return_value = (1, "{}")
-
         fetch_schema_id = f"{mock_wallet.get_public_did.return_value.did}:{2}:schema_name:schema_version"
         mock_check_existing.side_effect = [None, (fetch_schema_id, "{}")]
 
+        issuer = async_mock.MagicMock(BaseIssuer)
+        issuer.create_and_store_schema.return_value = ("1", "{}")
         ledger = IndyLedger("name", mock_wallet)
         ledger._submit = async_mock.CoroutineMock(
             side_effect=LedgerTransactionError("UnauthorizedClientRequest")
@@ -526,7 +513,7 @@ class TestIndyLedger(AsyncTestCase):
 
         async with ledger:
             schema_id, schema_def = await ledger.create_and_send_schema(
-                "schema_name", "schema_version", [1, 2, 3]
+                issuer, "schema_name", "schema_version", [1, 2, 3]
             )
             assert schema_id == fetch_schema_id
 
@@ -536,12 +523,10 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("indy.pool.close_pool_ledger")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger.check_existing_schema")
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.add_record")
-    @async_mock.patch("indy.anoncreds.issuer_create_schema")
     @async_mock.patch("indy.ledger.build_schema_request")
     async def test_send_schema_ledger_transaction_error(
         self,
         mock_build_schema_req,
-        mock_create_schema,
         mock_add_record,
         mock_check_existing,
         mock_close_pool,
@@ -555,14 +540,14 @@ class TestIndyLedger(AsyncTestCase):
         mock_wallet.get_public_did = async_mock.CoroutineMock()
         mock_wallet.get_public_did.return_value.did = "abc"
 
-        mock_create_schema.return_value = (1, "{}")
-
         fetch_schema_id = (
             f"{mock_wallet.get_public_did.return_value.did}:{2}:"
             "schema_name:schema_version"
         )
         mock_check_existing.side_effect = [None, fetch_schema_id]
 
+        issuer = async_mock.MagicMock(BaseIssuer)
+        issuer.create_and_store_schema.return_value = ("1", "{}")
         ledger = IndyLedger("name", mock_wallet)
         ledger._submit = async_mock.CoroutineMock(
             side_effect=LedgerTransactionError("Some other error message")
@@ -571,17 +556,14 @@ class TestIndyLedger(AsyncTestCase):
         async with ledger:
             with self.assertRaises(LedgerTransactionError):
                 await ledger.create_and_send_schema(
-                    "schema_name", "schema_version", [1, 2, 3]
+                    issuer, "schema_name", "schema_version", [1, 2, 3]
                 )
 
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_open")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_close")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger.fetch_schema_by_id")
     async def test_check_existing_schema(
-        self,
-        mock_fetch_schema_by_id,
-        mock_close,
-        mock_open,
+        self, mock_fetch_schema_by_id, mock_close, mock_open,
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
@@ -589,9 +571,7 @@ class TestIndyLedger(AsyncTestCase):
         mock_did = mock_wallet.get_public_did.return_value
         mock_did.did = self.test_did
 
-        mock_fetch_schema_by_id.return_value = {
-            "attrNames": ['a', 'b', 'c']
-        }
+        mock_fetch_schema_by_id.return_value = {"attrNames": ["a", "b", "c"]}
 
         ledger = IndyLedger("name", mock_wallet)
         async with ledger:
@@ -599,7 +579,7 @@ class TestIndyLedger(AsyncTestCase):
                 public_did=self.test_did,
                 schema_name="test",
                 schema_version="1.0",
-                attribute_names=['c', 'b', 'a']
+                attribute_names=["c", "b", "a"],
             )
             assert schema_id == f"{self.test_did}:2:test:1.0"
 
@@ -608,7 +588,7 @@ class TestIndyLedger(AsyncTestCase):
                     public_did=self.test_did,
                     schema_name="test",
                     schema_version="1.0",
-                    attribute_names=['a', 'b', 'c', 'd']
+                    attribute_names=["a", "b", "c", "d"],
                 )
 
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_open")
@@ -656,11 +636,7 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._submit")
     @async_mock.patch("indy.ledger.build_get_schema_request")
     async def test_get_schema_not_found(
-        self,
-        mock_build_get_schema_req,
-        mock_submit,
-        mock_close,
-        mock_open,
+        self, mock_build_get_schema_req, mock_submit, mock_close, mock_open,
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
@@ -713,23 +689,16 @@ class TestIndyLedger(AsyncTestCase):
                         "data": {
                             "txn": {
                                 "type": "101",
-                                "metadata": {
-                                    "from": self.test_did
-                                },
+                                "metadata": {"from": self.test_did},
                                 "data": {
-                                    "data": {
-                                        "name": "preferences",
-                                        "version": "1.0"
-                                    }
-                                }
+                                    "data": {"name": "preferences", "version": "1.0"}
+                                },
                             }
                         }
                     }
                 }
             ),
-            json.dumps(
-                {"result": {"seqNo": 999}}
-            )
+            json.dumps({"result": {"seqNo": 999}}),
         ]  # need to subscript these in assertions later
         mock_submit.side_effect = [
             sub for sub in submissions
@@ -743,16 +712,14 @@ class TestIndyLedger(AsyncTestCase):
             mock_wallet.get_public_did.assert_called_once_with()
             mock_build_get_txn_req.assert_called_once_with(None, None, seq_no=999)
             mock_build_get_schema_req.assert_called_once_with(
-                mock_did.did,
-                f"{self.test_did}:2:preferences:1.0"
+                mock_did.did, f"{self.test_did}:2:preferences:1.0"
             )
             mock_submit.assert_has_calls(
                 [
                     async_mock.call(mock_build_get_txn_req.return_value),
                     async_mock.call(
-                        mock_build_get_schema_req.return_value,
-                        sign_did=mock_did
-                    )
+                        mock_build_get_schema_req.return_value, sign_did=mock_did
+                    ),
                 ]
             )
             mock_parse_get_schema_resp.assert_called_once_with(submissions[1])
@@ -783,20 +750,8 @@ class TestIndyLedger(AsyncTestCase):
         mock_parse_get_schema_resp.return_value = (None, '{"attrNames": ["a", "b"]}')
 
         submissions = [
-            json.dumps(
-                {
-                    "result": {
-                        "data": {
-                            "txn": {
-                                "type": "102",  # not a schema
-                            }
-                        }
-                    }
-                }
-            ),
-            json.dumps(
-                {"result": {"seqNo": 999}}
-            )
+            json.dumps({"result": {"data": {"txn": {"type": "102",}}}}),  # not a schema
+            json.dumps({"result": {"seqNo": 999}}),
         ]  # need to subscript these in assertions later
         mock_submit.side_effect = [
             sub for sub in submissions
@@ -817,14 +772,10 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._submit")
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.search_records")
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.add_record")
-    @async_mock.patch("indy.anoncreds.issuer_create_and_store_credential_def")
-    @async_mock.patch("indy.anoncreds.issuer_create_credential_offer")
     @async_mock.patch("indy.ledger.build_cred_def_request")
     async def test_send_credential_definition(
         self,
         mock_build_cred_def,
-        mock_create_offer,
-        mock_create_store_cred_def,
         mock_add_record,
         mock_search_records,
         mock_submit,
@@ -840,18 +791,10 @@ class TestIndyLedger(AsyncTestCase):
             return_value=[]
         )
 
-        mock_create_offer.side_effect = IndyError(
-            error_code=ErrorCode.CommonInvalidStructure
-        )
-        mock_get_schema.return_value = {'seqNo': 999}
+        mock_get_schema.return_value = {"seqNo": 999}
         cred_def_id = f"{self.test_did}:3:CL:999:default"
         cred_def_value = {
-            "primary": {
-                "n": "...",
-                "s": "...",
-                "r": "...",
-                "revocation": None
-            }
+            "primary": {"n": "...", "s": "...", "r": "...", "revocation": None}
         }
         cred_def = {
             "ver": "1.0",
@@ -859,14 +802,19 @@ class TestIndyLedger(AsyncTestCase):
             "schemaId": "999",
             "type": "CL",
             "tag": "default",
-            "value": cred_def_value
+            "value": cred_def_value,
         }
         cred_def_json = json.dumps(cred_def)
 
-        mock_create_store_cred_def.return_value = (cred_def_id, cred_def_json)
-
         mock_fetch_cred_def.side_effect = [None, cred_def]
 
+        issuer = async_mock.MagicMock(BaseIssuer)
+        issuer.make_credential_definition_id.return_value = cred_def_id
+        issuer.create_and_store_credential_definition.return_value = (
+            cred_def_id,
+            cred_def_json,
+        )
+        issuer.credential_definition_in_wallet.return_value = False
         ledger = IndyLedger("name", mock_wallet)
 
         schema_id = "schema_issuer_did:name:1.0"
@@ -877,17 +825,19 @@ class TestIndyLedger(AsyncTestCase):
             mock_wallet.get_public_did.return_value = None
 
             with self.assertRaises(BadLedgerRequestError):
-                await ledger.create_and_send_credential_definition(schema_id, tag)
+                await ledger.create_and_send_credential_definition(
+                    issuer, schema_id, None, tag
+                )
 
             mock_wallet.get_public_did = async_mock.CoroutineMock()
             mock_wallet.get_public_did.return_value = DIDInfo(
-                self.test_did,
-                self.test_verkey,
-                None
+                self.test_did, self.test_verkey, None
             )
             mock_did = mock_wallet.get_public_did.return_value
 
-            result_id, result_def = await ledger.create_and_send_credential_definition(schema_id, tag)
+            result_id, result_def = await ledger.create_and_send_credential_definition(
+                issuer, schema_id, None, tag
+            )
             assert result_id == cred_def_id
 
             mock_wallet.get_public_did.assert_called_once_with()
@@ -899,16 +849,14 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_open")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_close")
     async def test_send_credential_definition_no_such_schema(
-        self,
-        mock_close,
-        mock_open,
-        mock_get_schema,
+        self, mock_close, mock_open, mock_get_schema,
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
 
         mock_get_schema.return_value = {}
 
+        issuer = async_mock.MagicMock(BaseIssuer)
         ledger = IndyLedger("name", mock_wallet)
 
         schema_id = "schema_issuer_did:name:1.0"
@@ -918,7 +866,9 @@ class TestIndyLedger(AsyncTestCase):
             mock_wallet.get_public_did = async_mock.CoroutineMock()
 
             with self.assertRaises(LedgerError):
-                await ledger.create_and_send_credential_definition(schema_id, tag)
+                await ledger.create_and_send_credential_definition(
+                    issuer, schema_id, None, tag
+                )
 
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger.get_schema")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_open")
@@ -929,14 +879,10 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._submit")
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.search_records")
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.add_record")
-    @async_mock.patch("indy.anoncreds.issuer_create_and_store_credential_def")
-    @async_mock.patch("indy.anoncreds.issuer_create_credential_offer")
     @async_mock.patch("indy.ledger.build_cred_def_request")
     async def test_send_credential_definition_offer_exception(
         self,
         mock_build_cred_def,
-        mock_create_offer,
-        mock_create_store_cred_def,
         mock_add_record,
         mock_search_records,
         mock_submit,
@@ -952,12 +898,16 @@ class TestIndyLedger(AsyncTestCase):
             return_value=[]
         )
 
-        mock_create_offer.side_effect = IndyError(
-            error_code=ErrorCode.CommonIOError,
-            error_details={"message": "cover indy error message wrapping"}
-        )
-        mock_get_schema.return_value = {'seqNo': 999}
+        mock_get_schema.return_value = {"seqNo": 999}
 
+        issuer = async_mock.MagicMock(BaseIssuer)
+        # issuer.create_and_store_credential_definition.return_value = (
+        #     cred_def_id,
+        #     cred_def_json,
+        # )
+        issuer.credential_definition_in_wallet.side_effect = IssuerError(
+            "common IO error"
+        )
         ledger = IndyLedger("name", mock_wallet)
 
         schema_id = "schema_issuer_did:name:1.0"
@@ -967,7 +917,9 @@ class TestIndyLedger(AsyncTestCase):
             mock_wallet.get_public_did = async_mock.CoroutineMock()
 
             with self.assertRaises(LedgerError):
-                await ledger.create_and_send_credential_definition(schema_id, tag)
+                await ledger.create_and_send_credential_definition(
+                    issuer, schema_id, None, tag
+                )
 
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger.get_schema")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_open")
@@ -975,27 +927,16 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch(
         "aries_cloudagent.ledger.indy.IndyLedger.fetch_credential_definition"
     )
-    @async_mock.patch("indy.anoncreds.issuer_create_credential_offer")
     async def test_send_credential_definition_cred_def_in_wallet_not_ledger(
-        self,
-        mock_create_offer,
-        mock_fetch_cred_def,
-        mock_close,
-        mock_open,
-        mock_get_schema,
+        self, mock_fetch_cred_def, mock_close, mock_open, mock_get_schema,
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
 
-        mock_get_schema.return_value = {'seqNo': 999}
+        mock_get_schema.return_value = {"seqNo": 999}
         cred_def_id = f"{self.test_did}:3:CL:999:default"
         cred_def_value = {
-            "primary": {
-                "n": "...",
-                "s": "...",
-                "r": "...",
-                "revocation": None
-            }
+            "primary": {"n": "...", "s": "...", "r": "...", "revocation": None}
         }
         cred_def = {
             "ver": "1.0",
@@ -1003,12 +944,13 @@ class TestIndyLedger(AsyncTestCase):
             "schemaId": "999",
             "type": "CL",
             "tag": "default",
-            "value": cred_def_value
+            "value": cred_def_value,
         }
         cred_def_json = json.dumps(cred_def)
 
         mock_fetch_cred_def.return_value = {}
 
+        issuer = async_mock.MagicMock(BaseIssuer)
         ledger = IndyLedger("name", mock_wallet)
 
         schema_id = "schema_issuer_did:name:1.0"
@@ -1018,7 +960,9 @@ class TestIndyLedger(AsyncTestCase):
             mock_wallet.get_public_did = async_mock.CoroutineMock()
 
             with self.assertRaises(LedgerError):
-                await ledger.create_and_send_credential_definition(schema_id, tag)
+                await ledger.create_and_send_credential_definition(
+                    issuer, schema_id, None, tag
+                )
 
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger.get_schema")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_open")
@@ -1026,27 +970,16 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch(
         "aries_cloudagent.ledger.indy.IndyLedger.fetch_credential_definition"
     )
-    @async_mock.patch("indy.anoncreds.issuer_create_credential_offer")
     async def test_send_credential_definition_cred_def_on_ledger_not_in_wallet(
-        self,
-        mock_create_offer,
-        mock_fetch_cred_def,
-        mock_close,
-        mock_open,
-        mock_get_schema,
+        self, mock_fetch_cred_def, mock_close, mock_open, mock_get_schema,
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
 
-        mock_get_schema.return_value = {'seqNo': 999}
+        mock_get_schema.return_value = {"seqNo": 999}
         cred_def_id = f"{self.test_did}:3:CL:999:default"
         cred_def_value = {
-            "primary": {
-                "n": "...",
-                "s": "...",
-                "r": "...",
-                "revocation": None
-            }
+            "primary": {"n": "...", "s": "...", "r": "...", "revocation": None}
         }
         cred_def = {
             "ver": "1.0",
@@ -1054,16 +987,16 @@ class TestIndyLedger(AsyncTestCase):
             "schemaId": "999",
             "type": "CL",
             "tag": "default",
-            "value": cred_def_value
+            "value": cred_def_value,
         }
         cred_def_json = json.dumps(cred_def)
 
         mock_fetch_cred_def.return_value = cred_def
 
-        mock_create_offer.side_effect = IndyError(
-            error_code=ErrorCode.CommonInvalidStructure
+        issuer = async_mock.MagicMock(BaseIssuer)
+        issuer.credential_definition_in_wallet.side_effect = IssuerError(
+            "invalid structure"
         )
-
         ledger = IndyLedger("name", mock_wallet)
 
         schema_id = "schema_issuer_did:name:1.0"
@@ -1073,7 +1006,9 @@ class TestIndyLedger(AsyncTestCase):
             mock_wallet.get_public_did = async_mock.CoroutineMock()
 
             with self.assertRaises(LedgerError):
-                await ledger.create_and_send_credential_definition(schema_id, tag)
+                await ledger.create_and_send_credential_definition(
+                    issuer, schema_id, None, tag
+                )
 
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger.get_schema")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_open")
@@ -1084,14 +1019,10 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._submit")
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.search_records")
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.add_record")
-    @async_mock.patch("indy.anoncreds.issuer_create_and_store_credential_def")
-    @async_mock.patch("indy.anoncreds.issuer_create_credential_offer")
     @async_mock.patch("indy.ledger.build_cred_def_request")
     async def test_send_credential_definition_on_ledger_in_wallet(
         self,
         mock_build_cred_def,
-        mock_create_offer,
-        mock_create_store_cred_def,
         mock_add_record,
         mock_search_records,
         mock_submit,
@@ -1107,15 +1038,10 @@ class TestIndyLedger(AsyncTestCase):
             return_value=[]
         )
 
-        mock_get_schema.return_value = {'seqNo': 999}
+        mock_get_schema.return_value = {"seqNo": 999}
         cred_def_id = f"{self.test_did}:3:CL:999:default"
         cred_def_value = {
-            "primary": {
-                "n": "...",
-                "s": "...",
-                "r": "...",
-                "revocation": None
-            }
+            "primary": {"n": "...", "s": "...", "r": "...", "revocation": None}
         }
         cred_def = {
             "ver": "1.0",
@@ -1123,14 +1049,18 @@ class TestIndyLedger(AsyncTestCase):
             "schemaId": "999",
             "type": "CL",
             "tag": "default",
-            "value": cred_def_value
+            "value": cred_def_value,
         }
         cred_def_json = json.dumps(cred_def)
 
-        mock_create_store_cred_def.return_value = (cred_def_id, cred_def_json)
-
         mock_fetch_cred_def.return_value = cred_def
 
+        issuer = async_mock.MagicMock(BaseIssuer)
+        issuer.make_credential_definition_id.return_value = cred_def_id
+        issuer.create_and_store_credential_definition.return_value = (
+            cred_def_id,
+            cred_def_json,
+        )
         ledger = IndyLedger("name", mock_wallet)
 
         schema_id = "schema_issuer_did:name:1.0"
@@ -1141,17 +1071,19 @@ class TestIndyLedger(AsyncTestCase):
             mock_wallet.get_public_did.return_value = None
 
             with self.assertRaises(BadLedgerRequestError):
-                await ledger.create_and_send_credential_definition(schema_id, tag)
+                await ledger.create_and_send_credential_definition(
+                    issuer, schema_id, None, tag
+                )
 
             mock_wallet.get_public_did = async_mock.CoroutineMock()
             mock_wallet.get_public_did.return_value = DIDInfo(
-                self.test_did,
-                self.test_verkey,
-                None
+                self.test_did, self.test_verkey, None
             )
             mock_did = mock_wallet.get_public_did.return_value
 
-            result_id, result_def = await ledger.create_and_send_credential_definition(schema_id, tag)
+            result_id, result_def = await ledger.create_and_send_credential_definition(
+                issuer, schema_id, None, tag
+            )
             assert result_id == cred_def_id
 
             mock_wallet.get_public_did.assert_called_once_with()
@@ -1168,14 +1100,10 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._submit")
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.search_records")
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.add_record")
-    @async_mock.patch("indy.anoncreds.issuer_create_and_store_credential_def")
-    @async_mock.patch("indy.anoncreds.issuer_create_credential_offer")
     @async_mock.patch("indy.ledger.build_cred_def_request")
     async def test_send_credential_definition_create_cred_def_exception(
         self,
         mock_build_cred_def,
-        mock_create_offer,
-        mock_create_store_cred_def,
         mock_add_record,
         mock_search_records,
         mock_submit,
@@ -1191,18 +1119,10 @@ class TestIndyLedger(AsyncTestCase):
             return_value=[]
         )
 
-        mock_create_offer.side_effect = IndyError(
-            error_code=ErrorCode.CommonInvalidStructure
-        )
-        mock_get_schema.return_value = {'seqNo': 999}
+        mock_get_schema.return_value = {"seqNo": 999}
         cred_def_id = f"{self.test_did}:3:CL:999:default"
         cred_def_value = {
-            "primary": {
-                "n": "...",
-                "s": "...",
-                "r": "...",
-                "revocation": None
-            }
+            "primary": {"n": "...", "s": "...", "r": "...", "revocation": None}
         }
         cred_def = {
             "ver": "1.0",
@@ -1210,16 +1130,19 @@ class TestIndyLedger(AsyncTestCase):
             "schemaId": "999",
             "type": "CL",
             "tag": "default",
-            "value": cred_def_value
+            "value": cred_def_value,
         }
         cred_def_json = json.dumps(cred_def)
 
-        mock_create_store_cred_def.side_effect = IndyError(
-            error_code=ErrorCode.CommonInvalidStructure
-        )
-
         mock_fetch_cred_def.return_value = None
 
+        issuer = async_mock.MagicMock(BaseIssuer)
+        issuer.create_and_store_credential_definition.side_effect = IssuerError(
+            "invalid structure"
+        )
+        # issuer.credential_definition_in_wallet.side_effect = IndyError(
+        #     error_code=ErrorCode.CommonInvalidStructure
+        # )
         ledger = IndyLedger("name", mock_wallet)
 
         schema_id = "schema_issuer_did:name:1.0"
@@ -1228,25 +1151,23 @@ class TestIndyLedger(AsyncTestCase):
         async with ledger:
             mock_wallet.get_public_did = async_mock.CoroutineMock()
             mock_wallet.get_public_did.return_value = DIDInfo(
-                self.test_did,
-                self.test_verkey,
-                None
+                self.test_did, self.test_verkey, None
             )
 
             with self.assertRaises(LedgerError):
-                await ledger.create_and_send_credential_definition(schema_id, tag)
+                await ledger.create_and_send_credential_definition(
+                    issuer, schema_id, None, tag
+                )
 
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_open")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_close")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._submit")
-    @async_mock.patch("indy.anoncreds.issuer_create_schema")
     @async_mock.patch("indy.ledger.build_get_cred_def_request")
     @async_mock.patch("indy.ledger.parse_get_cred_def_response")
     async def test_get_credential_definition(
         self,
         mock_parse_get_cred_def_resp,
         mock_build_get_cred_def_req,
-        mock_create_schema,
         mock_submit,
         mock_close,
         mock_open,
@@ -1258,7 +1179,7 @@ class TestIndyLedger(AsyncTestCase):
 
         mock_parse_get_cred_def_resp.return_value = (
             None,
-            json.dumps({'result': {'seqNo': 1}})
+            json.dumps({"result": {"seqNo": 1}}),
         )
 
         ledger = IndyLedger("name", mock_wallet, cache=BasicCache())
@@ -1287,14 +1208,12 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_open")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_close")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._submit")
-    @async_mock.patch("indy.anoncreds.issuer_create_schema")
     @async_mock.patch("indy.ledger.build_get_cred_def_request")
     @async_mock.patch("indy.ledger.parse_get_cred_def_response")
     async def test_get_credential_definition_ledger_not_found(
         self,
         mock_parse_get_cred_def_resp,
         mock_build_get_cred_def_req,
-        mock_create_schema,
         mock_submit,
         mock_close,
         mock_open,
@@ -1305,8 +1224,7 @@ class TestIndyLedger(AsyncTestCase):
         mock_did = mock_wallet.get_public_did.return_value
 
         mock_parse_get_cred_def_resp.side_effect = IndyError(
-            error_code=ErrorCode.LedgerNotFound,
-            error_details={'message': 'not today'}
+            error_code=ErrorCode.LedgerNotFound, error_details={"message": "not today"}
         )
 
         ledger = IndyLedger("name", mock_wallet)
@@ -1332,37 +1250,28 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("indy.ledger.build_get_nym_request")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._submit")
     async def test_get_key_for_did(
-        self,
-        mock_submit,
-        mock_build_get_nym_req,
-        mock_close,
-        mock_open
+        self, mock_submit, mock_build_get_nym_req, mock_close, mock_open
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
 
         mock_submit.return_value = json.dumps(
-            {
-                "result": {
-                    "data": json.dumps({"verkey": self.test_verkey})
-                }
-            }
+            {"result": {"data": json.dumps({"verkey": self.test_verkey})}}
         )
         ledger = IndyLedger("name", mock_wallet)
 
         async with ledger:
             mock_wallet.get_public_did = async_mock.CoroutineMock(
-                return_value = self.test_did_info
+                return_value=self.test_did_info
             )
             response = await ledger.get_key_for_did(self.test_did)
 
             assert mock_build_get_nym_req.called_once_with(
-                self.test_did,
-                ledger.did_to_nym(self.test_did)
+                self.test_did, ledger.did_to_nym(self.test_did)
             )
             assert mock_submit.called_once_with(
                 mock_build_get_nym_req.return_value,
-                sign_did=mock_wallet.get_public_did.return_value
+                sign_did=mock_wallet.get_public_did.return_value,
             )
             assert response == self.test_verkey
 
@@ -1371,47 +1280,29 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("indy.ledger.build_get_attrib_request")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._submit")
     async def test_get_endpoint_for_did(
-        self,
-        mock_submit,
-        mock_build_get_attrib_req,
-        mock_close,
-        mock_open
+        self, mock_submit, mock_build_get_attrib_req, mock_close, mock_open
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
 
         endpoint = "http://aries.ca"
         mock_submit.return_value = json.dumps(
-            {
-                "result": {
-                    "data": json.dumps(
-                        {
-                            "endpoint": {
-                                "endpoint": endpoint
-                            }
-                        }
-                    )
-                }
-            }
+            {"result": {"data": json.dumps({"endpoint": {"endpoint": endpoint}})}}
         )
         ledger = IndyLedger("name", mock_wallet)
 
         async with ledger:
             mock_wallet.get_public_did = async_mock.CoroutineMock(
-                return_value = self.test_did_info
+                return_value=self.test_did_info
             )
             response = await ledger.get_endpoint_for_did(self.test_did)
 
             assert mock_build_get_attrib_req.called_once_with(
-                self.test_did,
-                ledger.did_to_nym(self.test_did),
-                "endpoint",
-                None,
-                None
+                self.test_did, ledger.did_to_nym(self.test_did), "endpoint", None, None
             )
             assert mock_submit.called_once_with(
                 mock_build_get_attrib_req.return_value,
-                sign_did=mock_wallet.get_public_did.return_value
+                sign_did=mock_wallet.get_public_did.return_value,
             )
             assert response == endpoint
 
@@ -1420,40 +1311,24 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("indy.ledger.build_get_attrib_request")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._submit")
     async def test_get_endpoint_for_did_address_none(
-        self,
-        mock_submit,
-        mock_build_get_attrib_req,
-        mock_close,
-        mock_open
+        self, mock_submit, mock_build_get_attrib_req, mock_close, mock_open
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
 
         mock_submit.return_value = json.dumps(
-            {
-                "result": {
-                    "data": json.dumps(
-                        {
-                            "endpoint": None
-                        }
-                    )
-                }
-            }
+            {"result": {"data": json.dumps({"endpoint": None})}}
         )
         ledger = IndyLedger("name", mock_wallet)
 
         async with ledger:
             mock_wallet.get_public_did = async_mock.CoroutineMock(
-                return_value = self.test_did_info
+                return_value=self.test_did_info
             )
             response = await ledger.get_endpoint_for_did(self.test_did)
 
             assert mock_build_get_attrib_req.called_once_with(
-                self.test_did,
-                ledger.did_to_nym(self.test_did),
-                "endpoint",
-                None,
-                None
+                self.test_did, ledger.did_to_nym(self.test_did), "endpoint", None, None
             )
             assert mock_submit.called_once_with(
                 mock_build_get_attrib_req.return_value,
@@ -1466,40 +1341,26 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("indy.ledger.build_get_attrib_request")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._submit")
     async def test_get_endpoint_for_did_no_endpoint(
-        self,
-        mock_submit,
-        mock_build_get_attrib_req,
-        mock_close,
-        mock_open
+        self, mock_submit, mock_build_get_attrib_req, mock_close, mock_open
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
 
-        mock_submit.return_value = json.dumps(
-            {
-                "result": {
-                    "data": None
-                }
-            }
-        )
+        mock_submit.return_value = json.dumps({"result": {"data": None}})
         ledger = IndyLedger("name", mock_wallet)
 
         async with ledger:
             mock_wallet.get_public_did = async_mock.CoroutineMock(
-                return_value = self.test_did_info
+                return_value=self.test_did_info
             )
             response = await ledger.get_endpoint_for_did(self.test_did)
 
             assert mock_build_get_attrib_req.called_once_with(
-                self.test_did,
-                ledger.did_to_nym(self.test_did),
-                "endpoint",
-                None,
-                None
+                self.test_did, ledger.did_to_nym(self.test_did), "endpoint", None, None
             )
             assert mock_submit.called_once_with(
                 mock_build_get_attrib_req.return_value,
-                sign_did=mock_wallet.get_public_did.return_value
+                sign_did=mock_wallet.get_public_did.return_value,
             )
             assert response is None
 
@@ -1514,7 +1375,7 @@ class TestIndyLedger(AsyncTestCase):
         mock_build_attrib_req,
         mock_build_get_attrib_req,
         mock_close,
-        mock_open
+        mock_open,
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
@@ -1524,43 +1385,30 @@ class TestIndyLedger(AsyncTestCase):
             json.dumps(
                 {
                     "result": {
-                        "data": json.dumps(
-                            {
-                                "endpoint": {
-                                    "endpoint": endpoint[i]
-                                }
-                            }
-                        )
+                        "data": json.dumps({"endpoint": {"endpoint": endpoint[i]}})
                     }
                 }
-            ) for i in range(len(endpoint))
+            )
+            for i in range(len(endpoint))
         ]
         ledger = IndyLedger("name", mock_wallet)
 
         async with ledger:
             mock_wallet.get_public_did = async_mock.CoroutineMock(
-                return_value = self.test_did_info
+                return_value=self.test_did_info
             )
             response = await ledger.update_endpoint_for_did(self.test_did, endpoint[1])
 
             assert mock_build_get_attrib_req.called_once_with(
-                self.test_did,
-                ledger.did_to_nym(self.test_did),
-                "endpoint",
-                None,
-                None
+                self.test_did, ledger.did_to_nym(self.test_did), "endpoint", None, None
             )
             mock_submit.assert_has_calls(
                 [
                     async_mock.call(
                         mock_build_get_attrib_req.return_value,
-                        sign_did=mock_wallet.get_public_did.return_value
+                        sign_did=mock_wallet.get_public_did.return_value,
                     ),
-                    async_mock.call(
-                        mock_build_attrib_req.return_value,
-                        True,
-                        True
-                    )
+                    async_mock.call(mock_build_attrib_req.return_value, True, True),
                 ]
             )
             assert response
@@ -1570,47 +1418,29 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("indy.ledger.build_get_attrib_request")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._submit")
     async def test_update_endpoint_for_did_duplicate(
-        self,
-        mock_submit,
-        mock_build_get_attrib_req,
-        mock_close,
-        mock_open
+        self, mock_submit, mock_build_get_attrib_req, mock_close, mock_open
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
 
         endpoint = "http://aries.ca"
         mock_submit.return_value = json.dumps(
-            {
-                "result": {
-                    "data": json.dumps(
-                        {
-                            "endpoint": {
-                                "endpoint": endpoint
-                            }
-                        }
-                    )
-                }
-            }
+            {"result": {"data": json.dumps({"endpoint": {"endpoint": endpoint}})}}
         )
         ledger = IndyLedger("name", mock_wallet)
 
         async with ledger:
             mock_wallet.get_public_did = async_mock.CoroutineMock(
-                return_value = self.test_did_info
+                return_value=self.test_did_info
             )
             response = await ledger.update_endpoint_for_did(self.test_did, endpoint)
 
             assert mock_build_get_attrib_req.called_once_with(
-                self.test_did,
-                ledger.did_to_nym(self.test_did),
-                "endpoint",
-                None,
-                None
+                self.test_did, ledger.did_to_nym(self.test_did), "endpoint", None, None
             )
             assert mock_submit.called_once_with(
                 mock_build_get_attrib_req.return_value,
-                sign_did=mock_wallet.get_public_did.return_value
+                sign_did=mock_wallet.get_public_did.return_value,
             )
             assert not response
 
@@ -1619,11 +1449,7 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("indy.ledger.build_nym_request")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._submit")
     async def test_register_nym(
-        self,
-        mock_submit,
-        mock_build_nym_req,
-        mock_close,
-        mock_open
+        self, mock_submit, mock_build_nym_req, mock_close, mock_open
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
@@ -1632,35 +1458,24 @@ class TestIndyLedger(AsyncTestCase):
 
         async with ledger:
             mock_wallet.get_public_did = async_mock.CoroutineMock(
-                return_value = self.test_did_info
+                return_value=self.test_did_info
             )
-            await ledger.register_nym(
-                self.test_did,
-                self.test_verkey,
-                "alias",
-                None
-            )
+            await ledger.register_nym(self.test_did, self.test_verkey, "alias", None)
 
             assert mock_build_nym_req.called_once_with(
-                self.test_did,
-                self.test_did,
-                self.test_verkey,
-                "alias",
-                None
+                self.test_did, self.test_did, self.test_verkey, "alias", None
             )
             assert mock_submit.called_once_with(
                 mock_build_nym_req.return_value,
                 True,
                 True,
-                sign_did=mock_wallet.get_public_did.return_value
+                sign_did=mock_wallet.get_public_did.return_value,
             )
 
     @async_mock.patch("indy.pool.open_pool_ledger")
     @async_mock.patch("indy.pool.close_pool_ledger")
     async def test_taa_digest_bad_value(
-        self,
-        mock_close_pool,
-        mock_open_ledger,
+        self, mock_close_pool, mock_open_ledger,
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
@@ -1682,46 +1497,38 @@ class TestIndyLedger(AsyncTestCase):
         mock_build_get_taa_req,
         mock_build_get_acc_mech_req,
         mock_close,
-        mock_open
+        mock_open,
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
 
         txn_result_data = {"text": "text", "version": "1.0"}
         mock_submit.side_effect = [
-            json.dumps(
-                {
-                    "result": {
-                        "data": txn_result_data
-                    }
-                }
-            ) for i in range(2)
+            json.dumps({"result": {"data": txn_result_data}}) for i in range(2)
         ]
 
         ledger = IndyLedger("name", mock_wallet)
 
         async with ledger:
             mock_wallet.get_public_did = async_mock.CoroutineMock(
-                return_value = self.test_did_info
+                return_value=self.test_did_info
             )
             response = await ledger.get_txn_author_agreement(reload=True)
 
             assert mock_build_get_acc_mech_req.called_once_with(
-                self.test_did,
-                None,
-                None
+                self.test_did, None, None
             )
             assert mock_build_get_taa_req.called_once_with(self.test_did, None)
             mock_submit.assert_has_calls(
                 [
                     async_mock.call(
                         mock_build_get_acc_mech_req.return_value,
-                        sign_did=mock_wallet.get_public_did.return_value
+                        sign_did=mock_wallet.get_public_did.return_value,
                     ),
                     async_mock.call(
                         mock_build_get_taa_req.return_value,
-                        sign_did=mock_wallet.get_public_did.return_value
-                    )
+                        sign_did=mock_wallet.get_public_did.return_value,
+                    ),
                 ]
             )
             assert response == {
@@ -1729,11 +1536,10 @@ class TestIndyLedger(AsyncTestCase):
                 "taa_record": {
                     **txn_result_data,
                     "digest": ledger.taa_digest(
-                        txn_result_data["version"],
-                        txn_result_data["text"]
-                    )
+                        txn_result_data["version"], txn_result_data["text"]
+                    ),
                 },
-                "taa_required": True
+                "taa_required": True,
             }
 
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_open")
@@ -1741,11 +1547,7 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.add_record")
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.search_records")
     async def test_accept_and_get_latest_txn_author_agreement(
-        self,
-        mock_search_records,
-        mock_add_record,
-        mock_close,
-        mock_open
+        self, mock_search_records, mock_add_record, mock_close, mock_open
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"
@@ -1778,9 +1580,7 @@ class TestIndyLedger(AsyncTestCase):
 
         async with ledger:
             await ledger.accept_txn_author_agreement(
-                taa_record=taa_record,
-                mechanism="dummy",
-                accept_time=None
+                taa_record=taa_record, mechanism="dummy", accept_time=None
             )
 
             await ledger.cache.clear(f"{TAA_ACCEPTED_RECORD_TYPE}::{ledger.pool_name}")
@@ -1792,10 +1592,7 @@ class TestIndyLedger(AsyncTestCase):
     @async_mock.patch("aries_cloudagent.ledger.indy.IndyLedger._context_close")
     @async_mock.patch("aries_cloudagent.storage.indy.IndyStorage.search_records")
     async def test_get_latest_txn_author_agreement_none(
-        self,
-        mock_search_records,
-        mock_close,
-        mock_open
+        self, mock_search_records, mock_close, mock_open
     ):
         mock_wallet = async_mock.MagicMock()
         mock_wallet.WALLET_TYPE = "indy"

--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -7,6 +7,7 @@ from aiohttp_apispec import docs, request_schema, response_schema
 
 from marshmallow import fields, Schema
 
+from ...issuer.base import BaseIssuer
 from ...ledger.base import BaseLedger
 from ...storage.base import BaseStorage
 
@@ -106,10 +107,15 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
     tag = body.get("tag")
 
     ledger: BaseLedger = await context.inject(BaseLedger)
+    issuer: BaseIssuer = await context.inject(BaseIssuer)
     async with ledger:
         credential_definition_id, credential_definition = await shield(
             ledger.create_and_send_credential_definition(
-                schema_id, tag=tag, support_revocation=support_revocation
+                issuer,
+                schema_id,
+                signature_type=None,
+                tag=tag,
+                support_revocation=support_revocation,
             )
         )
 

--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -7,6 +7,7 @@ from aiohttp_apispec import docs, request_schema, response_schema
 
 from marshmallow import fields, Schema
 
+from ...issuer.base import BaseIssuer
 from ...ledger.base import BaseLedger
 from ...storage.base import BaseStorage
 from ..valid import INDY_SCHEMA_ID, INDY_VERSION
@@ -88,9 +89,12 @@ async def schemas_send_schema(request: web.BaseRequest):
     attributes = body.get("attributes")
 
     ledger: BaseLedger = await context.inject(BaseLedger)
+    issuer: BaseIssuer = await context.inject(BaseIssuer)
     async with ledger:
         schema_id, schema_def = await shield(
-            ledger.create_and_send_schema(schema_name, schema_version, attributes)
+            ledger.create_and_send_schema(
+                issuer, schema_name, schema_version, attributes
+            )
         )
 
     return web.json_response({"schema_id": schema_id, "schema": schema_def})

--- a/aries_cloudagent/protocols/credentials/manager.py
+++ b/aries_cloudagent/protocols/credentials/manager.py
@@ -173,11 +173,16 @@ class CredentialManager:
 
                 holder: BaseHolder = await self.context.inject(BaseHolder)
                 (
-                    credential_exchange_record.credential_request,
-                    credential_exchange_record.credential_request_metadata,
+                    cred_req_json,
+                    cred_req_meta_json,
                 ) = await holder.create_credential_request(
                     credential_offer, credential_definition, did
                 )
+                (
+                    credential_exchange_record.credential_request,
+                    credential_exchange_record.credential_request_metadata,
+                ) = (json.loads(cred_req_json), json.loads(cred_req_meta_json))
+
                 await CredentialExchange.set_cached_key(
                     self.context,
                     cache_key,
@@ -339,11 +344,11 @@ class CredentialManager:
             credential_id=credential_id,
         )
 
-        credential = await holder.get_credential(credential_id)
+        credential_json = await holder.get_credential(credential_id)
 
         credential_exchange_record.state = CredentialExchange.STATE_STORED
         credential_exchange_record.credential_id = credential_id
-        credential_exchange_record.credential = credential
+        credential_exchange_record.credential = json.loads(credential_json)
 
         await credential_exchange_record.save(self.context, reason="Store credential")
 

--- a/aries_cloudagent/protocols/credentials/manager.py
+++ b/aries_cloudagent/protocols/credentials/manager.py
@@ -70,9 +70,10 @@ class CredentialManager:
             credential_offer = cached["offer"]
         else:
             issuer: BaseIssuer = await self.context.inject(BaseIssuer)
-            credential_offer = await issuer.create_credential_offer(
+            credential_offer_json = await issuer.create_credential_offer(
                 credential_definition_id
             )
+            credential_offer = json.loads(credential_offer_json)
             await CredentialExchange.set_cached_key(
                 self.context, cache_key, {"offer": credential_offer}, 3600
             )
@@ -259,11 +260,12 @@ class CredentialManager:
 
             issuer: BaseIssuer = await self.context.inject(BaseIssuer)
             (
-                credential_exchange_record.credential,
-                _,  # credential_revocation_id
+                credential_json,
+                credential_exchange_record.revocation_id,
             ) = await issuer.create_credential(
                 schema, credential_offer, credential_request, credential_values
             )
+            credential_exchange_record.credential = json.loads(credential_json)
 
         credential_exchange_record.state = CredentialExchange.STATE_ISSUED
 

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -377,10 +377,13 @@ class CredentialManager:
                 )
 
             holder: BaseHolder = await self.context.inject(BaseHolder)
-            request, metadata = await holder.create_credential_request(
+            request_json, metadata_json = await holder.create_credential_request(
                 credential_offer, credential_definition, holder_did
             )
-            return {"request": request, "metadata": metadata}
+            return {
+                "request": json.loads(request_json),
+                "metadata": json.loads(metadata_json),
+            }
 
         if credential_exchange_record.credential_request:
             self._logger.warning(
@@ -627,13 +630,14 @@ class CredentialManager:
                 credential_exchange_record.credential_request_metadata,
                 mime_types,
                 credential_id=credential_id,
-                rev_reg_def_json=revoc_reg_def,
+                rev_reg_def=revoc_reg_def,
             )
         except IndyError as e:
             self._logger.error(f"Error storing credential. {e.error_code}: {e.message}")
             raise e
 
-        credential = await holder.get_credential(credential_id)
+        credential_json = await holder.get_credential(credential_id)
+        credential = json.loads(credential_json)
 
         credential_exchange_record.state = V10CredentialExchange.STATE_ACKED
         credential_exchange_record.credential_id = credential_id

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -506,9 +506,9 @@ class CredentialManager:
                 # FIXME exception on missing
 
                 registry = await registry_record.get_registry()
-                tails_reader = await registry.create_tails_reader(self.context)
+                tails_path = registry.tails_local_path
             else:
-                tails_reader = None
+                tails_path = None
 
             issuer: BaseIssuer = await self.context.inject(BaseIssuer)
             (
@@ -520,7 +520,7 @@ class CredentialManager:
                 credential_request,
                 credential_values,
                 credential_exchange_record.revoc_reg_id,
-                tails_reader,
+                tails_path,
             )
             credential_exchange_record.credential = json.loads(credential_json)
 
@@ -617,10 +617,6 @@ class CredentialManager:
         if revoc_reg_def:
             revoc_reg = RevocationRegistry.from_definition(revoc_reg_def, True)
             if not revoc_reg.has_local_tails_file(self.context):
-                self._logger.info(
-                    "Downloading the tails file for the revocation registry: "
-                    f"{revoc_reg.registry_id}"
-                )
                 await revoc_reg.retrieve_tails(self.context)
 
         try:
@@ -709,10 +705,11 @@ class CredentialManager:
         # FIXME exception on missing
 
         registry = await registry_record.get_registry()
-        tails_reader = await registry.create_tails_reader(self.context)
 
         delta_json = await issuer.revoke_credential(
-            registry.registry_id, tails_reader, credential_exchange_record.revocation_id
+            registry.registry_id,
+            registry.tails_local_path,
+            credential_exchange_record.revocation_id,
         )
         delta = json.loads(delta_json)
 

--- a/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_manager.py
@@ -495,10 +495,10 @@ class TestCredentialManager(AsyncTestCase):
                 return_value=cred_def
             )
 
-            cred_req_meta = object()
+            cred_req_meta = {}
             holder = async_mock.MagicMock()
             holder.create_credential_request = async_mock.CoroutineMock(
-                return_value=(indy_cred_req, cred_req_meta)
+                return_value=(json.dumps(indy_cred_req), json.dumps(cred_req_meta))
             )
             self.context.injector.bind_instance(BaseHolder, holder)
 
@@ -560,10 +560,10 @@ class TestCredentialManager(AsyncTestCase):
                 return_value=cred_def
             )
 
-            cred_req_meta = object()
+            cred_req_meta = {}
             holder = async_mock.MagicMock()
             holder.create_credential_request = async_mock.CoroutineMock(
-                return_value=(indy_cred_req, cred_req_meta)
+                return_value=(json.dumps(indy_cred_req), json.dumps(cred_req_meta))
             )
             self.context.injector.bind_instance(BaseHolder, holder)
 
@@ -762,7 +762,9 @@ class TestCredentialManager(AsyncTestCase):
         holder = async_mock.MagicMock()
         holder.store_credential = async_mock.CoroutineMock(return_value=cred_id)
         stored_cred = {"stored": "cred"}
-        holder.get_credential = async_mock.CoroutineMock(return_value=stored_cred)
+        holder.get_credential = async_mock.CoroutineMock(
+            return_value=json.dumps(stored_cred)
+        )
         self.context.injector.bind_instance(BaseHolder, holder)
 
         with async_mock.patch.object(
@@ -785,7 +787,7 @@ class TestCredentialManager(AsyncTestCase):
                 cred_req_meta,
                 mock_preview_deserialize.return_value.mime_types.return_value,
                 credential_id=None,
-                rev_reg_def_json=None,
+                rev_reg_def=None,
             )
 
             holder.get_credential.assert_called_once_with(cred_id)
@@ -823,7 +825,9 @@ class TestCredentialManager(AsyncTestCase):
         holder = async_mock.MagicMock()
         holder.store_credential = async_mock.CoroutineMock(return_value=cred_id)
         stored_cred = {"stored": "cred"}
-        holder.get_credential = async_mock.CoroutineMock(return_value=stored_cred)
+        holder.get_credential = async_mock.CoroutineMock(
+            return_value=json.dumps(stored_cred)
+        )
         self.context.injector.bind_instance(BaseHolder, holder)
 
         with async_mock.patch.object(
@@ -844,7 +848,7 @@ class TestCredentialManager(AsyncTestCase):
                 cred_req_meta,
                 None,
                 credential_id=None,
-                rev_reg_def_json=None,
+                rev_reg_def=None,
             )
 
             holder.get_credential.assert_called_once_with(cred_id)

--- a/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_manager.py
@@ -1,3 +1,4 @@
+import json
 from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
 from time import time
@@ -241,7 +242,7 @@ class TestCredentialManager(AsyncTestCase):
             cred_offer = {"cred_def_id": cred_def_id, "schema_id": schema_id}
             issuer = async_mock.MagicMock(BaseIssuer, autospec=True)
             issuer.create_credential_offer = async_mock.CoroutineMock(
-                return_value=cred_offer
+                return_value=json.dumps(cred_offer)
             )
             self.context.injector.bind_instance(BaseIssuer, issuer)
 
@@ -296,7 +297,7 @@ class TestCredentialManager(AsyncTestCase):
             cred_offer = {"cred_def_id": cred_def_id, "schema_id": schema_id}
             issuer = async_mock.MagicMock(BaseIssuer, autospec=True)
             issuer.create_credential_offer = async_mock.CoroutineMock(
-                return_value=cred_offer
+                return_value=json.dumps(cred_offer)
             )
             self.context.injector.bind_instance(BaseIssuer, issuer)
 
@@ -663,7 +664,7 @@ class TestCredentialManager(AsyncTestCase):
         cred = {"indy": "credential"}
         cred_revoc = object()
         issuer.create_credential = async_mock.CoroutineMock(
-            return_value=(cred, cred_revoc)
+            return_value=(json.dumps(cred), cred_revoc)
         )
         self.context.injector.bind_instance(BaseIssuer, issuer)
 

--- a/aries_cloudagent/protocols/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/manager.py
@@ -287,7 +287,9 @@ class PresentationManager:
         for referent in requested_referents:
             credential_id = requested_referents[referent]["cred_id"]
             if credential_id not in credentials:
-                credentials[credential_id] = await holder.get_credential(credential_id)
+                credentials[credential_id] = json.loads(
+                    await holder.get_credential(credential_id)
+                )
 
         # Get all schema, credential definition, and revocation registry in use
         ledger: BaseLedger = await self.context.inject(BaseLedger)
@@ -341,8 +343,10 @@ class PresentationManager:
                     if "to" not in non_revoked_timespan:
                         non_revoked_timespan["to"] = current_timestamp
 
-                    key = f"{rev_reg_id}_{non_revoked_timespan['from']}_" \
-                          f"{non_revoked_timespan['to']}"
+                    key = (
+                        f"{rev_reg_id}_{non_revoked_timespan['from']}_"
+                        f"{non_revoked_timespan['to']}"
+                    )
                     if key not in revoc_reg_deltas:
                         (delta, delta_timestamp) = await ledger.get_revoc_reg_delta(
                             rev_reg_id,
@@ -396,13 +400,14 @@ class PresentationManager:
                     "timestamp"
                 ] = referented["timestamp"]
 
-        indy_proof = await holder.create_presentation(
+        indy_proof_json = await holder.create_presentation(
             presentation_exchange_record.presentation_request,
             requested_credentials,
             schemas,
             credential_definitions,
             revocation_states,
         )
+        indy_proof = json.loads(indy_proof_json)
 
         presentation_message = Presentation(
             comment=comment,

--- a/aries_cloudagent/protocols/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/manager.py
@@ -373,17 +373,20 @@ class PresentationManager:
                 revocation_states[rev_reg_id] = {}
 
             rev_reg = revocation_registries[rev_reg_id]
-            if not rev_reg.has_local_tails_file(self.context):
-                await rev_reg.retrieve_tails(self.context)
+            tails_local_path = await rev_reg.get_or_fetch_local_tails_path(self.context)
 
             try:
-                revocation_states[rev_reg_id][
-                    delta_timestamp
-                ] = await rev_reg.create_revocation_state(
-                    self.context, credential["cred_rev_id"], delta, delta_timestamp
+                revocation_states[rev_reg_id][delta_timestamp] = json.loads(
+                    await holder.create_revocation_state(
+                        credential["cred_rev_id"],
+                        rev_reg.reg_def,
+                        delta,
+                        delta_timestamp,
+                        tails_local_path,
+                    )
                 )
             except IndyError as e:
-                logging.error(
+                self._logger.error(
                     f"Failed to create revocation state: {e.error_code}, {e.message}"
                 )
                 raise e

--- a/aries_cloudagent/protocols/present_proof/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/tests/test_manager.py
@@ -1,3 +1,5 @@
+import json
+
 from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
 
@@ -77,11 +79,9 @@ class TestPresentationManager(AsyncTestCase):
             )
         )
         self.holder.get_credential = async_mock.CoroutineMock(
-            return_value={"schema_id": S_ID, "cred_def_id": CD_ID}
+            return_value=json.dumps({"schema_id": S_ID, "cred_def_id": CD_ID})
         )
-        self.holder.create_presentation = async_mock.CoroutineMock(
-            return_value=async_mock.MagicMock()
-        )
+        self.holder.create_presentation = async_mock.CoroutineMock(return_value="{}")
         self.context.injector.bind_instance(BaseHolder, self.holder)
 
         Verifier = async_mock.MagicMock(IndyVerifier, autospec=True)
@@ -98,24 +98,24 @@ class TestPresentationManager(AsyncTestCase):
             V10PresentationExchange(
                 presentation_exchange_id="dummy-0",
                 thread_id="thread-0",
-                role=V10PresentationExchange.ROLE_PROVER
+                role=V10PresentationExchange.ROLE_PROVER,
             )
         ] * 2
         diff = [
             V10PresentationExchange(
                 presentation_exchange_id="dummy-1",
-                role=V10PresentationExchange.ROLE_PROVER
+                role=V10PresentationExchange.ROLE_PROVER,
             ),
             V10PresentationExchange(
                 presentation_exchange_id="dummy-0",
                 thread_id="thread-1",
-                role=V10PresentationExchange.ROLE_PROVER
+                role=V10PresentationExchange.ROLE_PROVER,
             ),
             V10PresentationExchange(
                 presentation_exchange_id="dummy-1",
                 thread_id="thread-0",
-                role=V10PresentationExchange.ROLE_VERIFIER
-            )
+                role=V10PresentationExchange.ROLE_VERIFIER,
+            ),
         ]
 
         for i in range(len(same) - 1):
@@ -244,8 +244,7 @@ class TestPresentationManager(AsyncTestCase):
             )
 
             req_creds = await indy_proof_req_preview2indy_requested_creds(
-                indy_proof_req,
-                holder=self.holder
+                indy_proof_req, holder=self.holder
             )
 
             (exchange_out, pres_msg) = await self.manager.create_presentation(
@@ -263,8 +262,7 @@ class TestPresentationManager(AsyncTestCase):
 
         with self.assertRaises(ValueError):
             await indy_proof_req_preview2indy_requested_creds(
-                indy_proof_req,
-                holder=self.holder
+                indy_proof_req, holder=self.holder
             )
 
         self.holder.get_credentials_for_presentation_request_by_referent.return_value = (
@@ -285,18 +283,10 @@ class TestPresentationManager(AsyncTestCase):
                         "spec/present-proof/1.0/presentation-preview"
                     ),
                     "attributes": [
-                        {
-                            "name": "favourite",
-                            "cred_def_id": CD_ID,
-                            "value": "potato"
-                        },
-                        {
-                            "name": "icon",
-                            "cred_def_id": CD_ID,
-                            "value": "cG90YXRv"
-                        }
+                        {"name": "favourite", "cred_def_id": CD_ID, "value": "potato"},
+                        {"name": "icon", "cred_def_id": CD_ID, "value": "cG90YXRv"},
                     ],
-                    "predicates": []
+                    "predicates": [],
                 }
             },
             presentation_request={
@@ -306,21 +296,13 @@ class TestPresentationManager(AsyncTestCase):
                 "requested_attributes": {
                     "0_favourite_uuid": {
                         "name": "favourite",
-                        "restrictions": [
-                            {
-                                "cred_def_id": CD_ID,
-                            }
-                        ]
+                        "restrictions": [{"cred_def_id": CD_ID,}],
                     },
                     "1_icon_uuid": {
                         "name": "icon",
-                        "restrictions": [
-                            {
-                                "cred_def_id": CD_ID,
-                            }
-                        ]
-                    }
-                }
+                        "restrictions": [{"cred_def_id": CD_ID,}],
+                    },
+                },
             },
             presentation={
                 "proof": {
@@ -330,35 +312,34 @@ class TestPresentationManager(AsyncTestCase):
                             "0_favourite_uuid": {
                                 "sub_proof_index": 0,
                                 "raw": "potato",
-                                "encoded": "12345678901234567890"
+                                "encoded": "12345678901234567890",
                             },
                             "1_icon_uuid": {
                                 "sub_proof_index": 1,
                                 "raw": "cG90YXRv",
-                                "encoded": "12345678901234567890"
-                            }
+                                "encoded": "12345678901234567890",
+                            },
                         },
                         "self_attested_attrs": {},
                         "unrevealed_attrs": {},
-                        "predicates": {
-                        }
-                    }
+                        "predicates": {},
+                    },
                 },
                 "identifiers": [
                     {
                         "schema_id": S_ID,
                         "cred_def_id": CD_ID,
                         "rev_reg_id": None,
-                        "timestamp": None
+                        "timestamp": None,
                     },
                     {
                         "schema_id": S_ID,
                         "cred_def_id": CD_ID,
                         "rev_reg_id": None,
-                        "timestamp": None
-                    }
-                ]
-            }
+                        "timestamp": None,
+                    },
+                ],
+            },
         )
         self.context.message = async_mock.MagicMock()
 
@@ -395,15 +376,11 @@ class TestPresentationManager(AsyncTestCase):
                         {
                             "name": "favourite",
                             "cred_def_id": CD_ID,
-                            "value": "no potato"
+                            "value": "no potato",
                         },
-                        {
-                            "name": "icon",
-                            "cred_def_id": CD_ID,
-                            "value": "cG90YXRv"
-                        }
+                        {"name": "icon", "cred_def_id": CD_ID, "value": "cG90YXRv"},
                     ],
-                    "predicates": []
+                    "predicates": [],
                 }
             },
             presentation_request={
@@ -413,61 +390,50 @@ class TestPresentationManager(AsyncTestCase):
                 "requested_attributes": {
                     "0_favourite_uuid": {
                         "name": "favourite",
-                        "restrictions": [
-                            {
-                                "cred_def_id": CD_ID,
-                            }
-                        ]
+                        "restrictions": [{"cred_def_id": CD_ID,}],
                     },
                     "1_icon_uuid": {
                         "name": "icon",
-                        "restrictions": [
-                            {
-                                "cred_def_id": CD_ID,
-                            }
-                        ]
-                    }
-                }
-            }
+                        "restrictions": [{"cred_def_id": CD_ID,}],
+                    },
+                },
+            },
         )
         self.context.message = async_mock.MagicMock()
         self.context.message.indy_proof = async_mock.MagicMock(
             return_value={
-                "proof": {
-                    "proofs": [],
-                },
+                "proof": {"proofs": [],},
                 "requested_proof": {
                     "revealed_attrs": {
                         "0_favourite_uuid": {
                             "sub_proof_index": 0,
                             "raw": "potato",
-                            "encoded": "12345678901234567890"
+                            "encoded": "12345678901234567890",
                         },
                         "1_icon_uuid": {
                             "sub_proof_index": 1,
                             "raw": "cG90YXRv",
-                            "encoded": "23456789012345678901"
-                        }
+                            "encoded": "23456789012345678901",
+                        },
                     },
                     "self_attested_attrs": {},
                     "unrevealed_attrs": {},
-                    "predicates": {
-                    }
+                    "predicates": {},
                 },
                 "identifiers": [
                     {
                         "schema_id": S_ID,
                         "cred_def_id": CD_ID,
                         "rev_reg_id": None,
-                        "timestamp": None
+                        "timestamp": None,
                     },
                     {
                         "schema_id": S_ID,
                         "cred_def_id": CD_ID,
                         "rev_reg_id": None,
-                        "timestamp": None
-                    }
-                ]
+                        "timestamp": None,
+                    },
+                ],
             }
         )
 
@@ -492,9 +458,7 @@ class TestPresentationManager(AsyncTestCase):
             retrieve_ex.return_value = exchange_dummy
             exchange_out = await self.manager.receive_presentation()
             retrieve_ex.assert_called_once_with(
-                self.context,
-                {"thread_id": self.context.message._thread_id},
-                None,
+                self.context, {"thread_id": self.context.message._thread_id}, None,
             )
             save_ex.assert_called_once()
 

--- a/aries_cloudagent/revocation/models/tests/test_issuer_revocation_record.py
+++ b/aries_cloudagent/revocation/models/tests/test_issuer_revocation_record.py
@@ -8,6 +8,8 @@ import pytest
 from asynctest import TestCase as AsyncTestCase, mock as async_mock
 
 from ....config.injection_context import InjectionContext
+from ....issuer.base import BaseIssuer
+from ....issuer.indy import IndyIssuer
 from ....ledger.base import BaseLedger
 from ....storage.base import BaseStorage
 from ....storage.basic import BasicStorage
@@ -43,36 +45,30 @@ class TestRecord(AsyncTestCase):
         REV_REG_ID = f"{TestRecord.test_did}:4:{CRED_DEF_ID}:CL_ACCUM:0"
 
         rec = IssuerRevocationRecord(
-            issuer_did=TestRecord.test_did,
-            cred_def_id=CRED_DEF_ID
+            issuer_did=TestRecord.test_did, cred_def_id=CRED_DEF_ID
+        )
+        issuer = async_mock.MagicMock(BaseIssuer)
+        self.context.injector.bind_instance(BaseIssuer, issuer)
+
+        issuer.create_and_store_revocation_registry.return_value = (
+            REV_REG_ID,
+            json.dumps(
+                {
+                    "value": {
+                        "tailsHash": "59NY25UEV8a5CzNkXFQMppwofUxtYtf4FDp1h9xgeLcK",
+                        "tailsLocation": "point at infinity",
+                    }
+                }
+            ),
+            json.dumps({"revoc_reg_entry": "dummy-entry"}),
         )
 
-        with async_mock.patch.object(
-            indy.blob_storage, "open_writer", async_mock.CoroutineMock()
-        ) as mock_blob_open_writer, async_mock.patch.object(
-            indy.anoncreds,
-            "issuer_create_and_store_revoc_reg",
-            async_mock.CoroutineMock()
-        ) as mock_create_rr:
-            mock_create_rr.return_value = (
-                REV_REG_ID,
-                json.dumps(
-                    {
-                        "value": {
-                            "tailsHash": "59NY25UEV8a5CzNkXFQMppwofUxtYtf4FDp1h9xgeLcK",
-                            "tailsLocation": "point at infinity"
-                        }
-                    }
-                ),
-                json.dumps({"revoc_reg_entry": "dummy-entry"})
-            )
+        await rec.generate_registry(self.context, None)
 
-            await rec.generate_registry(self.context, None)
-
-            assert rec.revoc_reg_id == REV_REG_ID
-            assert rec.state == IssuerRevocationRecord.STATE_GENERATED
-            assert rec.tails_hash == "59NY25UEV8a5CzNkXFQMppwofUxtYtf4FDp1h9xgeLcK"
-            assert rec.tails_local_path == "point at infinity"
+        assert rec.revoc_reg_id == REV_REG_ID
+        assert rec.state == IssuerRevocationRecord.STATE_GENERATED
+        assert rec.tails_hash == "59NY25UEV8a5CzNkXFQMppwofUxtYtf4FDp1h9xgeLcK"
+        assert rec.tails_local_path == "point at infinity"
 
         rec.set_tails_file_public_uri("dummy")
         assert rec.tails_public_uri == "dummy"
@@ -91,13 +87,12 @@ class TestRecord(AsyncTestCase):
         queried = await IssuerRevocationRecord.query_by_cred_def_id(
             context=self.context,
             cred_def_id=CRED_DEF_ID,
-            state=IssuerRevocationRecord.STATE_GENERATED
+            state=IssuerRevocationRecord.STATE_GENERATED,
         )
         assert len(queried) == 1
 
         retrieved = await IssuerRevocationRecord.retrieve_by_revoc_reg_id(
-            context=self.context,
-            revoc_reg_id=rec.revoc_reg_id
+            context=self.context, revoc_reg_id=rec.revoc_reg_id
         )
         assert retrieved.revoc_reg_id == rec.revoc_reg_id
 
@@ -109,16 +104,17 @@ class TestRecord(AsyncTestCase):
         assert isinstance(model_instance, IssuerRevocationRecord)
         assert model_instance == rec
 
- 
-    async def test_generate_registry_not_indy_wallet(self):
-        self.wallet = async_mock.MagicMock()
-        self.wallet.WALLET_TYPE = "not-indy"
-        self.context.injector.clear_binding(BaseWallet)
-        self.context.injector.bind_instance(BaseWallet, self.wallet)
+    # async def test_generate_registry_not_indy_wallet(self):
+    #     self.wallet = async_mock.MagicMock()
+    #     self.wallet.WALLET_TYPE = "not-indy"
+    #     self.context.injector.clear_binding(BaseWallet)
+    #     self.context.injector.bind_instance(BaseWallet, self.wallet)
+    #     issuer = IndyIssuer(self.wallet)
+    #     self.context.injector.bind_instance(BaseIssuer, issuer)
 
-        rec = IssuerRevocationRecord()
-        with self.assertRaises(RevocationError):
-            await rec.generate_registry(self.context, None)
+    #     rec = IssuerRevocationRecord()
+    #     with self.assertRaises(RevocationError):
+    #         await rec.generate_registry(self.context, ".")
 
     async def test_set_tails_file_public_uri_rev_reg_undef(self):
         rec = IssuerRevocationRecord()
@@ -129,7 +125,7 @@ class TestRecord(AsyncTestCase):
         rec = IssuerRevocationRecord()
         with self.assertRaises(RevocationError):
             await rec.publish_registry_definition(self.context)
-        
+
         with self.assertRaises(RevocationError):
             await rec.publish_registry_entry(self.context)
 


### PR DESCRIPTION
Allows the class to be swapped out for indy-credx.

Probably reduces test coverage because the ledger tests were also testing the issuer code.