### PR TITLE
Key rotation operations

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -744,7 +744,14 @@ class WalletGroup(ArgumentGroup):
             "--wallet-key",
             type=str,
             metavar="<wallet-key>",
-            help="Specifies the master key value to use for opening the wallet.",
+            help="Specifies the master key value to use to open the wallet.",
+        )
+        parser.add_argument(
+            "--wallet-rekey",
+            type=str,
+            metavar="<wallet-rekey>",
+            help="Specifies a new master key value to which to rotate and to\
+            open the wallet next time.",
         )
         parser.add_argument(
             "--wallet-name",
@@ -801,6 +808,8 @@ class WalletGroup(ArgumentGroup):
             settings["wallet.seed"] = args.seed
         if args.wallet_key:
             settings["wallet.key"] = args.wallet_key
+        if args.wallet_rekey:
+            settings["wallet.rekey"] = args.wallet_rekey
         if args.wallet_name:
             settings["wallet.name"] = args.wallet_name
         if args.wallet_storage_type:

--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -68,6 +68,15 @@ class BaseLedger(ABC, metaclass=ABCMeta):
     def nym_to_did(self, nym: str) -> str:
         """Format a nym with the ledger's DID prefix."""
 
+    @abstractmethod
+    async def rotate_public_did_keypair(self, next_seed: str = None) -> None:
+        """
+        Rotate keypair for public DID: create new key, submit to ledger, update wallet.
+
+        Args:
+            next_seed: seed for incoming ed25519 keypair (default random)
+        """
+
     def did_to_nym(self, did: str) -> str:
         """Remove the ledger's DID prefix to produce a nym."""
         if did:

--- a/aries_cloudagent/ledger/tests/test_routes.py
+++ b/aries_cloudagent/ledger/tests/test_routes.py
@@ -31,6 +31,9 @@ class TestLedgerRoutes(AsyncTestCase):
             await test_module.register_ledger_nym(request)
 
         with self.assertRaises(HTTPForbidden):
+            await test_module.rotate_public_did_keypair(request)
+
+        with self.assertRaises(HTTPForbidden):
             await test_module.get_did_verkey(request)
 
         with self.assertRaises(HTTPForbidden):
@@ -109,6 +112,32 @@ class TestLedgerRoutes(AsyncTestCase):
         )
         with self.assertRaises(HTTPForbidden):
             await test_module.register_ledger_nym(request)
+
+    async def test_rotate_public_did_keypair(self):
+        request = async_mock.MagicMock()
+        request.app = self.app
+
+        with async_mock.patch.object(
+            test_module.web, "json_response", async_mock.Mock()
+        ) as json_response:
+            self.ledger.rotate_public_did_keypair = async_mock.CoroutineMock()
+
+            await test_module.rotate_public_did_keypair(request)
+            json_response.assert_called_once_with({})
+
+    async def test_rotate_public_did_keypair_public_wallet_x(self):
+        request = async_mock.MagicMock()
+        request.app = self.app
+
+        with async_mock.patch.object(
+            test_module.web, "json_response", async_mock.Mock()
+        ) as json_response:
+            self.ledger.rotate_public_did_keypair = async_mock.CoroutineMock(
+                side_effect=test_module.WalletError("Exception")
+            )
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.rotate_public_did_keypair(request)
 
     async def test_taa_forbidden(self):
         request = async_mock.MagicMock()

--- a/aries_cloudagent/wallet/base.py
+++ b/aries_cloudagent/wallet/base.py
@@ -102,6 +102,37 @@ class BaseWallet(ABC):
         """
 
     @abstractmethod
+    async def rotate_keys_start(self, did: str, next_seed: str = None) -> str:
+        """
+        Begin key rotation for DID that wallet owns: generate new keys.
+
+        Args:
+            did: signing DID 
+            next_seed: incoming replacement seed (default random)
+
+        Returns:
+            The new verification key
+
+        Raises:
+            WalletNotFoundError: if wallet does not own DID
+
+        """
+
+    @abstractmethod
+    async def rotate_keys_apply(self, did: str) -> None:
+        """
+        Apply temporary keys as main for DID that wallet owns.
+
+        Args:
+            did: signing DID 
+
+        Raises:
+            WalletNotFoundError: if wallet does not own DID
+            WalletError: if wallet has not started key rotation
+
+        """
+
+    @abstractmethod
     async def create_local_did(
         self, seed: str = None, did: str = None, metadata: dict = None
     ) -> DIDInfo:

--- a/aries_cloudagent/wallet/base.py
+++ b/aries_cloudagent/wallet/base.py
@@ -102,7 +102,7 @@ class BaseWallet(ABC):
         """
 
     @abstractmethod
