### PR TITLE
W.I.P. Add trace events to aca-py

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -601,20 +601,20 @@ class ProtocolGroup(ArgumentGroup):
         if args.timing_log:
             settings["timing.log_file"] = args.timing_log
         if args.trace:
+            # note that you can configure tracing without actually enabling it
+            # this is to allow message- or exchange-specific tracing (vs global)
             settings["trace.enabled"] = True
             settings["trace.target"] = "log"
             settings["trace.tag"] = ""
         if args.trace_target:
-            settings["trace.enabled"] = True
             settings["trace.target"] = args.trace_target
         if args.trace_tag:
-            settings["trace.enabled"] = True
             settings["trace.tag"] = args.trace_tag
         if settings.get("trace.enabled"):
             try:
                 trace_event(
-                    settings, 
-                    None, 
+                    settings,
+                    None,
                     handler="ArgParse",
                     outcome="Successfully configured aca-py",
                     raise_errors=True

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_issue_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_issue_handler.py
@@ -1,5 +1,6 @@
 """Credential issue message handler."""
 
+import time
 
 from .....messaging.base_handler import (
     BaseHandler,
@@ -10,6 +11,8 @@ from .....messaging.base_handler import (
 
 from ..manager import CredentialManager
 from ..messages.credential_issue import CredentialIssue
+
+from .....utils.tracing import trace_event
 
 
 class CredentialIssueHandler(BaseHandler):
@@ -24,6 +27,8 @@ class CredentialIssueHandler(BaseHandler):
             responder: responder callback
 
         """
+        r_time = time.perf_counter()
+
         self._logger.debug("CredentialHandler called with context %s", context)
         assert isinstance(context.message, CredentialIssue)
         self._logger.info(
@@ -38,6 +43,16 @@ class CredentialIssueHandler(BaseHandler):
 
         credential_exchange_record = await credential_manager.receive_credential()
 
+        r_time = trace_event(
+            context.settings,
+            context.message,
+            handler=context.settings.get("default_label")
+            if context and context.settings and context.settings.get("default_label")
+            else "aca-py.agent",
+            outcome="CredentialIssueHandler.handle.END",
+            perf_counter=r_time
+        )
+
         # Automatically move to next state if flag is set
         if context.settings.get("debug.auto_store_credential"):
             (
@@ -47,3 +62,13 @@ class CredentialIssueHandler(BaseHandler):
 
             # Ack issuer that holder stored credential
             await responder.send_reply(credential_ack_message)
+
+            trace_event(
+                context.settings,
+                credential_ack_message,
+                handler=context.settings.get("default_label")
+                if context.settings and context.settings.get("default_label")
+                else "aca-py.agent",
+                outcome="CredentialIssueHandler.handle.STORE",
+                perf_counter=r_time
+            )

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -490,7 +490,7 @@ class CredentialManager:
                     credential_exchange_record.credential_definition_id
                 )
 
-            if credential_definition["value"]["revocation"]:
+            if credential_definition["value"].get("revocation"):
                 issuer_rev_regs = await IssuerRevRegRecord.query_by_cred_def_id(
                     self.context,
                     credential_exchange_record.credential_definition_id,

--- a/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
@@ -1,6 +1,7 @@
 """Credential exchange admin routes."""
 
 import json
+import time
 
 from aiohttp import web
 from aiohttp_apispec import docs, request_schema, response_schema
@@ -33,6 +34,8 @@ from .models.credential_exchange import (
     V10CredentialExchange,
     V10CredentialExchangeSchema,
 )
+
+from ....utils.tracing import trace_event
 
 
 class V10AttributeMimeTypesResultSchema(Schema):
@@ -253,6 +256,8 @@ async def credential_exchange_send(request: web.BaseRequest):
         The credential exchange record
 
     """
+    r_time = time.perf_counter()
+
     context = request.app["request_context"]
     outbound_handler = request.app["outbound_message_router"]
 
@@ -283,6 +288,15 @@ async def credential_exchange_send(request: web.BaseRequest):
         **{t: body.get(t) for t in CRED_DEF_TAGS if body.get(t)},
     )
 
+    trace_event(
+        context.settings,
+        credential_proposal,
+        handler=context.settings.get("default_label")
+        if context and context.settings and context.settings.get("default_label")
+        else "aca-py.agent",
+        outcome="credential_exchange_send.START",
+    )
+
     credential_manager = CredentialManager(context)
 
     (
@@ -296,6 +310,16 @@ async def credential_exchange_send(request: web.BaseRequest):
     )
     await outbound_handler(
         credential_offer_message, connection_id=credential_exchange_record.connection_id
+    )
+
+    trace_event(
+        context.settings,
+        credential_offer_message,
+        handler=context.settings.get("default_label")
+        if context and context.settings and context.settings.get("default_label")
+        else "aca-py.agent",
+        outcome="credential_exchange_send.END",
+        perf_counter=r_time
     )
 
     return web.json_response(credential_exchange_record.serialize())
@@ -315,6 +339,8 @@ async def credential_exchange_send_proposal(request: web.BaseRequest):
         The credential exchange record
 
     """
+    r_time = time.perf_counter()
+
     context = request.app["request_context"]
     outbound_handler = request.app["outbound_message_router"]
 
@@ -348,11 +374,22 @@ async def credential_exchange_send_proposal(request: web.BaseRequest):
         **{t: body.get(t) for t in CRED_DEF_TAGS if body.get(t)},
     )
 
-    await outbound_handler(
-        CredentialProposal.deserialize(
+    credential_proposal = CredentialProposal.deserialize(
             credential_exchange_record.credential_proposal_dict
-        ),
+        )
+    await outbound_handler(
+        credential_proposal,
         connection_id=connection_id,
+    )
+
+    trace_event(
+        context.settings,
+        credential_proposal,
+        handler=context.settings.get("default_label")
+        if context and context.settings and context.settings.get("default_label")
+        else "aca-py.agent",
+        outcome="credential_exchange_send_proposal.END",
+        perf_counter=r_time
     )
 
     return web.json_response(credential_exchange_record.serialize())
@@ -378,6 +415,7 @@ async def credential_exchange_send_free_offer(request: web.BaseRequest):
         The credential exchange record
 
     """
+    r_time = time.perf_counter()
 
     context = request.app["request_context"]
     outbound_handler = request.app["outbound_message_router"]
@@ -445,6 +483,16 @@ async def credential_exchange_send_free_offer(request: web.BaseRequest):
 
     await outbound_handler(credential_offer_message, connection_id=connection_id)
 
+    trace_event(
+        context.settings,
+        credential_offer_message,
+        handler=context.settings.get("default_label")
+        if context and context.settings and context.settings.get("default_label")
+        else "aca-py.agent",
+        outcome="credential_exchange_send_free_offer.END",
+        perf_counter=r_time
+    )
+
     return web.json_response(credential_exchange_record.serialize())
 
 
@@ -467,6 +515,7 @@ async def credential_exchange_send_bound_offer(request: web.BaseRequest):
         The credential exchange record
 
     """
+    r_time = time.perf_counter()
 
     context = request.app["request_context"]
     outbound_handler = request.app["outbound_message_router"]
@@ -499,6 +548,16 @@ async def credential_exchange_send_bound_offer(request: web.BaseRequest):
 
     await outbound_handler(credential_offer_message, connection_id=connection_id)
 
+    trace_event(
+        context.settings,
+        credential_offer_message,
+        handler=context.settings.get("default_label")
+        if context and context.settings and context.settings.get("default_label")
+        else "aca-py.agent",
+        outcome="credential_exchange_send_bound_offer.END",
+        perf_counter=r_time
+    )
+
     return web.json_response(credential_exchange_record.serialize())
 
 
@@ -515,6 +574,8 @@ async def credential_exchange_send_request(request: web.BaseRequest):
         The credential exchange record
 
     """
+    r_time = time.perf_counter()
+
     context = request.app["request_context"]
     outbound_handler = request.app["outbound_message_router"]
 
@@ -548,6 +609,17 @@ async def credential_exchange_send_request(request: web.BaseRequest):
     )
 
     await outbound_handler(credential_request_message, connection_id=connection_id)
+
+    trace_event(
+        context.settings,
+        credential_request_message,
+        handler=context.settings.get("default_label")
+        if context and context.settings and context.settings.get("default_label")
+        else "aca-py.agent",
+        outcome="credential_exchange_send_request.END",
+        perf_counter=r_time
+    )
+
     return web.json_response(credential_exchange_record.serialize())
 
 
@@ -565,6 +637,8 @@ async def credential_exchange_issue(request: web.BaseRequest):
         The credential exchange record
 
     """
+    r_time = time.perf_counter()
+
     context = request.app["request_context"]
     outbound_handler = request.app["outbound_message_router"]
 
@@ -610,6 +684,17 @@ async def credential_exchange_issue(request: web.BaseRequest):
         raise web.HTTPBadRequest(reason="Revocation registry is full.")
 
     await outbound_handler(credential_issue_message, connection_id=connection_id)
+
+    trace_event(
+        context.settings,
+        credential_issue_message,
+        handler=context.settings.get("default_label")
+        if context and context.settings and context.settings.get("default_label")
+        else "aca-py.agent",
+        outcome="credential_exchange_issue.END",
+        perf_counter=r_time
+    )
+
     return web.json_response(cred_exch_record.serialize())
 
 
@@ -627,6 +712,8 @@ async def credential_exchange_store(request: web.BaseRequest):
         The credential exchange record
 
     """
+    r_time = time.perf_counter()
+
     context = request.app["request_context"]
     outbound_handler = request.app["outbound_message_router"]
 
@@ -666,6 +753,17 @@ async def credential_exchange_store(request: web.BaseRequest):
     )
 
     await outbound_handler(credential_stored_message, connection_id=connection_id)
