### PR TITLE
Get tails file response type annotation

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -19,6 +19,7 @@ from marshmallow import fields, Schema
 from ..config.injection_context import InjectionContext
 from ..core.plugin_registry import PluginRegistry
 from ..messaging.responder import BaseResponder
+from ..revocation.routes import set_tails_file_binary_response_schema
 from ..transport.queue.basic import BasicMessageQueue
 from ..transport.outbound.message import OutboundMessage
 from ..utils.stats import Collector
@@ -256,6 +257,8 @@ class AdminServer(BaseAdminServer):
         self.app = await self.make_application()
         runner = web.AppRunner(self.app)
         await runner.setup()
+        set_tails_file_binary_response_schema(self.app)  # aiohttp_apispec needs hack
+
         self.site = web.TCPSite(runner, host=self.host, port=self.port)
 
         try:

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -261,7 +261,7 @@ class AdminServer(BaseAdminServer):
             PluginRegistry, required=False
         )
         if plugin_registry:
-            plugin_registry.set_openapi_file_responses(self.app)
+            plugin_registry.post_process_routes(self.app)
 
         self.site = web.TCPSite(runner, host=self.host, port=self.port)
 

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -19,7 +19,6 @@ from marshmallow import fields, Schema
 from ..config.injection_context import InjectionContext
 from ..core.plugin_registry import PluginRegistry
 from ..messaging.responder import BaseResponder
-from ..revocation.routes import set_tails_file_binary_response_schema
 from ..transport.queue.basic import BasicMessageQueue
 from ..transport.outbound.message import OutboundMessage
 from ..utils.stats import Collector
@@ -257,7 +256,12 @@ class AdminServer(BaseAdminServer):
         self.app = await self.make_application()
         runner = web.AppRunner(self.app)
         await runner.setup()
-        set_tails_file_binary_response_schema(self.app)  # aiohttp_apispec needs hack
+
+        plugin_registry: PluginRegistry = await self.context.inject(
+            PluginRegistry, required=False
+        )
+        if plugin_registry:
+            plugin_registry.set_openapi_file_responses(self.app)
 
         self.site = web.TCPSite(runner, host=self.host, port=self.port)
 

--- a/aries_cloudagent/core/plugin_registry.py
+++ b/aries_cloudagent/core/plugin_registry.py
@@ -272,7 +272,7 @@ class PluginRegistry:
                 if mod and hasattr(mod, "register"):
                     await mod.register(app)
 
-    def set_openapi_file_responses(self, app):
+    def post_process_routes(self, app):
         """Call route binary file response OpenAPI fixups if applicable."""
         for plugin in self._plugins.values():
             definition = ClassLoader.load_module("definition", plugin.__name__)
@@ -286,8 +286,8 @@ class PluginRegistry:
                     except ModuleLoadError as e:
                         LOGGER.error("Error loading admin routes: %s", e)
                         continue
-                    if mod and hasattr(mod, "set_openapi_file_responses"):
-                        mod.set_openapi_file_responses(app)
+                    if mod and hasattr(mod, "post_process_routes"):
+                        mod.post_process_routes(app)
             else:
                 # Set binary file responses for routes not in a versioned package.
                 try:
@@ -295,8 +295,8 @@ class PluginRegistry:
                 except ModuleLoadError as e:
                     LOGGER.error("Error loading admin routes: %s", e)
                     continue
-                if mod and hasattr(mod, "set_openapi_file_responses"):
-                    mod.set_openapi_file_responses(app)
+                if mod and hasattr(mod, "post_process_routes"):
+                    mod.post_process_routes(app)
 
     def __repr__(self) -> str:
         """Return a string representation for this class."""

--- a/aries_cloudagent/core/plugin_registry.py
+++ b/aries_cloudagent/core/plugin_registry.py
@@ -272,6 +272,32 @@ class PluginRegistry:
                 if mod and hasattr(mod, "register"):
                     await mod.register(app)
 
