### PR TITLE
integrate revocation into present-proof protocol; test coverage

### DIFF
--- a/aries_cloudagent/protocols/present_proof/v1_0/messages/inner/presentation_preview.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/messages/inner/presentation_preview.py
@@ -12,7 +12,9 @@ from ......ledger.indy import IndyLedger
 from ......messaging.models.base import BaseModel, BaseModelSchema
 from ......messaging.util import canon
 from ......messaging.valid import INDY_CRED_DEF_ID, INDY_PREDICATE
+from ......revocation.models.indy import NonRevocationInterval
 from ......wallet.util import b64_to_str
+
 
 from ...message_types import PRESENTATION_PREVIEW
 from ...util.predicate import Predicate
@@ -283,7 +285,7 @@ class PresentationPreview(BaseModel):
         version: str = None,
         nonce: str = None,
         ledger: IndyLedger = None,
-        timestamps: Mapping[str, int] = None,
+        non_revoc_intervals: Mapping[str, NonRevocationInterval] = None,
     ) -> dict:
         """
         Return indy proof request corresponding to presentation preview.
@@ -295,23 +297,26 @@ class PresentationPreview(BaseModel):
             version: version for proof request
             nonce: nonce for proof request
             ledger: ledger with credential definitions, to check for revocation support
-            timestamps: dict mapping cred def ids to non-revocation
-                timestamps to use (default current time where applicable)
+            non_revoc_intervals: non-revocation interval to use per cred def id
+                where applicable (default from and to the current time if applicable)
 
         Returns:
             Indy proof request dict.
 
         """
 
-        def non_revo(cred_def_id: str):
-            """Non-revocation timestamp to use for input cred def id."""
+        def non_revoc(cred_def_id: str) -> NonRevocationInterval:
+            """Non-revocation interval to use for input cred def id."""
 
             nonlocal epoch_now
-            nonlocal timestamps
+            nonlocal non_revoc_intervals
 
-            return (timestamps or {}).get(cred_def_id, epoch_now)
+            return (non_revoc_intervals or {}).get(
+                cred_def_id,
+                NonRevocationInterval(epoch_now, epoch_now)
+            )
 
-        epoch_now = int(time())  # TODO: take cred_def_id->timestamp here, default now
+        epoch_now = int(time())
 
         proof_req = {
             "name": name or "proof-request",
@@ -331,14 +336,13 @@ class PresentationPreview(BaseModel):
                 }
             else:
                 cd_id = attr_spec.cred_def_id
-                revo_support = bool(
-                    ledger
-                    and await ledger.get_credential_definition(cd_id)["value"][
-                        "revocation"
-                    ]
+                revoc_support = bool(
+                    ledger and (
+                        await ledger.get_credential_definition(cd_id)
+                    )["value"]["revocation"]
                 )
 
-                timestamp = non_revo(attr_spec.cred_def_id)
+                interval = non_revoc(cd_id) if revoc_support else None
 
                 if attr_spec.referent:
                     if attr_spec.referent in attr_specs_names:
@@ -350,9 +354,9 @@ class PresentationPreview(BaseModel):
                             "names": [canon(attr_spec.name)],
                             "restrictions": [{"cred_def_id": cd_id}],
                             **{
-                                "non_revoked": {"from": timestamp, "to": timestamp}
+                                "non_revoked": interval.serialize()
                                 for _ in [""]
-                                if revo_support
+                                if revoc_support
                             },
                         }
                 else:
@@ -365,9 +369,9 @@ class PresentationPreview(BaseModel):
                         "name": canon(attr_spec.name),
                         "restrictions": [{"cred_def_id": cd_id}],
                         **{
-                            "non_revoked": {"from": timestamp, "to": timestamp}
+                            "non_revoked": interval.serialize()
                             for _ in [""]
-                            if revo_support
+                            if revoc_support
                         },
                     }
         for (reft, attr_spec) in attr_specs_names.items():
@@ -380,12 +384,14 @@ class PresentationPreview(BaseModel):
 
         for pred_spec in self.predicates:
             cd_id = pred_spec.cred_def_id