+
+    trace_event(
+        context.settings,
+        credential_stored_message,
+        handler=context.settings.get("default_label")
+        if context and context.settings and context.settings.get("default_label")
+        else "aca-py.agent",
+        outcome="credential_exchange_store.END",
+        perf_counter=r_time
+    )
+
     return web.json_response(credential_exchange_record.serialize())
 
 
@@ -681,6 +779,8 @@ async def credential_exchange_problem_report(request: web.BaseRequest):
         request: aiohttp request object
 
     """
+    r_time = time.perf_counter()
+
     context = request.app["request_context"]
     outbound_handler = request.app["outbound_message_router"]
 
@@ -700,6 +800,17 @@ async def credential_exchange_problem_report(request: web.BaseRequest):
     await outbound_handler(
         error_result, connection_id=credential_exchange_record.connection_id
     )
+
+    trace_event(
+        context.settings,
+        error_result,
+        handler=context.settings.get("default_label")
+        if context and context.settings and context.settings.get("default_label")
+        else "aca-py.agent",
+        outcome="credential_exchange_problem_report.END",
+        perf_counter=r_time
+    )
+
     return web.json_response({})
 
 
@@ -728,7 +839,6 @@ async def credential_exchange_revoke(request: web.BaseRequest):
         The credential request details.
 
     """
