### PR TITLE
Revisit issue cred vs rfc 36

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -221,30 +221,26 @@ class CredentialManager:
             A tuple (credential exchange record, credential offer message)
 
         """
-        if credential_exchange_record.credential_proposal_dict:
-            credential_proposal_message = CredentialProposal.deserialize(
-                credential_exchange_record.credential_proposal_dict
-            )
-            credential_proposal_message.assign_trace_decorator(
-                self.context.settings, credential_exchange_record.trace
-            )
-            cred_def_id = await self._match_sent_cred_def_id(
-                {
-                    t: getattr(credential_proposal_message, t)
-                    for t in CRED_DEF_TAGS
-                    if getattr(credential_proposal_message, t)
-                }
-            )
-
-            cred_preview = credential_proposal_message.credential_proposal
-        else:
-            cred_def_id = credential_exchange_record.credential_definition_id
-            cred_preview = None
 
         async def _create(cred_def_id):
             issuer: BaseIssuer = await self.context.inject(BaseIssuer)
             offer_json = await issuer.create_credential_offer(cred_def_id)
             return json.loads(offer_json)
+
+        credential_proposal_message = CredentialProposal.deserialize(
+            credential_exchange_record.credential_proposal_dict
+        )
+        credential_proposal_message.assign_trace_decorator(
+            self.context.settings, credential_exchange_record.trace
+        )
+        cred_def_id = await self._match_sent_cred_def_id(
+            {
+                t: getattr(credential_proposal_message, t)
+                for t in CRED_DEF_TAGS
+                if getattr(credential_proposal_message, t)
+            }
+        )
+        cred_preview = credential_proposal_message.credential_proposal
 
         credential_offer = None
         cache_key = f"credential_offer::{cred_def_id}"
@@ -301,15 +297,12 @@ class CredentialManager:
         schema_id = indy_offer["schema_id"]
         cred_def_id = indy_offer["cred_def_id"]
 
-        if credential_preview:
-            credential_proposal_dict = CredentialProposal(
-                comment=credential_offer_message.comment,
-                credential_proposal=credential_preview,
-                schema_id=schema_id,
-                cred_def_id=cred_def_id,
-            ).serialize()
-        else:
-            credential_proposal_dict = None
+        credential_proposal_dict = CredentialProposal(
+            comment=credential_offer_message.comment,
+            credential_proposal=credential_preview,
+            schema_id=schema_id,
+            cred_def_id=cred_def_id,
+        ).serialize()
 
         # Get credential exchange record (holder sent proposal first)
         # or create it (issuer sent offer first)

--- a/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
@@ -678,9 +678,17 @@ async def credential_exchange_send_bound_offer(request: web.BaseRequest):
         raise web.HTTPNotFound(
             reason=f"No record of credential exchange id {credential_exchange_id}"
         )
-    assert credential_exchange_record.state == (
+
+    if credential_exchange_record.state != (
         V10CredentialExchange.STATE_PROPOSAL_RECEIVED
-    )
+    ):
+        raise web.HTTPBadRequest(
+            reason=(
+                f"Credential exchange {credential_exchange_id} "
+                f"in {credential_exchange_record.state} state "
+                f"(must be {V10CredentialExchange.STATE_PROPOSAL_RECEIVED})"
+            )
+        )
 
     connection_id = credential_exchange_record.connection_id
     try:
@@ -742,9 +750,14 @@ async def credential_exchange_send_request(request: web.BaseRequest):
         )
     connection_id = credential_exchange_record.connection_id
 
-    assert credential_exchange_record.state == (
-        V10CredentialExchange.STATE_OFFER_RECEIVED
-    )
+    if credential_exchange_record.state != (V10CredentialExchange.STATE_OFFER_RECEIVED):
+        raise web.HTTPBadRequest(
+            reason=(
+                f"Credential exchange {credential_exchange_id} "
+                f"in {credential_exchange_record.state} state "
+                f"(must be {V10CredentialExchange.STATE_OFFER_RECEIVED})"
+            )
+        )
 
     try:
         connection_record = await ConnectionRecord.retrieve_by_id(
@@ -814,7 +827,14 @@ async def credential_exchange_issue(request: web.BaseRequest):
         )
     connection_id = cred_exch_record.connection_id
 
-    assert cred_exch_record.state == V10CredentialExchange.STATE_REQUEST_RECEIVED
+    if cred_exch_record.state != (V10CredentialExchange.STATE_REQUEST_RECEIVED):
+        raise web.HTTPBadRequest(
+            reason=(
+                f"Credential exchange {credential_exchange_id} "
+                f"in {cred_exch_record.state} state "
+                f"(must be {V10CredentialExchange.STATE_REQUEST_RECEIVED})"
+            )
+        )
 
     try:
         connection_record = await ConnectionRecord.retrieve_by_id(
@@ -891,9 +911,16 @@ async def credential_exchange_store(request: web.BaseRequest):
         )
     connection_id = credential_exchange_record.connection_id
 
-    assert credential_exchange_record.state == (
+    if credential_exchange_record.state != (
         V10CredentialExchange.STATE_CREDENTIAL_RECEIVED
-    )
+    ):
+        raise web.HTTPBadRequest(
+            reason=(
+                f"Credential exchange {credential_exchange_id} "
+                f"in {credential_exchange_record.state} state "
+                f"(must be {V10CredentialExchange.STATE_CREDENTIAL_RECEIVED})"
+            )
+        )
 
     try:
         connection_record = await ConnectionRecord.retrieve_by_id(

--- a/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
@@ -7,6 +7,7 @@ from .....config.injection_context import InjectionContext
 from .....storage.error import StorageNotFoundError
 from .....holder.base import BaseHolder
 from .....messaging.request_context import RequestContext
+from .....wallet.base import DIDInfo
 
 from .. import routes as test_module
 
@@ -325,6 +326,223 @@ class TestCredentialRoutes(AsyncTestCase):
 
             with self.assertRaises(test_module.web.HTTPForbidden):
                 await test_module.credential_exchange_send_proposal(mock)
+
+    async def test_credential_exchange_create_free_offer(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock(
+            return_value={
+                "auto_issue": False,
+                "cred_def_id": "cred-def-id",
+                "connection_id": "dummy",
+                "credential_preview": {
+                    "attributes": [{"name": "hello", "value": "world"}]
+                },
+            }
+        )
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
+        }
+        mock.app["request_context"].settings = {
+            "default_endpoint": "http://1.2.3.4:8081"
+        }
+        mock.app["request_context"].inject = async_mock.CoroutineMock(
+            return_value=async_mock.MagicMock(
+                retrieve_by_id=async_mock.CoroutineMock(
+                    return_value=async_mock.MagicMock(my_did="did")
+                ),
+                get_local_did=async_mock.CoroutineMock(
+                    return_value=DIDInfo("did", "verkey", {"meta": "data"})
+                ),
+            )
+        )
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_credential_manager, async_mock.patch.object(
+            test_module, "serialize_outofband"
+        ) as mock_seroob, async_mock.patch.object(
+            test_module.web, "json_response"
+        ) as mock_response:
+
+            mock_credential_manager.return_value.create_offer = (
+                async_mock.CoroutineMock()
+            )
+
+            mock_cred_ex_record = async_mock.MagicMock()
+
+            mock_credential_manager.return_value.create_offer.return_value = (
+                mock_cred_ex_record,
+                async_mock.MagicMock(),
+            )
+
+            mock_seroob.return_value = "abc123"
+
+            await test_module.credential_exchange_create_free_offer(mock)
+
+            mock_response.assert_called_once_with(
+                {
+                    "record": mock_cred_ex_record.serialize.return_value,
+                    "oob_url": "abc123",
+                }
+            )
+
+    async def test_credential_exchange_create_free_offer_no_cred_def_id(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock(
+            return_value={
+                "auto_issue": False,
+                "connection_id": "dummy",
+                "credential_preview": {
+                    "attributes": [{"name": "hello", "value": "world"}]
+                },
+            }
+        )
+
+        with self.assertRaises(test_module.web.HTTPBadRequest):
+            await test_module.credential_exchange_create_free_offer(mock)
+
+    async def test_credential_exchange_create_free_offer_no_preview(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+        mock.json.return_value = {"comment": "comment", "cred_def_id": "dummy"}
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
+        }
+        mock.app["request_context"].settings = {}
+
+        with self.assertRaises(test_module.web.HTTPBadRequest):
+            await test_module.credential_exchange_create_free_offer(mock)
+
+    async def test_credential_exchange_create_free_offer_no_conn_id(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock(
+            return_value={
+                "auto_issue": False,
+                "cred_def_id": "cred-def-id",
+                "credential_preview": {
+                    "attributes": [{"name": "hello", "value": "world"}]
+                },
+            }
+        )
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
+        }
+        mock.app["request_context"].settings = {
+            "default_endpoint": "http://1.2.3.4:8081"
+        }
+        mock.app["request_context"].inject = async_mock.CoroutineMock(
+            return_value=async_mock.MagicMock(
+                get_public_did=async_mock.CoroutineMock(
+                    return_value=DIDInfo("did", "verkey", {"meta": "data"})
+                )
+            )
+        )
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_credential_manager, async_mock.patch.object(
+            test_module, "serialize_outofband"
+        ) as mock_seroob, async_mock.patch.object(
+            test_module.web, "json_response"
+        ) as mock_response:
+
+            mock_credential_manager.return_value.create_offer = (
+                async_mock.CoroutineMock()
+            )
+
+            mock_cred_ex_record = async_mock.MagicMock()
+
+            mock_credential_manager.return_value.create_offer.return_value = (
+                mock_cred_ex_record,
+                async_mock.MagicMock(),
+            )
+
+            mock_seroob.return_value = "abc123"
+
+            await test_module.credential_exchange_create_free_offer(mock)
+
+            mock_response.assert_called_once_with(
+                {
+                    "record": mock_cred_ex_record.serialize.return_value,
+                    "oob_url": "abc123",
+                }
+            )
+
+    async def test_credential_exchange_create_free_offer_no_conn_id_no_public_did(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock(
+            return_value={
+                "auto_issue": False,
+                "cred_def_id": "cred-def-id",
+                "credential_preview": {
+                    "attributes": [{"name": "hello", "value": "world"}]
+                },
+            }
+        )
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
+        }
+        mock.app["request_context"].settings = {
+            "default_endpoint": "http://1.2.3.4:8081"
+        }
+        mock.app["request_context"].inject = async_mock.CoroutineMock(
+            return_value=async_mock.MagicMock(
+                get_public_did=async_mock.CoroutineMock(return_value=None)
+            )
+        )
+
+        with self.assertRaises(test_module.web.HTTPBadRequest):
+            await test_module.credential_exchange_create_free_offer(mock)
+
+    async def test_credential_exchange_create_free_offer_no_endpoint(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock(
+            return_value={
+                "auto_issue": False,
+                "cred_def_id": "cred-def-id",
+                "credential_preview": {
+                    "attributes": [{"name": "hello", "value": "world"}]
+                },
+            }
+        )
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
+        }
+        mock.app["request_context"].settings = {}
+        mock.app["request_context"].inject = async_mock.CoroutineMock(
+            return_value=async_mock.MagicMock(
+                get_public_did=async_mock.CoroutineMock(
+                    return_value=DIDInfo("did", "verkey", {"meta": "data"})
+                )
+            )
+        )
+
+        with self.assertRaises(test_module.web.HTTPBadRequest):
+            await test_module.credential_exchange_create_free_offer(mock)
 
     async def test_credential_exchange_send_free_offer(self):
         mock = async_mock.MagicMock()

--- a/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
@@ -804,6 +804,28 @@ class TestCredentialRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.credential_exchange_send_bound_offer(mock)
 
+    async def test_credential_exchange_send_bound_offer_bad_state(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
+        }
+        mock.app["request_context"].settings = {}
+
+        with async_mock.patch.object(
+            test_module, "V10CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_ACKED
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.credential_exchange_send_bound_offer(mock)
+
     async def test_credential_exchange_send_bound_offer_not_ready(self):
         mock = async_mock.MagicMock()
         mock.json = async_mock.CoroutineMock()
@@ -903,6 +925,28 @@ class TestCredentialRoutes(AsyncTestCase):
             mock_cred_ex.retrieve_by_id.side_effect = test_module.StorageNotFoundError()
 
             with self.assertRaises(test_module.web.HTTPNotFound):
+                await test_module.credential_exchange_send_request(mock)
+
+    async def test_credential_exchange_send_request_bad_state(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
+        }
+        mock.app["request_context"].settings = {}
+
+        with async_mock.patch.object(
+            test_module, "V10CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_ACKED
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.credential_exchange_send_request(mock)
 
     async def test_credential_exchange_send_request_no_conn_record(self):
@@ -1072,6 +1116,28 @@ class TestCredentialRoutes(AsyncTestCase):
             mock_cred_ex.retrieve_by_id.side_effect = test_module.StorageNotFoundError()
 
             with self.assertRaises(test_module.web.HTTPNotFound):
+                await test_module.credential_exchange_issue(mock)
+
+    async def test_credential_exchange_issue_bad_state(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
+        }
+        mock.app["request_context"].settings = {}
+
+        with async_mock.patch.object(
+            test_module, "V10CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_ACKED
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.credential_exchange_issue(mock)
 
     async def test_credential_exchange_issue_no_conn_record(self):
@@ -1323,6 +1389,28 @@ class TestCredentialRoutes(AsyncTestCase):
             mock_cred_ex.retrieve_by_id.side_effect = test_module.StorageNotFoundError()
 
             with self.assertRaises(test_module.web.HTTPNotFound):
+                await test_module.credential_exchange_store(mock)
+
+    async def test_credential_exchange_store_bad_state(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
+        }
+        mock.app["request_context"].settings = {}
+
+        with async_mock.patch.object(
+            test_module, "V10CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value.state = mock_cred_ex.STATE_ACKED
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.credential_exchange_store(mock)
 
     async def test_credential_exchange_store_no_conn_record(self):


### PR DESCRIPTION
I hope this doesn't blow anyone's use case up: aries offers always have previews (pure-indy offers don't - they're just a handshake to prove issuer's bona fides).