### PR TITLE
Correct revocation API in credential revocation documentation

### DIFF
--- a/docs/GettingStartedAriesDev/CredentialRevocation.md
+++ b/docs/GettingStartedAriesDev/CredentialRevocation.md
@@ -64,9 +64,10 @@ These are the ACA-py steps and APIs involved to support credential revocation.
         "credential_exchange_id": credential_exchange_id
     }   
    ```
-0. Revoking credential (cred_rev_id is revocation_id from /issue-credential​/records)
+0. Revoking credential
     ```
-    POST /issue-credential/revoke
+    POST /issue-credential/revoke?rev_reg_id=<revocation_registry_id>
+         &cred_rev_id=<credential_revocation_id>&publish=<true|false>
     ```
 
 0. When asking for proof, specify the timespan when the credential is NOT revoked

--- a/docs/GettingStartedAriesDev/CredentialRevocation.md
+++ b/docs/GettingStartedAriesDev/CredentialRevocation.md
@@ -64,9 +64,9 @@ These are the ACA-py steps and APIs involved to support credential revocation.
         "credential_exchange_id": credential_exchange_id
     }   
    ```
-0. Revoking credential
+0. Revoking credential (cred_rev_id is revocation_id from /issue-credential​/records)
     ```
-    POST /issue-credential/records/{cred_ex_id}/revoke
+    POST /issue-credential/revoke
     ```
 
 0. When asking for proof, specify the timespan when the credential is NOT revoked


### PR DESCRIPTION
I found that changes of the revocation API (https://github.com/hyperledger/aries-cloudagent-python/issues/428) have not yet been applied to the credential revocation documentation.
Changed to the correct revocation API.

Signed-off-by: Ethan Sung <baegjae@gmail.com>