-
     context = request.app["request_context"]
     try:
         credential_exchange_id = request.match_info["cred_ex_id"]
@@ -767,7 +877,6 @@ async def credential_exchange_publish_revocations(request: web.BaseRequest):
         Credential revocation ids published as revoked by revocation registry id.
 
     """
-
     context = request.app["request_context"]
 
     credential_manager = CredentialManager(context)

--- a/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
@@ -23,6 +23,7 @@ class TestCredentialRoutes(AsyncTestCase):
         mock.app = {
             "request_context": context,
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(test_module.web, "json_response") as mock_response:
             await test_module.attribute_mime_types_get(mock)
@@ -36,9 +37,11 @@ class TestCredentialRoutes(AsyncTestCase):
             "role": "dummy",
             "state": "dummy",
         }
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
         mock.app = {
-            "request_context": "context",
+            "request_context": context,
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "V10CredentialExchange", autospec=True
@@ -59,9 +62,11 @@ class TestCredentialRoutes(AsyncTestCase):
     async def test_credential_exchange_retrieve(self):
         mock = async_mock.MagicMock()
         mock.match_info = {"cred_ex_id": "dummy"}
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
         mock.app = {
-            "request_context": "context",
+            "request_context": context,
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "V10CredentialExchange", autospec=True
@@ -82,9 +87,11 @@ class TestCredentialRoutes(AsyncTestCase):
     async def test_credential_exchange_retrieve_not_found(self):
         mock = async_mock.MagicMock()
         mock.match_info = {"cred_ex_id": "dummy"}
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
         mock.app = {
-            "request_context": "context",
+            "request_context": context,
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "V10CredentialExchange", autospec=True
@@ -100,11 +107,12 @@ class TestCredentialRoutes(AsyncTestCase):
     async def test_credential_exchange_send(self):
         mock = async_mock.MagicMock()
         mock.json = async_mock.CoroutineMock()
-
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": context,
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -145,10 +153,12 @@ class TestCredentialRoutes(AsyncTestCase):
         mock.json = async_mock.CoroutineMock(
             return_value={"connection_id": conn_id}
         )
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": context,
         }
+        mock.app["request_context"].settings = {}
 
         with self.assertRaises(test_module.web.HTTPBadRequest) as x_http:
             await test_module.credential_exchange_send(mock)
@@ -162,10 +172,12 @@ class TestCredentialRoutes(AsyncTestCase):
         mock.json = async_mock.CoroutineMock(
             return_value={"connection_id": conn_id, "credential_proposal": preview_spec}
         )
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": context,
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -192,10 +204,13 @@ class TestCredentialRoutes(AsyncTestCase):
         mock.json = async_mock.CoroutineMock(
             return_value={"connection_id": conn_id, "credential_proposal": preview_spec}
         )
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": context,
         }
+        mock.app["request_context"].settings = {}
+
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -222,10 +237,12 @@ class TestCredentialRoutes(AsyncTestCase):
         mock.json = async_mock.CoroutineMock(
             return_value={"connection_id": conn_id, "credential_proposal": preview_spec}
         )
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": context,
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -256,11 +273,12 @@ class TestCredentialRoutes(AsyncTestCase):
     async def test_credential_exchange_send_proposal_no_conn_record(self):
         mock = async_mock.MagicMock()
         mock.json = async_mock.CoroutineMock()
-
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": context,
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -285,11 +303,12 @@ class TestCredentialRoutes(AsyncTestCase):
     async def test_credential_exchange_send_proposal_not_ready(self):
         mock = async_mock.MagicMock()
         mock.json = async_mock.CoroutineMock()
-
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": context,
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -509,8 +528,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -550,8 +572,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -588,8 +613,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -625,8 +653,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -662,8 +693,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -700,8 +734,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -737,8 +774,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -786,8 +826,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with self.assertRaises(test_module.web.HTTPBadRequest):
             await test_module.credential_exchange_issue(mock)
@@ -798,8 +841,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -845,8 +891,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -891,8 +940,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -939,8 +991,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -978,8 +1033,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -1015,8 +1073,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -1050,8 +1111,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -1086,8 +1150,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": mock_outbound,
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -1119,8 +1186,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": mock_outbound,
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "ConnectionRecord", autospec=True
@@ -1146,8 +1216,11 @@ class TestCredentialRoutes(AsyncTestCase):
 
         mock.app = {
             "outbound_message_router": async_mock.CoroutineMock(),
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "V10CredentialExchange", autospec=True
@@ -1185,8 +1258,11 @@ class TestCredentialRoutes(AsyncTestCase):
         )
 
         mock.app = {
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "V10CredentialExchange", autospec=True
@@ -1219,8 +1295,11 @@ class TestCredentialRoutes(AsyncTestCase):
         )
 
         mock.app = {
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "V10CredentialExchange", autospec=True
@@ -1243,8 +1322,11 @@ class TestCredentialRoutes(AsyncTestCase):
         )
 
         mock.app = {
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "V10CredentialExchange", autospec=True
@@ -1269,8 +1351,11 @@ class TestCredentialRoutes(AsyncTestCase):
     async def test_credential_exchange_publish_revocations(self):
         mock = async_mock.MagicMock()
         mock.app = {
-            "request_context": "context",
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
         }
+        mock.app["request_context"].settings = {}
 
         with async_mock.patch.object(
             test_module, "CredentialManager", autospec=True

--- a/aries_cloudagent/utils/tests/test_tracing.py
+++ b/aries_cloudagent/utils/tests/test_tracing.py
@@ -1,0 +1,57 @@
+from asynctest import mock, TestCase
+
+import requests
+
+from ...transport.inbound.message import InboundMessage
+from ...transport.outbound.message import OutboundMessage
+from ...messaging.agent_message import AgentMessage
+from ...protocols.trustping.messages.ping import Ping
+
+from .. import tracing as test_module
+
+
+class TestTracing(TestCase):
+    def test_log_event(self):
+        message = Ping()
+        message._thread = {"thid": "dummy_thread_id_12345"}
+        context = {
+            "trace.enabled": True,
+            "trace.target": "log",
+            "trace.tag": "acapy.trace"
+        }
+        test_module.trace_event(
+            context, 
+            message, 
+            handler="message_handler",
+            ellapsed_milli=27,
+            outcome="processed OK"
+        )
+
+    async def test_post_event(self):
+        message = Ping()
+        message._thread = {"thid": "dummy_thread_id_12345"}
+        context = {
+            "trace.enabled": True,
+            "trace.target": "http://fluentd:8080/",
+            "trace.tag": "acapy.trace"
+        }
+        test_module.trace_event(
+            context, 
+            message, 
+            handler="message_handler",
+            ellapsed_milli=27,
+            outcome="processed OK",
+        )
+
+        try:
+            test_module.trace_event(
+                context, 
+                message, 
+                handler="message_handler",
+                ellapsed_milli=27,
+                outcome="processed OK",
+                raise_errors=True,
+            )
+            assert False
+        except requests.exceptions.ConnectionError as e:
+            pass

--- a/aries_cloudagent/utils/tests/test_tracing.py
+++ b/aries_cloudagent/utils/tests/test_tracing.py
@@ -19,11 +19,18 @@ class TestTracing(TestCase):
             "trace.target": "log",
             "trace.tag": "acapy.trace"
         }
+        ret = test_module.trace_event(
+            context, 
+            message, 
+            handler="message_handler",
+            perf_counter=None,
+            outcome="processed Start"
+        )
         test_module.trace_event(
             context, 
             message, 
             handler="message_handler",
-            ellapsed_milli=27,
+            perf_counter=ret,
             outcome="processed OK"
         )
 
@@ -39,16 +46,24 @@ class TestTracing(TestCase):
             context, 
             message, 
             handler="message_handler",
-            ellapsed_milli=27,
+            perf_counter=None,
             outcome="processed OK",
         )
 
+    async def test_post_event_with_error(self):
+        message = Ping()
+        message._thread = {"thid": "dummy_thread_id_12345"}
+        context = {
+            "trace.enabled": True,
+            "trace.target": "http://fluentd-dummy:8080/",
+            "trace.tag": "acapy.trace"
+        }
         try:
             test_module.trace_event(
                 context, 
                 message, 
                 handler="message_handler",
-                ellapsed_milli=27,
+                perf_counter=None,
                 outcome="processed OK",
                 raise_errors=True,
             )

--- a/aries_cloudagent/utils/tracing.py
+++ b/aries_cloudagent/utils/tracing.py
@@ -17,10 +17,11 @@ def trace_event(
         context,
         message,
         handler: str = None,
-        ellapsed_milli: int = None,
         outcome: str = None,
+        perf_counter: float = None,
         force_trace: bool = False,
-        raise_errors: bool = False):
+        raise_errors: bool = False
+) -> float:
     """
     Log a trace event to a configured target.
 