-            revo_support = bool(
-                ledger
-                and await ledger.get_credential_definition(cd_id)["value"]["revocation"]
+            revoc_support = bool(
+                ledger and (
+                    await ledger.get_credential_definition(cd_id)
+                )["value"]["revocation"]
             )
 
-            timestamp = non_revo(pred_spec.cred_def_id)
+            interval = non_revoc(cd_id) if revoc_support else None
+
             proof_req["requested_predicates"][
                 "{}_{}_{}_uuid".format(
                     len(proof_req["requested_predicates"]),
@@ -397,11 +403,7 @@ class PresentationPreview(BaseModel):
                 "p_type": pred_spec.predicate,
                 "p_value": pred_spec.threshold,
                 "restrictions": [{"cred_def_id": cd_id}],
-                **{
-                    "non_revoked": {"from": timestamp, "to": timestamp}
-                    for _ in [""]
-                    if revo_support
-                },
+                **{"non_revoked": interval.serialize() for _ in [""] if revoc_support}
             }
 
         return proof_req

--- a/aries_cloudagent/protocols/present_proof/v1_0/messages/inner/tests/test_presentation_preview.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/messages/inner/tests/test_presentation_preview.py
@@ -1,16 +1,15 @@
-from copy import deepcopy
-from datetime import datetime, timezone
-from unittest import TestCase
-
 import json
+import pytest
+
+from copy import deepcopy
+from time import time
+from unittest import TestCase
 
 from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
 
-import pytest
-
-from .......holder.indy import IndyHolder
-from .......messaging.util import canon, str_to_datetime, str_to_epoch
+from .......messaging.util import canon
+from .......revocation.models.indy import NonRevocationInterval
 
 from ....message_types import PRESENTATION_PREVIEW
 from ....util.predicate import Predicate
@@ -22,8 +21,6 @@ from ..presentation_preview import (
 )
 
 
-NOW_8601 = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(" ", "seconds")
-NOW_EPOCH = str_to_epoch(NOW_8601)
 S_ID = {
     "score": "NcYxiDXkpYi6ov5FcYDi1e:2:score:1.0",
     "membership": "NcYxiDXkpYi6ov5FcYDi1e:2:membership:1.0"
@@ -491,6 +488,95 @@ class TestPresentationPreviewAsync(AsyncTestCase):
         )
 
     @pytest.mark.asyncio
+    async def test_to_indy_proof_request_revo_default_interval(self):
+        """Test pres preview to indy proof req with revocation support, defaults."""
+
+        canon_indy_proof_req = deepcopy(INDY_PROOF_REQ)
+        for spec in canon_indy_proof_req["requested_attributes"].values():
+            spec["name"] = canon(spec["name"])
+        for spec in canon_indy_proof_req["requested_predicates"].values():
+            spec["name"] = canon(spec["name"])
+
+        pres_preview = deepcopy(PRES_PREVIEW)
+        mock_ledger = async_mock.MagicMock(
+            get_credential_definition=async_mock.CoroutineMock(
+                return_value={
+                    "value": {
+                        "revocation": {
+                            "...": "..."
+                        }
+                    }
+                }
+            )
+        )
+        
+        indy_proof_req = await pres_preview.indy_proof_request(
+            **{k: INDY_PROOF_REQ[k] for k in ("name", "version", "nonce")},
+            ledger=mock_ledger
+        )
+
+        for uuid, attr_spec in indy_proof_req["requested_attributes"].items():
+            assert set(attr_spec.get("non_revoked", {}).keys()) == {"from", "to"}
+            canon_indy_proof_req["requested_attributes"][uuid]["non_revoked"] = (
+                attr_spec["non_revoked"]
+            )
+        for uuid, pred_spec in indy_proof_req["requested_predicates"].items():
+            assert set(pred_spec.get("non_revoked", {}).keys()) == {"from", "to"}
+            canon_indy_proof_req["requested_predicates"][uuid]["non_revoked"] = (
+                pred_spec["non_revoked"]
+            )
+
+        assert canon_indy_proof_req == indy_proof_req
+
+    @pytest.mark.asyncio
+    async def test_to_indy_proof_request_revo(self):
+        """Test pres preview to indy proof req with revocation support, interval."""
+
+        EPOCH_NOW = int(time())
+        canon_indy_proof_req = deepcopy(INDY_PROOF_REQ)
+        for spec in canon_indy_proof_req["requested_attributes"].values():
+            spec["name"] = canon(spec["name"])
+        for spec in canon_indy_proof_req["requested_predicates"].values():
+            spec["name"] = canon(spec["name"])
+
+        pres_preview = deepcopy(PRES_PREVIEW)
+        mock_ledger = async_mock.MagicMock(
+            get_credential_definition=async_mock.CoroutineMock(
+                return_value={
+                    "value": {
+                        "revocation": {
+                            "...": "..."
+                        }
+                    }
+                }
+            )
+        )
+        
+        indy_proof_req = await pres_preview.indy_proof_request(
+            **{k: INDY_PROOF_REQ[k] for k in ("name", "version", "nonce")},
+            ledger=mock_ledger,
+            non_revoc_intervals={
+                CD_ID[s_id]: NonRevocationInterval(
+                    1234567890,
+                    EPOCH_NOW
+                ) for s_id in S_ID
+            }
+        )
+
+        for uuid, attr_spec in indy_proof_req["requested_attributes"].items():
+            assert set(attr_spec.get("non_revoked", {}).keys()) == {"from", "to"}
+            canon_indy_proof_req["requested_attributes"][uuid]["non_revoked"] = (
+                attr_spec["non_revoked"]
+            )
+        for uuid, pred_spec in indy_proof_req["requested_predicates"].items():
+            assert set(pred_spec.get("non_revoked", {}).keys()) == {"from", "to"}
+            canon_indy_proof_req["requested_predicates"][uuid]["non_revoked"] = (
+                pred_spec["non_revoked"]
+            )
+
+        assert canon_indy_proof_req == indy_proof_req
+
+    @pytest.mark.asyncio
     async def test_satisfaction(self):
         """Test presentation preview predicate satisfaction."""
 
@@ -523,6 +609,11 @@ class TestPresentationPreview(TestCase):
         """Test initializer."""
         assert PRES_PREVIEW.attributes
         assert PRES_PREVIEW.predicates
+        assert PRES_PREVIEW.has_attr_spec(
+            cred_def_id=CD_ID["score"],
+            name="player",
+            value="Richie Knucklez"
+        )
 
     def test_type(self):
         """Test type."""

--- a/aries_cloudagent/protocols/present_proof/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/tests/test_manager.py
@@ -1,5 +1,7 @@
 import json
 
+from time import time
+
 from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
 
@@ -30,8 +32,10 @@ from ..util.indy import indy_proof_req_preview2indy_requested_creds
 
 
 CONN_ID = "connection_id"
-S_ID = "NcYxiDXkpYi6ov5FcYDi1e:2:vidya:1.0"
-CD_ID = f"NcYxiDXkpYi6ov5FcYDi1e:3:CL:{S_ID}:tag1"
+ISSUER_DID = "NcYxiDXkpYi6ov5FcYDi1e"
+S_ID = f"{ISSUER_DID}:2:vidya:1.0"
+CD_ID = f"{ISSUER_DID}:3:CL:{S_ID}:tag1"
+RR_ID = f"{ISSUER_DID}:4:{CD_ID}:CL_ACCUM:0"
 PRES_PREVIEW = PresentationPreview(
     attributes=[
         PresAttrSpec(name="player", cred_def_id=CD_ID, value="Richie Knucklez"),
@@ -52,6 +56,7 @@ PROOF_REQ_NAME = "name"
 PROOF_REQ_VERSION = "1.0"
 PROOF_REQ_NONCE = "12345"
 
+NOW = int(time())
 
 class TestPresentationManager(AsyncTestCase):
     async def setUp(self):
@@ -64,24 +69,98 @@ class TestPresentationManager(AsyncTestCase):
         self.ledger.get_schema = async_mock.CoroutineMock(
             return_value=async_mock.MagicMock()
         )
-        self.ledger.get_credential_definition = async_mock.CoroutineMock(
-            return_value=async_mock.MagicMock()
+        self.ledger.get_credential_definition=async_mock.CoroutineMock(
+            return_value={
+                "value": {
+                    "revocation": {
+                        "...": "..."
+                    }
+                }
+            }
+        )
+        self.ledger.get_revoc_reg_def = async_mock.CoroutineMock(
+            return_value={
+                "ver": "1.0",
+                "id": RR_ID,
+                "revocDefType": "CL_ACCUM",
+                "tag": RR_ID.split(":")[-1],
+                "credDefId": CD_ID,
+                "value": {
+                    "IssuanceType": "ISSUANCE_BY_DEFAULT",
+                    "maxCredNum": 1000,
+                    "publicKeys": {
+                        "accumKey": {
+                            "z": "1 ...",
+                        }
+                    },
+                    "tailsHash": "3MLjUFQz9x9n5u9rFu8Ba9C5bo4HNFjkPNc54jZPSNaZ",
+                    "tailsLocation": "http://sample.ca/path"
+                },
+            }
+        )
+        self.ledger.get_revoc_reg_delta = async_mock.CoroutineMock(
+            return_value=(
+                {
+                    "ver": "1.0",
+                    "value": {
+                        "prevAccum": "1 ...",
+                        "accum": "21 ...",
+                        "issued": [1]
+                    }
+                },
+                NOW
+            )
+        )
+        self.ledger.get_revoc_reg_entry = async_mock.CoroutineMock(
+            return_value=(
+                {
+                    "ver": "1.0",
+                    "value": {
+                        "prevAccum": "1 ...",
+                        "accum": "21 ...",
+                        "issued": [1]
+                    }
+                },
+                NOW
+            )
         )
         self.context.injector.bind_instance(BaseLedger, self.ledger)
 
         Holder = async_mock.MagicMock(IndyHolder, autospec=True)
         self.holder = Holder()
-        self.holder.get_credentials_for_presentation_request_by_referent = async_mock.CoroutineMock(
-            return_value=(
-                {
-                    "cred_info": {"referent": "dummy_reft"}
-                },  # leave this comma: return a tuple
+        self.holder.get_credentials_for_presentation_request_by_referent = (
+            async_mock.CoroutineMock(
+                return_value=(
+                    {
+                        "cred_info": {"referent": "dummy_reft"}
+                    },  # leave this comma: return a tuple
+                )
             )
         )
         self.holder.get_credential = async_mock.CoroutineMock(
-            return_value=json.dumps({"schema_id": S_ID, "cred_def_id": CD_ID})
+            return_value=json.dumps(
+                {
+                    "schema_id": S_ID,
+                    "cred_def_id": CD_ID,
+                    "rev_reg_id": RR_ID,
+                    "cred_rev_id": 1
+                }
+            )
         )
         self.holder.create_presentation = async_mock.CoroutineMock(return_value="{}")
+        self.holder.create_revocation_state = async_mock.CoroutineMock(
+            return_value=json.dumps(
+                {
+                    "witness": {
+                        "omega": "1 ..."
+                    },
+                    "rev_reg": {
+                        "accum": "21 ..."
+                    },
+                    "timestamp": NOW
+                }
+            )
+        )
         self.context.injector.bind_instance(BaseHolder, self.holder)
 
         Verifier = async_mock.MagicMock(IndyVerifier, autospec=True)
@@ -225,7 +304,10 @@ class TestPresentationManager(AsyncTestCase):
 
         exchange_in = V10PresentationExchange()
         indy_proof_req = await PRES_PREVIEW.indy_proof_request(
-            name=PROOF_REQ_NAME, version=PROOF_REQ_VERSION, nonce=PROOF_REQ_NONCE
+            name=PROOF_REQ_NAME,
+            version=PROOF_REQ_VERSION,
+            nonce=PROOF_REQ_NONCE,
+            ledger=await self.context.inject(BaseLedger, required=False)
         )
 
         exchange_in.presentation_request = indy_proof_req
@@ -234,11 +316,22 @@ class TestPresentationManager(AsyncTestCase):
         request._thread_id = "dummy"
         self.context.message = request
 
+        more_magic_rr = async_mock.MagicMock(
+            get_or_fetch_local_tails_path=async_mock.CoroutineMock(
+                return_value="/tmp/sample/tails/path"
+            )
+        )
         with async_mock.patch.object(
             V10PresentationExchange, "save", autospec=True
         ) as save_ex, async_mock.patch.object(
             test_module, "AttachDecorator", autospec=True
-        ) as mock_attach_decorator:
+        ) as mock_attach_decorator, async_mock.patch.object(
+            test_module, "RevocationRegistry", autospec=True
+        ) as mock_rr:
+            mock_rr.from_definition = async_mock.MagicMock(
+                return_value=more_magic_rr
+            )
+
             mock_attach_decorator.from_indy_dict = async_mock.MagicMock(
                 return_value=mock_attach_decorator
             )
@@ -253,10 +346,174 @@ class TestPresentationManager(AsyncTestCase):
             save_ex.assert_called_once()
             assert exchange_out.state == V10PresentationExchange.STATE_PRESENTATION_SENT
 
+    async def test_create_presentation_no_revocation(self):
+        self.context.connection_record = async_mock.MagicMock()
+        self.context.connection_record.connection_id = CONN_ID
+
+        exchange_in = V10PresentationExchange()
+        indy_proof_req = await PRES_PREVIEW.indy_proof_request(
+            name=PROOF_REQ_NAME,
+            version=PROOF_REQ_VERSION,
+            nonce=PROOF_REQ_NONCE,
+            ledger=await self.context.inject(BaseLedger, required=False)
+        )
+
+        exchange_in.presentation_request = indy_proof_req
+        request = async_mock.MagicMock()
+        request.indy_proof_request = async_mock.MagicMock()
+        request._thread_id = "dummy"
+        self.context.message = request
+
+        Holder = async_mock.MagicMock(IndyHolder, autospec=True)
+        self.holder = Holder()
+        self.holder.get_credentials_for_presentation_request_by_referent = (
+            async_mock.CoroutineMock(
+                return_value=(
+                    {
+                        "cred_info": {"referent": "dummy_reft"}
+                    },  # leave this comma: return a tuple
+                )
+            )
+        )
+        self.holder.get_credential = async_mock.CoroutineMock(
+            return_value=json.dumps(
+                {
+                    "schema_id": S_ID,
+                    "cred_def_id": CD_ID,
+                    "rev_reg_id": None,
+                    "cred_rev_id": None
+                }
+            )
+        )
+        self.holder.create_presentation = async_mock.CoroutineMock(return_value="{}")
+        self.holder.create_revocation_state = async_mock.CoroutineMock(
+            return_value=json.dumps(
+                {
+                    "witness": {
+                        "omega": "1 ..."
+                    },
+                    "rev_reg": {
+                        "accum": "21 ..."
+                    },
+                    "timestamp": NOW
+                }
+            )
+        )
+        self.context.injector.clear_binding(BaseHolder)
+        self.context.injector.bind_instance(BaseHolder, self.holder)
+
+        more_magic_rr = async_mock.MagicMock(
+            get_or_fetch_local_tails_path=async_mock.CoroutineMock(
+                return_value="/tmp/sample/tails/path"
+            )
+        )
+        with async_mock.patch.object(
+            V10PresentationExchange, "save", autospec=True
+        ) as save_ex, async_mock.patch.object(
+            test_module, "AttachDecorator", autospec=True
+        ) as mock_attach_decorator, async_mock.patch.object(
+            test_module, "RevocationRegistry", autospec=True
+        ) as mock_rr:
+            mock_rr.from_definition = async_mock.MagicMock(
+                return_value=more_magic_rr
+            )
+
+            mock_attach_decorator.from_indy_dict = async_mock.MagicMock(
+                return_value=mock_attach_decorator
+            )
+
+            req_creds = await indy_proof_req_preview2indy_requested_creds(
+                indy_proof_req, holder=self.holder
+            )
+
+            (exchange_out, pres_msg) = await self.manager.create_presentation(
+                exchange_in, req_creds
+            )
+            save_ex.assert_called_once()
+            assert exchange_out.state == V10PresentationExchange.STATE_PRESENTATION_SENT
+
+    async def test_create_presentation_bad_revoc_state(self):
+        self.context.connection_record = async_mock.MagicMock()
+        self.context.connection_record.connection_id = CONN_ID
+
+        exchange_in = V10PresentationExchange()
+        indy_proof_req = await PRES_PREVIEW.indy_proof_request(
+            name=PROOF_REQ_NAME,
+            version=PROOF_REQ_VERSION,
+            nonce=PROOF_REQ_NONCE,
+            ledger=await self.context.inject(BaseLedger, required=False)
+        )
+
+        exchange_in.presentation_request = indy_proof_req
+        request = async_mock.MagicMock()
+        request.indy_proof_request = async_mock.MagicMock()
+        request._thread_id = "dummy"
+        self.context.message = request
+
+        Holder = async_mock.MagicMock(IndyHolder, autospec=True)
+        self.holder = Holder()
+        self.holder.get_credentials_for_presentation_request_by_referent = (
+            async_mock.CoroutineMock(
+                return_value=(
+                    {
+                        "cred_info": {"referent": "dummy_reft"}
+                    },  # leave this comma: return a tuple
+                )
+            )
+        )
+        self.holder.get_credential = async_mock.CoroutineMock(
+            return_value=json.dumps(
+                {
+                    "schema_id": S_ID,
+                    "cred_def_id": CD_ID,
+                    "rev_reg_id": RR_ID,
+                    "cred_rev_id": 1
+                }
+            )
+        )
+        self.holder.create_presentation = async_mock.CoroutineMock(return_value="{}")
+        self.holder.create_revocation_state = async_mock.CoroutineMock(
+            side_effect=test_module.IndyError(706, {"message": "Nope"})
+        )
+        self.context.injector.clear_binding(BaseHolder)
+        self.context.injector.bind_instance(BaseHolder, self.holder)
+
+        more_magic_rr = async_mock.MagicMock(
+            get_or_fetch_local_tails_path=async_mock.CoroutineMock(
+                return_value="/tmp/sample/tails/path"
+            )
+        )
+        with async_mock.patch.object(
+            V10PresentationExchange, "save", autospec=True
+        ) as save_ex, async_mock.patch.object(
+            test_module, "AttachDecorator", autospec=True
+        ) as mock_attach_decorator, async_mock.patch.object(
+            test_module, "RevocationRegistry", autospec=True
+        ) as mock_rr:
+            mock_rr.from_definition = async_mock.MagicMock(
+                return_value=more_magic_rr
+            )
+
+            mock_attach_decorator.from_indy_dict = async_mock.MagicMock(
+                return_value=mock_attach_decorator
+            )
+
+            req_creds = await indy_proof_req_preview2indy_requested_creds(
+                indy_proof_req, holder=self.holder
+            )
+
+            with self.assertRaises(test_module.IndyError):
+                await self.manager.create_presentation(
+                    exchange_in, req_creds
+                )
+
     async def test_no_matching_creds_for_proof_req(self):
         exchange_in = V10PresentationExchange()
         indy_proof_req = await PRES_PREVIEW.indy_proof_request(
-            name=PROOF_REQ_NAME, version=PROOF_REQ_VERSION, nonce=PROOF_REQ_NONCE
+            name=PROOF_REQ_NAME,
+            version=PROOF_REQ_VERSION,
+            nonce=PROOF_REQ_NONCE,
+            ledger=await self.context.inject(BaseLedger, required=False)
         )
         self.holder.get_credentials_for_presentation_request_by_referent.return_value = ()
 
@@ -470,6 +727,33 @@ class TestPresentationManager(AsyncTestCase):
         exchange_in = V10PresentationExchange()
         exchange_in.presentation = {
             "identifiers": [{"schema_id": S_ID, "cred_def_id": CD_ID}]
+        }
+
+        with async_mock.patch.object(
+            V10PresentationExchange, "save", autospec=True
+        ) as save_ex:
+            exchange_out = await self.manager.verify_presentation(exchange_in)
+            save_ex.assert_called_once()
+
+            assert exchange_out.state == (V10PresentationExchange.STATE_VERIFIED)
+
+    async def test_verify_presentation_with_revocation(self):
+        exchange_in = V10PresentationExchange()
+        exchange_in.presentation = {
+            "identifiers": [
+                {
+                    "schema_id": S_ID,
+                    "cred_def_id": CD_ID,
+                    "rev_reg_id": RR_ID,
+                    "timestamp": NOW
+                },
+                {  # cover multiple instances of same rev reg
+                    "schema_id": S_ID,
+                    "cred_def_id": CD_ID,
+                    "rev_reg_id": RR_ID,
+                    "timestamp": NOW
+                }
+            ]
         }
 
         with async_mock.patch.object(

--- a/aries_cloudagent/revocation/models/indy.py
+++ b/aries_cloudagent/revocation/models/indy.py
@@ -1,0 +1,72 @@
+"""Indy utilities for revocation."""
+
+from time import time
+
+from marshmallow import fields
+
+from ...messaging.models.base import BaseModel, BaseModelSchema
+from ...messaging.valid import INT_EPOCH
+
+
+class NonRevocationInterval(BaseModel):
+    """Indy non-revocation interval."""
+
+    class Meta:
+        """NonRevocationInterval metadata."""
+
+        schema_class = "NonRevocationIntervalSchema"
+
+    def __init__(
+        self,
+        fro: int = None,
+        to: int = None,
+        **kwargs
+    ):
+        """Initialize non-revocation interval.
+
+        Args:
+            fro: earliest time of interest
+            to: latest time of interest
+
+        """
+        super().__init__(**kwargs)
+        self.fro = fro
+        self.to = to
+
+    def covers(self, timestamp: int = None) -> bool:
+        """Whether input timestamp (default now) lies within non-revocation interval.
+
+        Args:
+            timestamp: time of interest
+
+        Returns:
+            whether input time satisfies non-revocation interval
+
+        """
+        timestamp = timestamp or int(time())
+        return (self.fro or 0) <= timestamp <= (self.to or timestamp)
+
+    def timestamp(self) -> bool:
+        """Return a timestamp that the non-revocation interval covers."""
+        return self.to or self.fro or int(time())
+
+
+class NonRevocationIntervalSchema(BaseModelSchema):
+    """Schema to allow serialization/deserialization of non-revocation intervals."""
+
+    class Meta:
+        """NonRevocationIntervalchema metadata."""
+
+        model_class = NonRevocationInterval
+
+    fro = fields.Int(
+        required=False,
+        description="Earliest time of interest in non-revocation interval",
+        data_key="from",
+        **INT_EPOCH
+    )
+    to = fields.Int(
+        required=False,
+        description="Latest time of interest in non-revocation interval",
+        **INT_EPOCH
+    )

--- a/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
+++ b/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
@@ -98,7 +98,7 @@ class IssuerRevRegRecord(BaseRecord):
         self.tails_hash = tails_hash
         self.tails_local_path = tails_local_path
         self.tails_public_uri = tails_public_uri
-        self.pending_pub = list(set(pending_pub)) if pending_pub else []
+        self.pending_pub = sorted(list(set(pending_pub))) if pending_pub else []
 
     @property
     def record_id(self) -> str:
@@ -205,6 +205,7 @@ class IssuerRevRegRecord(BaseRecord):
         """
         if cred_rev_id not in self.pending_pub:
             self.pending_pub.append(cred_rev_id)
+            self.pending_pub.sort()
 
         await self.save(context)
 
@@ -288,7 +289,7 @@ class IssuerRevRegRecordSchema(BaseRecordSchema):
     """Schema to allow serialization/deserialization of revocation registry records."""
 
     class Meta:
-        """ConnectionRecordSchema metadata."""
+        """IssuerRevRegRecordSchema metadata."""
 
         model_class = IssuerRevRegRecord
 

--- a/aries_cloudagent/revocation/models/tests/test_indy.py
+++ b/aries_cloudagent/revocation/models/tests/test_indy.py
@@ -1,0 +1,50 @@
+from unittest import TestCase
+
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
+
+import pytest
+
+from ..indy import NonRevocationInterval
+
+FROM = 1000000000
+TO = 1234567890
+
+INTERVAL_FROM = NonRevocationInterval(
+    fro=FROM
+)
+INTERVAL_TO = NonRevocationInterval(
+    to=TO
+)
+INTERVAL = NonRevocationInterval(
+    fro=FROM,
+    to=TO
+)
+
+class TestInterval(TestCase):
+    """Non-revocation interval tests"""
+
+    def test_serde(self):
+        """Test serialization and deserialization."""
+        for interval in (INTERVAL_FROM, INTERVAL_TO, INTERVAL):
+            non_revo_dict = interval.serialize()
+            assert non_revo_dict.get("from") == interval.fro
+            assert non_revo_dict.get("to") == interval.to
+
+            model = NonRevocationInterval.deserialize(non_revo_dict)
+            assert model.fro == interval.fro and model.to == interval.to
+            assert model.timestamp()
+
+    def test_covers(self):
+        """Test spanning check."""
+        assert INTERVAL_FROM.covers(FROM)
+        assert INTERVAL_FROM.covers(TO)
+        assert INTERVAL_FROM.covers()
+
+        assert INTERVAL_TO.covers(FROM)
+        assert INTERVAL_TO.covers(TO)
+        assert not INTERVAL_TO.covers()
+
+        assert INTERVAL.covers(FROM)
+        assert INTERVAL.covers(TO)
+        assert not INTERVAL.covers()

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -28,7 +28,11 @@ class RevRegCreateRequestSchema(Schema):
         description="Credential definition identifier", **INDY_CRED_DEF_ID
     )
 
-    max_cred_num = fields.Int(description="Maximum credential numbers", required=False)
+    max_cred_num = fields.Int(
+        description="Maximum credential numbers",
+        example=100,
+        required=False
+    )
 
 
 class RevRegCreateResultSchema(Schema):


### PR DESCRIPTION
For end-to-end testing, I have to perform similar work in the issue-credential protocol beforehand - that's a separate PR, coming soon.

Signed-off-by: sklump <srklump@hotmail.com>