-    async def rotate_keys_start(self, did: str, next_seed: str = None) -> str:
+    async def rotate_did_keys_start(self, did: str, next_seed: str = None) -> str:
         """
         Begin key rotation for DID that wallet owns: generate new keys.
 
@@ -119,7 +119,7 @@ class BaseWallet(ABC):
         """
 
     @abstractmethod
-    async def rotate_keys_apply(self, did: str) -> None:
+    async def rotate_did_keys_apply(self, did: str) -> None:
         """
         Apply temporary keys as main for DID that wallet owns.
 

--- a/aries_cloudagent/wallet/base.py
+++ b/aries_cloudagent/wallet/base.py
@@ -102,13 +102,13 @@ class BaseWallet(ABC):
         """
 
     @abstractmethod
-    async def rotate_did_keys_start(self, did: str, next_seed: str = None) -> str:
+    async def rotate_did_keypair_start(self, did: str, next_seed: str = None) -> str:
         """
-        Begin key rotation for DID that wallet owns: generate new keys.
+        Begin key rotation for DID that wallet owns: generate new keypair.
 
         Args:
-            did: signing DID 
-            next_seed: incoming replacement seed (default random)
+            did: signing DID
+            next_seed: seed for incoming ed25519 key pair (default random)
 
         Returns:
             The new verification key
@@ -119,12 +119,12 @@ class BaseWallet(ABC):
         """
 
     @abstractmethod
-    async def rotate_did_keys_apply(self, did: str) -> None:
+    async def rotate_did_keypair_apply(self, did: str) -> None:
         """
-        Apply temporary keys as main for DID that wallet owns.
+        Apply temporary keypair as main for DID that wallet owns.
 
         Args:
-            did: signing DID 
+            did: signing DID
 
         Raises:
             WalletNotFoundError: if wallet does not own DID

--- a/aries_cloudagent/wallet/basic.py
+++ b/aries_cloudagent/wallet/basic.py
@@ -137,12 +137,12 @@ class BasicWallet(BaseWallet):
             raise WalletNotFoundError("Key not found: {}".format(verkey))
         self._keys[verkey]["metadata"] = metadata.copy() if metadata else {}
 
-    async def rotate_did_keys_start(self, did: str, next_seed: str = None) -> str:
+    async def rotate_did_keypair_start(self, did: str, next_seed: str = None) -> str:
         """
-        Begin key rotation for DID that wallet owns: generate new keys.
+        Begin key rotation for DID that wallet owns: generate new keypair.
 
         Args:
-            did: signing DID 
+            did: signing DID
             next_seed: incoming replacement seed (default random)
 
         Returns:
@@ -158,12 +158,12 @@ class BasicWallet(BaseWallet):
         key_info = await self.create_signing_key(next_seed, {"did": did})
         return key_info.verkey
 
-    async def rotate_did_keys_apply(self, did: str) -> None:
+    async def rotate_did_keypair_apply(self, did: str) -> None:
         """
-        Apply temporary keys as main for DID that wallet owns.
+        Apply temporary keypair as main for DID that wallet owns.
 
         Args:
-            did: signing DID 
+            did: signing DID
 
         Raises:
             WalletNotFoundError: if wallet does not own DID

--- a/aries_cloudagent/wallet/indy.py
+++ b/aries_cloudagent/wallet/indy.py
@@ -355,12 +355,12 @@ class IndyWallet(BaseWallet):
         await self.get_signing_key(verkey)  # throw exception if key is undefined
         await indy.crypto.set_key_metadata(self.handle, verkey, meta_json)
 
-    async def rotate_did_keys_start(self, did: str, next_seed: str = None) -> str:
+    async def rotate_did_keypair_start(self, did: str, next_seed: str = None) -> str:
         """
-        Begin key rotation for DID that wallet owns: generate new keys.
+        Begin key rotation for DID that wallet owns: generate new keypair.
 
         Args:
-            did: signing DID 
+            did: signing DID
             next_seed: incoming replacement seed (default random)
 
         Returns:
@@ -386,12 +386,12 @@ class IndyWallet(BaseWallet):
 
         return verkey
 