@@ -34,6 +35,8 @@ def trace_event(
                 InboundMessage or OutboundMessage
         event: Dict that will be converted to json and posted to the target
     """
+
+    ret = time.perf_counter()
 
     if force_trace or context.get("trace.enabled"):
         # build the event to log
@@ -58,7 +61,7 @@ def trace_event(
             "traced_type": msg_type,
             "timestamp": time.time(),
             "handler": handler,
-            "ellapsed_milli": ellapsed_milli,
+            "ellapsed_milli": int(1000 * (ret - perf_counter)) if perf_counter else 0,
             "outcome": outcome,
         }
         event_str = json.dumps(event)
@@ -95,3 +98,5 @@ def trace_event(
     else:
         # trace is not enabled so just return
         pass
+
+    return ret

--- a/aries_cloudagent/utils/tracing.py
+++ b/aries_cloudagent/utils/tracing.py
@@ -55,9 +55,13 @@ def trace_event(
         elif message and isinstance(message, OutboundMessage):
             # TODO
             pass
+        elif message and isinstance(message, dict):
+            msg_id = message["msg_id"]
+            thread_id = message["thread_id"]
+            msg_type = message["type"]
         event = {
             "message_id": msg_id,
-            "thread_id": thread_id,
+            "thread_id": thread_id if thread_id else msg_id,
             "traced_type": msg_type,
             "timestamp": time.time(),
             "handler": handler,

--- a/aries_cloudagent/utils/tracing.py
+++ b/aries_cloudagent/utils/tracing.py
@@ -1,0 +1,77 @@
+import json
+import logging
+import time
+import requests
+
+from ..transport.inbound.message import InboundMessage
+from ..transport.outbound.message import OutboundMessage
+from ..messaging.agent_message import AgentMessage
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def trace_event(
+        context, 
+        message, 
+        handler: str = None,
+        ellapsed_milli: int = None,
+        outcome: str = None,
+        raise_errors: bool = False):
+    """
+    Log a trace event to a configured target.
+
+    Args:
+        context: The application context, attributes of interest are:
+            context["trace.enabled"]: True if we are logging events
+            context["trace.target"]: Trace target ("log", "message" or an http endpoint)
+            context["trace.tag"]: Tag to be included in trace output
+        message: the current message, can be an AgentMessage, InboundMessage or OutboundMessage
+        event: Dict that will be converted to json and posted to the target
+    """
+
+    if context.get("trace.enabled"):
+        # build the event to log
+        # TODO check instance type of message to determine how to get message and thread id's
+        event = {
+            "message_id": message._id if message else "",
+            "thread_id": message._thread.thid if message else "",
+            "traced_type": message._type if message else "",
+            "timestamp": time.time(),
+            "handler": handler,
+            "ellapsed_milli": ellapsed_milli,
+            "outcome": outcome,
+        }
+        event_str = json.dumps(event)
+
+        try:
+            # check our target
+            if context["trace.target"] == "message":
+                # TODO, just log for now
+                LOGGER.setLevel(logging.INFO)
+                LOGGER.info(" %s %s", context["trace.tag"], event_str)
+            elif context["trace.target"] == "log":
+                # write to standard log file
+                LOGGER.setLevel(logging.INFO)
+                LOGGER.info(" %s %s", context["trace.tag"], event_str)
+            else:
+                # should be an http endpoint
+                resp = requests.post(
+                    context["trace.target"] + (context["trace.tag"] if context["trace.tag"] else ""),
+                    data=event_str,
+                    headers={"Content-Type": "application/json"}
+                )
+        except Exception as e:
+            if raise_errors:
+                raise
+            LOGGER.error(
+                "Error logging trace %s %s %s",
+                context["trace.target"],
+                context["trace.tag"],
+                event_str
+            )
+            LOGGER.exception(e)
+
+    else:
+        # trace is not enabled so just return
+        pass

--- a/demo/EFK-stack/LICENSE
+++ b/demo/EFK-stack/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2018 Gianfranco Reppucci
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/demo/EFK-stack/README.md
+++ b/demo/EFK-stack/README.md
@@ -1,0 +1,87 @@
+# EFK stack
+
+Note - this code was originally obtained from [https://github.com/giefferre/EFK-stack](https://github.com/giefferre/EFK-stack)
+
+A sample environment running an [EFK stack][efk] on your local machine.
+
+Includes:
+
+- [Elasticsearch][elasticsearch]
+- [Fluentd][fluentd]
+- [Kibana][kibana]
+
+## Introduction
+
+As software systems grow and become more and more decoupled, log aggregation is a key aspect to take care of.
+
+The issues to tackle down with logging are:
+
+- Having a centralized overview of all log events
+- Normalizing different log types
+- Automated processing of log messages
+- Supporting several and very different event sources
+
+While [Elasticsearch][elasticsearch] and [Kibana][kibana] are the reference products *de facto* for log searching and visualization in the open source community, there's no such agreement for log collectors.
+
+The two most-popular data collectors are:
+
+- [Logstash][logstash], most known for being part of the [ELK Stack][elk]
+- [Fluentd][fluentd], used by communities of users of software such as [Docker][docker-fluentd] and [GCP][gcp-fluentd]
+
+Logging systems using Fluentd as collector are usually referenced as [EFK stack][efk].
+
+Aim of this repository is to run an EFK stack on your local machine using docker-compose.
+
+I'm not personally involved with companies supporting Logstash nor Fluentd.
+
+If you need help to choose between Logstash and Fluent, take a look to the [reference](#reference).
+
+## Launching the EFK stack
+
+### Requirements
+
+On your machine, make sure you have installed:
+
+- [Docker][docker]
+- [Docker Compose][docker-compose]
+
+### Run
+
+```bash
+docker-compose up
+```
+
+Please note: in this example Fluentd will run on port `8080` instead of the default `24224`.
+
+This settings has been changed to show how to configure Fluentd to listen on a different port.
+
+Kibana is exposed on port `5601`.
+
+### Testing with sample data
+
+If you are running macOS and you want to send sample data to test the EFK stack, you'll need [RESTed][rested].
+
+Files are available in the [examples](examples) folder.
+
+Please note that RESTed is not strictly necessary as any other REST client application will work fine.
+
+## Reference
+
+- [Quora - What is the ELK stack](https://www.quora.com/What-is-the-ELK-stack)
+- [Fluentd vs. LogStash: A Feature Comparison](https://www.loomsystems.com/blog/single-post/2017/01/30/a-comparison-of-fluentd-vs-logstash-log-collector)
+- [Panda Strike: Fluentd vs Logstash](https://www.pandastrike.com/posts/20150807-fluentd-vs-logstash)
+- [Log Aggregation with Fluentd, Elasticsearch and Kibana - Haufe-Lexware.github.io](http://work.haufegroup.io/log-aggregation/)
+- [Fluentd vs Logstash, An unbiased comparison](https://techstricks.com/fluentd-vs-logstash/)
+- [Fluentd vs. Logstash: A Comparison of Log Collectors | Logz.io](https://logz.io/blog/fluentd-logstash/)
+
+[elasticsearch]: https://www.elastic.co/products/elasticsearch
+[fluentd]: https://www.fluentd.org/
+[kibana]: https://www.elastic.co/products/kibana
+[logstash]: https://www.elastic.co/products/logstash
+[elk]: https://www.elastic.co/videos/introduction-to-the-elk-stack
+[docker-fluentd]: https://docs.docker.com/reference/logging/fluentd/
+[gcp-fluentd]: https://github.com/GoogleCloudPlatform/google-fluentd
+[efk]: https://docs.openshift.com/enterprise/3.1/install_config/aggregate_logging.html#overview
+[docker]: https://www.docker.com/
+[docker-compose]: https://docs.docker.com/compose/
+[rested]: https://itunes.apple.com/au/app/rested-simple-http-requests/id421879749?mt=12

--- a/demo/EFK-stack/docker-compose.yml
+++ b/demo/EFK-stack/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.4.2
+    environment:
+      discovery.type: single-node
+    ports:
+      - 9200:9200
+      - 9300:9300
+    networks:
+      - efk_net
+
+  fluentd:
+    build: ./fluentd
+    volumes:
+      - ./fluentd/conf:/fluentd/etc
+      - ./logs:/logs
+    ports:
+      - 8080:8080
+    networks:
+      - efk_net
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.4.2
+    environment:
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+    ports:
+      - 5601:5601
+    networks:
+      - efk_net
+
+networks:
+  efk_net:

--- a/demo/EFK-stack/examples/anotherapp.log.request
+++ b/demo/EFK-stack/examples/anotherapp.log.request
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>baseURL</key>
+	<string>http://localhost:8080/anotherapp.log</string>
+	<key>bodyString</key>
+	<string>json={"action":"logout","userId":"5b07fbbb4e6b8"}</string>
+	<key>followRedirect</key>
+	<true/>
+	<key>handleJSONPCallbacks</key>
+	<false/>
+	<key>headers</key>
+	<array>
+		<dict>
+			<key>header</key>
+			<string>Content-Type</string>
+			<key>inUse</key>
+			<true/>
+			<key>value</key>
+			<string>application/x-www-form-urlencoded</string>
+		</dict>
+	</array>
+	<key>httpMethod</key>
+	<string>POST</string>
+	<key>jsonpScript</key>
+	<string></string>
+	<key>paramBodyUIChoice</key>
+	<integer>0</integer>
+	<key>parameters</key>
+	<array/>
+	<key>parametersType</key>
+	<integer>0</integer>
+	<key>presentBeforeChallenge</key>
+	<false/>
+	<key>stringEncoding</key>
+	<integer>4</integer>
+	<key>usingHTTPBody</key>
+	<true/>
+</dict>
+</plist>

--- a/demo/EFK-stack/examples/myapp.log.request
+++ b/demo/EFK-stack/examples/myapp.log.request
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>baseURL</key>
+	<string>http://localhost:8080/myapp.log</string>
+	<key>bodyString</key>
+	<string>json={"action":"login","userId":"5b07fbbb4e6b8"}</string>
+	<key>followRedirect</key>
+	<true/>
+	<key>handleJSONPCallbacks</key>
+	<false/>
+	<key>headers</key>
+	<array>
+		<dict>
+			<key>header</key>
+			<string>Content-Type</string>
+			<key>inUse</key>
+			<true/>
+			<key>value</key>
+			<string>application/x-www-form-urlencoded</string>
+		</dict>
+	</array>
+	<key>httpMethod</key>
+	<string>POST</string>
+	<key>jsonpScript</key>
+	<string></string>
+	<key>paramBodyUIChoice</key>
+	<integer>0</integer>
+	<key>parameters</key>
+	<array/>
+	<key>parametersType</key>
+	<integer>0</integer>
+	<key>presentBeforeChallenge</key>
+	<false/>
+	<key>stringEncoding</key>
+	<integer>4</integer>
+	<key>usingHTTPBody</key>
+	<true/>
+</dict>
+</plist>

--- a/demo/EFK-stack/fluentd/Dockerfile
+++ b/demo/EFK-stack/fluentd/Dockerfile
@@ -1,0 +1,9 @@
+FROM fluent/fluentd:stable
+RUN apk add --update --virtual .build-deps \
+    sudo build-base ruby-dev \
+    && sudo gem install \
+    fluent-plugin-elasticsearch \
+    && sudo gem sources --clear-all \
+    && apk del .build-deps \
+    && rm -rf /var/cache/apk/* \
+    /home/fluent/.gem/ruby/2.3.0/cache/*.gem

--- a/demo/EFK-stack/fluentd/conf/fluent.conf
+++ b/demo/EFK-stack/fluentd/conf/fluent.conf
@@ -1,0 +1,54 @@
+# Fluentd main configuration file
+# Reference: https://docs.fluentd.org/v1.0/articles/config-file
+
+# Set Fluentd to listen via http on port 8080, listening on all hosts
+<source>
+  @type http
+  port 8080
+  bind 0.0.0.0
+</source>
+
+<match acapy.**>
+  @type copy
+  <store>
+    @type elasticsearch
+    host elasticsearch
+    port 9200
+    index_name fluentd
+    type_name fluentd
+    logstash_format true
+    logstash_prefix fluentd
+    logstash_dateformat %Y%m%d
+    include_tag_key true
+    tag_key @log_name
+    flush_interval 1s
+  </store>
+</match>
+
+# Events having prefix 'myapp.' will be stored both on Elasticsearch and files.
+<match myapp.**>
+  @type copy
+  <store>
+    @type elasticsearch
+    host elasticsearch
+    port 9200
+    index_name fluentd
+    type_name fluentd
+    logstash_format true
+    logstash_prefix fluentd
+    logstash_dateformat %Y%m%d
+    include_tag_key true
+    tag_key @log_name
+    flush_interval 1s
+  </store>
+  <store>
+    @type file
+    path /logs/myapp
+    flush_interval 30s
+  </store>
+</match>
+
+# All other events will be printed to stdout
+<match **>
+  @type stdout
+</match>

--- a/demo/run_demo
+++ b/demo/run_demo
@@ -23,6 +23,18 @@ do
 		fi
 		continue
 	;;
+    --trace-log)
+        TRACE_TARGET=log
+        TRACE_TAG=acapy.events
+        SKIP=1
+        continue
+    ;;
+    --trace-http)
+        TRACE_TARGET=http://${TRACE_TARGET_URL}
+        TRACE_TAG=acapy.events
+        SKIP=1
+        continue
+    ;;
     --debug-ptvsd)
         ENABLE_PTVSD=1
         continue
@@ -76,6 +88,8 @@ Usage:
 	--events - display on the terminal the webhook events from the ACA-Py agent.
 	--timing - at the end of the run, display timing; relevant to the "performance" agent.
 	--bg - run the agent in the background; for use when using OpenAPI/Swagger interface
+    --trace-log - log events to the standard log file
+    --trace-http - log events to an http endmoint specified in env var TRACE_TARGET_URL
 	debug options: --debug-pycharm-agent-port <port>; --debug-pycharm-controller-port <port>
 	               --debug-pycharm; --debug-ptvsd
 
@@ -144,6 +158,10 @@ if ! [ -z "$GENESIS_URL" ]; then
 fi
 if ! [ -z "$EVENTS" ]; then
     DOCKER_ENV="${DOCKER_ENV} -e EVENTS=1"
+fi
+if ! [ -z "$TRACE_TARGET" ]; then
+    DOCKER_ENV="${DOCKER_ENV} -e TRACE_TARGET=${TRACE_TARGET}"
+    DOCKER_ENV="${DOCKER_ENV} -e TRACE_TAG=${TRACE_TAG}"
 fi
 if ! [ -z "$PUBLIC_TAILS_URL" ]; then
     DOCKER_ENV="${DOCKER_ENV} -e PUBLIC_TAILS_URL=${PUBLIC_TAILS_URL}"

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -32,6 +32,10 @@ EVENT_LOGGER.setLevel(logging.DEBUG if DEBUG_EVENTS else logging.NOTSET)
 EVENT_LOGGER.addHandler(event_stream_handler)
 EVENT_LOGGER.propagate = False
 
+TRACE_TARGET = os.getenv("TRACE_TARGET")
+TRACE_TAG    = os.getenv("TRACE_TAG")
+TRACE_ENABLED = True if TRACE_TARGET else False
+
 DEFAULT_POSTGRES = bool(os.getenv("POSTGRES"))
 DEFAULT_INTERNAL_HOST = "127.0.0.1"
 DEFAULT_EXTERNAL_HOST = "localhost"
@@ -124,6 +128,9 @@ class DemoAgent:
         self.timing_log = timing_log
         self.postgres = DEFAULT_POSTGRES if postgres is None else postgres
         self.extra_args = extra_args
+        self.trace_enabled = TRACE_ENABLED
+        self.trace_target = TRACE_TARGET
+        self.trace_tag = TRACE_TAG
 
         self.admin_url = f"http://{self.internal_host}:{admin_port}"
         if RUN_MODE == "pwd":
@@ -267,6 +274,14 @@ class DemoAgent:
             )
         if self.webhook_url:
             result.append(("--webhook-url", self.webhook_url))
+        if self.trace_enabled:
+            result.extend(
+                [
+                    ("--trace",),
+                    ("--trace-target", self.trace_target),
+                    ("--trace-tag", self.trace_tag),
+                ]
+            )
         if self.extra_args:
             result.extend(self.extra_args)
 


### PR DESCRIPTION
Current - can be configured to write events (json format) to standard log file or http endpoint.

(Future - append to exchange and message records)

Sample docker-based EFK stack under demo/EFK-stack - runs Elasticsearch, Fluentd and Kibana - for testing writing events to monitoring and reporting tool.

Currently includes event tracing on credential exchange only.