### PR TITLE
fixing cred_preview issue in issuing credential offer

### DIFF
--- a/aries_cloudagent/config/default_context.py
+++ b/aries_cloudagent/config/default_context.py
@@ -14,7 +14,6 @@ from ..issuer.base import BaseIssuer
 from ..holder.base import BaseHolder
 from ..verifier.base import BaseVerifier
 
-# FIXME: We shouldn't rely on a hardcoded message version here.
 from ..protocols.actionmenu.v1_0.base_service import BaseMenuService
 from ..protocols.actionmenu.v1_0.driver_service import DriverMenuService
 from ..protocols.introduction.v0_1.base_service import BaseIntroductionService

--- a/aries_cloudagent/connections/models/connection_record.py
+++ b/aries_cloudagent/connections/models/connection_record.py
@@ -6,7 +6,6 @@ from ...config.injection_context import InjectionContext
 from ...messaging.models.base_record import BaseRecord, BaseRecordSchema
 from ...messaging.valid import INDY_DID, INDY_RAW_PUBLIC_KEY, UUIDFour
 
-# FIXME: We shouldn't rely on a hardcoded message version here.
 from ...protocols.connections.v1_0.messages.connection_invitation import (
     ConnectionInvitation,
 )

--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -19,8 +19,6 @@ from ..config.ledger import ledger_config
 from ..config.logging import LoggingConfigurator
 from ..config.wallet import wallet_config
 from ..messaging.responder import BaseResponder
-
-# FIXME: We shouldn't rely on a hardcoded message version here.
 from ..protocols.connections.v1_0.manager import (
     ConnectionManager,
     ConnectionManagerError,

--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -21,8 +21,6 @@ from ..messaging.request_context import RequestContext
 from ..messaging.responder import BaseResponder
 from ..messaging.util import datetime_now
 from .error import ProtocolMinorVersionNotSupported
-
-# FIXME: We shouldn't rely on a hardcoded message version here.
 from ..protocols.connections.v1_0.manager import ConnectionManager
 from ..protocols.problem_report.v1_0.message import ProblemReport
 

--- a/aries_cloudagent/core/tests/test_conductor.py
+++ b/aries_cloudagent/core/tests/test_conductor.py
@@ -17,7 +17,6 @@ from ...connections.models.diddoc import (
 )
 from ...core.protocol_registry import ProtocolRegistry
 
-# FIXME: We shouldn't rely on a hardcoded message version here.
 from ...protocols.connections.v1_0.manager import ConnectionManager
 from ...storage.base import BaseStorage
 from ...storage.basic import BasicStorage

--- a/aries_cloudagent/core/tests/test_dispatcher.py
+++ b/aries_cloudagent/core/tests/test_dispatcher.py
@@ -9,7 +9,6 @@ from ...core.protocol_registry import ProtocolRegistry
 from ...messaging.agent_message import AgentMessage, AgentMessageSchema
 from ...messaging.util import datetime_now
 
-# FIXME: We shouldn't rely on a hardcoded message version here.
 from ...protocols.problem_report.v1_0.message import ProblemReport
 
 from ...transport.inbound.message import InboundMessage

--- a/aries_cloudagent/holder/indy.py
+++ b/aries_cloudagent/holder/indy.py
@@ -243,15 +243,17 @@ class IndyHolder(BaseHolder):
             credential_json = await indy.anoncreds.prover_get_credential(
                 self.wallet.handle, credential_id
             )
-        except IndyError as e:
-            if e.error_code == ErrorCode.WalletItemNotFound:
+        except IndyError as err:
+            if err.error_code == ErrorCode.WalletItemNotFound:
                 raise WalletNotFoundError(
-                    "Credential not found in the wallet: {}".format(credential_id)
+                    "Credential {} not found in wallet {}".format(
+                        credential_id, self.wallet.name
+                    )
                 )
             else:
                 raise IndyErrorHandler.wrap_error(
-                    e, "Error when fetching credential", HolderError
-                ) from e
+                    err, f"Error when fetching credential {credential_id}", HolderError
+                ) from err
 
         return credential_json
 
@@ -277,15 +279,17 @@ class IndyHolder(BaseHolder):
             await indy.anoncreds.prover_delete_credential(
                 self.wallet.handle, credential_id
             )
