### PR TITLE
Fix #427 websocket --admin-api-key connect issue

### DIFF
--- a/aries_cloudagent/transport/queue/basic.py
+++ b/aries_cloudagent/transport/queue/basic.py
@@ -14,6 +14,7 @@ class BasicMessageQueue(BaseMessageQueue):
         self.queue = self.make_queue()
         self.logger = logging.getLogger(__name__)
         self.stop_event = asyncio.Event()
+        self.api_key_authenticated = False
 
     def make_queue(self):
         """Create the queue instance."""


### PR DESCRIPTION
This is the proposed option number 2. It uses the websocket
to expect a message with the admin api key before it is being
used to transmit any other messages than 'ping'

Signed-off-by: Matthias Binzer <matthias.binzer.ext@bosch.com>