+    def set_openapi_file_responses(self, app):
+        """Call route binary file response OpenAPI fixups if applicable."""
+        for plugin in self._plugins.values():
+            definition = ClassLoader.load_module("definition", plugin.__name__)
+            if definition:
+                # Set binary file responses for routes that are in a versioned package.
+                for plugin_version in definition.versions:
+                    try:
+                        mod = ClassLoader.load_module(
+                            f"{plugin.__name__}.{plugin_version['path']}.routes"
+                        )
+                    except ModuleLoadError as e:
+                        LOGGER.error("Error loading admin routes: %s", e)
+                        continue
+                    if mod and hasattr(mod, "set_openapi_file_responses"):
+                        mod.set_openapi_file_responses(app)
+            else:
+                # Set binary file responses for routes not in a versioned package.
+                try:
+                    mod = ClassLoader.load_module(f"{plugin.__name__}.routes")
+                except ModuleLoadError as e:
+                    LOGGER.error("Error loading admin routes: %s", e)
+                    continue
+                if mod and hasattr(mod, "set_openapi_file_responses"):
+                    mod.set_openapi_file_responses(app)
+
     def __repr__(self) -> str:
         """Return a string representation for this class."""
         return "<{}>".format(self.__class__.__name__)

--- a/aries_cloudagent/core/tests/test_plugin_registry.py
+++ b/aries_cloudagent/core/tests/test_plugin_registry.py
@@ -105,13 +105,13 @@ class TestPluginRegistry(AsyncTestCase):
             load_module.assert_has_calls(calls)
         assert mod.routes.register.call_count == 1
 
-    async def test_set_openapi_file_responses(self):
+    async def test_post_process_routes(self):
         mod_name = "test_mod"
         mod = async_mock.MagicMock()
         mod.__name__ = mod_name
         app = async_mock.MagicMock()
         self.registry._plugins[mod_name] = mod
-        mod.routes.set_openapi_file_responses = async_mock.MagicMock()
+        mod.routes.post_process_routes = async_mock.MagicMock()
         definition = async_mock.MagicMock()
         definition.versions = [
             {
@@ -127,30 +127,30 @@ class TestPluginRegistry(AsyncTestCase):
             "load_module",
             async_mock.MagicMock(side_effect=[definition, mod.routes]),
         ) as load_module:
-            self.registry.set_openapi_file_responses(app)
+            self.registry.post_process_routes(app)
 
             calls = [
                 call("definition", mod_name),
                 call(f"{mod_name}.{definition.versions[0]['path']}.routes"),
             ]
             load_module.assert_has_calls(calls)
-        assert mod.routes.set_openapi_file_responses.call_count == 1
+        assert mod.routes.post_process_routes.call_count == 1
 
         with async_mock.patch.object(
             ClassLoader,
             "load_module",
             async_mock.MagicMock(side_effect=[definition, ModuleLoadError()]),
         ) as load_module:
-            self.registry.set_openapi_file_responses(app)
+            self.registry.post_process_routes(app)
 
             calls = [
                 call("definition", mod_name),
                 call(f"{mod_name}.{definition.versions[0]['path']}.routes"),
             ]
             load_module.assert_has_calls(calls)
-        assert mod.routes.set_openapi_file_responses.call_count == 1
+        assert mod.routes.post_process_routes.call_count == 1
 
-    async def test_set_openapi_file_responses_mod_no_version(self):
+    async def test_post_process_routes_mod_no_version(self):
         mod_name = "test_mod"
         mod = async_mock.MagicMock()
         mod.__name__ = mod_name
@@ -163,22 +163,22 @@ class TestPluginRegistry(AsyncTestCase):
             "load_module",
             async_mock.MagicMock(side_effect=[None, mod.routes]),
         ) as load_module:
-            self.registry.set_openapi_file_responses(app)
+            self.registry.post_process_routes(app)
 
             calls = [call("definition", mod_name), call(f"{mod_name}.routes")]
             load_module.assert_has_calls(calls)