-    async def rotate_did_keys_apply(self, did: str) -> DIDInfo:
+    async def rotate_did_keypair_apply(self, did: str) -> DIDInfo:
         """
-        Apply temporary keys as main for DID that wallet owns.
+        Apply temporary keypair as main for DID that wallet owns.
 
         Args:
-            did: signing DID 
+            did: signing DID
 
         Returns:
             DIDInfo with new verification key and metadata for DID

--- a/aries_cloudagent/wallet/provider.py
+++ b/aries_cloudagent/wallet/provider.py
@@ -40,4 +40,11 @@ class WalletProvider(BaseProvider):
             wallet_cfg["storage_creds"] = settings["wallet.storage_creds"]
         wallet = ClassLoader.load_class(wallet_class)(wallet_cfg)
         await wallet.open()
+
+        if "wallet.rekey" in settings:
+            await wallet.close()
+            await wallet.open()
+            LOGGER.info(
+                "Rotated wallet %s master encryption key", wallet_cfg.get("name", "")
+            )
         return wallet

--- a/aries_cloudagent/wallet/provider.py
+++ b/aries_cloudagent/wallet/provider.py
@@ -27,6 +27,8 @@ class WalletProvider(BaseProvider):
         wallet_cfg = {}
         if "wallet.key" in settings:
             wallet_cfg["key"] = settings["wallet.key"]
+        if "wallet.rekey" in settings:
+            wallet_cfg["rekey"] = settings["wallet.rekey"]
         if "wallet.name" in settings:
             wallet_cfg["name"] = settings["wallet.name"]
         if "wallet.storage_type" in settings:

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -239,11 +239,18 @@ async def wallet_set_public_did(request: web.BaseRequest):
     return web.json_response({"result": format_did_info(info)})
 
 
-@docs(tags=["wallet"], summary="Rotate keys for a local non-public DID")
+@docs(tags=["wallet"], summary="Rotate keypair for a local non-public DID")
 @querystring_schema(DIDQueryStringSchema())
-async def wallet_rotate_did_keys(request: web.BaseRequest):
+async def wallet_rotate_did_keypair(request: web.BaseRequest):
     """