-        except IndyError as e:
-            if e.error_code == ErrorCode.WalletItemNotFound:
+        except IndyError as err:
+            if err.error_code == ErrorCode.WalletItemNotFound:
                 raise WalletNotFoundError(
-                    "Credential not found in the wallet: {}".format(credential_id)
+                    "Credential {} not found in wallet {}".format(
+                        credential_id, self.wallet.name
+                    )
                 )
             else:
                 raise IndyErrorHandler.wrap_error(
-                    e, "Error when deleting credential", HolderError
-                ) from e
+                    err, "Error when deleting credential", HolderError
+                ) from err
 
     async def get_mime_type(
         self, credential_id: str, attr: str = None

--- a/aries_cloudagent/holder/routes.py
+++ b/aries_cloudagent/holder/routes.py
@@ -113,8 +113,8 @@ async def credentials_get(request: web.BaseRequest):
     holder: BaseHolder = await context.inject(BaseHolder)
     try:
         credential = await holder.get_credential(credential_id)
-    except WalletNotFoundError:
-        raise web.HTTPNotFound()
+    except WalletNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
 
     credential_json = json.loads(credential)
     return web.json_response(credential_json)
@@ -140,8 +140,8 @@ async def credentials_remove(request: web.BaseRequest):
     holder: BaseHolder = await context.inject(BaseHolder)
     try:
         await holder.delete_credential(credential_id)
-    except WalletNotFoundError:
-        raise web.HTTPNotFound()
+    except WalletNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
 
     return web.json_response({})
 
@@ -178,8 +178,8 @@ async def credentials_list(request: web.BaseRequest):
     holder: BaseHolder = await context.inject(BaseHolder)
     try:
         credentials = await holder.get_credentials(start, count, wql)
-    except HolderError as x_holder:
-        raise web.HTTPBadRequest(reason=x_holder.message)
+    except HolderError as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     return web.json_response({"results": credentials})
 

--- a/aries_cloudagent/messaging/jsonld/create_verify_data.py
+++ b/aries_cloudagent/messaging/jsonld/create_verify_data.py
@@ -1,5 +1,6 @@
 """
 Contains the functions needed to produce and verify a json-ld signature.
+
 This file was ported from
 https://github.com/transmute-industries/Ed25519Signature2018/blob/master/src/createVerifyData/index.js
 """
@@ -42,7 +43,7 @@ class DroppedAttributeException(Exception):
 
 
 def create_verify_data(data, signature_options):
-    """Encapsulates the process of constructing the string used during sign and verify."""
+    """Encapsulate the process of constructing the string used during sign and verify."""
 
     if "creator" in signature_options:
         signature_options["verificationMethod"] = signature_options["creator"]

--- a/aries_cloudagent/messaging/jsonld/create_verify_data.py
+++ b/aries_cloudagent/messaging/jsonld/create_verify_data.py
@@ -1,5 +1,10 @@
-# ported from
-# https://github.com/transmute-industries/Ed25519Signature2018/blob/master/src/createVerifyData/index.js
+"""
+Contains the functions needed to produce and verify a json-ld signature.
+This file was ported from
+https://github.com/transmute-industries/Ed25519Signature2018/blob/master/src/createVerifyData/index.js
+"""
+
+
 import datetime
 
 from pyld import jsonld
@@ -31,10 +36,14 @@ def _cannonize_document(doc):
 
 
 class DroppedAttributeException(Exception):
+    """Exception used to track that an attribute was removed."""
+
     pass
 
 
 def create_verify_data(data, signature_options):
+    """Encapsulates the process of constructing the string used during sign and verify."""
+
     if "creator" in signature_options:
         signature_options["verificationMethod"] = signature_options["creator"]
 

--- a/aries_cloudagent/messaging/jsonld/create_verify_data.py
+++ b/aries_cloudagent/messaging/jsonld/create_verify_data.py
@@ -1,0 +1,87 @@
+# ported from
+# https://github.com/transmute-industries/Ed25519Signature2018/blob/master/src/createVerifyData/index.js
+import datetime
+
+from pyld import jsonld
+import hashlib
+
+
+def _canonize(data):
+    return jsonld.normalize(data, {
+        'algorithm': 'URDNA2015',
+        'format': 'application/n-quads'
+    })
+
+
+def _sha256(data):
+    return hashlib.sha256(data.encode('ascii')).hexdigest()
+
+
+def _cannonize_signature_options(signatureOptions):
+    _signatureOptions = {
+        **signatureOptions,
+        "@context": "https://w3id.org/security/v2"
+    }
+    _signatureOptions.pop('jws', None)
+    _signatureOptions.pop('signatureValue', None)
+    _signatureOptions.pop('proofValue', None)
+    return _canonize(_signatureOptions)
+
+
+def _cannonize_document(doc):
+    _doc = {**doc}
+    _doc.pop("proof", None)
+    return _canonize(_doc)
+
+
+class DroppedAttributeException(Exception):
+    pass
+
+
+def create_verify_data(data, signature_options):
+    if 'creator' in signature_options:
+        signature_options['verificationMethod'] = signature_options['creator']
+
+    if not signature_options['verificationMethod']:
+        raise Exception("signature_options.verificationMethod is required")
+
+    if 'created' not in signature_options:
+        signature_options['created'] = \
+            datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    if 'type' not in signature_options \
+            or signature_options['type'] != "Ed25519Signature2018":
+        signature_options['type'] = "Ed25519Signature2018"
+
+    [expanded] = jsonld.expand(data)
+    framed = jsonld.compact(
+        expanded,
+        "https://w3id.org/security/v2",
+        {"skipExpansion": True}
+    )
+
+    # Detect any dropped attributes during the expand/contract step.
+
+    if len(data) != len(framed):
+        raise DroppedAttributeException("Extra Attribute Detected")
+    if 'proof' in data \
+            and 'proof' in framed \
+            and len(data['proof']) != len(framed['proof']):
+        raise DroppedAttributeException("Extra Attribute Detected")
+    if 'credentialSubject' in data \
+            and 'https://www.w3.org/2018/credentials#credentialSubject' in framed \
+            and len(data['credentialSubject']) != \
+            len(framed['https://www.w3.org/2018/credentials#credentialSubject']):
+        raise DroppedAttributeException("Extra Attribute Detected")
+
+    cannonized_signature_options = _cannonize_signature_options(
+        signature_options
+    )
+    hash_of_cannonized_signature_options = _sha256(cannonized_signature_options)
+    cannonized_document = _cannonize_document(framed)
+    hash_of_cannonized_document = _sha256(cannonized_document)
+
+    return (
+        framed,
+        hash_of_cannonized_signature_options + hash_of_cannonized_document
+    )

--- a/aries_cloudagent/messaging/jsonld/credential.py
+++ b/aries_cloudagent/messaging/jsonld/credential.py
@@ -29,12 +29,12 @@ def did_key(verkey: str) -> str:
 
 
 def b64encode(str):
-    """URLSafe B64 Encode."""
+    """Url Safe B64 Encode."""
     return str_to_b64(str, urlsafe=True, pad=False)
 
 
 def b64decode(bytes):
-    """URLSafe B64 Decode."""
+    """Url Safe B64 Decode."""
     return b64_to_str(bytes, urlsafe=True)
 
 

--- a/aries_cloudagent/messaging/jsonld/credential.py
+++ b/aries_cloudagent/messaging/jsonld/credential.py
@@ -1,3 +1,7 @@
+"""
+sign and verify functions for json-ld based credentials
+"""
+
 import json
 from aries_cloudagent.wallet.util import (
     b58_to_bytes,
@@ -27,18 +31,23 @@ def did_key(verkey: str) -> str:
 
 
 def b64encode(str):
+    """ URLSafe B64 Encode. """
     return str_to_b64(str, urlsafe=True, pad=False)
 
 
 def b64decode(bytes):
+    """ URLSafe B64 Decode. """
     return b64_to_str(bytes, urlsafe=True)
 
 
 def create_jws(encoded_header, verify_data):
+    """ Compose JWS. """
     return (encoded_header + ".").encode("utf-8") + verify_data
 
 
 async def jws_sign(verify_data, verkey, wallet):
+    """ Sign JWS. """
+
     header = {"alg": "EdDSA", "b64": False, "crit": ["b64"]}
 
     encoded_header = b64encode(json.dumps(header))
@@ -53,6 +62,8 @@ async def jws_sign(verify_data, verkey, wallet):
 
 
 def verify_jws_header(header):
+    """ Check header requirements. """
+
     if (
         not (
             header["alg"] == "EdDSA"
@@ -67,6 +78,8 @@ def verify_jws_header(header):
 
 
 async def jws_verify(verify_data, signature, public_key, wallet):
+    """ Detatched jws verify handling."""
+
     encoded_header, _, encoded_signature = signature.partition("..")
     decoded_header = json.loads(b64decode(encoded_header))
 
@@ -82,6 +95,8 @@ async def jws_verify(verify_data, signature, public_key, wallet):
 
 
 async def sign_credential(credential, signature_options, verkey, wallet):
+    """ Sign Credential. """
+
     framed, verify_data_hex_string = create_verify_data(credential, signature_options)
     verify_data_bytes = bytes.fromhex(verify_data_hex_string)
     jws = await jws_sign(verify_data_bytes, verkey, wallet)
@@ -90,6 +105,8 @@ async def sign_credential(credential, signature_options, verkey, wallet):
 
 
 async def verify_credential(doc, verkey, wallet):
+    """ Verify credential. """
+
     framed, verify_data_hex_string = create_verify_data(doc, doc["proof"])
     verify_data_bytes = bytes.fromhex(verify_data_hex_string)
     valid = await jws_verify(verify_data_bytes, framed["proof"]["jws"], verkey, wallet)

--- a/aries_cloudagent/messaging/jsonld/credential.py
+++ b/aries_cloudagent/messaging/jsonld/credential.py
@@ -1,7 +1,7 @@
 """Sign and verify functions for json-ld based credentials."""
 
 import json
-from aries_cloudagent.wallet.util import (
+from ...wallet.util import (
     b58_to_bytes,
     b64_to_bytes,
     b64_to_str,

--- a/aries_cloudagent/messaging/jsonld/credential.py
+++ b/aries_cloudagent/messaging/jsonld/credential.py
@@ -1,0 +1,102 @@
+import json
+from aries_cloudagent.wallet.util import (
+    b58_to_bytes,
+    b64_to_bytes,
+    b64_to_str,
+    bytes_to_b58,
+    bytes_to_b64,
+    str_to_b64,
+)
+
+from .create_verify_data import create_verify_data
+
+
+MULTIBASE_B58_BTC = "z"
+MULTICODEC_ED25519_PUB = b"\xed"
+
+
+def did_key(verkey: str) -> str:
+    """Qualify verkey into DID key if need be."""
+
+    if verkey.startswith(f"did:key:{MULTIBASE_B58_BTC}"):
+        return verkey
+
+    return f"did:key:{MULTIBASE_B58_BTC}" + bytes_to_b58(
+        MULTICODEC_ED25519_PUB + b58_to_bytes(verkey)
+    )
+
+
+def b64encode(str):
+    return str_to_b64(str, urlsafe=True, pad=False)
+
+
+def b64decode(bytes):
+    return b64_to_str(bytes, urlsafe=True)
+
+
+def create_jws(encoded_header, verify_data):
+    return (encoded_header + ".").encode('utf-8') + verify_data
+
+
+async def jws_sign(verify_data, verkey, wallet):
+    header = {
+        "alg": "EdDSA",
+        "b64": False,
+        "crit": ["b64"]
+    }
+
+    encoded_header = b64encode(json.dumps(header))
+
+    jws_to_sign = create_jws(encoded_header, verify_data)
+
+    signature = await wallet.sign_message(jws_to_sign, verkey)
+
+    encoded_signature = bytes_to_b64(signature, urlsafe=True, pad=False)
+
+    return encoded_header + ".." + encoded_signature
+
+
+def verify_jws_header(header):
+    if not(header['alg'] == "EdDSA" and
+           header['b64'] is False and
+           isinstance(header['crit'], list) and
+           len(header['crit']) == 1 and
+           header['crit'][0] == "b64"
+           ) and len(header) == 3:
+        raise Exception("Invalid JWS header parameters for Ed25519Signature2018.")
+
+
+async def jws_verify(verify_data, signature, public_key, wallet):
+    encoded_header, _,  encoded_signature = signature.partition("..")
+    decoded_header = json.loads(b64decode(encoded_header))
+
+    verify_jws_header(decoded_header)
+
+    decoded_signature = b64_to_bytes(encoded_signature, urlsafe=True)
+
+    jws_to_verify = create_jws(encoded_header, verify_data)
+
+    verified = await wallet.verify_message(jws_to_verify, decoded_signature, public_key)
+
+    return verified
+
+
+async def sign_credential(credential, signature_options, verkey, wallet):
+    framed, verify_data_hex_string = create_verify_data(credential, signature_options)
+    verify_data_bytes = bytes.fromhex(verify_data_hex_string)
+    jws = await jws_sign(verify_data_bytes, verkey, wallet)
+    document_with_proof = {
+        **credential,
+        "proof": {
+            **signature_options,
+            "jws": jws
+        }
+    }
+    return document_with_proof
+
+
+async def verify_credential(doc, verkey, wallet):
+    framed, verify_data_hex_string = create_verify_data(doc, doc['proof'])
+    verify_data_bytes = bytes.fromhex(verify_data_hex_string)
+    valid = await jws_verify(verify_data_bytes, framed['proof']['jws'], verkey, wallet)
+    return valid

--- a/aries_cloudagent/messaging/jsonld/credential.py
+++ b/aries_cloudagent/messaging/jsonld/credential.py
@@ -1,6 +1,4 @@
-"""
-sign and verify functions for json-ld based credentials
-"""
+"""Sign and verify functions for json-ld based credentials."""
 
 import json
 from aries_cloudagent.wallet.util import (
@@ -31,22 +29,22 @@ def did_key(verkey: str) -> str:
 
 
 def b64encode(str):
-    """ URLSafe B64 Encode. """
+    """URLSafe B64 Encode."""
     return str_to_b64(str, urlsafe=True, pad=False)
 
 
 def b64decode(bytes):
-    """ URLSafe B64 Decode. """
+    """URLSafe B64 Decode."""
     return b64_to_str(bytes, urlsafe=True)
 
 
 def create_jws(encoded_header, verify_data):
-    """ Compose JWS. """
+    """Compose JWS."""
     return (encoded_header + ".").encode("utf-8") + verify_data
 
 
 async def jws_sign(verify_data, verkey, wallet):
-    """ Sign JWS. """
+    """Sign JWS."""
 
     header = {"alg": "EdDSA", "b64": False, "crit": ["b64"]}
 
@@ -62,7 +60,7 @@ async def jws_sign(verify_data, verkey, wallet):
 
 
 def verify_jws_header(header):
-    """ Check header requirements. """
+    """Check header requirements."""
 
     if (
         not (
@@ -78,7 +76,7 @@ def verify_jws_header(header):
 
 
 async def jws_verify(verify_data, signature, public_key, wallet):
-    """ Detatched jws verify handling."""
+    """Detatched jws verify handling."""
 
     encoded_header, _, encoded_signature = signature.partition("..")
     decoded_header = json.loads(b64decode(encoded_header))
@@ -95,7 +93,7 @@ async def jws_verify(verify_data, signature, public_key, wallet):
 
 
 async def sign_credential(credential, signature_options, verkey, wallet):
-    """ Sign Credential. """
+    """Sign Credential."""
 
     framed, verify_data_hex_string = create_verify_data(credential, signature_options)
     verify_data_bytes = bytes.fromhex(verify_data_hex_string)
@@ -105,7 +103,7 @@ async def sign_credential(credential, signature_options, verkey, wallet):
 
 
 async def verify_credential(doc, verkey, wallet):
-    """ Verify credential. """
+    """Verify credential."""
 
     framed, verify_data_hex_string = create_verify_data(doc, doc["proof"])
     verify_data_bytes = bytes.fromhex(verify_data_hex_string)

--- a/aries_cloudagent/messaging/jsonld/credential.py
+++ b/aries_cloudagent/messaging/jsonld/credential.py
@@ -35,15 +35,11 @@ def b64decode(bytes):
 
 
 def create_jws(encoded_header, verify_data):
-    return (encoded_header + ".").encode('utf-8') + verify_data
+    return (encoded_header + ".").encode("utf-8") + verify_data
 
 
 async def jws_sign(verify_data, verkey, wallet):
-    header = {
-        "alg": "EdDSA",
-        "b64": False,
-        "crit": ["b64"]
-    }
+    header = {"alg": "EdDSA", "b64": False, "crit": ["b64"]}
 
     encoded_header = b64encode(json.dumps(header))
 
@@ -57,17 +53,21 @@ async def jws_sign(verify_data, verkey, wallet):
 
 
 def verify_jws_header(header):
-    if not(header['alg'] == "EdDSA" and
-           header['b64'] is False and
-           isinstance(header['crit'], list) and
-           len(header['crit']) == 1 and
-           header['crit'][0] == "b64"
-           ) and len(header) == 3:
+    if (
+        not (
+            header["alg"] == "EdDSA"
+            and header["b64"] is False
+            and isinstance(header["crit"], list)
+            and len(header["crit"]) == 1
+            and header["crit"][0] == "b64"
+        )
+        and len(header) == 3
+    ):
         raise Exception("Invalid JWS header parameters for Ed25519Signature2018.")
 
 
 async def jws_verify(verify_data, signature, public_key, wallet):
-    encoded_header, _,  encoded_signature = signature.partition("..")
+    encoded_header, _, encoded_signature = signature.partition("..")
     decoded_header = json.loads(b64decode(encoded_header))
 
     verify_jws_header(decoded_header)
@@ -85,18 +85,12 @@ async def sign_credential(credential, signature_options, verkey, wallet):
     framed, verify_data_hex_string = create_verify_data(credential, signature_options)
     verify_data_bytes = bytes.fromhex(verify_data_hex_string)
     jws = await jws_sign(verify_data_bytes, verkey, wallet)
-    document_with_proof = {
-        **credential,
-        "proof": {
-            **signature_options,
-            "jws": jws
-        }
-    }
+    document_with_proof = {**credential, "proof": {**signature_options, "jws": jws}}
     return document_with_proof
 
 
 async def verify_credential(doc, verkey, wallet):
-    framed, verify_data_hex_string = create_verify_data(doc, doc['proof'])
+    framed, verify_data_hex_string = create_verify_data(doc, doc["proof"])
     verify_data_bytes = bytes.fromhex(verify_data_hex_string)
-    valid = await jws_verify(verify_data_bytes, framed['proof']['jws'], verkey, wallet)
+    valid = await jws_verify(verify_data_bytes, framed["proof"]["jws"], verkey, wallet)
     return valid

--- a/aries_cloudagent/messaging/jsonld/routes.py
+++ b/aries_cloudagent/messaging/jsonld/routes.py
@@ -1,0 +1,108 @@
+"""jsonld admin routes."""
+
+from aiohttp import web
+from aiohttp_apispec import docs, request_schema, response_schema
+
+from aries_cloudagent.messaging.jsonld.credential \
+    import sign_credential, verify_credential
+from aries_cloudagent.wallet.base import BaseWallet
+
+from marshmallow import fields, Schema
+
+
+class SignRequestSchema(Schema):
+    """Request schema for signing a jsonld doc."""
+    verkey = fields.Str(required=True, description="verkey to use for signing")
+    doc = fields.Dict(required=True, description="JSON-LD Doc to sign")
+
+
+class SignResponseSchema(Schema):
+    """Response schema for a signed jsonld doc."""
+    signed_doc = fields.Dict(required=True)
+
+
+@docs(tags=["jsonld"], summary="Sign a JSON-LD structure and return it")
+@request_schema(SignRequestSchema())
+@response_schema(SignResponseSchema(), 200)
+async def sign(request: web.BaseRequest):
+    """
+    Request handler for signing a jsonld doc.
+
+    Args:
+        request: aiohttp request object
+
+    """
+    response = {
+
+    }
+    try:
+        context = request.app["request_context"]
+        wallet: BaseWallet = await context.inject(BaseWallet)
+        if not wallet:
+            raise web.HTTPForbidden()
+
+        body = await request.json()
+        verkey = body.get("verkey")
+        doc = body.get("doc")
+        credential = doc['credential']
+        signature_options = doc['options']
+
+        document_with_proof = \
+            await sign_credential(credential, signature_options, verkey, wallet)
+
+        response['signed_doc'] = document_with_proof
+    except Exception as e:
+        response['error'] = str(e)
+
+    return web.json_response(response)
+
+
+class VerifyRequestSchema(Schema):
+    """Request schema for signing a jsonld doc."""
+    verkey = fields.Str(required=True, description="verkey to use for doc verification")
+    doc = fields.Dict(required=True, description="JSON-LD Doc to verify")
+
+
+class VerifyResponseSchema(Schema):
+    """Response schema for verification result."""
+    valid = fields.Bool(required=True)
+
+
+@docs(tags=["jsonld"], summary="Verify a JSON-LD structure.")
+@request_schema(VerifyRequestSchema())
+@response_schema(VerifyResponseSchema(), 200)
+async def verify(request: web.BaseRequest):
+    """
+    Request handler for signing a jsonld doc.
+
+    Args:
+        request: aiohttp request object
+
+    """
+    response = {
+        "valid": False
+    }
+    try:
+        context = request.app["request_context"]
+        wallet: BaseWallet = await context.inject(BaseWallet)
+        if not wallet:
+            raise web.HTTPForbidden()
+
+        body = await request.json()
+        verkey = body.get("verkey")
+        doc = body.get("doc")
+
+        valid = await verify_credential(doc, verkey, wallet)
+
+        response["valid"] = valid
+    except Exception as e:
+        response["error"] = str(e)
+
+    return web.json_response(response)
+
+
+async def register(app: web.Application):
+    """Register routes."""
+
+    app.add_routes([web.post("/jsonld/sign", sign)])
+    app.add_routes([web.post("/jsonld/verify", verify)])

--- a/aries_cloudagent/messaging/jsonld/routes.py
+++ b/aries_cloudagent/messaging/jsonld/routes.py
@@ -40,6 +40,7 @@ async def sign(request: web.BaseRequest):
     try:
         context = request.app["request_context"]
         wallet: BaseWallet = await context.inject(BaseWallet)
+        wallet: BaseWallet = await context.inject(BaseWallet)
         if not wallet:
             raise web.HTTPForbidden()
 

--- a/aries_cloudagent/messaging/jsonld/routes.py
+++ b/aries_cloudagent/messaging/jsonld/routes.py
@@ -40,7 +40,6 @@ async def sign(request: web.BaseRequest):
     try:
         context = request.app["request_context"]
         wallet: BaseWallet = await context.inject(BaseWallet)
-        wallet: BaseWallet = await context.inject(BaseWallet)
         if not wallet:
             raise web.HTTPForbidden()
 

--- a/aries_cloudagent/messaging/jsonld/routes.py
+++ b/aries_cloudagent/messaging/jsonld/routes.py
@@ -3,8 +3,10 @@
 from aiohttp import web
 from aiohttp_apispec import docs, request_schema, response_schema
 
-from aries_cloudagent.messaging.jsonld.credential \
-    import sign_credential, verify_credential
+from aries_cloudagent.messaging.jsonld.credential import (
+    sign_credential,
+    verify_credential,
+)
 from aries_cloudagent.wallet.base import BaseWallet
 
 from marshmallow import fields, Schema
@@ -12,12 +14,14 @@ from marshmallow import fields, Schema
 
 class SignRequestSchema(Schema):
     """Request schema for signing a jsonld doc."""
+
     verkey = fields.Str(required=True, description="verkey to use for signing")
     doc = fields.Dict(required=True, description="JSON-LD Doc to sign")
 
 
 class SignResponseSchema(Schema):
     """Response schema for a signed jsonld doc."""
+
     signed_doc = fields.Dict(required=True)
 
 
@@ -32,9 +36,7 @@ async def sign(request: web.BaseRequest):
         request: aiohttp request object
 
     """
-    response = {
-
-    }
+    response = {}
     try:
         context = request.app["request_context"]
         wallet: BaseWallet = await context.inject(BaseWallet)
@@ -44,27 +46,30 @@ async def sign(request: web.BaseRequest):
         body = await request.json()
         verkey = body.get("verkey")
         doc = body.get("doc")
-        credential = doc['credential']
-        signature_options = doc['options']
+        credential = doc["credential"]
+        signature_options = doc["options"]
 
-        document_with_proof = \
-            await sign_credential(credential, signature_options, verkey, wallet)
+        document_with_proof = await sign_credential(
+            credential, signature_options, verkey, wallet
+        )
 
-        response['signed_doc'] = document_with_proof
+        response["signed_doc"] = document_with_proof
     except Exception as e:
-        response['error'] = str(e)
+        response["error"] = str(e)
 
     return web.json_response(response)
 
 
 class VerifyRequestSchema(Schema):
     """Request schema for signing a jsonld doc."""
+
     verkey = fields.Str(required=True, description="verkey to use for doc verification")
     doc = fields.Dict(required=True, description="JSON-LD Doc to verify")
 
 
 class VerifyResponseSchema(Schema):
     """Response schema for verification result."""
+
     valid = fields.Bool(required=True)
 
 
@@ -79,9 +84,7 @@ async def verify(request: web.BaseRequest):
         request: aiohttp request object
 
     """
-    response = {
-        "valid": False
-    }
+    response = {"valid": False}
     try:
         context = request.app["request_context"]
         wallet: BaseWallet = await context.inject(BaseWallet)

--- a/aries_cloudagent/messaging/jsonld/routes.py
+++ b/aries_cloudagent/messaging/jsonld/routes.py
@@ -3,11 +3,11 @@
 from aiohttp import web
 from aiohttp_apispec import docs, request_schema, response_schema
 
-from aries_cloudagent.messaging.jsonld.credential import (
+from ...messaging.jsonld.credential import (
     sign_credential,
     verify_credential,
 )
-from aries_cloudagent.wallet.base import BaseWallet
+from ...wallet.base import BaseWallet
 
 from marshmallow import fields, Schema
 

--- a/aries_cloudagent/messaging/jsonld/tests/test_routes.py
+++ b/aries_cloudagent/messaging/jsonld/tests/test_routes.py
@@ -31,45 +31,41 @@ class TestJSONLDRoutes(AsyncTestCase):
                 return_value={  # posted json
                     "verkey": "5yKdnU7ToTjAoRNDzfuzVTfWBH38qyhE1b9xh4v8JaWF",  # pulled from the did:key in example
                     "doc": {
-                      "@context": [
-                        "https://www.w3.org/2018/credentials/v1",
-                        "https://www.w3.org/2018/credentials/examples/v1"
-                      ],
-                      "id": "http://example.gov/credentials/3732",
-                      "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-                      "issuer": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
-                      "issuanceDate": "2020-03-10T04:24:12.164Z",
-                      "credentialSubject": {
-                        "id": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
-                        "degree": {
-                          "type": "BachelorDegree",
-                          "name": "Bachelor of Science and Arts"
-                        }
-                      },
-                      "proof": {
-                        "type": "Ed25519Signature2018",
-                        "created": "2020-04-10T21:35:35Z",
-                        "verificationMethod": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd#z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
-                        "proofPurpose": "assertionMethod",
-                        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..l9d0YHjcFAH2H4dB9xlWFZQLUpixVCWJk0eOt4CXQe1NXKWZwmhmn9OQp6YxX0a2LffegtYESTCJEoGVXLqWAA"
-                      }
-                    }
+                        "@context": [
+                            "https://www.w3.org/2018/credentials/v1",
+                            "https://www.w3.org/2018/credentials/examples/v1",
+                        ],
+                        "id": "http://example.gov/credentials/3732",
+                        "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+                        "issuer": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
+                        "issuanceDate": "2020-03-10T04:24:12.164Z",
+                        "credentialSubject": {
+                            "id": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
+                            "degree": {
+                                "type": "BachelorDegree",
+                                "name": "Bachelor of Science and Arts",
+                            },
+                        },
+                        "proof": {
+                            "type": "Ed25519Signature2018",
+                            "created": "2020-04-10T21:35:35Z",
+                            "verificationMethod": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd#z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
+                            "proofPurpose": "assertionMethod",
+                            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..l9d0YHjcFAH2H4dB9xlWFZQLUpixVCWJk0eOt4CXQe1NXKWZwmhmn9OQp6YxX0a2LffegtYESTCJEoGVXLqWAA",
+                        },
+                    },
                 }
             ),
         )
 
         with async_mock.patch.object(test_module.web, "json_response") as mock_response:
-            result = await test_module.verify(
-                mock_request
-            )
+            result = await test_module.verify(mock_request)
             assert result == mock_response.return_value
-            mock_response.assert_called_once_with( #expected response
-                {"valid": True}
-            )
+            mock_response.assert_called_once_with({"valid": True})  # expected response
 
     async def test_sign_credential(self):
 
-        wallet: BaseWallet = await self.app['request_context'].inject(BaseWallet)
+        wallet: BaseWallet = await self.app["request_context"].inject(BaseWallet)
 
         did_info = await wallet.create_local_did()
 
@@ -80,38 +76,39 @@ class TestJSONLDRoutes(AsyncTestCase):
                     "verkey": did_info.verkey,
                     "doc": {
                         "credential": {
-                          "@context": [
-                            "https://www.w3.org/2018/credentials/v1",
-                            "https://www.w3.org/2018/credentials/examples/v1"
-                          ],
-                          "id": "http://example.gov/credentials/3732",
-                          "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-                          "issuer": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
-                          "issuanceDate": "2020-03-10T04:24:12.164Z",
-                          "credentialSubject": {
-                            "id": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
-                            "degree": {
-                              "type": "BachelorDegree",
-                              "name": "Bachelor of Science and Arts"
-                            }
-                          }
+                            "@context": [
+                                "https://www.w3.org/2018/credentials/v1",
+                                "https://www.w3.org/2018/credentials/examples/v1",
+                            ],
+                            "id": "http://example.gov/credentials/3732",
+                            "type": [
+                                "VerifiableCredential",
+                                "UniversityDegreeCredential",
+                            ],
+                            "issuer": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
+                            "issuanceDate": "2020-03-10T04:24:12.164Z",
+                            "credentialSubject": {
+                                "id": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
+                                "degree": {
+                                    "type": "BachelorDegree",
+                                    "name": "Bachelor of Science and Arts",
+                                },
+                            },
                         },
-                      "options": {
-                        "type": "Ed25519Signature2018",
-                        "created": "2020-04-10T21:35:35Z",
-                        "verificationMethod": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd#z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
-                        "proofPurpose": "assertionMethod",
-                      }
-                    }
+                        "options": {
+                            "type": "Ed25519Signature2018",
+                            "created": "2020-04-10T21:35:35Z",
+                            "verificationMethod": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd#z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
+                            "proofPurpose": "assertionMethod",
+                        },
+                    },
                 }
             ),
         )
 
         with async_mock.patch.object(test_module.web, "json_response") as mock_response:
-            result = await test_module.sign(
-                mock_request
-            )
+            result = await test_module.sign(mock_request)
             assert result == mock_response.return_value
             mock_response.assert_called_once()
-            assert 'signed_doc' in mock_response.call_args[0][0]
-            assert 'error' not in mock_response.call_args[0][0]
+            assert "signed_doc" in mock_response.call_args[0][0]
+            assert "error" not in mock_response.call_args[0][0]

--- a/aries_cloudagent/messaging/jsonld/tests/test_routes.py
+++ b/aries_cloudagent/messaging/jsonld/tests/test_routes.py
@@ -1,0 +1,117 @@
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
+
+from aries_cloudagent.config.injection_context import InjectionContext
+from aries_cloudagent.wallet.base import BaseWallet
+from aries_cloudagent.wallet.basic import BasicWallet
+from ....storage.base import BaseStorage
+from .. import routes as test_module
+
+
+# TODO: Add tests
+class TestJSONLDRoutes(AsyncTestCase):
+    def setUp(self):
+        self.context = InjectionContext(enforce_typing=False)
+
+        self.storage = async_mock.create_autospec(BaseStorage)
+
+        self.context.injector.bind_instance(BaseStorage, self.storage)
+
+        self.wallet = self.wallet = BasicWallet()
+        self.context.injector.bind_instance(BaseWallet, self.wallet)
+
+        self.app = {
+            "request_context": self.context,
+        }
+
+    async def test_verify_credential(self):
+        mock_request = async_mock.MagicMock(
+            app=self.app,
+            json=async_mock.CoroutineMock(
+                return_value={  # posted json
+                    "verkey": "5yKdnU7ToTjAoRNDzfuzVTfWBH38qyhE1b9xh4v8JaWF",  # pulled from the did:key in example
+                    "doc": {
+                      "@context": [
+                        "https://www.w3.org/2018/credentials/v1",
+                        "https://www.w3.org/2018/credentials/examples/v1"
+                      ],
+                      "id": "http://example.gov/credentials/3732",
+                      "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+                      "issuer": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
+                      "issuanceDate": "2020-03-10T04:24:12.164Z",
+                      "credentialSubject": {
+                        "id": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
+                        "degree": {
+                          "type": "BachelorDegree",
+                          "name": "Bachelor of Science and Arts"
+                        }
+                      },
+                      "proof": {
+                        "type": "Ed25519Signature2018",
+                        "created": "2020-04-10T21:35:35Z",
+                        "verificationMethod": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd#z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
+                        "proofPurpose": "assertionMethod",
+                        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..l9d0YHjcFAH2H4dB9xlWFZQLUpixVCWJk0eOt4CXQe1NXKWZwmhmn9OQp6YxX0a2LffegtYESTCJEoGVXLqWAA"
+                      }
+                    }
+                }
+            ),
+        )
+
+        with async_mock.patch.object(test_module.web, "json_response") as mock_response:
+            result = await test_module.verify(
+                mock_request
+            )
+            assert result == mock_response.return_value
+            mock_response.assert_called_once_with( #expected response
+                {"valid": True}
+            )
+
+    async def test_sign_credential(self):
+
+        wallet: BaseWallet = await self.app['request_context'].inject(BaseWallet)
+
+        did_info = await wallet.create_local_did()
+
+        mock_request = async_mock.MagicMock(
+            app=self.app,
+            json=async_mock.CoroutineMock(
+                return_value={  # posted json
+                    "verkey": did_info.verkey,
+                    "doc": {
+                        "credential": {
+                          "@context": [
+                            "https://www.w3.org/2018/credentials/v1",
+                            "https://www.w3.org/2018/credentials/examples/v1"
+                          ],
+                          "id": "http://example.gov/credentials/3732",
+                          "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+                          "issuer": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
+                          "issuanceDate": "2020-03-10T04:24:12.164Z",
+                          "credentialSubject": {
+                            "id": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
+                            "degree": {
+                              "type": "BachelorDegree",
+                              "name": "Bachelor of Science and Arts"
+                            }
+                          }
+                        },
+                      "options": {
+                        "type": "Ed25519Signature2018",
+                        "created": "2020-04-10T21:35:35Z",
+                        "verificationMethod": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd#z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
+                        "proofPurpose": "assertionMethod",
+                      }
+                    }
+                }
+            ),
+        )
+
+        with async_mock.patch.object(test_module.web, "json_response") as mock_response:
+            result = await test_module.sign(
+                mock_request
+            )
+            assert result == mock_response.return_value
+            mock_response.assert_called_once()
+            assert 'signed_doc' in mock_response.call_args[0][0]
+            assert 'error' not in mock_response.call_args[0][0]

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -62,7 +62,7 @@ class BaseRecord(BaseModel):
         """Initialize a new BaseRecord."""
         if not self.RECORD_TYPE:
             raise TypeError(
-                "Can't instantiate abstract class {} with no RECORD_TYPE".format(
+                "Cannot instantiate abstract class {} with no RECORD_TYPE".format(
                     self.__class__.__name__
                 )
             )
@@ -241,10 +241,20 @@ class BaseRecord(BaseModel):
             vals = json.loads(record.value)
             if match_post_filter(vals, post_filter):
                 if found:
-                    raise StorageDuplicateError("Multiple records located")
+                    raise StorageDuplicateError(
+                        "Multiple {} records located for {}{}".format(
+                            cls.__name__,
+                            tag_filter,
+                            f", {post_filter}" if post_filter else "",
+                        )
+                    )
                 found = cls.from_storage(record.id, vals)
         if not found:
-            raise StorageNotFoundError("Record not found")
+            raise StorageNotFoundError(
+                "{} record not found for {}{}".format(
+                    cls.__name__, tag_filter, f", {post_filter}" if post_filter else ""
+                )
+            )
         return found
 
     @classmethod

--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -119,7 +119,7 @@ async def schemas_send_schema(request: web.BaseRequest):
                 )
             )
         except (IssuerError, LedgerError) as err:
-            raise web.HTTPBadRequest(reason=err.roll_up)
+            raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     return web.json_response({"schema_id": schema_id, "schema": schema_def})
 
@@ -182,7 +182,7 @@ async def schemas_get_schema(request: web.BaseRequest):
         try:
             schema = await ledger.get_schema(schema_id)
         except LedgerError as err:
-            raise web.HTTPBadRequest(reason=err.roll_up)
+            raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     return web.json_response({"schema": schema})
 

--- a/aries_cloudagent/protocols/actionmenu/v1_0/base_service.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/base_service.py
@@ -2,9 +2,9 @@
 
 from abc import ABC, abstractmethod
 
-from aries_cloudagent.config.injection_context import InjectionContext
-from aries_cloudagent.connections.models.connection_record import ConnectionRecord
-from aries_cloudagent.messaging.agent_message import AgentMessage
+from ....config.injection_context import InjectionContext
+from ....connections.models.connection_record import ConnectionRecord
+from ....messaging.agent_message import AgentMessage
 
 from .messages.menu import Menu
 

--- a/aries_cloudagent/protocols/actionmenu/v1_0/controller.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/controller.py
@@ -2,7 +2,7 @@
 
 from typing import Sequence
 
-from aries_cloudagent.config.injection_context import InjectionContext
+from ....config.injection_context import InjectionContext
 
 from .base_service import BaseMenuService
 

--- a/aries_cloudagent/protocols/actionmenu/v1_0/driver_service.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/driver_service.py
@@ -2,9 +2,9 @@
 
 import logging
 
-from aries_cloudagent.connections.models.connection_record import ConnectionRecord
-from aries_cloudagent.messaging.agent_message import AgentMessage
-from aries_cloudagent.messaging.responder import BaseResponder
+from ....connections.models.connection_record import ConnectionRecord
+from ....messaging.agent_message import AgentMessage
+from ....messaging.responder import BaseResponder
 
 from .base_service import BaseMenuService
 from .messages.menu import Menu

--- a/aries_cloudagent/protocols/actionmenu/v1_0/handlers/menu_handler.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/handlers/menu_handler.py
@@ -1,6 +1,6 @@
 """Action menu message handler."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     RequestContext,

--- a/aries_cloudagent/protocols/actionmenu/v1_0/handlers/menu_request_handler.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/handlers/menu_request_handler.py
@@ -1,6 +1,6 @@
 """Action menu request message handler."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     RequestContext,

--- a/aries_cloudagent/protocols/actionmenu/v1_0/handlers/perform_handler.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/handlers/perform_handler.py
@@ -1,6 +1,6 @@
 """Action menu perform request message handler."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     RequestContext,

--- a/aries_cloudagent/protocols/actionmenu/v1_0/messages/menu.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/messages/menu.py
@@ -4,7 +4,7 @@ from typing import Sequence
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import MENU, PROTOCOL_PACKAGE
 from ..models.menu_option import MenuOption, MenuOptionSchema

--- a/aries_cloudagent/protocols/actionmenu/v1_0/messages/menu_request.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/messages/menu_request.py
@@ -1,6 +1,6 @@
 """Represents a request for an action menu."""
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import MENU_REQUEST, PROTOCOL_PACKAGE
 

--- a/aries_cloudagent/protocols/actionmenu/v1_0/messages/perform.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/messages/perform.py
@@ -4,7 +4,7 @@ from typing import Mapping
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import PERFORM, PROTOCOL_PACKAGE
 

--- a/aries_cloudagent/protocols/actionmenu/v1_0/models/menu_form.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/models/menu_form.py
@@ -4,7 +4,7 @@ from typing import Sequence
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.models.base import BaseModel, BaseModelSchema
+from .....messaging.models.base import BaseModel, BaseModelSchema
 
 from .menu_form_param import MenuFormParam, MenuFormParamSchema
 

--- a/aries_cloudagent/protocols/actionmenu/v1_0/models/menu_form_param.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/models/menu_form_param.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.models.base import BaseModel, BaseModelSchema
+from .....messaging.models.base import BaseModel, BaseModelSchema
 
 
 class MenuFormParam(BaseModel):

--- a/aries_cloudagent/protocols/actionmenu/v1_0/models/menu_option.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/models/menu_option.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.models.base import BaseModel, BaseModelSchema
+from .....messaging.models.base import BaseModel, BaseModelSchema
 
 from .menu_form import MenuForm, MenuFormSchema
 

--- a/aries_cloudagent/protocols/actionmenu/v1_0/routes.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/routes.py
@@ -10,7 +10,7 @@ from marshmallow import fields, Schema
 from aries_cloudagent.connections.models.connection_record import ConnectionRecord
 from aries_cloudagent.messaging.models.base import BaseModelError
 from aries_cloudagent.messaging.valid import UUIDFour
-from aries_cloudagent.storage.error import StorageNotFoundError
+from aries_cloudagent.storage.error import StorageError, StorageNotFoundError
 
 from .messages.menu import Menu
 from .messages.menu_request import MenuRequest
@@ -88,10 +88,19 @@ async def actionmenu_close(request: web.BaseRequest):
     menu = await retrieve_connection_menu(connection_id, context)
     if not menu:
         raise web.HTTPNotFound(
+<<<<<<< HEAD
             reason=f"No {MENU_RECORD_TYPE} record found for connection {connection_id}"
         )
+=======
+            reason=f"No connection menu for connection {connection_id}"
+        )
 
-    await save_connection_menu(None, connection_id, context)
+    try:
+        await save_connection_menu(None, connection_id, context)
+    except StorageError as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
+>>>>>>> work in progress
+
     return web.json_response({})
 
 
@@ -190,7 +199,7 @@ async def actionmenu_send(request: web.BaseRequest):
         msg = Menu.deserialize(menu_json["menu"])
     except BaseModelError as err:
         LOGGER.exception("Exception deserializing menu: %s", err.roll_up)
-        raise
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     try:
         connection = await ConnectionRecord.retrieve_by_id(context, connection_id)

--- a/aries_cloudagent/protocols/actionmenu/v1_0/routes.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/routes.py
@@ -7,10 +7,10 @@ from aiohttp_apispec import docs, match_info_schema, request_schema
 
 from marshmallow import fields, Schema
 
-from aries_cloudagent.connections.models.connection_record import ConnectionRecord
-from aries_cloudagent.messaging.models.base import BaseModelError
-from aries_cloudagent.messaging.valid import UUIDFour
-from aries_cloudagent.storage.error import StorageError, StorageNotFoundError
+from ....connections.models.connection_record import ConnectionRecord
+from ....messaging.models.base import BaseModelError
+from ....messaging.valid import UUIDFour
+from ....storage.error import StorageError, StorageNotFoundError
 
 from .messages.menu import Menu
 from .messages.menu_request import MenuRequest

--- a/aries_cloudagent/protocols/actionmenu/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/tests/test_routes.py
@@ -241,10 +241,10 @@ class TestActionMenuRoutes(AsyncTestCase):
 
             mock_connection_record.retrieve_by_id = async_mock.CoroutineMock()
             mock_menu.deserialize = async_mock.MagicMock(
-                side_effect=ValueError("cannot deserialize")
+                side_effect=test_module.BaseModelError("cannot deserialize")
             )
 
-            with self.assertRaises(ValueError):
+            with self.assertRaises(test_module.BaseModelError):
                 await test_module.actionmenu_send(mock_request)
 
     async def test_actionmenu_send_no_conn_record(self):

--- a/aries_cloudagent/protocols/actionmenu/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/tests/test_routes.py
@@ -23,6 +23,23 @@ class TestActionMenuRoutes(AsyncTestCase):
             res = await test_module.actionmenu_close(mock_request)
             mock_response.assert_called_once_with({})
 
+    async def test_actionmenu_close_x(self):
+        mock_request = async_mock.MagicMock()
+        mock_request.json = async_mock.CoroutineMock()
+
+        mock_request.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": "context",
+        }
+
+        test_module.retrieve_connection_menu = async_mock.CoroutineMock()
+        test_module.save_connection_menu = async_mock.CoroutineMock(
+            side_effect=test_module.StorageError()
+        )
+
+        with self.assertRaises(test_module.web.HTTPBadRequest):
+            await test_module.actionmenu_close(mock_request)
+
     async def test_actionmenu_close_not_found(self):
         mock_request = async_mock.MagicMock()
         mock_request.json = async_mock.CoroutineMock()
@@ -244,7 +261,11 @@ class TestActionMenuRoutes(AsyncTestCase):
                 side_effect=test_module.BaseModelError("cannot deserialize")
             )
 
+<<<<<<< HEAD
             with self.assertRaises(test_module.BaseModelError):
+=======
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+>>>>>>> work in progress
                 await test_module.actionmenu_send(mock_request)
 
     async def test_actionmenu_send_no_conn_record(self):

--- a/aries_cloudagent/protocols/actionmenu/v1_0/util.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/util.py
@@ -1,8 +1,8 @@
 """Action menu utility methods."""
 
-from aries_cloudagent.config.injection_context import InjectionContext
-from aries_cloudagent.messaging.responder import BaseResponder
-from aries_cloudagent.storage.base import (
+from ....config.injection_context import InjectionContext
+from ....messaging.responder import BaseResponder
+from ....storage.base import (
     BaseStorage,
     StorageRecord,
     StorageNotFoundError,

--- a/aries_cloudagent/protocols/basicmessage/v1_0/handlers/basicmessage_handler.py
+++ b/aries_cloudagent/protocols/basicmessage/v1_0/handlers/basicmessage_handler.py
@@ -1,6 +1,6 @@
 """Basic message handler."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     RequestContext,

--- a/aries_cloudagent/protocols/basicmessage/v1_0/messages/basicmessage.py
+++ b/aries_cloudagent/protocols/basicmessage/v1_0/messages/basicmessage.py
@@ -5,9 +5,9 @@ from typing import Union
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
-from aries_cloudagent.messaging.util import datetime_now, datetime_to_str
-from aries_cloudagent.messaging.valid import INDY_ISO8601_DATETIME
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.util import datetime_now, datetime_to_str
+from .....messaging.valid import INDY_ISO8601_DATETIME
 
 from ..message_types import BASIC_MESSAGE, PROTOCOL_PACKAGE
 

--- a/aries_cloudagent/protocols/basicmessage/v1_0/routes.py
+++ b/aries_cloudagent/protocols/basicmessage/v1_0/routes.py
@@ -45,8 +45,8 @@ async def connections_send_message(request: web.BaseRequest):
 
     try:
         connection = await ConnectionRecord.retrieve_by_id(context, connection_id)
-    except StorageNotFoundError:
-        raise web.HTTPNotFound()
+    except StorageNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
 
     if connection.is_ready:
         msg = BasicMessage(content=params["content"])

--- a/aries_cloudagent/protocols/basicmessage/v1_0/routes.py
+++ b/aries_cloudagent/protocols/basicmessage/v1_0/routes.py
@@ -5,9 +5,9 @@ from aiohttp_apispec import docs, match_info_schema, request_schema
 
 from marshmallow import fields, Schema
 
-from aries_cloudagent.connections.models.connection_record import ConnectionRecord
-from aries_cloudagent.messaging.valid import UUIDFour
-from aries_cloudagent.storage.error import StorageNotFoundError
+from ....connections.models.connection_record import ConnectionRecord
+from ....messaging.valid import UUIDFour
+from ....storage.error import StorageNotFoundError
 
 from .message_types import SPEC_URI
 from .messages.basicmessage import BasicMessage

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/connection_invitation_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/connection_invitation_handler.py
@@ -1,6 +1,6 @@
 """Connect invitation handler."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     RequestContext,

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/connection_request_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/connection_request_handler.py
@@ -1,6 +1,6 @@
 """Connection request handler."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     RequestContext,

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/connection_response_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/connection_response_handler.py
@@ -1,13 +1,11 @@
 """Connection response handler."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     RequestContext,
 )
-
-# FIXME: We shouldn't rely on a hardcoded message version here.
-from aries_cloudagent.protocols.trustping.v1_0.messages.ping import Ping
+from .....protocols.trustping.v1_0.messages.ping import Ping
 
 from ..manager import ConnectionManager, ConnectionManagerError
 from ..messages.connection_response import ConnectionResponse

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/tests/test_response_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/tests/test_response_handler.py
@@ -12,7 +12,6 @@ from aries_cloudagent.messaging.base_handler import HandlerException
 from aries_cloudagent.messaging.request_context import RequestContext
 from aries_cloudagent.messaging.responder import MockResponder
 
-# FIXME: We shouldn't rely on a hardcoded message version here.
 from aries_cloudagent.protocols.trustping.v1_0.messages.ping import Ping
 
 from aries_cloudagent.transport.inbound.receipt import MessageReceipt

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -4,31 +4,29 @@ import logging
 
 from typing import Sequence, Tuple
 
-from aries_cloudagent.cache.base import BaseCache
-from aries_cloudagent.connections.models.connection_record import ConnectionRecord
-from aries_cloudagent.connections.models.connection_target import ConnectionTarget
-from aries_cloudagent.connections.models.diddoc import (
+from ....cache.base import BaseCache
+from ....connections.models.connection_record import ConnectionRecord
+from ....connections.models.connection_target import ConnectionTarget
+from ....connections.models.diddoc import (
     DIDDoc,
     PublicKey,
     PublicKeyType,
     Service,
 )
-from aries_cloudagent.config.base import InjectorError
-from aries_cloudagent.config.injection_context import InjectionContext
-from aries_cloudagent.core.error import BaseError
-from aries_cloudagent.ledger.base import BaseLedger
-from aries_cloudagent.messaging.responder import BaseResponder
-from aries_cloudagent.storage.base import BaseStorage
-from aries_cloudagent.storage.error import StorageError, StorageNotFoundError
-from aries_cloudagent.storage.record import StorageRecord
-from aries_cloudagent.transport.inbound.receipt import MessageReceipt
-from aries_cloudagent.wallet.base import BaseWallet, DIDInfo
-from aries_cloudagent.wallet.crypto import create_keypair, seed_to_did
-from aries_cloudagent.wallet.error import WalletNotFoundError
-from aries_cloudagent.wallet.util import bytes_to_b58
-
-# FIXME: We shouldn't rely on a hardcoded message version here.
-from aries_cloudagent.protocols.routing.v1_0.manager import RoutingManager
+from ....config.base import InjectorError
+from ....config.injection_context import InjectionContext
+from ....core.error import BaseError
+from ....ledger.base import BaseLedger
+from ....messaging.responder import BaseResponder
+from ....storage.base import BaseStorage
+from ....storage.error import StorageError, StorageNotFoundError
+from ....storage.record import StorageRecord
+from ....transport.inbound.receipt import MessageReceipt
+from ....wallet.base import BaseWallet, DIDInfo
+from ....wallet.crypto import create_keypair, seed_to_did
+from ....wallet.error import WalletNotFoundError
+from ....wallet.util import bytes_to_b58
+from ....protocols.routing.v1_0.manager import RoutingManager
 
 from .messages.connection_invitation import ConnectionInvitation
 from .messages.connection_request import ConnectionRequest

--- a/aries_cloudagent/protocols/connections/v1_0/messages/connection_invitation.py
+++ b/aries_cloudagent/protocols/connections/v1_0/messages/connection_invitation.py
@@ -5,9 +5,9 @@ from urllib.parse import parse_qs, urljoin, urlparse
 
 from marshmallow import ValidationError, fields, validates_schema
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
-from aries_cloudagent.messaging.valid import INDY_DID, INDY_RAW_PUBLIC_KEY
-from aries_cloudagent.wallet.util import b64_to_bytes, bytes_to_b64
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.valid import INDY_DID, INDY_RAW_PUBLIC_KEY
+from .....wallet.util import b64_to_bytes, bytes_to_b64
 
 from ..message_types import CONNECTION_INVITATION, PROTOCOL_PACKAGE
 

--- a/aries_cloudagent/protocols/connections/v1_0/messages/connection_request.py
+++ b/aries_cloudagent/protocols/connections/v1_0/messages/connection_request.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import CONNECTION_REQUEST, PROTOCOL_PACKAGE
 from ..models.connection_detail import ConnectionDetail, ConnectionDetailSchema

--- a/aries_cloudagent/protocols/connections/v1_0/messages/connection_response.py
+++ b/aries_cloudagent/protocols/connections/v1_0/messages/connection_response.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import CONNECTION_RESPONSE, PROTOCOL_PACKAGE
 from ..models.connection_detail import ConnectionDetail, ConnectionDetailSchema

--- a/aries_cloudagent/protocols/connections/v1_0/messages/problem_report.py
+++ b/aries_cloudagent/protocols/connections/v1_0/messages/problem_report.py
@@ -3,7 +3,7 @@
 from enum import Enum
 from marshmallow import fields, validate
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import PROBLEM_REPORT
 

--- a/aries_cloudagent/protocols/connections/v1_0/models/connection_detail.py
+++ b/aries_cloudagent/protocols/connections/v1_0/models/connection_detail.py
@@ -2,9 +2,9 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.connections.models.diddoc import DIDDoc
-from aries_cloudagent.messaging.models.base import BaseModel, BaseModelSchema
-from aries_cloudagent.messaging.valid import INDY_DID
+from .....connections.models.diddoc import DIDDoc
+from .....messaging.models.base import BaseModel, BaseModelSchema
+from .....messaging.valid import INDY_DID
 
 
 class DIDDocWrapper(fields.Field):

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -283,7 +283,10 @@ async def connections_retrieve(request: web.BaseRequest):
         raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     return web.json_response(result)
+<<<<<<< HEAD
 >>>>>>> work in progress
+=======
+>>>>>>> raise 400 series on exceptions within protocols
 
 
 @docs(
@@ -565,7 +568,9 @@ async def connections_create_static(request: web.BaseRequest):
     connection_mgr = ConnectionManager(context)
     try:
         (
-            my_info, their_info, connection
+            my_info,
+            their_info,
+            connection,
         ) = await connection_mgr.create_static_connection(
             my_seed=body.get("my_seed") or None,
             my_did=body.get("my_did") or None,

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -13,20 +13,21 @@ from aiohttp_apispec import (
 
 from marshmallow import fields, Schema, validate, validates_schema
 
-from aries_cloudagent.connections.models.connection_record import (
+from ....connections.models.connection_record import (
     ConnectionRecord,
     ConnectionRecordSchema,
 )
-from aries_cloudagent.messaging.models.base import BaseModelError
-from aries_cloudagent.messaging.valid import (
+from ....messaging.models.base import BaseModelError
+from ....messaging.valid import (
     ENDPOINT,
     INDY_DID,
     INDY_RAW_PUBLIC_KEY,
     UUIDFour,
 )
-from aries_cloudagent.storage.error import StorageNotFoundError
+from ....storage.error import StorageError, StorageNotFoundError
+from ....wallet.error import WalletError
 
-from .manager import ConnectionManager
+from .manager import ConnectionManager, ConnectionManagerError
 from .message_types import SPEC_URI
 from .messages.connection_invitation import (
     ConnectionInvitation,
@@ -242,9 +243,12 @@ async def connections_list(request: web.BaseRequest):
     ):
         if param_name in request.query and request.query[param_name] != "":
             post_filter[param_name] = request.query[param_name]
-    records = await ConnectionRecord.query(context, tag_filter, post_filter)
-    results = [record.serialize() for record in records]
-    results.sort(key=connection_sort_key)
+    try:
+        records = await ConnectionRecord.query(context, tag_filter, post_filter)
+        results = [record.serialize() for record in records]
+        results.sort(key=connection_sort_key)
+    except (StorageError, BaseModelError) as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
     return web.json_response({"results": results})
 
 
@@ -264,11 +268,22 @@ async def connections_retrieve(request: web.BaseRequest):
     """
     context = request.app["request_context"]
     connection_id = request.match_info["conn_id"]
+
     try:
         record = await ConnectionRecord.retrieve_by_id(context, connection_id)
+<<<<<<< HEAD
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
     return web.json_response(record.serialize())
+=======
+        result = record.serialize()
+    except StorageNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
+    except BaseModelError as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
+
+    return web.json_response(result)
+>>>>>>> work in progress
 
 
 @docs(
@@ -295,19 +310,27 @@ async def connections_create_invitation(request: web.BaseRequest):
 
     if public and not context.settings.get("public_invites"):
         raise web.HTTPForbidden(
+<<<<<<< HEAD
             reason="Configuration does not include public invitations"
+=======
+            reason="Configuration does not include invitation creation on public DID"
+>>>>>>> work in progress
         )
     base_url = context.settings.get("invite_base_url")
 
     connection_mgr = ConnectionManager(context)
-    (connection, invitation) = await connection_mgr.create_invitation(
-        auto_accept=auto_accept, public=public, multi_use=multi_use, alias=alias
-    )
-    result = {
-        "connection_id": connection and connection.connection_id,
-        "invitation": invitation.serialize(),
-        "invitation_url": invitation.to_url(base_url),
-    }
+    try:
+        (connection, invitation) = await connection_mgr.create_invitation(
+            auto_accept=auto_accept, public=public, multi_use=multi_use, alias=alias
+        )
+
+        result = {
+            "connection_id": connection and connection.connection_id,
+            "invitation": invitation.serialize(),
+            "invitation_url": invitation.to_url(base_url),
+        }
+    except (ConnectionManagerError, BaseModelError) as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     if connection and connection.alias:
         result["alias"] = connection.alias
@@ -335,22 +358,33 @@ async def connections_receive_invitation(request: web.BaseRequest):
     context = request.app["request_context"]
     if context.settings.get("admin.no_receive_invites"):
         raise web.HTTPForbidden(
+<<<<<<< HEAD
             reason="Configuration does not allow receipt of invitations"
+=======
+            reason="Configuration does not include invitation receipt"
+>>>>>>> work in progress
         )
     connection_mgr = ConnectionManager(context)
     invitation_json = await request.json()
+
     try:
         invitation = ConnectionInvitation.deserialize(invitation_json)
+<<<<<<< HEAD
     except BaseModelError as err:
         raise web.HTTPBadRequest(reason=err.roll_up) from err
+=======
+        auto_accept = json.loads(request.query.get("auto_accept", "null"))
+        alias = request.query.get("alias")
+>>>>>>> work in progress
 
-    auto_accept = json.loads(request.query.get("auto_accept", "null"))
-    alias = request.query.get("alias")
+        connection = await connection_mgr.receive_invitation(
+            invitation, auto_accept=auto_accept, alias=alias
+        )
+        result = connection.serialize()
+    except (ConnectionManagerError, StorageError, BaseModelError) as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
 
-    connection = await connection_mgr.receive_invitation(
-        invitation, auto_accept=auto_accept, alias=alias
-    )
-    return web.json_response(connection.serialize())
+    return web.json_response(result)
 
 
 @docs(
@@ -373,16 +407,30 @@ async def connections_accept_invitation(request: web.BaseRequest):
     context = request.app["request_context"]
     outbound_handler = request.app["outbound_message_router"]
     connection_id = request.match_info["conn_id"]
+
     try:
         connection = await ConnectionRecord.retrieve_by_id(context, connection_id)
+<<<<<<< HEAD
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
     connection_mgr = ConnectionManager(context)
     my_label = request.query.get("my_label") or None
     my_endpoint = request.query.get("my_endpoint") or None
     request = await connection_mgr.create_request(connection, my_label, my_endpoint)
+=======
+        connection_mgr = ConnectionManager(context)
+        my_label = request.query.get("my_label") or None
+        my_endpoint = request.query.get("my_endpoint") or None
+        request = await connection_mgr.create_request(connection, my_label, my_endpoint)
+        result = connection.serialize()
+    except StorageNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
+    except (StorageError, WalletError, ConnectionManagerError, BaseModelError) as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
+
+>>>>>>> work in progress
     await outbound_handler(request, connection_id=connection.connection_id)
-    return web.json_response(connection.serialize())
+    return web.json_response(result)
 
 
 @docs(
@@ -405,15 +453,28 @@ async def connections_accept_request(request: web.BaseRequest):
     context = request.app["request_context"]
     outbound_handler = request.app["outbound_message_router"]
     connection_id = request.match_info["conn_id"]
+
     try:
         connection = await ConnectionRecord.retrieve_by_id(context, connection_id)
+<<<<<<< HEAD
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
     connection_mgr = ConnectionManager(context)
     my_endpoint = request.query.get("my_endpoint") or None
     response = await connection_mgr.create_response(connection, my_endpoint)
+=======
+        connection_mgr = ConnectionManager(context)
+        my_endpoint = request.query.get("my_endpoint") or None
+        response = await connection_mgr.create_response(connection, my_endpoint)
+        result = connection.serialize()
+    except StorageNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
+    except (StorageError, WalletError, ConnectionManagerError, BaseModelError) as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
+
+>>>>>>> work in progress
     await outbound_handler(response, connection_id=connection.connection_id)
-    return web.json_response(connection.serialize())
+    return web.json_response(result)
 
 
 @docs(
@@ -431,14 +492,27 @@ async def connections_establish_inbound(request: web.BaseRequest):
     connection_id = request.match_info["conn_id"]
     outbound_handler = request.app["outbound_message_router"]
     inbound_connection_id = request.match_info["ref_id"]
+
     try:
         connection = await ConnectionRecord.retrieve_by_id(context, connection_id)
+<<<<<<< HEAD
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
     connection_mgr = ConnectionManager(context)
     await connection_mgr.establish_inbound(
         connection, inbound_connection_id, outbound_handler
     )
+=======
+        connection_mgr = ConnectionManager(context)
+        await connection_mgr.establish_inbound(
+            connection, inbound_connection_id, outbound_handler
+        )
+    except StorageNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
+    except (StorageError, WalletError, ConnectionManagerError) as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
+
+>>>>>>> work in progress
     return web.json_response({})
 
 
@@ -453,11 +527,21 @@ async def connections_remove(request: web.BaseRequest):
     """
     context = request.app["request_context"]
     connection_id = request.match_info["conn_id"]
+
     try:
         connection = await ConnectionRecord.retrieve_by_id(context, connection_id)
+<<<<<<< HEAD
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
     await connection.delete_record(context)
+=======
+        await connection.delete_record(context)
+    except StorageNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
+    except StorageError as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
+
+>>>>>>> work in progress
     return web.json_response({})
 
 
@@ -479,25 +563,30 @@ async def connections_create_static(request: web.BaseRequest):
     body = await request.json()
 
     connection_mgr = ConnectionManager(context)
-    (my_info, their_info, connection) = await connection_mgr.create_static_connection(
-        my_seed=body.get("my_seed") or None,
-        my_did=body.get("my_did") or None,
-        their_seed=body.get("their_seed") or None,
-        their_did=body.get("their_did") or None,
-        their_verkey=body.get("their_verkey") or None,
-        their_endpoint=body.get("their_endpoint") or None,
-        their_role=body.get("their_role") or None,
-        their_label=body.get("their_label") or None,
-        alias=body.get("alias") or None,
-    )
-    response = {
-        "my_did": my_info.did,
-        "my_verkey": my_info.verkey,
-        "my_endpoint": context.settings.get("default_endpoint"),
-        "their_did": their_info.did,
-        "their_verkey": their_info.verkey,
-        "record": connection.serialize(),
-    }
+    try:
+        (
+            my_info, their_info, connection
+        ) = await connection_mgr.create_static_connection(
+            my_seed=body.get("my_seed") or None,
+            my_did=body.get("my_did") or None,
+            their_seed=body.get("their_seed") or None,
+            their_did=body.get("their_did") or None,
+            their_verkey=body.get("their_verkey") or None,
+            their_endpoint=body.get("their_endpoint") or None,
+            their_role=body.get("their_role") or None,
+            their_label=body.get("their_label") or None,
+            alias=body.get("alias") or None,
+        )
+        response = {
+            "my_did": my_info.did,
+            "my_verkey": my_info.verkey,
+            "my_endpoint": context.settings.get("default_endpoint"),
+            "their_did": their_info.did,
+            "their_verkey": their_info.verkey,
+            "record": connection.serialize(),
+        }
+    except (WalletError, StorageError, BaseModelError) as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     return web.json_response(response)
 

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
@@ -74,6 +74,29 @@ class TestConnectionRoutes(AsyncTestCase):
                     }  # sorted
                 )
 
+    async def test_connections_list_x(self):
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
+        mock_req = async_mock.MagicMock()
+        mock_req.app = {
+            "request_context": context,
+        }
+        mock_req.query = {
+            "invitation_id": "dummy",
+            "initiator": ConnectionRecord.INITIATOR_SELF,
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_conn_rec:
+            mock_conn_rec.STATE_INVITATION = ConnectionRecord.STATE_INVITATION
+            mock_conn_rec.STATE_INACTIVE = ConnectionRecord.STATE_INACTIVE
+            mock_conn_rec.query = async_mock.CoroutineMock(
+                side_effect=test_module.StorageError()
+            )
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.connections_list(mock_req)
+
     async def test_connections_retrieve(self):
         context = RequestContext(base_context=InjectionContext(enforce_typing=False))
         mock_req = async_mock.MagicMock()
@@ -81,7 +104,6 @@ class TestConnectionRoutes(AsyncTestCase):
             "request_context": context,
         }
         mock_req.match_info = {"conn_id": "dummy"}
-
         mock_conn_rec = async_mock.MagicMock()
         mock_conn_rec.serialize = async_mock.MagicMock(return_value={"hello": "world"})
 
@@ -90,7 +112,6 @@ class TestConnectionRoutes(AsyncTestCase):
         ) as mock_conn_rec_retrieve_by_id, async_mock.patch.object(
             test_module.web, "json_response"
         ) as mock_response:
-
             mock_conn_rec_retrieve_by_id.return_value = mock_conn_rec
 
             await test_module.connections_retrieve(mock_req)
@@ -110,6 +131,26 @@ class TestConnectionRoutes(AsyncTestCase):
             mock_conn_rec_retrieve_by_id.side_effect = StorageNotFoundError()
 
             with self.assertRaises(test_module.web.HTTPNotFound):
+                await test_module.connections_retrieve(mock_req)
+
+    async def test_connections_retrieve_x(self):
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
+        mock_req = async_mock.MagicMock()
+        mock_req.app = {
+            "request_context": context,
+        }
+        mock_req.match_info = {"conn_id": "dummy"}
+        mock_conn_rec = async_mock.MagicMock()
+        mock_conn_rec.serialize = async_mock.MagicMock(
+            side_effect=test_module.BaseModelError()
+        )
+
+        with async_mock.patch.object(
+            test_module.ConnectionRecord, "retrieve_by_id", async_mock.CoroutineMock()
+        ) as mock_conn_rec_retrieve_by_id:
+            mock_conn_rec_retrieve_by_id.return_value = mock_conn_rec
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.connections_retrieve(mock_req)
 
     async def test_connections_create_invitation(self):
@@ -153,6 +194,30 @@ class TestConnectionRoutes(AsyncTestCase):
                     "alias": "conn-alias",
                 }
             )
+
+    async def test_connections_create_invitation_x(self):
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
+        mock_req = async_mock.MagicMock()
+        context.update_settings({"public_invites": True})
+        mock_req.app = {
+            "request_context": context,
+        }
+        mock_req.query = {
+            "auto_accept": "true",
+            "alias": "alias",
+            "public": "true",
+            "multi_use": "true",
+        }
+
+        with async_mock.patch.object(
+            test_module, "ConnectionManager", autospec=True
+        ) as mock_conn_mgr:
+            mock_conn_mgr.return_value.create_invitation = async_mock.CoroutineMock(
+                side_effect=test_module.ConnectionManagerError()
+            )
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.connections_create_invitation(mock_req)
 
     async def test_connections_create_invitation_public_forbidden(self):
         context = RequestContext(base_context=InjectionContext(enforce_typing=False))
@@ -280,6 +345,27 @@ class TestConnectionRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPNotFound):
                 await test_module.connections_accept_invitation(mock_req)
 
+    async def test_connections_accept_invitation_x(self):
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
+        mock_req = async_mock.MagicMock()
+        mock_req.app = {
+            "request_context": context,
+            "outbound_message_router": async_mock.CoroutineMock(),
+        }
+        mock_req.match_info = {"conn_id": "dummy"}
+
+        with async_mock.patch.object(
+            test_module.ConnectionRecord, "retrieve_by_id", async_mock.CoroutineMock()
+        ) as mock_conn_rec_retrieve_by_id, async_mock.patch.object(
+            test_module, "ConnectionManager", autospec=True
+        ) as mock_conn_mgr:
+            mock_conn_mgr.return_value.create_request = async_mock.CoroutineMock(
+                side_effect=test_module.ConnectionManagerError()
+            )
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.connections_accept_invitation(mock_req)
+
     async def test_connections_accept_request(self):
         context = RequestContext(base_context=InjectionContext(enforce_typing=False))
         mock_req = async_mock.MagicMock()
@@ -325,6 +411,29 @@ class TestConnectionRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPNotFound):
                 await test_module.connections_accept_request(mock_req)
 
+    async def test_connections_accept_request_x(self):
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
+        mock_req = async_mock.MagicMock()
+        mock_req.app = {
+            "request_context": context,
+            "outbound_message_router": async_mock.CoroutineMock(),
+        }
+        mock_req.match_info = {"conn_id": "dummy"}
+
+        with async_mock.patch.object(
+            test_module.ConnectionRecord, "retrieve_by_id", async_mock.CoroutineMock()
+        ) as mock_conn_rec_retrieve_by_id, async_mock.patch.object(
+            test_module, "ConnectionManager", autospec=True
+        ) as mock_conn_mgr, async_mock.patch.object(
+            test_module.web, "json_response"
+        ) as mock_response:
+            mock_conn_mgr.return_value.create_response = async_mock.CoroutineMock(
+                side_effect=test_module.ConnectionManagerError()
+            )
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.connections_accept_request(mock_req)
+
     async def test_connections_establish_inbound(self):
         context = RequestContext(base_context=InjectionContext(enforce_typing=False))
         mock_req = async_mock.MagicMock()
@@ -336,7 +445,6 @@ class TestConnectionRoutes(AsyncTestCase):
         mock_req.query = {
             "my_endpoint": "http://endpoint.ca",
         }
-
         mock_conn_rec = async_mock.MagicMock()
 
         with async_mock.patch.object(
@@ -346,7 +454,6 @@ class TestConnectionRoutes(AsyncTestCase):
         ) as mock_conn_mgr, async_mock.patch.object(
             test_module.web, "json_response"
         ) as mock_response:
-
             mock_conn_rec_retrieve_by_id.return_value = mock_conn_rec
             mock_conn_mgr.return_value.establish_inbound = async_mock.CoroutineMock()
 
@@ -370,6 +477,31 @@ class TestConnectionRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPNotFound):
                 await test_module.connections_establish_inbound(mock_req)
 
+    async def test_connections_establish_inbound_x(self):
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
+        mock_req = async_mock.MagicMock()
+        mock_req.app = {
+            "request_context": context,
+            "outbound_message_router": async_mock.CoroutineMock(),
+        }
+        mock_req.match_info = {"conn_id": "dummy", "ref_id": "ref"}
+        mock_req.query = {
+            "my_endpoint": "http://endpoint.ca",
+        }
+        mock_conn_rec = async_mock.MagicMock()
+
+        with async_mock.patch.object(
+            test_module.ConnectionRecord, "retrieve_by_id", async_mock.CoroutineMock()
+        ) as mock_conn_rec_retrieve_by_id, async_mock.patch.object(
+            test_module, "ConnectionManager", autospec=True
+        ) as mock_conn_mgr:
+            mock_conn_rec_retrieve_by_id.return_value = mock_conn_rec
+            mock_conn_mgr.return_value.establish_inbound = async_mock.CoroutineMock(
+                side_effect=test_module.ConnectionManagerError()
+            )
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.connections_establish_inbound(mock_req)
+
     async def test_connections_remove(self):
         context = RequestContext(base_context=InjectionContext(enforce_typing=False))
         mock_req = async_mock.MagicMock()
@@ -377,7 +509,6 @@ class TestConnectionRoutes(AsyncTestCase):
             "request_context": context,
         }
         mock_req.match_info = {"conn_id": "dummy"}
-
         mock_conn_rec = async_mock.MagicMock()
         mock_conn_rec.delete_record = async_mock.CoroutineMock()
 
@@ -407,6 +538,27 @@ class TestConnectionRoutes(AsyncTestCase):
             mock_conn_rec_retrieve_by_id.side_effect = StorageNotFoundError()
 
             with self.assertRaises(test_module.web.HTTPNotFound):
+                await test_module.connections_remove(mock_req)
+
+    async def test_connections_remove_x(self):
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
+        mock_req = async_mock.MagicMock()
+        mock_req.app = {
+            "request_context": context,
+        }
+        mock_req.match_info = {"conn_id": "dummy"}
+        mock_conn_rec = async_mock.MagicMock(
+            delete_record = async_mock.CoroutineMock(
+                side_effect=test_module.StorageError()
+            )
+        )
+
+        with async_mock.patch.object(
+            test_module.ConnectionRecord, "retrieve_by_id", async_mock.CoroutineMock()
+        ) as mock_conn_rec_retrieve_by_id:
+            mock_conn_rec_retrieve_by_id.return_value = mock_conn_rec
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.connections_remove(mock_req)
 
     async def test_connections_create_static(self):
@@ -447,7 +599,6 @@ class TestConnectionRoutes(AsyncTestCase):
         ) as mock_conn_mgr, async_mock.patch.object(
             test_module.web, "json_response"
         ) as mock_response:
-
             mock_conn_mgr.return_value.create_static_connection = async_mock.CoroutineMock(
                 return_value=(mock_my_info, mock_their_info, mock_conn_rec)
             )
@@ -463,6 +614,49 @@ class TestConnectionRoutes(AsyncTestCase):
                     "record": mock_conn_rec.serialize.return_value,
                 }
             )
+
+    async def test_connections_create_static_x(self):
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
+        mock_req = async_mock.MagicMock()
+        mock_req.app = {
+            "request_context": context,
+        }
+        mock_req.json = async_mock.CoroutineMock(
+            return_value={
+                "my_seed": "my_seed",
+                "my_did": "my_did",
+                "their_seed": "their_seed",
+                "their_did": "their_did",
+                "their_verkey": "their_verkey",
+                "their_endpoint": "their_endpoint",
+                "their_role": "their_role",
+                "alias": "alias",
+            }
+        )
+        mock_req.query = {
+            "auto_accept": "true",
+            "alias": "alias",
+        }
+        mock_req.match_info = {"conn_id": "dummy"}
+
+        mock_conn_rec = async_mock.MagicMock()
+        mock_conn_rec.serialize = async_mock.MagicMock()
+        mock_my_info = async_mock.MagicMock()
+        mock_my_info.did = "my_did"
+        mock_my_info.verkey = "my_verkey"
+        mock_their_info = async_mock.MagicMock()
+        mock_their_info.did = "their_did"
+        mock_their_info.verkey = "their_verkey"
+
+        with async_mock.patch.object(
+            test_module, "ConnectionManager", autospec=True
+        ) as mock_conn_mgr:
+            mock_conn_mgr.return_value.create_static_connection = async_mock.CoroutineMock(
+                side_effect=test_module.WalletError()
+            )
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.connections_create_static(mock_req)
 
     async def test_register(self):
         mock_app = async_mock.MagicMock()

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
@@ -548,7 +548,7 @@ class TestConnectionRoutes(AsyncTestCase):
         }
         mock_req.match_info = {"conn_id": "dummy"}
         mock_conn_rec = async_mock.MagicMock(
-            delete_record = async_mock.CoroutineMock(
+            delete_record=async_mock.CoroutineMock(
                 side_effect=test_module.StorageError()
             )
         )

--- a/aries_cloudagent/protocols/discovery/v1_0/handlers/disclose_handler.py
+++ b/aries_cloudagent/protocols/discovery/v1_0/handlers/disclose_handler.py
@@ -1,6 +1,6 @@
 """Handler for incoming disclose messages."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     RequestContext,

--- a/aries_cloudagent/protocols/discovery/v1_0/handlers/query_handler.py
+++ b/aries_cloudagent/protocols/discovery/v1_0/handlers/query_handler.py
@@ -1,7 +1,7 @@
 """Handler for incoming query messages."""
 
-from aries_cloudagent.core.protocol_registry import ProtocolRegistry
-from aries_cloudagent.messaging.base_handler import (
+from .....core.protocol_registry import ProtocolRegistry
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     RequestContext,

--- a/aries_cloudagent/protocols/discovery/v1_0/messages/disclose.py
+++ b/aries_cloudagent/protocols/discovery/v1_0/messages/disclose.py
@@ -4,7 +4,7 @@ from typing import Mapping, Sequence
 
 from marshmallow import fields, Schema, validate
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import DISCLOSE, PROTOCOL_PACKAGE
 

--- a/aries_cloudagent/protocols/discovery/v1_0/messages/query.py
+++ b/aries_cloudagent/protocols/discovery/v1_0/messages/query.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import QUERY, PROTOCOL_PACKAGE
 

--- a/aries_cloudagent/protocols/discovery/v1_0/routes.py
+++ b/aries_cloudagent/protocols/discovery/v1_0/routes.py
@@ -2,10 +2,9 @@
 
 from aiohttp import web
 from aiohttp_apispec import docs, querystring_schema, response_schema
-
 from marshmallow import fields, Schema
 
-from aries_cloudagent.core.protocol_registry import ProtocolRegistry
+from ....core.protocol_registry import ProtocolRegistry
 
 from .message_types import SPEC_URI
 

--- a/aries_cloudagent/protocols/introduction/v0_1/base_service.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/base_service.py
@@ -2,8 +2,8 @@
 
 from abc import ABC, abstractmethod
 
-from aries_cloudagent.core.error import BaseError
-from aries_cloudagent.messaging.request_context import RequestContext
+from ....core.error import BaseError
+from ....messaging.request_context import RequestContext
 
 from .messages.invitation import Invitation
 

--- a/aries_cloudagent/protocols/introduction/v0_1/demo_service.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/demo_service.py
@@ -3,8 +3,8 @@
 import json
 import logging
 
-from aries_cloudagent.connections.models.connection_record import ConnectionRecord
-from aries_cloudagent.storage.base import (
+from ....connections.models.connection_record import ConnectionRecord
+from ....storage.base import (
     BaseStorage,
     StorageRecord,
     StorageNotFoundError,

--- a/aries_cloudagent/protocols/introduction/v0_1/demo_service.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/demo_service.py
@@ -45,20 +45,28 @@ class DemoIntroductionService(BaseIntroductionService):
                 self._context, init_connection_id
             )
         except StorageNotFoundError:
-            raise IntroductionError("Initiator connection not found")
+            raise IntroductionError(
+                f"Initiator connection {init_connection_id} not found"
+            )
 
         if init_connection.state != "active":
-            raise IntroductionError("Initiator connection is not active")
+            raise IntroductionError(
+                f"Initiator connection {init_connection_id} not active"
+            )
 
         try:
             target_connection = await ConnectionRecord.retrieve_by_id(
                 self._context, target_connection_id
             )
         except StorageNotFoundError:
-            raise IntroductionError("Target connection not found")
+            raise IntroductionError(
+                "Target connection {target_connection_id} not found"
+            )
 
         if target_connection.state != "active":
-            raise IntroductionError("Target connection is not active")
+            raise IntroductionError(
+                "Target connection {target_connection_id} not active"
+            )
 
         msg = InvitationRequest(responder=init_connection.their_label, message=message)
 

--- a/aries_cloudagent/protocols/introduction/v0_1/handlers/forward_invitation_handler.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/handlers/forward_invitation_handler.py
@@ -1,14 +1,12 @@
 """Handler for incoming forward invitation messages."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     HandlerException,
     RequestContext,
 )
-
-# FIXME: We shouldn't rely on a hardcoded message version here.
-from aries_cloudagent.protocols.connections.v1_0.manager import ConnectionManager
+from .....protocols.connections.v1_0.manager import ConnectionManager
 
 from ..messages.forward_invitation import ForwardInvitation
 

--- a/aries_cloudagent/protocols/introduction/v0_1/handlers/invitation_handler.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/handlers/invitation_handler.py
@@ -1,6 +1,6 @@
 """Handler for incoming invitation messages."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     HandlerException,

--- a/aries_cloudagent/protocols/introduction/v0_1/handlers/invitation_request_handler.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/handlers/invitation_request_handler.py
@@ -1,14 +1,12 @@
 """Handler for incoming invitation request messages."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     HandlerException,
     RequestContext,
 )
-
-# FIXME: We shouldn't rely on a hardcoded message version here.
-from aries_cloudagent.protocols.connections.v1_0.manager import ConnectionManager
+from .....protocols.connections.v1_0.manager import ConnectionManager
 from ..messages.invitation_request import InvitationRequest
 from ..messages.invitation import Invitation
 

--- a/aries_cloudagent/protocols/introduction/v0_1/handlers/tests/test_forward_invitation_handler.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/handlers/tests/test_forward_invitation_handler.py
@@ -6,8 +6,6 @@ from aries_cloudagent.connections.models.connection_record import ConnectionReco
 from aries_cloudagent.messaging.base_handler import HandlerException
 from aries_cloudagent.messaging.request_context import RequestContext
 from aries_cloudagent.messaging.responder import MockResponder
-
-# FIXME: We shouldn't rely on a hardcoded message version here.
 from aries_cloudagent.protocols.connections.v1_0.messages.connection_invitation import (
     ConnectionInvitation,
 )

--- a/aries_cloudagent/protocols/introduction/v0_1/handlers/tests/test_invitation_handler.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/handlers/tests/test_invitation_handler.py
@@ -8,8 +8,6 @@ from aries_cloudagent.messaging.request_context import RequestContext
 from aries_cloudagent.messaging.responder import MockResponder
 from aries_cloudagent.storage.base import BaseStorage
 from aries_cloudagent.storage.basic import BasicStorage
-
-# FIXME: We shouldn't rely on a hardcoded message version here.
 from aries_cloudagent.protocols.connections.v1_0.messages.connection_invitation import (
     ConnectionInvitation,
 )

--- a/aries_cloudagent/protocols/introduction/v0_1/handlers/tests/test_invitation_request_handler.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/handlers/tests/test_invitation_request_handler.py
@@ -6,8 +6,6 @@ from aries_cloudagent.connections.models.connection_record import ConnectionReco
 from aries_cloudagent.messaging.base_handler import HandlerException
 from aries_cloudagent.messaging.request_context import RequestContext
 from aries_cloudagent.messaging.responder import MockResponder
-
-# FIXME: We shouldn't rely on a hardcoded message version here.
 from aries_cloudagent.protocols.connections.v1_0.messages.connection_invitation import (
     ConnectionInvitation,
 )

--- a/aries_cloudagent/protocols/introduction/v0_1/messages/forward_invitation.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/messages/forward_invitation.py
@@ -2,10 +2,8 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
-
-# FIXME: We shouldn't rely on a hardcoded message version here.
-from aries_cloudagent.protocols.connections.v1_0.messages.connection_invitation import (
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....protocols.connections.v1_0.messages.connection_invitation import (
     ConnectionInvitation,
     ConnectionInvitationSchema,
 )

--- a/aries_cloudagent/protocols/introduction/v0_1/messages/invitation.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/messages/invitation.py
@@ -2,10 +2,8 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
-
-# FIXME: We shouldn't rely on a hardcoded message version here.
-from aries_cloudagent.protocols.connections.v1_0.messages.connection_invitation import (
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....protocols.connections.v1_0.messages.connection_invitation import (
     ConnectionInvitation,
     ConnectionInvitationSchema,
 )

--- a/aries_cloudagent/protocols/introduction/v0_1/messages/invitation_request.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/messages/invitation_request.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import INVITATION_REQUEST, PROTOCOL_PACKAGE
 

--- a/aries_cloudagent/protocols/introduction/v0_1/messages/tests/test_forward_invitation.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/messages/tests/test_forward_invitation.py
@@ -1,8 +1,7 @@
 from unittest import mock, TestCase
 from asynctest import TestCase as AsyncTestCase
 
-# FIXME: We shouldn't rely on a hardcoded message version here.
-from aries_cloudagent.protocols.connections.v1_0.messages.connection_invitation import (
+from ......protocols.connections.v1_0.messages.connection_invitation import (
     ConnectionInvitation,
 )
 

--- a/aries_cloudagent/protocols/introduction/v0_1/messages/tests/test_invitation.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/messages/tests/test_invitation.py
@@ -1,8 +1,7 @@
 from unittest import mock, TestCase
 from asynctest import TestCase as AsyncTestCase
 
-# FIXME: We shouldn't rely on a hardcoded message version here.
-from aries_cloudagent.protocols.connections.v1_0.messages.connection_invitation import (
+from ......protocols.connections.v1_0.messages.connection_invitation import (
     ConnectionInvitation,
 )
 

--- a/aries_cloudagent/protocols/introduction/v0_1/routes.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/routes.py
@@ -8,6 +8,7 @@ from aiohttp_apispec import docs, match_info_schema, querystring_schema
 from marshmallow import fields, Schema
 
 from ....messaging.valid import UUIDFour
+from ....storage.error import StorageError
 
 from .base_service import BaseIntroductionService, IntroductionError
 
@@ -59,13 +60,23 @@ async def introduction_start(request: web.BaseRequest):
         BaseIntroductionService, required=False
     )
     if not service:
+<<<<<<< HEAD
         raise web.HTTPForbidden(reason="Introduction service not available")
+=======
+        raise web.HTTPForbidden(
+            reason="Configuration does not include introduction service"
+        )
+>>>>>>> work in progress
 
     try:
         await service.start_introduction(
             init_connection_id, target_connection_id, message, outbound_handler
         )
+<<<<<<< HEAD
     except IntroductionError as err:
+=======
+    except (IntroductionError, StorageError) as err:
+>>>>>>> work in progress
         raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     return web.json_response({})

--- a/aries_cloudagent/protocols/introduction/v0_1/tests/test_routes.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/tests/test_routes.py
@@ -59,7 +59,6 @@ class TestIntroductionRoutes(AsyncTestCase):
             "target_connection_id": "dummy",
             "message": "Hello",
         }
-
         mock_conn_rec = async_mock.MagicMock()
         mock_conn_rec.serialize = async_mock.MagicMock()
 
@@ -103,7 +102,10 @@ class TestIntroductionRoutes(AsyncTestCase):
             "target_connection_id": "dummy",
             "message": "Hello",
         }
+<<<<<<< HEAD
 
+=======
+>>>>>>> work in progress
         mock_conn_rec = async_mock.MagicMock()
         mock_conn_rec.serialize = async_mock.MagicMock()
 
@@ -112,7 +114,11 @@ class TestIntroductionRoutes(AsyncTestCase):
         ) as mock_ctx_inject:
             mock_ctx_inject.return_value = async_mock.MagicMock(
                 start_introduction=async_mock.CoroutineMock(
+<<<<<<< HEAD
                     side_effect=test_module.IntroductionError()
+=======
+                    side_effect=test_module.StorageError()
+>>>>>>> work in progress
                 )
             )
 

--- a/aries_cloudagent/protocols/introduction/v0_1/tests/test_routes.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/tests/test_routes.py
@@ -81,6 +81,44 @@ class TestIntroductionRoutes(AsyncTestCase):
             )
             mock_response.assert_called_once_with({})
 
+    async def test_introduction_start_x(self):
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
+
+        mock_req = async_mock.MagicMock()
+        mock_req.app = {"request_context": context, "outbound_message_router": None}
+        mock_req.json = async_mock.CoroutineMock(
+            return_value={
+                "my_seed": "my_seed",
+                "my_did": "my_did",
+                "their_seed": "their_seed",
+                "their_did": "their_did",
+                "their_verkey": "their_verkey",
+                "their_endpoint": "their_endpoint",
+                "their_role": "their_role",
+                "alias": "alias",
+            }
+        )
+        mock_req.match_info = {"conn_id": "dummy"}
+        mock_req.query = {
+            "target_connection_id": "dummy",
+            "message": "Hello",
+        }
+
+        mock_conn_rec = async_mock.MagicMock()
+        mock_conn_rec.serialize = async_mock.MagicMock()
+
+        with async_mock.patch.object(
+            context, "inject", async_mock.CoroutineMock()
+        ) as mock_ctx_inject:
+            mock_ctx_inject.return_value = async_mock.MagicMock(
+                start_introduction=async_mock.CoroutineMock(
+                    side_effect=test_module.IntroductionError()
+                )
+            )
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.introduction_start(mock_req)
+
     async def test_register(self):
         mock_app = async_mock.MagicMock()
         mock_app.add_routes = async_mock.MagicMock()

--- a/aries_cloudagent/protocols/introduction/v0_1/tests/test_service.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/tests/test_service.py
@@ -8,8 +8,6 @@ from aries_cloudagent.messaging.responder import MockResponder
 from aries_cloudagent.storage.base import BaseStorage
 from aries_cloudagent.storage.basic import BasicStorage
 from aries_cloudagent.storage.error import StorageNotFoundError
-
-# FIXME: We shouldn't rely on a hardcoded message version here.
 from aries_cloudagent.protocols.connections.v1_0.messages.connection_invitation import (
     ConnectionInvitation,
 )

--- a/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
@@ -32,7 +32,6 @@ from ....storage.error import StorageError, StorageNotFoundError
 from ....wallet.base import BaseWallet
 from ....utils.outofband import serialize_outofband
 
-# FIXME: We shouldn't rely on a hardcoded message version here.
 from ...problem_report.v1_0.message import ProblemReport
 
 from .manager import CredentialManager

--- a/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
@@ -266,8 +266,8 @@ async def credential_exchange_list(request: web.BaseRequest):
     try:
         records = await V10CredentialExchange.query(context, tag_filter, post_filter)
         results = [record.serialize() for record in records]
-    except (StorageError, BaseModelError)  as err:
-        raise web.HTTPBadRequest(reason=roll_up) from err
+    except (StorageError, BaseModelError) as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     return web.json_response({"results": results})
 
@@ -360,6 +360,7 @@ async def credential_exchange_send(request: web.BaseRequest):
     if not connection_record.is_ready:
         raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
 
+<<<<<<< HEAD
     credential_proposal = CredentialProposal(
         comment=comment,
         credential_proposal=preview,
@@ -372,16 +373,23 @@ async def credential_exchange_send(request: web.BaseRequest):
     trace_event(
         context.settings, credential_proposal, outcome="credential_exchange_send.START",
     )
+=======
+        trace_event(
+            context.settings,
+            credential_proposal,
+            outcome="credential_exchange_send.START",
+        )
+>>>>>>> raise 400 series on exceptions within protocols
 
     credential_manager = CredentialManager(context)
     try:
         (
             credential_exchange_record,
-            credential_offer_message
+            credential_offer_message,
         ) = await credential_manager.prepare_send(
             connection_id,
             credential_proposal=credential_proposal,
-            auto_remove=auto_remove
+            auto_remove=auto_remove,
         )
         result = credential_exchange_record.serialize()
     except (StorageError, BaseModelError) as err:
@@ -502,8 +510,20 @@ async def _create_free_offer(
         auto_remove=auto_remove,
         trace=trace_msg,
     )
+<<<<<<< HEAD
 
     credential_manager = CredentialManager(context)
+=======
+
+    credential_manager = CredentialManager(context)
+
+    (
+        credential_exchange_record,
+        credential_offer_message,
+    ) = await credential_manager.create_offer(
+        credential_exchange_record, comment=comment
+    )
+>>>>>>> raise 400 series on exceptions within protocols
 
     (
         credential_exchange_record,
@@ -572,27 +592,40 @@ async def credential_exchange_create_free_offer(request: web.BaseRequest):
     if not endpoint:
         raise web.HTTPBadRequest(reason="A public endpoint required")
 
-    (credential_exchange_record, credential_offer_message) = await _create_free_offer(
-        context,
-        cred_def_id,
-        connection_id,
-        auto_issue,
-        auto_remove,
-        preview_spec,
-        comment,
-        trace_msg,
-    )
+    try:
+        (
+            credential_exchange_record,
+            credential_offer_message,
+        ) = await _create_free_offer(
+            context,
+            cred_def_id,
+            connection_id,
+            auto_issue,
+            auto_remove,
+            preview_spec,
+            comment,
+            trace_msg,
+        )
 
-    trace_event(
-        context.settings,
-        credential_offer_message,
-        outcome="credential_exchange_create_free_offer.END",
-        perf_counter=r_time,
-    )
+        trace_event(
+            context.settings,
+            credential_offer_message,
+            outcome="credential_exchange_create_free_offer.END",
+            perf_counter=r_time,
+        )
 
+<<<<<<< HEAD
     oob_url = serialize_outofband(context, credential_offer_message, conn_did, endpoint)
 
     response = {"record": credential_exchange_record.serialize(), "oob_url": oob_url}
+=======
+        oob_url = serialize_outofband(
+            context, credential_offer_message, conn_did, endpoint
+        )
+        result = credential_exchange_record.serialize()
+    except BaseModelError as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
+>>>>>>> raise 400 series on exceptions within protocols
 
     return web.json_response(response)
 
@@ -650,6 +683,7 @@ async def credential_exchange_send_free_offer(request: web.BaseRequest):
     if not connection_record.is_ready:
         raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
 
+<<<<<<< HEAD
     (credential_exchange_record, credential_offer_message) = await _create_free_offer(
         context,
         cred_def_id,
@@ -660,6 +694,24 @@ async def credential_exchange_send_free_offer(request: web.BaseRequest):
         comment,
         trace_msg,
     )
+=======
+        (
+            credential_exchange_record,
+            credential_offer_message,
+        ) = await _create_free_offer(
+            context,
+            cred_def_id,
+            connection_id,
+            auto_issue,
+            auto_remove,
+            preview_spec,
+            comment,
+            trace_msg,
+        )
+        result = credential_exchange_record.serialize()
+    except (StorageNotFoundError, BaseModelError) as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
+>>>>>>> raise 400 series on exceptions within protocols
 
     await outbound_handler(credential_offer_message, connection_id=connection_id)
 
@@ -728,7 +780,17 @@ async def credential_exchange_send_bound_offer(request: web.BaseRequest):
     if not connection_record.is_ready:
         raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
 
+<<<<<<< HEAD
     credential_manager = CredentialManager(context)
+=======
+        credential_manager = CredentialManager(context)
+        (
+            credential_exchange_record,
+            credential_offer_message,
+        ) = await credential_manager.create_offer(
+            credential_exchange_record, comment=None
+        )
+>>>>>>> raise 400 series on exceptions within protocols
 
     (
         credential_exchange_record,
@@ -885,10 +947,21 @@ async def credential_exchange_issue(request: web.BaseRequest):
             comment=comment,
             credential_values=credential_preview.attr_dict(decode=False),
         )
+<<<<<<< HEAD
     except IssuerRevocationRegistryFullError as err:
         raise web.HTTPBadRequest(
             reason=f"Revocation registry {connection_record.revoc_reg_id} is full"
         ) from err
+=======
+
+        result = credential_exchange_record.serialize()
+    except (
+        StorageNotFoundError,
+        IssuerRevocationRegistryFullError,
+        BaseModelError,
+    ) as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
+>>>>>>> raise 400 series on exceptions within protocols
 
     await outbound_handler(credential_issue_message, connection_id=connection_id)
 

--- a/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
@@ -397,7 +397,6 @@ async def credential_exchange_send_proposal(request: web.BaseRequest):
     connection_id = body.get("connection_id")
     comment = body.get("comment")
     preview_spec = body.get("credential_proposal")
-    preview = CredentialPreview.deserialize(preview_spec) if preview_spec else None
     auto_remove = body.get("auto_remove")
     trace_msg = body.get("trace")
 

--- a/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
@@ -298,6 +298,36 @@ class TestCredentialRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.credential_exchange_send_proposal(mock)
 
+    async def test_credential_exchange_send_proposal_deser_x(self):
+        conn_id = "connection-id"
+        preview_spec = {"attributes": [{"name": "attr", "value": "value"}]}
+
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock(
+            return_value={"connection_id": conn_id, "credential_proposal": preview_spec}
+        )
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": context,
+        }
+        mock.app["request_context"].settings = {}
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_credential_manager, async_mock.patch.object(
+            test_module.CredentialProposal, "deserialize", autospec=True
+        ) as mock_proposal_deserialize:
+            mock_cred_ex_record = async_mock.MagicMock()
+            mock_credential_manager.return_value.create_proposal.return_value = (
+                mock_cred_ex_record
+            )
+            mock_proposal_deserialize.side_effect = test_module.BaseModelError()
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.credential_exchange_send_proposal(mock)
+
     async def test_credential_exchange_send_proposal_not_ready(self):
         mock = async_mock.MagicMock()
         mock.json = async_mock.CoroutineMock()
@@ -1286,7 +1316,43 @@ class TestCredentialRoutes(AsyncTestCase):
 
             with self.assertRaises(test_module.web.HTTPBadRequest) as context:
                 await test_module.credential_exchange_issue(mock)
-            assert "Revocation registry is full" in str(context.exception)
+            assert "Revocation registry" in str(context.exception)
+
+    async def test_credential_exchange_issue_deser_x(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock()
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
+        }
+        mock.app["request_context"].settings = {}
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_credential_manager, async_mock.patch.object(
+            test_module, "V10CredentialExchange", autospec=True
+        ) as mock_cred_ex, async_mock.patch.object(
+            test_module, "CredentialPreview", autospec=True
+        ) as mock_cred_preview:
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value.state = (
+                mock_cred_ex.STATE_REQUEST_RECEIVED
+            )
+            mock_cred_ex_record = async_mock.MagicMock()
+            mock_credential_manager.return_value.issue_credential.return_value = (
+                mock_cred_ex_record,
+                async_mock.MagicMock(),
+            )
+            mock_cred_preview.deserialize = async_mock.MagicMock(
+                side_effect=test_module.BaseModelError()
+            )
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.credential_exchange_issue(mock)
 
     async def test_credential_exchange_store(self):
         mock = async_mock.MagicMock()

--- a/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
@@ -60,6 +60,29 @@ class TestCredentialRoutes(AsyncTestCase):
                     {"results": [mock_cred_ex.serialize.return_value]}
                 )
 
+    async def test_credential_exchange_list_x(self):
+        mock = async_mock.MagicMock()
+        mock.query = {
+            "thread_id": "dummy",
+            "connection_id": "dummy",
+            "role": "dummy",
+            "state": "dummy",
+        }
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
+        mock.app = {
+            "request_context": context,
+        }
+        mock.app["request_context"].settings = {}
+
+        with async_mock.patch.object(
+            test_module, "V10CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+            mock_cred_ex.query = async_mock.CoroutineMock(
+                side_effect=test_module.StorageError()
+            )
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.credential_exchange_list(mock)
+
     async def test_credential_exchange_retrieve(self):
         mock = async_mock.MagicMock()
         mock.match_info = {"cred_ex_id": "dummy"}
@@ -84,6 +107,44 @@ class TestCredentialRoutes(AsyncTestCase):
                 mock_response.assert_called_once_with(
                     mock_cred_ex.serialize.return_value
                 )
+
+    async def test_credential_exchange_retrieve_not_found(self):
+        mock = async_mock.MagicMock()
+        mock.match_info = {"cred_ex_id": "dummy"}
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
+        mock.app = {
+            "request_context": context,
+        }
+        mock.app["request_context"].settings = {}
+
+        with async_mock.patch.object(
+            test_module, "V10CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock(
+                side_effect=test_module.StorageNotFoundError()
+            )
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.credential_exchange_retrieve(mock)
+
+    async def test_credential_exchange_retrieve_x(self):
+        mock = async_mock.MagicMock()
+        mock.match_info = {"cred_ex_id": "dummy"}
+        context = RequestContext(base_context=InjectionContext(enforce_typing=False))
+        mock.app = {
+            "request_context": context,
+        }
+        mock.app["request_context"].settings = {}
+
+        with async_mock.patch.object(
+            test_module, "V10CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cred_ex.retrieve_by_id.return_value = mock_cred_ex
+            mock_cred_ex.serialize = async_mock.MagicMock(
+                side_effect=test_module.BaseModelError()
+            )
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.credential_exchange_retrieve(mock)
 
     async def test_credential_exchange_retrieve_not_found(self):
         mock = async_mock.MagicMock()
@@ -399,18 +460,14 @@ class TestCredentialRoutes(AsyncTestCase):
         ) as mock_seroob, async_mock.patch.object(
             test_module.web, "json_response"
         ) as mock_response:
-
             mock_credential_manager.return_value.create_offer = (
                 async_mock.CoroutineMock()
             )
-
             mock_cred_ex_record = async_mock.MagicMock()
-
             mock_credential_manager.return_value.create_offer.return_value = (
                 mock_cred_ex_record,
                 async_mock.MagicMock(),
             )
-
             mock_seroob.return_value = "abc123"
 
             await test_module.credential_exchange_create_free_offer(mock)
@@ -452,6 +509,40 @@ class TestCredentialRoutes(AsyncTestCase):
 
         with self.assertRaises(test_module.web.HTTPBadRequest):
             await test_module.credential_exchange_create_free_offer(mock)
+
+    async def test_credential_exchange_create_free_offer_retrieve_conn_rec_x(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock(
+            return_value={
+                "auto_issue": False,
+                "cred_def_id": "cred-def-id",
+                "connection_id": "dummy",
+                "credential_preview": {
+                    "attributes": [{"name": "hello", "value": "world"}]
+                },
+            }
+        )
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
+        }
+        mock.app["request_context"].settings = {}
+        mock.app["request_context"].inject = async_mock.CoroutineMock(
+            return_value=async_mock.MagicMock(
+                get_local_did=async_mock.CoroutineMock(
+                    side_effect=test_module.WalletError()
+                )
+            )
+        )
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record:
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.credential_exchange_create_free_offer(mock)
 
     async def test_credential_exchange_create_free_offer_no_conn_id(self):
         mock = async_mock.MagicMock()
@@ -573,6 +664,55 @@ class TestCredentialRoutes(AsyncTestCase):
 
         with self.assertRaises(test_module.web.HTTPBadRequest):
             await test_module.credential_exchange_create_free_offer(mock)
+
+    async def test_credential_exchange_create_free_offer_deser_x(self):
+        mock = async_mock.MagicMock()
+        mock.json = async_mock.CoroutineMock(
+            return_value={
+                "auto_issue": False,
+                "cred_def_id": "cred-def-id",
+                "connection_id": "dummy",
+                "credential_preview": {
+                    "attributes": [{"name": "hello", "value": "world"}]
+                },
+            }
+        )
+
+        mock.app = {
+            "outbound_message_router": async_mock.CoroutineMock(),
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
+        }
+        mock.app["request_context"].settings = {
+            "default_endpoint": "http://1.2.3.4:8081"
+        }
+        mock.app["request_context"].inject = async_mock.CoroutineMock(
+            return_value=async_mock.MagicMock(
+                retrieve_by_id=async_mock.CoroutineMock(
+                    return_value=async_mock.MagicMock(my_did="did")
+                ),
+                get_local_did=async_mock.CoroutineMock(
+                    return_value=DIDInfo("did", "verkey", {"meta": "data"})
+                ),
+            )
+        )
+
+        with async_mock.patch.object(
+            test_module, "ConnectionRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_credential_manager:
+            mock_credential_manager.return_value.create_offer = (
+                async_mock.CoroutineMock()
+            )
+            mock_cred_ex_record = async_mock.MagicMock()
+            mock_credential_manager.return_value.create_offer.side_effect = (
+                test_module.BaseModelError()
+            )
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.credential_exchange_create_free_offer(mock)
 
     async def test_credential_exchange_send_free_offer(self):
         mock = async_mock.MagicMock()
@@ -1580,7 +1720,7 @@ class TestCredentialRoutes(AsyncTestCase):
 
             mock_response.assert_called_once_with({})
 
-    async def test_credential_exchange_remove_bad_cred_id(self):
+    async def test_credential_exchange_remove_bad_cred_ex_id(self):
         mock = async_mock.MagicMock()
 
         mock_outbound = async_mock.CoroutineMock()
@@ -1594,6 +1734,27 @@ class TestCredentialRoutes(AsyncTestCase):
             )
 
             with self.assertRaises(test_module.web.HTTPNotFound):
+                await test_module.credential_exchange_remove(mock)
+
+    async def test_credential_exchange_remove_x(self):
+        mock = async_mock.MagicMock()
+
+        mock_outbound = async_mock.CoroutineMock()
+
+        with async_mock.patch.object(
+            test_module, "V10CredentialExchange", autospec=True
+        ) as mock_cred_ex:
+            # Emulate storage not found (bad cred ex id)
+            mock_rec = async_mock.MagicMock(
+                delete_record=async_mock.CoroutineMock(
+                    side_effect=test_module.StorageError()
+                )
+            )
+            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock(
+                return_value=mock_rec
+            )
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.credential_exchange_remove(mock)
 
     async def test_credential_exchange_revoke(self):
@@ -1663,6 +1824,26 @@ class TestCredentialRoutes(AsyncTestCase):
             await test_module.credential_exchange_publish_revocations(mock)
 
             mock_response.assert_called_once_with({"results": pub_pending.return_value})
+
+    async def test_credential_exchange_publish_revocations_x(self):
+        mock = async_mock.MagicMock()
+        mock.app = {
+            "request_context": async_mock.patch.object(
+                aio_web, "BaseRequest", autospec=True
+            ),
+        }
+        mock.app["request_context"].settings = {}
+
+        with async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_cred_mgr:
+            pub_pending = async_mock.CoroutineMock(
+                side_effect=test_module.RevocationError()
+            )
+            mock_cred_mgr.return_value.publish_pending_revocations = pub_pending
+
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.credential_exchange_publish_revocations(mock)
 
     async def test_credential_exchange_problem_report(self):
         mock = async_mock.MagicMock()

--- a/aries_cloudagent/protocols/problem_report/v1_0/handler.py
+++ b/aries_cloudagent/protocols/problem_report/v1_0/handler.py
@@ -1,6 +1,6 @@
 """Generic problem report handler."""
 
-from aries_cloudagent.messaging.base_handler import (
+from ....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     RequestContext,

--- a/aries_cloudagent/protocols/problem_report/v1_0/message.py
+++ b/aries_cloudagent/protocols/problem_report/v1_0/message.py
@@ -4,7 +4,7 @@ from typing import Mapping, Sequence
 
 from marshmallow import fields, validate
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from ....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from .message_types import PROBLEM_REPORT, PROTOCOL_PACKAGE
 

--- a/aries_cloudagent/protocols/routing/v1_0/handlers/forward_handler.py
+++ b/aries_cloudagent/protocols/routing/v1_0/handlers/forward_handler.py
@@ -2,7 +2,7 @@
 
 import json
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     HandlerException,

--- a/aries_cloudagent/protocols/routing/v1_0/handlers/route_query_request_handler.py
+++ b/aries_cloudagent/protocols/routing/v1_0/handlers/route_query_request_handler.py
@@ -1,6 +1,6 @@
 """Handler for incoming route-query-request messages."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     HandlerException,

--- a/aries_cloudagent/protocols/routing/v1_0/handlers/route_query_response_handler.py
+++ b/aries_cloudagent/protocols/routing/v1_0/handlers/route_query_response_handler.py
@@ -1,6 +1,6 @@
 """Handler for incoming route-query-response messages."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     HandlerException,

--- a/aries_cloudagent/protocols/routing/v1_0/handlers/route_update_request_handler.py
+++ b/aries_cloudagent/protocols/routing/v1_0/handlers/route_update_request_handler.py
@@ -1,6 +1,6 @@
 """Handler for incoming route-update-request messages."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     HandlerException,

--- a/aries_cloudagent/protocols/routing/v1_0/handlers/route_update_response_handler.py
+++ b/aries_cloudagent/protocols/routing/v1_0/handlers/route_update_response_handler.py
@@ -1,15 +1,13 @@
 """Handler for incoming route-update-response messages."""
 
-from aries_cloudagent.connections.models.connection_record import ConnectionRecord
-from aries_cloudagent.messaging.base_handler import (
+from .....connections.models.connection_record import ConnectionRecord
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     HandlerException,
     RequestContext,
 )
-
-# FIXME: We shouldn't rely on a hardcoded message version here.
-from aries_cloudagent.protocols.connections.v1_0.manager import ConnectionManager
+from .....protocols.connections.v1_0.manager import ConnectionManager
 
 from ..messages.route_update_response import RouteUpdateResponse
 from ..models.route_update import RouteUpdate

--- a/aries_cloudagent/protocols/routing/v1_0/manager.py
+++ b/aries_cloudagent/protocols/routing/v1_0/manager.py
@@ -3,11 +3,11 @@
 import json
 from typing import Sequence
 
-from aries_cloudagent.config.injection_context import InjectionContext
-from aries_cloudagent.core.error import BaseError
-from aries_cloudagent.messaging.util import time_now
-from aries_cloudagent.storage.base import BaseStorage, StorageRecord
-from aries_cloudagent.storage.error import (
+from ....config.injection_context import InjectionContext
+from ....core.error import BaseError
+from ....messaging.util import time_now
+from ....storage.base import BaseStorage, StorageRecord
+from ....storage.error import (
     StorageError,
     StorageDuplicateError,
     StorageNotFoundError,

--- a/aries_cloudagent/protocols/routing/v1_0/messages/forward.py
+++ b/aries_cloudagent/protocols/routing/v1_0/messages/forward.py
@@ -6,7 +6,7 @@ from typing import Union
 
 from marshmallow import fields, pre_load
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import FORWARD, PROTOCOL_PACKAGE
 

--- a/aries_cloudagent/protocols/routing/v1_0/messages/route_query_request.py
+++ b/aries_cloudagent/protocols/routing/v1_0/messages/route_query_request.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import PROTOCOL_PACKAGE, ROUTE_QUERY_REQUEST
 from ..models.paginate import Paginate, PaginateSchema

--- a/aries_cloudagent/protocols/routing/v1_0/messages/route_query_response.py
+++ b/aries_cloudagent/protocols/routing/v1_0/messages/route_query_response.py
@@ -4,7 +4,7 @@ from typing import Sequence
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import PROTOCOL_PACKAGE, ROUTE_QUERY_RESPONSE
 from ..models.paginated import Paginated, PaginatedSchema

--- a/aries_cloudagent/protocols/routing/v1_0/messages/route_update_request.py
+++ b/aries_cloudagent/protocols/routing/v1_0/messages/route_update_request.py
@@ -4,7 +4,7 @@ from typing import Sequence
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import PROTOCOL_PACKAGE, ROUTE_UPDATE_REQUEST
 from ..models.route_update import RouteUpdate, RouteUpdateSchema

--- a/aries_cloudagent/protocols/routing/v1_0/messages/route_update_response.py
+++ b/aries_cloudagent/protocols/routing/v1_0/messages/route_update_response.py
@@ -4,7 +4,7 @@ from typing import Sequence
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import PROTOCOL_PACKAGE, ROUTE_UPDATE_RESPONSE
 from ..models.route_updated import RouteUpdated, RouteUpdatedSchema

--- a/aries_cloudagent/protocols/routing/v1_0/models/paginate.py
+++ b/aries_cloudagent/protocols/routing/v1_0/models/paginate.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.models.base import BaseModel, BaseModelSchema
+from .....messaging.models.base import BaseModel, BaseModelSchema
 
 
 class Paginate(BaseModel):

--- a/aries_cloudagent/protocols/routing/v1_0/models/paginated.py
+++ b/aries_cloudagent/protocols/routing/v1_0/models/paginated.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.models.base import BaseModel, BaseModelSchema
+from .....messaging.models.base import BaseModel, BaseModelSchema
 
 
 class Paginated(BaseModel):

--- a/aries_cloudagent/protocols/routing/v1_0/models/route_query_result.py
+++ b/aries_cloudagent/protocols/routing/v1_0/models/route_query_result.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.models.base import BaseModel, BaseModelSchema
+from .....messaging.models.base import BaseModel, BaseModelSchema
 
 
 class RouteQueryResult(BaseModel):

--- a/aries_cloudagent/protocols/routing/v1_0/models/route_record.py
+++ b/aries_cloudagent/protocols/routing/v1_0/models/route_record.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.models.base import BaseModel, BaseModelSchema
+from .....messaging.models.base import BaseModel, BaseModelSchema
 
 
 class RouteRecord(BaseModel):

--- a/aries_cloudagent/protocols/routing/v1_0/models/route_update.py
+++ b/aries_cloudagent/protocols/routing/v1_0/models/route_update.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.models.base import BaseModel, BaseModelSchema
+from .....messaging.models.base import BaseModel, BaseModelSchema
 
 
 class RouteUpdate(BaseModel):

--- a/aries_cloudagent/protocols/routing/v1_0/models/route_updated.py
+++ b/aries_cloudagent/protocols/routing/v1_0/models/route_updated.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.models.base import BaseModel, BaseModelSchema
+from .....messaging.models.base import BaseModel, BaseModelSchema
 
 
 class RouteUpdated(BaseModel):

--- a/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_handler.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_handler.py
@@ -1,6 +1,6 @@
 """Ping handler."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     RequestContext,

--- a/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_response_handler.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_response_handler.py
@@ -1,6 +1,6 @@
 """Ping response handler."""
 
-from aries_cloudagent.messaging.base_handler import (
+from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     RequestContext,

--- a/aries_cloudagent/protocols/trustping/v1_0/messages/ping.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/messages/ping.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import PING, PROTOCOL_PACKAGE
 

--- a/aries_cloudagent/protocols/trustping/v1_0/messages/ping_response.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/messages/ping_response.py
@@ -2,7 +2,7 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.messaging.agent_message import AgentMessage, AgentMessageSchema
+from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import PING_RESPONSE, PROTOCOL_PACKAGE
 

--- a/aries_cloudagent/protocols/trustping/v1_0/routes.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/routes.py
@@ -53,11 +53,11 @@ async def connections_send_ping(request: web.BaseRequest):
 
     try:
         connection = await ConnectionRecord.retrieve_by_id(context, connection_id)
-    except StorageNotFoundError:
-        raise web.HTTPNotFound()
+    except StorageNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
 
     if not connection.is_ready:
-        raise web.HTTPBadRequest()
+        raise web.HTTPBadRequest(reason=f"Connection {connection_id} not ready")
 
     msg = Ping(comment=comment)
     await outbound_handler(msg, connection_id=connection_id)

--- a/aries_cloudagent/protocols/trustping/v1_0/routes.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/routes.py
@@ -5,9 +5,9 @@ from aiohttp_apispec import docs, match_info_schema, request_schema, response_sc
 
 from marshmallow import fields, Schema
 
-from aries_cloudagent.connections.models.connection_record import ConnectionRecord
-from aries_cloudagent.messaging.valid import UUIDFour
-from aries_cloudagent.storage.error import StorageNotFoundError
+from ....connections.models.connection_record import ConnectionRecord
+from ....messaging.valid import UUIDFour
+from ....storage.error import StorageNotFoundError
 
 from .message_types import SPEC_URI
 from .messages.ping import Ping

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -310,10 +310,10 @@ async def publish_registry(request: web.BaseRequest):
 
         await revoc_registry.publish_registry_entry(context)
         LOGGER.debug("published registry entry: %s", registry_id)
-    except StorageNotFoundError as x_stor:
-        raise web.HTTPNotFound(reason=x_stor.roll_up) from x_stor
-    except RevocationError as x_revo:
-        raise web.HTTPBadRequest(reason=x_revo.roll_up) from x_revo
+    except StorageNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
+    except RevocationError as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     return web.json_response({"result": revoc_registry.serialize()})
 
@@ -347,10 +347,10 @@ async def update_registry(request: web.BaseRequest):
         revoc = IndyRevocation(context)
         revoc_registry = await revoc.get_issuer_rev_reg_record(registry_id)
         await revoc_registry.set_tails_file_public_uri(context, tails_public_uri)
-    except StorageNotFoundError as x_stor:
-        raise web.HTTPNotFound(reason=x_stor.roll_up) from x_stor
-    except RevocationError as x_revo:
-        raise web.HTTPBadRequest(reason=x_revo.roll_up) from x_revo
+    except StorageNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
+    except RevocationError as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     return web.json_response({"result": revoc_registry.serialize()})
 

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -19,7 +19,7 @@ from ..messaging.credential_definitions.util import CRED_DEF_SENT_RECORD_TYPE
 from ..messaging.valid import INDY_CRED_DEF_ID, INDY_REV_REG_ID
 from ..storage.base import BaseStorage, StorageNotFoundError
 
-from .error import RevocationNotSupportedError
+from .error import RevocationError, RevocationNotSupportedError
 from .indy import IndyRevocation
 from .models.issuer_rev_reg_record import IssuerRevRegRecord, IssuerRevRegRecordSchema
 from .models.revocation_registry import RevocationRegistry
@@ -140,7 +140,9 @@ async def revocation_create_registry(request: web.BaseRequest):
         tag_query={"cred_def_id": credential_definition_id},
     ).fetch_all()
     if not found:
-        raise web.HTTPNotFound()
+        raise web.HTTPNotFound(
+            reason=f"Not issuer of credential definition id {credential_definition_id}"
+        )
 
     try:
         issuer_did = credential_definition_id.split(":")[0]
@@ -213,8 +215,8 @@ async def get_registry(request: web.BaseRequest):
     try:
         revoc = IndyRevocation(context)
         revoc_registry = await revoc.get_issuer_rev_reg_record(registry_id)
-    except StorageNotFoundError as e:
-        raise web.HTTPNotFound() from e
+    except StorageNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
 
     return web.json_response({"result": revoc_registry.serialize()})
 
@@ -243,8 +245,8 @@ async def get_active_registry(request: web.BaseRequest):
     try:
         revoc = IndyRevocation(context)
         revoc_registry = await revoc.get_active_issuer_rev_reg_record(cred_def_id)
-    except StorageNotFoundError as e:
-        raise web.HTTPNotFound() from e
+    except StorageNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
 
     return web.json_response({"result": revoc_registry.serialize()})
 
@@ -274,8 +276,8 @@ async def get_tails_file(request: web.BaseRequest) -> web.FileResponse:
     try:
         revoc = IndyRevocation(context)
         revoc_registry = await revoc.get_issuer_rev_reg_record(registry_id)
-    except StorageNotFoundError as e:
-        raise web.HTTPNotFound() from e
+    except StorageNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
 
     return web.FileResponse(path=revoc_registry.tails_local_path, status=200)
 
@@ -302,13 +304,16 @@ async def publish_registry(request: web.BaseRequest):
     try:
         revoc = IndyRevocation(context)
         revoc_registry = await revoc.get_issuer_rev_reg_record(registry_id)
-    except StorageNotFoundError as e:
-        raise web.HTTPNotFound() from e
 
-    await revoc_registry.publish_registry_definition(context)
-    LOGGER.debug("published registry definition: %s", registry_id)
-    await revoc_registry.publish_registry_entry(context)
-    LOGGER.debug("published registry entry: %s", registry_id)
+        await revoc_registry.publish_registry_definition(context)
+        LOGGER.debug("published registry definition: %s", registry_id)
+
+        await revoc_registry.publish_registry_entry(context)
+        LOGGER.debug("published registry entry: %s", registry_id)
+    except StorageNotFoundError as x_stor:
+        raise web.HTTPNotFound(reason=x_stor.roll_up) from x_stor
+    except RevocationError as x_revo:
+        raise web.HTTPBadRequest(reason=x_revo.roll_up) from x_revo
 
     return web.json_response({"result": revoc_registry.serialize()})
 
@@ -341,10 +346,11 @@ async def update_registry(request: web.BaseRequest):
     try:
         revoc = IndyRevocation(context)
         revoc_registry = await revoc.get_issuer_rev_reg_record(registry_id)
-    except StorageNotFoundError as e:
-        raise web.HTTPNotFound() from e
-
-    await revoc_registry.set_tails_file_public_uri(context, tails_public_uri)
+        await revoc_registry.set_tails_file_public_uri(context, tails_public_uri)
+    except StorageNotFoundError as x_stor:
+        raise web.HTTPNotFound(reason=x_stor.roll_up) from x_stor
+    except RevocationError as x_revo:
+        raise web.HTTPBadRequest(reason=x_revo.roll_up) from x_revo
 
     return web.json_response({"result": revoc_registry.serialize()})
 

--- a/aries_cloudagent/storage/indy.py
+++ b/aries_cloudagent/storage/indy.py
@@ -251,9 +251,7 @@ class IndyStorageRecordSearch(BaseStorageRecordSearch):
             page_size: Size of page to return
 
         """
-        super().__init__(
-            store, type_filter, tag_query, page_size, options
-        )
+        super().__init__(store, type_filter, tag_query, page_size, options)
         self._handle = None
 
     @property

--- a/aries_cloudagent/storage/indy.py
+++ b/aries_cloudagent/storage/indy.py
@@ -105,7 +105,9 @@ class IndyStorage(BaseStorage):
             )
         except IndyError as x_indy:
             if x_indy.error_code == ErrorCode.WalletItemNotFound:
-                raise StorageNotFoundError("Record not found: {}".format(record_id))
+                raise StorageNotFoundError(
+                    f"{record_type} record not found: {record_id}"
+                )
             raise StorageError(str(x_indy))
         result = json.loads(result_json)
         return StorageRecord(
@@ -135,7 +137,7 @@ class IndyStorage(BaseStorage):
             )
         except IndyError as x_indy:
             if x_indy.error_code == ErrorCode.WalletItemNotFound:
-                raise StorageNotFoundError("Record not found: {}".format(record.id))
+                raise StorageNotFoundError(f"Record not found: {record.id}")
             raise StorageError(str(x_indy))
 
     async def update_record_tags(self, record: StorageRecord, tags: Mapping):
@@ -159,7 +161,7 @@ class IndyStorage(BaseStorage):
             )
         except IndyError as x_indy:
             if x_indy.error_code == ErrorCode.WalletItemNotFound:
-                raise StorageNotFoundError("Record not found: {}".format(record.id))
+                raise StorageNotFoundError(f"Record not found: {record.id}")
             raise StorageError(str(x_indy))
 
     async def delete_record_tags(
@@ -202,7 +204,7 @@ class IndyStorage(BaseStorage):
             )
         except IndyError as x_indy:
             if x_indy.error_code == ErrorCode.WalletItemNotFound:
-                raise StorageNotFoundError("Record not found: {}".format(record.id))
+                raise StorageNotFoundError(f"Record not found: {record.id}")
             raise StorageError(str(x_indy))
 
     def search_records(

--- a/aries_cloudagent/storage/indy.py
+++ b/aries_cloudagent/storage/indy.py
@@ -251,7 +251,7 @@ class IndyStorageRecordSearch(BaseStorageRecordSearch):
             page_size: Size of page to return
 
         """
-        super(IndyStorageRecordSearch, self).__init__(
+        super().__init__(
             store, type_filter, tag_query, page_size, options
         )
         self._handle = None

--- a/aries_cloudagent/transport/inbound/receipt.py
+++ b/aries_cloudagent/transport/inbound/receipt.py
@@ -274,10 +274,5 @@ class MessageReceipt:
             A human readable representation of this object
 
         """
-        skip = ()
-        items = (
-            "{}={}".format(k, repr(v))
-            for k, v in self.__dict__.items()
-            if k not in skip
-        )
+        items = ("{}={}".format(k, repr(v)) for k, v in self.__dict__.items())
         return "<{}({})>".format(self.__class__.__name__, ", ".join(items))

--- a/aries_cloudagent/transport/inbound/tests/test_session.py
+++ b/aries_cloudagent/transport/inbound/tests/test_session.py
@@ -134,6 +134,21 @@ class TestInboundSession(TestCase):
             thread_id=test_thread_id,
             sender_verkey=test_verkey,
         )
+
+        receipt.recipient_did = "dummy"
+        assert receipt.recipient_did == "dummy"
+        receipt.recipient_did_public = True
+        assert receipt.recipient_did_public
+        receipt.recipient_did = None
+        receipt.recipient_did_public = None
+        assert receipt.recipient_did is None
+        assert receipt.recipient_did_public is None
+        receipt.sender_did = "dummy"
+        assert receipt.sender_did == "dummy"
+        receipt.sender_did = None
+        assert receipt.sender_did is None
+        assert "direct_response_mode" in str(receipt)
+
         message = InboundMessage(payload=None, receipt=receipt)
         sess.process_inbound(message)
         assert sess.reply_mode == receipt.direct_response_mode

--- a/aries_cloudagent/transport/outbound/tests/test_ws_transport.py
+++ b/aries_cloudagent/transport/outbound/tests/test_ws_transport.py
@@ -46,3 +46,9 @@ class TestWsTransport(AioHTTPTestCase):
         transport = WsTransport()
         await asyncio.wait_for(send_message(transport, "{}", endpoint=server_addr), 5.0)
         assert self.message_results == [{}]
+
+        self.message_results.clear()
+        await asyncio.wait_for(
+            send_message(transport, b"{}", endpoint=server_addr), 5.0
+        )
+        assert self.message_results == [{}]

--- a/aries_cloudagent/transport/pack_format.py
+++ b/aries_cloudagent/transport/pack_format.py
@@ -7,7 +7,6 @@ from typing import Sequence, Tuple, Union
 from ..config.base import InjectorError
 from ..config.injection_context import InjectionContext
 
-# FIXME: We shouldn't rely on a hardcoded message version here.
 from ..protocols.routing.v1_0.messages.forward import Forward
 
 from ..messaging.util import time_now

--- a/aries_cloudagent/transport/tests/test_pack_format.py
+++ b/aries_cloudagent/transport/tests/test_pack_format.py
@@ -4,7 +4,6 @@ from asynctest import TestCase as AsyncTestCase, mock as async_mock
 
 from ...config.injection_context import InjectionContext
 
-# FIXME: We shouldn't rely on a hardcoded message version here.
 from ...protocols.routing.v1_0.message_types import FORWARD
 from ...wallet.base import BaseWallet
 from ...wallet.basic import BasicWallet

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -73,6 +73,13 @@ class TestWalletRoutes(AsyncTestCase):
             )
             assert result is json_response.return_value
 
+    async def test_create_did_x(self):
+        request = async_mock.MagicMock()
+        request.app = self.app
+        self.wallet.create_local_did.side_effect = test_module.WalletError()
+        with self.assertRaises(test_module.web.HTTPBadRequest):
+            await test_module.wallet_create_did(request)
+
     async def test_did_list(self):
         request = async_mock.MagicMock()
         request.app = self.app
@@ -210,6 +217,13 @@ class TestWalletRoutes(AsyncTestCase):
                 {"result": format_did_info.return_value}
             )
             assert result is json_response.return_value
+
+    async def test_get_public_did_x(self):
+        request = async_mock.MagicMock()
+        request.app = self.app
+        self.wallet.get_public_did.side_effect = test_module.WalletError()
+        with self.assertRaises(test_module.web.HTTPBadRequest):
+            await test_module.wallet_get_public_did(request)
 
     async def test_set_public_did(self):
         request = async_mock.MagicMock()
@@ -353,6 +367,17 @@ class TestWalletRoutes(AsyncTestCase):
         with self.assertRaises(test_module.web.HTTPForbidden):
             await test_module.wallet_get_tagging_policy(request)
 
+    async def test_get_catpol_wallet_err(self):
+        request = async_mock.MagicMock()
+        request.app = self.app
+
+        self.wallet.WALLET_TYPE = "indy"
+        self.wallet.get_credential_definition_tag_policy = async_mock.CoroutineMock(
+            side_effect=test_module.WalletError()
+        )
+        with self.assertRaises(test_module.web.HTTPBadRequest):
+            await test_module.wallet_get_tagging_policy(request)
+
     async def test_set_catpol(self):
         request = async_mock.MagicMock()
         request.app = self.app
@@ -380,6 +405,20 @@ class TestWalletRoutes(AsyncTestCase):
 
         self.wallet.WALLET_TYPE = "rich-corinthian-leather"
         with self.assertRaises(test_module.web.HTTPForbidden):
+            await test_module.wallet_set_tagging_policy(request)
+
+    async def test_set_catpol_wallet_err(self):
+        request = async_mock.MagicMock()
+        request.app = self.app
+        request.json = async_mock.CoroutineMock(
+            return_value={"taggables": ["a", "b", "c"]}
+        )
+
+        self.wallet.WALLET_TYPE = "indy"
+        self.wallet.set_credential_definition_tag_policy = async_mock.CoroutineMock(
+            side_effect=test_module.WalletError()
+        )
+        with self.assertRaises(test_module.web.HTTPBadRequest):
             await test_module.wallet_set_tagging_policy(request)
 
     async def test_register(self):

--- a/demo/AcmeDemoWorkshop.md
+++ b/demo/AcmeDemoWorkshop.md
@@ -232,10 +232,17 @@ with the following code:
                     "date": date.isoformat(date.today()),
                     "position": "CEO"
                 }
+                cred_preview = {
+                    "@type": CRED_PREVIEW_TYPE,
+                    "attributes": [
+                        {"name": n, "value": v} for (n, v) in cred_attrs.items()
+                    ],
+                }
                 offer_request = {
                     "connection_id": agent.connection_id,
                     "cred_def_id": credential_definition_id,
                     "comment": f"Offer on cred def id {credential_definition_id}",
+                    "credential_preview": cred_preview
                 }
                 await agent.admin_POST(
                     "/issue-credential/send-offer",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ msgpack~=0.6.1
 prompt_toolkit~=2.0.9
 pynacl~=1.3.0
 requests~=2.23.0
+pyld==2.0.1


### PR DESCRIPTION
In Issuing credential offer for Acme, cred_preview variable is missing and due to this acme agent will throw " Acme | Error during POST /issue-credential/send-offer: 422, message='Unprocessable Entity', url=URL('http://192.168.65.3:8041/issue-credential/send-offer')"

![cred_preview_error](https://user-images.githubusercontent.com/20536576/84073573-c406d180-a9d9-11ea-94dd-45611c2e909a.png)

So to fix this issue, I have added the cred_preiew object and add that property in offer_request object.