-        assert mod.routes.set_openapi_file_responses.call_count == 1
+        assert mod.routes.post_process_routes.call_count == 1
 
         with async_mock.patch.object(
             ClassLoader,
             "load_module",
             async_mock.MagicMock(side_effect=[None, ModuleLoadError()]),
         ) as load_module:
-            self.registry.set_openapi_file_responses(app)
+            self.registry.post_process_routes(app)
 
             calls = [call("definition", mod_name), call(f"{mod_name}.routes")]
             load_module.assert_has_calls(calls)
-        assert mod.routes.set_openapi_file_responses.call_count == 1
+        assert mod.routes.post_process_routes.call_count == 1
 
     async def test_validate_version_not_a_list(self):
         mod_name = "test_mod"

--- a/aries_cloudagent/revocation/models/indy.py
+++ b/aries_cloudagent/revocation/models/indy.py
@@ -50,7 +50,7 @@ class NonRevocationIntervalSchema(BaseModelSchema):
     """Schema to allow serialization/deserialization of non-revocation intervals."""
 
     class Meta:
-        """NonRevocationIntervalchema metadata."""
+        """NonRevocationIntervalSchema metadata."""
 
         model_class = NonRevocationInterval
 

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -378,7 +378,7 @@ async def register(app: web.Application):
     )
 
 
-def set_openapi_file_responses(app: web.Application):
+def post_process_routes(app: web.Application):
     """Set binary file responses within OpenAPI specification."""
 
     # aio_http-apispec polite API only works on schema for JSON objects, not files yet

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -16,6 +16,7 @@ from aiohttp_apispec import (
 from marshmallow import fields, Schema, validate
 
 from ..messaging.credential_definitions.util import CRED_DEF_SENT_RECORD_TYPE
+from ..messaging.models.base import BaseModel, BaseModelSchema
 from ..messaging.valid import INDY_CRED_DEF_ID, INDY_REV_REG_ID
 from ..storage.base import BaseStorage, StorageNotFoundError
 
@@ -71,11 +72,31 @@ class RevRegUpdateTailsFileUriSchema(Schema):
     )
 
 
-class TailsFileResponseSchema(Schema):
+class TailsFileResponse(BaseModel):
+    """Tails file response JSON schema specifier."""
+
+    class Meta:
+        """Tails file response JSON schema specifier metadata."""
+
+        schema_class = "TailsFileResponseSchema"
+
+    def __init__(self, type: str = None, **kwargs):
+        """Initializetails file response JSON schema specifier."""
+
+        super().__init__(**kwargs)
+        self.type = "file"
+
+
+class TailsFileResponseSchema(BaseModelSchema):
     """Response schema for get tails file request."""
 
-    type_ = fields.Constant(
-        description="Tails file type", constant="file", required=True, data_key="type"
+    class Meta:
+        """TailsFileResponseSchema metadata."""
+
+        model_class = TailsFileResponse
+
+    type = fields.Constant(
+        description="Tails file type", constant="file", required=True
     )
 
 
@@ -261,8 +282,9 @@ async def get_active_registry(request: web.BaseRequest):
     tags=["revocation"],
     summary="Download the tails file of revocation registry",
     produces="application/octet-stream",
+    responses={200: {"description": "tails file", "schema": TailsFileResponseSchema()}},
 )
