### PR TITLE
Check err_value is instance of IndyError

### DIFF
--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -58,7 +58,7 @@ class IndyErrorHandler:
 
     def __exit__(self, err_type, err_value, err_traceback):
         """Exit the context manager."""
-        if err_type is IndyError:
+        if isinstance(err_value, IndyError):
             raise self.wrap_error(
                 err_value, self.message, self.error_cls
             ) from err_value

--- a/aries_cloudagent/ledger/tests/test_indy.py
+++ b/aries_cloudagent/ledger/tests/test_indy.py
@@ -12,7 +12,6 @@ from aries_cloudagent.ledger.indy import (
     ClosedPoolError,
     ErrorCode,
     IndyErrorHandler,
-    IndyError,
     IndyLedger,
     GENESIS_TRANSACTION_PATH,
     LedgerConfigError,
@@ -23,6 +22,7 @@ from aries_cloudagent.ledger.indy import (
 from aries_cloudagent.storage.indy import IndyStorage
 from aries_cloudagent.storage.record import StorageRecord
 from aries_cloudagent.wallet.base import DIDInfo
+from indy.error import IndyError, CommonInvalidStructure
 
 
 @pytest.mark.indy
@@ -1843,3 +1843,8 @@ class TestIndyLedger(AsyncTestCase):
         with self.assertRaises(LedgerTransactionError):
             with IndyErrorHandler("message", LedgerTransactionError):
                 raise IndyError(error_code=1)
+
+    def test_error_handler_with_subclass_of_indyerror(self):
+        with self.assertRaises(LedgerTransactionError):
+            with IndyErrorHandler("message", LedgerTransactionError):
+                raise CommonInvalidStructure(error_code=1)


### PR DESCRIPTION
Rather than checking that err_type is IndyError. The Indy SDK wrapper now returns Errors that are a subclass of IndyError but not of type IndyError, failing the check in the handler. This causes the Error Handler to not properly wrap raised errors.

Signed-off-by: Daniel Bluhm <daniel.bluhm@sovrin.org>