-    Request handler for rotating local DID keys.
+    Request handler for rotating local DID keypair.
+
+    Args:
+        request: aiohttp request object
+
+    Returns:
+        An empty JSON response
+
     """
     context = request.app["request_context"]
     wallet: BaseWallet = await context.inject(BaseWallet, required=False)
@@ -262,8 +269,8 @@ async def wallet_rotate_did_keys(request: web.BaseRequest):
             # call from ledger API to propagate through ledger NYM transaction
             raise web.HTTPBadRequest()
 
-    await wallet.rotate_did_keys_start(did)  # do not take seed over the wire
-    await wallet.rotate_did_keys_apply(did)
+    await wallet.rotate_did_keypair_start(did)  # do not take seed over the wire
+    await wallet.rotate_did_keypair_apply(did)
 
     return web.json_response({})
 
@@ -332,7 +339,7 @@ async def register(app: web.Application):
             web.post("/wallet/did/create", wallet_create_did),
             web.get("/wallet/did/public", wallet_get_public_did, allow_head=False),
             web.post("/wallet/did/public", wallet_set_public_did),
-            web.patch("/wallet/did/local/rotate-keys", wallet_rotate_did_keys),
+            web.patch("/wallet/did/local/rotate-keypair", wallet_rotate_did_keypair),
             web.get(
                 "/wallet/tag-policy/{cred_def_id}",
                 wallet_get_tagging_policy,

--- a/aries_cloudagent/wallet/tests/test_basic_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_basic_wallet.py
@@ -103,20 +103,25 @@ class TestBasicWallet:
             _ = await wallet.create_local_did("invalid-seed", None)
 
     @pytest.mark.asyncio
-    async def test_rotate_did_keys(self, wallet):
+    async def test_rotate_did_keypair(self, wallet):
         with pytest.raises(WalletNotFoundError):
-            await wallet.rotate_did_keys_start(self.test_did)
+            await wallet.rotate_did_keypair_start(self.test_did)
 
         with pytest.raises(WalletNotFoundError):
-            await wallet.rotate_did_keys_apply(self.test_did)
+            await wallet.rotate_did_keypair_apply(self.test_did)
 
         info = await wallet.create_local_did(self.test_seed, self.test_did)
 
         with pytest.raises(WalletError):
-            await wallet.rotate_did_keys_apply(self.test_did)
+            await wallet.rotate_did_keypair_apply(self.test_did)
 
-        await wallet.rotate_did_keys_start(self.test_did)
-        await wallet.rotate_did_keys_apply(self.test_did)
+        new_verkey = await wallet.rotate_did_keypair_start(self.test_did)
+        assert info.verkey != new_verkey
+        await wallet.rotate_did_keypair_apply(self.test_did)
+
+        new_info = await wallet.get_local_did(self.test_did)
+        assert new_info.did == self.test_did
+        assert new_info.verkey != info.verkey
 
     @pytest.mark.asyncio
     async def test_create_local_with_did(self, wallet):

--- a/aries_cloudagent/wallet/tests/test_basic_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_basic_wallet.py
@@ -103,6 +103,22 @@ class TestBasicWallet:
             _ = await wallet.create_local_did("invalid-seed", None)
 
     @pytest.mark.asyncio
+    async def test_rotate_did_keys(self, wallet):
+        with pytest.raises(WalletNotFoundError):
+            await wallet.rotate_did_keys_start(self.test_did)
+
+        with pytest.raises(WalletNotFoundError):
+            await wallet.rotate_did_keys_apply(self.test_did)
+
+        info = await wallet.create_local_did(self.test_seed, self.test_did)
+
+        with pytest.raises(WalletError):
+            await wallet.rotate_did_keys_apply(self.test_did)
+
+        await wallet.rotate_did_keys_start(self.test_did)
+        await wallet.rotate_did_keys_apply(self.test_did)
+
+    @pytest.mark.asyncio
     async def test_create_local_with_did(self, wallet):
         info = await wallet.create_local_did(None, self.test_did)
         assert info.did == self.test_did

--- a/aries_cloudagent/wallet/tests/test_indy_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_indy_wallet.py
@@ -82,6 +82,30 @@ class TestIndyWallet(test_basic_wallet.TestBasicWallet):
             assert "outlier" in str(excinfo.value)
 
     @pytest.mark.asyncio
+    async def test_rotate_did_keys_x(self, wallet):
+        info = await wallet.create_local_did(self.test_seed, self.test_did)
+
+        with async_mock.patch.object(
+            indy.did, "replace_keys_start", async_mock.CoroutineMock()
+        ) as mock_repl_start:
+            mock_repl_start.side_effect = test_module.IndyError(
+                test_module.ErrorCode.CommonIOError, {"message": "outlier"}
+            )
+            with pytest.raises(test_module.WalletError) as excinfo:
+                await wallet.rotate_did_keys_start(self.test_did)
+            assert "outlier" in str(excinfo.value)
+
+        with async_mock.patch.object(
+            indy.did, "replace_keys_apply", async_mock.CoroutineMock()
+        ) as mock_repl_apply:
+            mock_repl_apply.side_effect = test_module.IndyError(
+                test_module.ErrorCode.CommonIOError, {"message": "outlier"}
+            )
+            with pytest.raises(test_module.WalletError) as excinfo:
+                await wallet.rotate_did_keys_apply(self.test_did)
+            assert "outlier" in str(excinfo.value)
+
+    @pytest.mark.asyncio
     async def test_create_signing_key_x(self, wallet):
         with async_mock.patch.object(
             indy.crypto, "create_key", async_mock.CoroutineMock()

--- a/aries_cloudagent/wallet/tests/test_indy_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_indy_wallet.py
@@ -82,7 +82,7 @@ class TestIndyWallet(test_basic_wallet.TestBasicWallet):
             assert "outlier" in str(excinfo.value)
 
     @pytest.mark.asyncio
-    async def test_rotate_did_keys_x(self, wallet):
+    async def test_rotate_did_keypair_x(self, wallet):
         info = await wallet.create_local_did(self.test_seed, self.test_did)
 
         with async_mock.patch.object(
@@ -92,7 +92,7 @@ class TestIndyWallet(test_basic_wallet.TestBasicWallet):
                 test_module.ErrorCode.CommonIOError, {"message": "outlier"}
             )
             with pytest.raises(test_module.WalletError) as excinfo:
-                await wallet.rotate_did_keys_start(self.test_did)
+                await wallet.rotate_did_keypair_start(self.test_did)
             assert "outlier" in str(excinfo.value)
 
         with async_mock.patch.object(
@@ -102,7 +102,7 @@ class TestIndyWallet(test_basic_wallet.TestBasicWallet):
                 test_module.ErrorCode.CommonIOError, {"message": "outlier"}
             )
             with pytest.raises(test_module.WalletError) as excinfo:
-                await wallet.rotate_did_keys_apply(self.test_did)
+                await wallet.rotate_did_keypair_apply(self.test_did)
             assert "outlier" in str(excinfo.value)
 
     @pytest.mark.asyncio

--- a/aries_cloudagent/wallet/tests/test_provider.py
+++ b/aries_cloudagent/wallet/tests/test_provider.py
@@ -2,11 +2,12 @@ from asynctest import TestCase as AsyncTestCase
 import pytest
 
 from ...config.settings import Settings
+from ..error import WalletError
 from .. import provider as test_module
 
 
 class TestProvider(AsyncTestCase):
-    async def test_provide(self):
+    async def test_provide_basic(self):
         provider = test_module.WalletProvider()
         settings = Settings(
             values={
@@ -20,4 +21,37 @@ class TestProvider(AsyncTestCase):
         )
         wallet = await provider.provide(settings, None)
 
+        assert wallet.opened
         assert wallet.name == "name"
+        await wallet.close()
+
+    async def test_provide_indy(self):
+        provider = test_module.WalletProvider()
+        settings = Settings(
+            values={"wallet.type": "indy", "wallet.key": "key", "wallet.name": "name",}
+        )
+        wallet = await provider.provide(settings, None)
+
+        assert wallet.opened
+        assert wallet.name == "name"
+        await wallet.close()
+        assert not wallet.opened
+
+        settings["wallet.rekey"] = "rekey"
+        assert settings["wallet.rekey"] == "rekey"
+
+        wallet = await provider.provide(settings, None)
+        assert wallet.opened
+
+        await wallet.close()
+        assert not wallet.opened
+
+        with pytest.raises(WalletError):  # make sure old key does not work
+            wallet = await provider.provide(settings, None)
+
+        settings["wallet.key"] = "rekey"
+        del settings["wallet.rekey"]
+
+        wallet = await provider.provide(settings, None)
+        assert wallet.opened
+        await wallet.close()

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -279,7 +279,7 @@ class TestWalletRoutes(AsyncTestCase):
             )
             assert result is json_response.return_value
 
-    async def test_rotate_did_keys(self):
+    async def test_rotate_did_keypair(self):
         request = async_mock.MagicMock()
         request.app = self.app
         request.query = {"did": "did"}
@@ -290,30 +290,30 @@ class TestWalletRoutes(AsyncTestCase):
             self.wallet.get_local_did = async_mock.CoroutineMock(
                 return_value=DIDInfo("did", "verkey", {"public": False})
             )
-            self.wallet.rotate_did_keys_start = async_mock.CoroutineMock()
-            self.wallet.rotate_did_keys_apply = async_mock.CoroutineMock()
+            self.wallet.rotate_did_keypair_start = async_mock.CoroutineMock()
+            self.wallet.rotate_did_keypair_apply = async_mock.CoroutineMock()
 
-            await test_module.wallet_rotate_did_keys(request)
+            await test_module.wallet_rotate_did_keypair(request)
             json_response.assert_called_once_with({})
 
-    async def test_rotate_did_keys_missing_wallet(self):
+    async def test_rotate_did_keypair_missing_wallet(self):
         request = async_mock.MagicMock()
         request.app = self.app
         request.query = {"did": "did"}
         self.context.injector.clear_binding(BaseWallet)
 
         with self.assertRaises(HTTPForbidden):
-            await test_module.wallet_rotate_did_keys(request)
+            await test_module.wallet_rotate_did_keypair(request)
 
-    async def test_rotate_did_keys_no_query_did(self):
+    async def test_rotate_did_keypair_no_query_did(self):
         request = async_mock.MagicMock()
         request.app = self.app
         request.query = {}
 
         with self.assertRaises(test_module.web.HTTPBadRequest):
-            await test_module.wallet_rotate_did_keys(request)
+            await test_module.wallet_rotate_did_keypair(request)
 
-    async def test_rotate_did_keys_did_not_local(self):
+    async def test_rotate_did_keypair_did_not_local(self):
         request = async_mock.MagicMock()
         request.app = self.app
         request.query = {"did": "did"}
@@ -322,13 +322,13 @@ class TestWalletRoutes(AsyncTestCase):
             side_effect=WalletNotFoundError("Unknown DID")
         )
         with self.assertRaises(test_module.web.HTTPBadRequest):
-            await test_module.wallet_rotate_did_keys(request)
+            await test_module.wallet_rotate_did_keypair(request)
 
         self.wallet.get_local_did = async_mock.CoroutineMock(
             return_value=DIDInfo("did", "verkey", {"public": True})
         )
         with self.assertRaises(test_module.web.HTTPBadRequest):
-            await test_module.wallet_rotate_did_keys(request)
+            await test_module.wallet_rotate_did_keypair(request)
 
     async def test_get_catpol(self):
         request = async_mock.MagicMock()
@@ -388,3 +388,8 @@ class TestWalletRoutes(AsyncTestCase):
 
         await test_module.register(mock_app)
         mock_app.add_routes.assert_called_once()
+
+    async def test_post_process_routes(self):
+        mock_app = async_mock.MagicMock(_state={"swagger_dict": {}})
+        test_module.post_process_routes(mock_app)
+        assert "tags" in mock_app._state["swagger_dict"]

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -9,6 +9,7 @@ from ...ledger.base import BaseLedger
 from ...wallet.base import BaseWallet, DIDInfo
 
 from .. import routes as test_module
+from ..error import WalletNotFoundError
 
 
 class TestWalletRoutes(AsyncTestCase):
@@ -277,6 +278,57 @@ class TestWalletRoutes(AsyncTestCase):
                 {"result": format_did_info.return_value}
             )
             assert result is json_response.return_value
+
+    async def test_rotate_did_keys(self):
+        request = async_mock.MagicMock()
+        request.app = self.app
+        request.query = {"did": "did"}
+
+        with async_mock.patch.object(
+            test_module.web, "json_response", async_mock.Mock()
+        ) as json_response:
+            self.wallet.get_local_did = async_mock.CoroutineMock(
+                return_value=DIDInfo("did", "verkey", {"public": False})
+            )
+            self.wallet.rotate_did_keys_start = async_mock.CoroutineMock()
+            self.wallet.rotate_did_keys_apply = async_mock.CoroutineMock()
+
+            await test_module.wallet_rotate_did_keys(request)
+            json_response.assert_called_once_with({})
+
+    async def test_rotate_did_keys_missing_wallet(self):
+        request = async_mock.MagicMock()
+        request.app = self.app
+        request.query = {"did": "did"}
+        self.context.injector.clear_binding(BaseWallet)
+
+        with self.assertRaises(HTTPForbidden):
+            await test_module.wallet_rotate_did_keys(request)
+
+    async def test_rotate_did_keys_no_query_did(self):
+        request = async_mock.MagicMock()
+        request.app = self.app
+        request.query = {}
+
+        with self.assertRaises(test_module.web.HTTPBadRequest):
+            await test_module.wallet_rotate_did_keys(request)
+
+    async def test_rotate_did_keys_did_not_local(self):
+        request = async_mock.MagicMock()
+        request.app = self.app
+        request.query = {"did": "did"}
+
+        self.wallet.get_local_did = async_mock.CoroutineMock(
+            side_effect=WalletNotFoundError("Unknown DID")
+        )
+        with self.assertRaises(test_module.web.HTTPBadRequest):
+            await test_module.wallet_rotate_did_keys(request)
+
+        self.wallet.get_local_did = async_mock.CoroutineMock(
+            return_value=DIDInfo("did", "verkey", {"public": True})
+        )
+        with self.assertRaises(test_module.web.HTTPBadRequest):
+            await test_module.wallet_rotate_did_keys(request)
 
     async def test_get_catpol(self):
         request = async_mock.MagicMock()


### PR DESCRIPTION
Please have a look. I think:
* the public DID key rotation should hang off the ledger API - it's defensive design against an off-line agent trying to the rotate key pair for a DID that's public.  Ledgers need wallets but wallets don't need ledgers; the operation initializes at the wallet, updates the ledger, then returns to the wallet to apply the update, and it uses the same wallet operations as for local DID key pair rotation below.
* the local DID key pair rotation should hang off the wallet because it only needs the wallet. There are two calls: start and apply; the `routes.py` calls one and then the other. The wallet needs to retain both calls to accommodate public DID key pair rotation as above.
* the wallet master encryption key rotation is a provision operation. Could you look this over in particular? On some level I can't believe it's this simple.

I'm open to the idea of renaming stuff in `routes.py` for ledger, wallet. I was toying with the idea of 'nym' instead of 'public-did' for symmetry, but we've used public-did everywhere else to refer to public DIDs, and properly the keys belong to the DID not the NYM.