-@response_schema(TailsFileResponseSchema(), code=200, description="tails file")
+# @response_schema(TailsFileResponseSchema(), code=200, description="tails file")
 @match_info_schema(RevRegIdMatchInfoSchema())
 async def get_tails_file(request: web.BaseRequest) -> web.FileResponse:
     """

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -280,18 +280,6 @@ async def get_tails_file(request: web.BaseRequest) -> web.FileResponse:
     return web.FileResponse(path=revoc_registry.tails_local_path, status=200)
 
 
-def set_tails_file_binary_response_schema(app: web.Application):
-    """Fix up swagger spec to cite response schema for binary file."""
-
-    # aio_http-apispec polite API only works on schema for JSON objects, not files yet
-    try:
-        app._state["swagger_dict"]["paths"][
-            "/revocation/registry/{rev_reg_id}/tails-file"
-        ]["get"]["responses"]["200"]["schema"] = {"type": "string", "format": "binary"}
-    except KeyError:
-        pass  # route not registered: carry on
-
-
 @docs(
     tags=["revocation"], summary="Publish a given revocation registry",
 )
@@ -388,3 +376,17 @@ async def register(app: web.Application):
             web.post("/revocation/registry/{rev_reg_id}/publish", publish_registry),
         ]
     )
+
+
+def set_openapi_file_responses(app: web.Application):
+    """Set binary file responses within OpenAPI specification."""
+
+    # aio_http-apispec polite API only works on schema for JSON objects, not files yet
+    methods = app._state["swagger_dict"]["paths"].get(
+        "/revocation/registry/{rev_reg_id}/tails-file"
+    )
+    if methods:
+        methods["get"]["responses"]["200"]["schema"] = {
+            "type": "string",
+            "format": "binary",
+        }

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -71,6 +71,14 @@ class RevRegUpdateTailsFileUriSchema(Schema):
     )
 
 
+class TailsFileResponseSchema(Schema):
+    """Response schema for get tails file request."""
+
+    type_ = fields.Constant(
+        description="Tails file type", constant="file", required=True, data_key="type"
+    )
+
+
 class RevRegsCreatedQueryStringSchema(Schema):
     """Query string parameters and validators for rev regs created request."""
 
@@ -253,8 +261,8 @@ async def get_active_registry(request: web.BaseRequest):
     tags=["revocation"],
     summary="Download the tails file of revocation registry",
     produces="application/octet-stream",
-    responses={200: {"description": "tails file"}},
 )
+@response_schema(TailsFileResponseSchema(), code=200, description="tails file")
 @match_info_schema(RevRegIdMatchInfoSchema())
 async def get_tails_file(request: web.BaseRequest) -> web.FileResponse:
     """

--- a/aries_cloudagent/revocation/tests/test_routes.py
+++ b/aries_cloudagent/revocation/tests/test_routes.py
@@ -389,3 +389,20 @@ class TestRevocationRoutes(AsyncTestCase):
 
         await test_module.register(mock_app)
         mock_app.add_routes.assert_called_once()
+
+    async def test_set_openapi_file_responses(self):
+        mock_app = async_mock.MagicMock(
+            _state={
+                "swagger_dict": {
+                    "paths": {
+                        "/revocation/registry/{rev_reg_id}/tails-file": {
+                            "get": {"responses": {"200": {"description": "tails file"}}}
+                        }
+                    }
+                }
+            }
+        )
+        test_module.set_openapi_file_responses(mock_app)
+        assert mock_app._state["swagger_dict"]["paths"][
+            "/revocation/registry/{rev_reg_id}/tails-file"
+        ]["get"]["responses"]["200"]["schema"] == {"type": "string", "format": "binary"}

--- a/aries_cloudagent/revocation/tests/test_routes.py
+++ b/aries_cloudagent/revocation/tests/test_routes.py
@@ -390,7 +390,7 @@ class TestRevocationRoutes(AsyncTestCase):
         await test_module.register(mock_app)
         mock_app.add_routes.assert_called_once()
 
-    async def test_set_openapi_file_responses(self):
+    async def test_post_process_routes(self):
         mock_app = async_mock.MagicMock(
             _state={
                 "swagger_dict": {
@@ -402,7 +402,7 @@ class TestRevocationRoutes(AsyncTestCase):
                 }
             }
         )
-        test_module.set_openapi_file_responses(mock_app)
+        test_module.post_process_routes(mock_app)
         assert mock_app._state["swagger_dict"]["paths"][
             "/revocation/registry/{rev_reg_id}/tails-file"
         ]["get"]["responses"]["200"]["schema"] == {"type": "string", "format": "binary"}


### PR DESCRIPTION
More formal implementation allows for any module to define free function `set_openapi_file_responses()` to set JSON in swagger (OpenAPI) for registered methods returning files. Admin server picks these up and executes them via plugin registry after initial aiohttp Web application setup.