### PR TITLE
Multitenent Functionality 

### DIFF
--- a/aries_cloudagent/config/default_context.py
+++ b/aries_cloudagent/config/default_context.py
@@ -2,7 +2,7 @@
 
 from .base_context import ContextBuilder
 from .injection_context import InjectionContext
-from .provider import CachedProvider, ClassProvider, StatsProvider
+from .provider import CachedProvider, ClassProvider, StatsProvider, DynamicProvider
 
 from ..cache.base import BaseCache
 from ..cache.basic import BasicCache
@@ -56,15 +56,15 @@ class DefaultContextBuilder(ContextBuilder):
 
         context.injector.bind_provider(
             BaseStorage,
-            CachedProvider(
-                StatsProvider(
-                    StorageProvider(), ("add_record", "get_record", "search_records")
-                )
-            ),
+            #CachedProvider(
+            StatsProvider(
+                StorageProvider(), ("add_record", "get_record", "search_records")
+            )
+            #),
         )
         context.injector.bind_provider(
             BaseWallet,
-            CachedProvider(
+            DynamicProvider(
                 StatsProvider(
                     WalletProvider(),
                     (
@@ -74,23 +74,24 @@ class DefaultContextBuilder(ContextBuilder):
                         # "unpack_message",
                         "get_local_did",
                     ),
-                )
+                ),
+                'wallet.name'
             ),
         )
 
         context.injector.bind_provider(
             BaseLedger,
-            CachedProvider(
-                StatsProvider(
-                    LedgerProvider(),
-                    (
-                        "create_and_send_credential_definition",
-                        "create_and_send_schema",
-                        "get_credential_definition",
-                        "get_schema",
-                    ),
-                )
-            ),
+            #CachedProvider(
+            StatsProvider(
+                LedgerProvider(),
+                (
+                    "create_and_send_credential_definition",
+                    "create_and_send_schema",
+                    "get_credential_definition",
+                    "get_schema",
+                ),
+            )
+            #),
         )
         context.injector.bind_provider(
             BaseIssuer,

--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -114,7 +114,7 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
         The credential definition identifier
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
 
     body = await request.json()
 
@@ -161,7 +161,7 @@ async def credential_definitions_created(request: web.BaseRequest):
         The identifiers of matching credential definitions.
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
 
     storage = await context.inject(BaseStorage)
     found = await storage.search_records(
@@ -193,7 +193,7 @@ async def credential_definitions_get_credential_definition(request: web.BaseRequ
         The credential definition details.
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
 
     credential_definition_id = request.match_info["cred_def_id"]
 

--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -15,6 +15,7 @@ from marshmallow import fields, Schema
 from marshmallow.validate import Regexp
 
 from ...issuer.base import BaseIssuer, IssuerError
+
 from ...ledger.base import BaseLedger
 from ...ledger.error import LedgerError
 from ...storage.base import BaseStorage
@@ -101,7 +102,7 @@ async def schemas_send_schema(request: web.BaseRequest):
         The schema id sent
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
 
     body = await request.json()
 
@@ -146,7 +147,7 @@ async def schemas_created(request: web.BaseRequest):
         The identifiers of matching schemas
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
 
     storage = await context.inject(BaseStorage)
     found = await storage.search_records(
@@ -173,7 +174,7 @@ async def schemas_get_schema(request: web.BaseRequest):
         The schema details.
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
 
     schema_id = request.match_info["schema_id"]
 
@@ -223,3 +224,4 @@ def post_process_routes(app: web.Application):
             },
         }
     )
+

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -226,7 +226,7 @@ async def connections_list(request: web.BaseRequest):
         The connection list response
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     tag_filter = {}
     for param_name in (
         "invitation_id",
@@ -268,7 +268,7 @@ async def connections_retrieve(request: web.BaseRequest):
         The connection record response
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     connection_id = request.match_info["conn_id"]
 
     try:
@@ -298,7 +298,7 @@ async def connections_create_invitation(request: web.BaseRequest):
         The connection invitation details
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     auto_accept = json.loads(request.query.get("auto_accept", "null"))
     alias = request.query.get("alias")
     public = json.loads(request.query.get("public", "false"))
@@ -347,7 +347,7 @@ async def connections_receive_invitation(request: web.BaseRequest):
         The resulting connection record details
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     if context.settings.get("admin.no_receive_invites"):
         raise web.HTTPForbidden(
             reason="Configuration does not allow receipt of invitations"
@@ -386,7 +386,7 @@ async def connections_accept_invitation(request: web.BaseRequest):
         The resulting connection record details
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
     connection_id = request.match_info["conn_id"]
 
@@ -423,7 +423,7 @@ async def connections_accept_request(request: web.BaseRequest):
         The resulting connection record details
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
     connection_id = request.match_info["conn_id"]
 
@@ -453,7 +453,7 @@ async def connections_establish_inbound(request: web.BaseRequest):
     Args:
         request: aiohttp request object
     """
-    context = request.app["request_context"]
+    context = request["context"]
     connection_id = request.match_info["conn_id"]
     outbound_handler = request.app["outbound_message_router"]
     inbound_connection_id = request.match_info["ref_id"]
@@ -481,7 +481,7 @@ async def connections_remove(request: web.BaseRequest):
     Args:
         request: aiohttp request object
     """
-    context = request.app["request_context"]
+    context = request["context"]
     connection_id = request.match_info["conn_id"]
 
     try:
@@ -509,7 +509,7 @@ async def connections_create_static(request: web.BaseRequest):
         The new connection record
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     body = await request.json()
 
     connection_mgr = ConnectionManager(context)

--- a/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
@@ -330,7 +330,7 @@ async def credential_exchange_list(request: web.BaseRequest):
         The connection list response
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     tag_filter = {}
     if "thread_id" in request.query and request.query["thread_id"] != "":
         tag_filter["thread_id"] = request.query["thread_id"]
@@ -363,7 +363,7 @@ async def credential_exchange_retrieve(request: web.BaseRequest):
         The credential exchange record
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     credential_exchange_id = request.match_info["cred_ex_id"]
@@ -404,7 +404,7 @@ async def credential_exchange_create(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
 
     body = await request.json()
 
@@ -477,7 +477,7 @@ async def credential_exchange_send(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     body = await request.json()
@@ -563,7 +563,7 @@ async def credential_exchange_send_proposal(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     body = await request.json()
@@ -684,7 +684,7 @@ async def credential_exchange_create_free_offer(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     body = await request.json()
@@ -785,7 +785,7 @@ async def credential_exchange_send_free_offer(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     body = await request.json()
@@ -873,7 +873,7 @@ async def credential_exchange_send_bound_offer(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     credential_exchange_id = request.match_info["cred_ex_id"]
@@ -945,7 +945,7 @@ async def credential_exchange_send_request(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     credential_exchange_id = request.match_info["cred_ex_id"]
@@ -1011,7 +1011,7 @@ async def credential_exchange_issue(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     body = await request.json()
@@ -1078,7 +1078,7 @@ async def credential_exchange_store(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     try:
@@ -1146,7 +1146,7 @@ async def credential_exchange_revoke(request: web.BaseRequest):
         The credential request details.
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
 
     rev_reg_id = request.query.get("rev_reg_id")
     cred_rev_id = request.query.get("cred_rev_id")  # numeric str here, which indy wants
@@ -1181,7 +1181,7 @@ async def credential_exchange_publish_revocations(request: web.BaseRequest):
         Credential revocation ids published as revoked by revocation registry id.
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     body = await request.json()
     rrid2crid = body.get("rrid2crid")
 
@@ -1208,7 +1208,7 @@ async def credential_exchange_clear_pending_revocations(request: web.BaseRequest
         Credential revocation ids still pending revocation by revocation registry id.
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     body = await request.json()
     purge = body.get("purge")
 
@@ -1233,7 +1233,7 @@ async def credential_exchange_remove(request: web.BaseRequest):
         request: aiohttp request object
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     credential_exchange_id = request.match_info["cred_ex_id"]
@@ -1266,7 +1266,7 @@ async def credential_exchange_problem_report(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     credential_exchange_id = request.match_info["cred_ex_id"]

--- a/aries_cloudagent/protocols/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/routes.py
@@ -434,7 +434,7 @@ async def presentation_exchange_list(request: web.BaseRequest):
         The presentation exchange list response
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     tag_filter = {}
     if "thread_id" in request.query and request.query["thread_id"] != "":
         tag_filter["thread_id"] = request.query["thread_id"]
@@ -467,7 +467,7 @@ async def presentation_exchange_retrieve(request: web.BaseRequest):
         The presentation exchange record response
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     presentation_exchange_id = request.match_info["pres_ex_id"]
@@ -502,7 +502,7 @@ async def presentation_exchange_credentials_list(request: web.BaseRequest):
         The credential list response
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     presentation_exchange_id = request.match_info["pres_ex_id"]
@@ -570,7 +570,7 @@ async def presentation_exchange_send_proposal(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     body = await request.json()
@@ -658,7 +658,7 @@ async def presentation_exchange_create_request(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     body = await request.json()
@@ -724,7 +724,7 @@ async def presentation_exchange_send_free_request(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     body = await request.json()
@@ -807,7 +807,7 @@ async def presentation_exchange_send_bound_request(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     presentation_exchange_id = request.match_info["pres_ex_id"]
@@ -883,7 +883,7 @@ async def presentation_exchange_send_presentation(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
     presentation_exchange_id = request.match_info["pres_ex_id"]
     pres_ex_record = await V10PresentationExchange.retrieve_by_id(
@@ -966,7 +966,7 @@ async def presentation_exchange_verify_presentation(request: web.BaseRequest):
     """
     r_time = get_timer()
 
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     presentation_exchange_id = request.match_info["pres_ex_id"]
@@ -1022,7 +1022,7 @@ async def presentation_exchange_remove(request: web.BaseRequest):
         request: aiohttp request object
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     outbound_handler = request.app["outbound_message_router"]
 
     presentation_exchange_id = request.match_info["pres_ex_id"]

--- a/aries_cloudagent/transport/inbound/http_custodial.py
+++ b/aries_cloudagent/transport/inbound/http_custodial.py
@@ -1,0 +1,146 @@
+"""Http Transport classes and functions."""
+
+import logging
+
+from aiohttp import web
+
+from ...messaging.error import MessageParseError
+
+from .base import BaseInboundTransport, InboundTransportSetupError
+
+from ...wallet_handler.handler import WalletHandler
+from ...wallet_handler.error import WalletNotFoundError
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CustodialHttpTransport(BaseInboundTransport):
+    """Http Transport class for a custodial agent."""
+
+    def __init__(self, host: str, port: int, create_session, **kwargs) -> None:
+        """
+        Initialize an inbound HTTP transport instance.
+
+        Args:
+            host: Host to listen on
+            port: Port to listen on
+            create_session: Method to create a new inbound session
+
+        """
+        super().__init__("http", create_session, **kwargs)
+        self.host = host
+        self.port = port
+        self.site: web.BaseSite = None
+
+    async def make_application(self) -> web.Application:
+        """Construct the aiohttp application."""
+        app_args = {}
+        if self.max_message_size:
+            app_args["client_max_size"] = self.max_message_size
+        app = web.Application(**app_args)
+        app.add_routes([web.get("/", self.invite_message_handler)])
+        app.add_routes([web.post("/{handle}", self.inbound_message_handler)])
+        return app
+
+    async def start(self) -> None:
+        """
+        Start this transport.
+
+        Raises:
+            InboundTransportSetupError: If there was an error starting the webserver
+
+        """
+        app = await self.make_application()
+        runner = web.AppRunner(app)
+        await runner.setup()
+        self.site = web.TCPSite(runner, host=self.host, port=self.port)
+        try:
+            await self.site.start()
+        except OSError:
+            raise InboundTransportSetupError(
+                "Unable to start webserver with host "
+                + f"'{self.host}' and port '{self.port}'\n"
+            )
+
+    async def stop(self) -> None:
+        """Stop this transport."""
+        if self.site:
+            await self.site.stop()
+            self.site = None
+
+    async def inbound_message_handler(self, request: web.BaseRequest):
+        """
+        Message handler for inbound messages.
+
+        Args:
+            request: aiohttp request object
+
+        Returns:
+            The web response
+
+        """
+        ctype = request.headers.get("content-type", "")
+        if ctype.split(";", 1)[0].lower() == "application/json":
+            body = await request.text()
+        else:
+            body = await request.read()
+
+        client_info = {"host": request.host, "remote": request.remote}
+
+        # Store inbound path in client info
+        client_info["inbound_path"] = request.match_info['handle']
+
+        session = await self.create_session(
+            accept_undelivered=True,
+            can_respond=True,
+            client_info=client_info,
+        )
+
+        async with session:
+
+            try:
+                inbound = await session.receive(body)
+            except MessageParseError:
+                raise web.HTTPBadRequest()
+
+            if inbound.receipt.direct_response_requested:
+                response = await session.wait_response()
+
+                # no more responses
+                session.can_respond = False
+                session.clear_response()
+
+                if response:
+                    if isinstance(response, bytes):
+                        return web.Response(
+                            body=response,
+                            status=200,
+                            headers={"Content-Type": "application/ssi-agent-wire"},
+                        )
+                    else:
+                        return web.Response(
+                            text=response,
+                            status=200,
+                            headers={"Content-Type": "application/json"},
+                        )
+
+        return web.Response(status=200)
+
+    async def invite_message_handler(self, request: web.BaseRequest):
+        """
+        Message handler for invites.
+
+        Args:
+            request: aiohttp request object
+
+        Returns:
+            The web response
+
+        """
+        if request.query.get("c_i"):
+            return web.Response(
+                text="You have received a connection invitation. To accept the "
+                "invitation, paste it into your agent application."
+            )
+        else:
+            return web.Response(status=200)

--- a/aries_cloudagent/utils/http.py
+++ b/aries_cloudagent/utils/http.py
@@ -14,16 +14,16 @@ class FetchError(BaseError):
 
 
 async def fetch_stream(
-    url: str,
-    *,
-    headers: dict = None,
-    retry: bool = True,
-    max_attempts: int = 5,
-    interval: float = 1.0,
-    backoff: float = 0.25,
-    request_timeout: float = 10.0,
-    connector: BaseConnector = None,
-    session: ClientSession = None,
+        url: str,
+        *,
+        headers: dict = None,
+        retry: bool = True,
+        max_attempts: int = 5,
+        interval: float = 1.0,
+        backoff: float = 0.25,
+        request_timeout: float = 10.0,
+        connector: BaseConnector = None,
+        session: ClientSession = None,
 ):
     """Fetch from an HTTP server with automatic retries and timeouts.
 
@@ -88,7 +88,10 @@ async def fetch(
     """
     limit = max_attempts if retry else 1
     if not session:
-        session = ClientSession(connector=connector, connector_owner=(not connector))
+        session = ClientSession(
+            connector=connector,
+            connector_owner=(not connector),
+            trust_env=True)
     async with session:
         async for attempt in RepeatSequence(limit, interval, backoff):
             try:

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -102,7 +102,7 @@ async def wallet_did_list(request: web.BaseRequest):
         The DID list response
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     wallet: BaseWallet = await context.inject(BaseWallet, required=False)
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")
@@ -162,7 +162,7 @@ async def wallet_create_did(request: web.BaseRequest):
         The DID info
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     wallet: BaseWallet = await context.inject(BaseWallet, required=False)
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")
@@ -187,7 +187,7 @@ async def wallet_get_public_did(request: web.BaseRequest):
         The DID info
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     wallet: BaseWallet = await context.inject(BaseWallet, required=False)
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")
@@ -213,7 +213,7 @@ async def wallet_set_public_did(request: web.BaseRequest):
         The updated DID info
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     wallet: BaseWallet = await context.inject(BaseWallet, required=False)
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")
@@ -259,7 +259,7 @@ async def wallet_set_did_endpoint(request: web.BaseRequest):
     Args:
         request: aiohttp request object
     """
-    context = request.app["request_context"]
+    context = request["context"]
     wallet: BaseWallet = await context.inject(BaseWallet, required=False)
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")
@@ -295,7 +295,7 @@ async def wallet_get_did_endpoint(request: web.BaseRequest):
         The updated DID info
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     wallet: BaseWallet = await context.inject(BaseWallet, required=False)
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")
@@ -326,7 +326,7 @@ async def wallet_rotate_did_keypair(request: web.BaseRequest):
         An empty JSON response
 
     """
-    context = request.app["request_context"]
+    context = request["context"]
     wallet: BaseWallet = await context.inject(BaseWallet, required=False)
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")

--- a/aries_cloudagent/wallet_handler/__init__.py
+++ b/aries_cloudagent/wallet_handler/__init__.py
@@ -1,0 +1,5 @@
+"""Wallet handler enables aca-py to manage multiple wallets with the same agent."""
+from .setup import setup
+from .handler import WalletHandler
+setup = setup
+WalletHanlder = WalletHandler

--- a/aries_cloudagent/wallet_handler/error.py
+++ b/aries_cloudagent/wallet_handler/error.py
@@ -1,0 +1,23 @@
+"""Wallet_handler related exceptions."""
+
+from ..wallet.error import WalletError
+
+
+class WalletAccessError(WalletError):
+    """Wallet access exception."""
+
+
+class KeyNotFoundError(WalletError):
+    """Missing key exception."""
+
+
+class WalletMissmatchError(WalletError):
+    """Wrong wallet exception."""
+
+
+class WalletNotFoundError(WalletError):
+    """No wallet for given information exception."""
+
+
+class DuplicateMappingError(WalletError):
+    """Mapping already exists exception."""

--- a/aries_cloudagent/wallet_handler/handler.py
+++ b/aries_cloudagent/wallet_handler/handler.py
@@ -1,0 +1,288 @@
+"""Multi wallet handler implementation of BaseWallet interface."""
+
+import json
+import re
+import time
+
+import indy.anoncreds
+import indy.did
+import indy.crypto
+import hashlib
+from indy.error import IndyError, ErrorCode
+from base64 import b64encode
+
+from ..wallet.base import BaseWallet
+from ..wallet.error import WalletError, WalletDuplicateError
+from ..wallet.plugin import load_postgres_plugin
+from ..utils.classloader import ClassLoader
+from ..config.provider import DynamicProvider
+from ..config.injection_context import InjectionContext
+from ..connections.models.connection_record import (
+    ConnectionRecord,
+)
+
+from .error import KeyNotFoundError
+from .error import WalletNotFoundError
+from .error import DuplicateMappingError
+
+
+class WalletHandler():
+    """Class to handle multiple wallets."""
+
+    WALLET_CLASSES = {
+        "basic": "aries_cloudagent.wallet.basic.BasicWallet",
+        "indy": "aries_cloudagent.wallet.indy.IndyWallet",
+    }
+    DEFAULT_KEY = ""
+    DEFAULT_KEY_DERIVIATION = "ARGON2I_MOD"
+    DEFAULT_NAME = "default"
+    DEFAULT_STORAGE_TYPE = None
+    DEFAULT_WALLET_CLASS = "aries_cloudagent.wallet.indy.IndyWallet"
+    DEFAULT_AUTO_ADD = True
+
+    KEY_DERIVATION_RAW = "RAW"
+    KEY_DERIVATION_ARGON2I_INT = "ARGON2I_INT"
+    KEY_DERIVATION_ARGON2I_MOD = "ARGON2I_MOD"
+
+    def __init__(self, provider: DynamicProvider, config: dict = None):
+        """Initilaize the handler."""
+        self._auto_create = config.get("auto_create", True)
+        self._auto_remove = config.get("auto_remove", False)
+        self._freshness_time = config.get("freshness_time", False)
+        self._key = config.get("key") or self.DEFAULT_KEY
+        self._key_derivation_method = (
+            config.get("key_derivation_method") or self.DEFAULT_KEY_DERIVIATION
+        )
+        self._storage_type = config.get("storage_type") or self.DEFAULT_STORAGE_TYPE
+        self._storage_config = config.get("storage_config", None)
+        self._storage_creds = config.get("storage_creds", None)
+        self._master_secret_id = None
+        self._wallet_class = config.get("wallet_class") or self.DEFAULT_WALLET_CLASS
+        if self._wallet_class == self.DEFAULT_WALLET_CLASS:
+            self.WALLET_TYPE = "indy"
+        else:
+            raise WalletError("Wallet handler only works with indy wallet.")
+        self._auto_add = config.get("auto_add") or self.DEFAULT_AUTO_ADD
+
+        if self._storage_type == "postgres_storage":
+            load_postgres_plugin(self._storage_config, self._storage_creds)
+
+        # Maps: `inbound path` -> `wallet`
+        self._path_mappings = {}
+        # Maps: `verkey` -> `wallet`
+        self._handled_keys = {}
+        # Maps: `connection_id` -> `wallet`
+        self._connections = {}
+
+        self._provider = provider
+
+    async def get_instances(self):
+        """Return list of handled instances."""
+        return list(self._provider._instances.keys())
+
+    async def add_instance(self, config: dict, context: InjectionContext):
+        """
+        Add a new instance to the handler to be used during runtime.
+
+        Args:
+            config: Settings for the new instance.
+            context: Injection context.
+        """
+
+        wallet_type = config['type'] or self.DEFAULT_WALLET_CLASS
+        wallet_class = self.WALLET_CLASSES[wallet_type]
+
+        if config["name"] in self._provider._instances.keys():
+            raise WalletDuplicateError()
+
+        # Pass default values into config
+        config["storage_type"] = self._storage_type
+        config["storage_config"] = self._storage_config
+        config["storage_creds"] = self._storage_creds
+        wallet = ClassLoader.load_class(wallet_class)(config)
+        await wallet.open()
+
+        # Store wallet in wallet provider.
+        # TODO: Handle errors and state resetting.
+        self._provider._instances[wallet.name] = wallet
+
+        # Get dids and check for paths in metadata.
+        dids = await wallet.get_local_dids()
+        for did in dids:
+            self._handled_keys[did.verkey] = wallet.name
+            # Get path matppings of wallet (path, wallet.name).
+            if did.metadata.get('path'):
+                path = did.metadata['path']
+                self.add_path_mapping(
+                    wallet.name, path)
+
+        # TODO: We need to change the requested instance so that the storage
+        # provider picks up the correct wallet for fetching the connections.
+        # Maybe there is a nicer way to handle this?
+        context.injector._providers[BaseWallet]._requested_instance = wallet.name
+
+        # Add connections of opened wallet to handler.
+        tag_filter = {}
+        post_filter = {}
+        # wallet_handler.set_instance(config["name"])
+        records = await ConnectionRecord.query(context, tag_filter, post_filter)
+        connections = [record.serialize() for record in records]
+        for connection in connections:
+            await self.add_connection(connection["connection_id"], config["name"])
+
+    async def set_instance(self, wallet: str):
+        """Set a specific wallet to open by the provider."""
+        instances = await self.get_instances()
+        if wallet not in instances:
+            raise WalletNotFoundError('Requested not exisiting wallet instance.')
+        self._provider._requested_instance = wallet
+
+    async def delete_instance(self, id: str):
+        """
+        Delete handled instance from handler and storage.
+
+        Args:
+            id: Identifier of the instance to be deleted.
+        """
+
+        try:
+            wallet = self._provider._instances.pop(id)
+        except KeyError:
+            raise WalletNotFoundError(f"Wallet not found: {id}")
+
+        if wallet.WALLET_TYPE == 'indy':
+            # Delete wallet from storage.
+            try:
+                await wallet.close()
+                await indy.wallet.delete_wallet(
+                    config=json.dumps(wallet._wallet_config),
+                    credentials=json.dumps(wallet._wallet_access),
+                )
+            except IndyError as x_indy:
+                if x_indy.error_code == ErrorCode.WalletNotFoundError:
+                    raise WalletNotFoundError(f"Wallet not found: {id}")
+                raise WalletError(str(x_indy))
+
+        # Remove all path mappings of wallet.
+        self._path_mappings = {
+            key: val for key, val in self._path_mappings.items() if val != id
+            }
+
+    async def generate_path_mapping(self, wallet_id: str, did: str = None) -> str:
+        """
+        Create and store new path mapped to the currently active wallet.
+
+        Args:
+            wallet_id: Identifier of the wallet for which a new path mapping
+                    shall be generated.
+            did: DID for which the path is generated.
+            key: [if no did] Key used as random input to generrate path mapping.
+
+        Returns:
+            path: path to use as postfix to add to default endpoint
+
+        """
+        if did:
+            digest = hashlib.sha256(str.encode(did)).digest()
+        else:
+            t = time.time()
+            digest = hashlib.sha256(str.encode(str(t) + wallet_id)).digest()
+
+        id = b64encode(digest).decode()
+        # Clear all special characters
+        path = re.sub('[^a-zA-Z0-9 \n]', '', id)
+        self._path_mappings[path] = wallet_id
+
+        # Store endpoint in did metadata
+        # TODO: check for old path in metadata.
+        # TODO: Add to metadata if already exist.
+        if did:
+            wallet = self._provider._instances[wallet_id]
+            metadata = {"path": path}
+            await wallet.replace_local_did_metadata(did, metadata)
+
+        return path
+
+    def add_path_mapping(self, wallet_id, path):
+        """Store a new path mapping.
+
+        Args:
+            wallet_id: Identifier of wallet for which to add the new mapping.
+            path: Path which shall be mapped to the wallet.
+
+        """
+        if path in self._path_mappings.keys():
+            raise DuplicateMappingError()
+        self._path_mappings[path] = wallet_id
+
+    def get_paths(self, wallet: str) -> []:
+        """
+        Return all connection handles exposed for the currently active wallet.
+
+        Returns:
+            handles: List of connection handles.
+
+        """
+
+        handles = [k for k, v in self._path_mappings.items() if v == wallet]
+
+        return handles
+
+    async def get_wallet_for_path(self, path: str) -> str:
+        """
+        Return the identifier of the wallet to which the given path belongs.
+
+        Args:
+            path: Inbound path for which the wallet shall be returned.
+
+        Raises:
+            KeyNotFoundError: if given key does not belong to handled_keys
+
+        """
+        wallet_id = self._path_mappings.get(path)
+        if wallet_id is None:
+            raise WalletNotFoundError()
+
+        return wallet_id
+
+    async def add_connection(self, connection_id: str, wallet_id: str):
+        """
+        Add a mapping between the given connection and wallet.
+
+        Args:
+            connection_id: Indentifier of the new connection.
+            wallet_id: Identifier of the wallet the connection belongs to.
+        """
+        self._connections[connection_id] = wallet_id
+
+    async def get_wallet_for_connection(self, connection_id: str) -> str:
+        """
+        Return the identifier of the wallet to which the given key belongs.
+
+        Args:
+            connection_id: Verkey for which the wallet shall be returned.
+
+        Raises:
+            KeyNotFoundError: if given key does not belong to handled_keys
+
+        """
+        if connection_id not in self._connections.keys():
+            raise KeyNotFoundError()
+
+        return self._connections[connection_id]
+
+    async def get_wallet_for_key(self, key: str) -> str:
+        """
+        Return the identifier of the wallet to which the given key belongs.
+
+        Args:
+            key: Verkey for which the wallet shall be returned.
+
+        Raises:
+            KeyNotFoundError: if given key does not belong to handled_keys
+
+        """
+        if key not in self._handled_keys.keys():
+            raise KeyNotFoundError()
+
+        return self._handled_keys[key]

--- a/aries_cloudagent/wallet_handler/routes.py
+++ b/aries_cloudagent/wallet_handler/routes.py
@@ -1,0 +1,434 @@
+"""Wallet handler admin routes."""
+
+from aiohttp import web
+from aiohttp_apispec import docs, request_schema, response_schema
+import hashlib
+import re
+from base64 import b64encode
+
+from .handler import WalletHandler
+from .error import WalletNotFoundError
+from ..wallet.base import BaseWallet
+from ..wallet.error import WalletError, WalletDuplicateError
+
+# from ..storage.base import BaseStorage
+# from ..storage.record import StorageRecord
+from ..storage.error import StorageNotFoundError
+
+from ..protocols.connections.v1_0.manager import ConnectionManager
+from ..protocols.connections.v1_0.routes import (
+    InvitationResultSchema,
+)
+
+from ..connections.models.connection_record import (
+    ConnectionRecord,
+    ConnectionRecordSchema,
+)
+
+from ..protocols.connections.v1_0.messages.connection_invitation import (
+    ConnectionInvitation,
+    ConnectionInvitationSchema,
+)
+
+from marshmallow import fields, Schema
+
+WALLET_TYPES = {
+    "basic": "aries_cloudagent.wallet.basic.BasicWallet",
+    "indy": "aries_cloudagent.wallet.indy.IndyWallet",
+}
+
+
+async def create_connection_handle(wallet: BaseWallet, n: int) -> str:
+    """
+    Create a new path for the currently active wallet.
+
+    Returns:
+        path: path to use as postfix to add to default endpoint
+
+    """
+    id_raw = wallet.name + '_' + str(n)
+    digest = hashlib.sha256(str.encode(id_raw)).digest()
+    id = b64encode(digest).decode()
+    # Clear all special characters
+    path = re.sub('[^a-zA-Z0-9 \n]', '', id)
+
+    return path
+
+
+class AddWalletSchema(Schema):
+    """Request schema for adding a new wallet which will be registered by the agent."""
+
+    wallet_name = fields.Str(
+        description="Wallet identifier.",
+        example='MyNewWallet'
+    )
+    wallet_key = fields.Str(
+        description="Master key used for key derivation.",
+        example='MySecretKey123'
+    )
+    seed = fields.Str(
+        description="Seed used for did derivation.",
+        example='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    )
+    wallet_type = fields.Str(
+        description="Type the newly generated wallet should be [basic | indy].",
+        example='indy',
+        default='indy'
+    )
+
+
+@docs(
+    tags=["wallet"],
+    summary="Add new wallet to be handled by this agent.",
+)
+@request_schema(AddWalletSchema())
+async def wallet_handler_add_wallet(request: web.BaseRequest):
+    """
+    Request handler for adding a new wallet for handling by the agent.
+
+    Args:
+        request: aiohttp request object
+
+    Raises:
+        HTTPBadRequest: if no name is provided to identify new wallet.
+        HTTPBadRequest: if a not supported wallet type is specified.
+
+    """
+    context = request.app["request_context"]
+
+    body = await request.json()
+
+    config = {}
+    if body.get("wallet_name"):
+        config["name"] = body.get("wallet_name")
+    else:
+        raise web.HTTPBadRequest(reason="Name needs to be provided to create a wallet.")
+    config["key"] = body.get("wallet_key")
+    wallet_type = body.get("wallet_type")
+    if wallet_type not in WALLET_TYPES:
+        raise web.HTTPBadRequest(reason="Specified wallet type is not supported.")
+    config["type"] = wallet_type
+
+    wallet_handler: WalletHandler = await context.inject(WalletHandler, required=False)
+
+    try:
+        await wallet_handler.add_instance(config, context)
+    except WalletDuplicateError:
+        raise web.HTTPBadRequest(reason="Wallet with specified name already exists.")
+
+    return web.Response(body='created', status=201)
+
+
+@docs(
+    tags=["wallet"],
+    summary="Get identifiers of all handled wallets.",
+)
+async def wallet_handler_get_wallets(request: web.BaseRequest):
+    """
+    Request handler to obtain all identifiers of the handled wallets.
+
+    Args:
+        request: aiohttp request object.
+
+    """
+    context = request["context"]
+
+    wallet_handler: WalletHandler = await context.inject(WalletHandler, required=False)
+    wallet_names = await wallet_handler.get_instances()
+
+    return web.json_response({"result": wallet_names})
+
+
+@docs(
+    tags=["wallet"],
+    summary="Remove a wallet from handled wallets and delete it from storage.",
+    parameters=[{"in": "path", "name": "id", "description": "Identifier of wallet."}],
+)
+async def wallet_handler_remove_wallet(request: web.BaseRequest):
+    """
+    Request handler to remove a wallet from agent and storage.
+
+    Args:
+        request: aiohttp request object.
+
+    """
+    context = request["context"]
+    wallet_name = request.match_info["id"]
+
+    wallet: BaseWallet = await context.inject(BaseWallet)
+
+    if wallet.name != wallet_name:
+        raise web.HTTPUnauthorized(reason="not owned wallet not allowed.")
+
+    wallet_handler: WalletHandler = await context.inject(WalletHandler)
+
+    try:
+        await wallet_handler.delete_instance(wallet_name)
+    #    raise web.HTTPBadRequest(reason="Wallet to delete not found.")
+    except WalletNotFoundError:
+        raise web.HTTPNotFound(reason=f"Requested wallet to delete not in storage.")
+    except WalletError:
+        raise web.HTTPError(reason=WalletError.message)
+
+    return web.json_response({"result": "Deleted wallet {}".format(wallet_name)})
+
+# ------------------------------------------------------------------------------
+# Connection endpoint handlers.
+# ------------------------------------------------------------------------------
+
+
+@docs(
+    tags=["connection"],
+    summary="Create a new connection invitation for a specific wallet.",
+    parameters=[
+        {
+            "name": "alias",
+            "in": "query",
+            "schema": {"type": "string"},
+            "required": False,
+        },
+        {
+            "name": "accept",
+            "in": "query",
+            "schema": {"type": "string", "enum": ["none", "auto"]},
+            "required": False,
+        },
+        {
+            "name": "public",
+            "in": "query",
+            "schema": {"type": "int"},
+            "required": False
+        },
+        {
+            "name": "multi_use",
+            "in": "query",
+            "schema": {"type": "int"},
+            "required": False
+        },
+    ],
+)
+@response_schema(InvitationResultSchema(), 200)
+async def connections_create_invitation(request: web.BaseRequest):
+    """
+    Request handler for creating a new connection invitation for custodial agent.
+
+    Args:
+        request: aiohttp request object
+
+    Returns:
+        The connection invitation details
+
+    """
+    context = request["context"]
+    alias = request.query.get("alias")
+    public = request.query.get("public")
+    multi_use = request.query.get("multi_use")
+
+    if public and not context.settings.get("public_invites"):
+        raise web.HTTPForbidden()
+    base_url = context.settings.get("invite_base_url")
+
+    wallet: BaseWallet = await context.inject(BaseWallet, required=False)
+    wallet_handler: WalletHandler = await context.inject(WalletHandler)
+    handle = await wallet_handler.generate_path_mapping(wallet.name)
+
+    endpoint = context.settings.get("default_endpoint") + "/" + handle
+
+    connection_mgr = ConnectionManager(context)
+    connection, invitation = await connection_mgr.create_invitation(
+        public=bool(public), multi_use=bool(multi_use), alias=alias,
+        my_endpoint=endpoint
+    )
+    result = {
+        "connection_id": connection and connection.connection_id,
+        "invitation": invitation.serialize(),
+        "invitation_url": invitation.to_url(base_url),
+    }
+    await wallet_handler.add_connection(connection.connection_id, wallet.name)
+
+    if connection and connection.alias:
+        result["alias"] = connection.alias
+
+    return web.json_response(result)
+
+
+@docs(
+    tags=["connection"],
+    summary="Receive a new connection invitation",
+    parameters=[
+        {
+            "name": "alias",
+            "in": "query",
+            "schema": {"type": "string"},
+            "required": False,
+        },
+        {
+            "name": "accept",
+            "in": "query",
+            "schema": {"type": "string", "enum": ["none", "auto"]},
+            "required": False,
+        },
+    ],
+)
+@request_schema(ConnectionInvitationSchema())
+@response_schema(ConnectionRecordSchema(), 200)
+async def connections_receive_invitation(request: web.BaseRequest):
+    """
+    Request handler for receiving a new connection invitation.
+
+    Args:
+        request: aiohttp request object
+
+    Returns:
+        The resulting connection record details
+
+    """
+    context = request["context"]
+    if context.settings.get("admin.no_receive_invites"):
+        raise web.HTTPForbidden()
+    connection_mgr = ConnectionManager(context)
+    invitation_json = await request.json()
+    invitation = ConnectionInvitation.deserialize(invitation_json)
+    alias = request.query.get("alias")
+    connection = await connection_mgr.receive_invitation(
+        invitation, alias=alias
+    )
+    wallet_handler: WalletHandler = await context.inject(WalletHandler)
+    wallet: BaseWallet = await context.inject(BaseWallet, required=False)
+    await wallet_handler.add_connection(connection.connection_id, wallet.name)
+    return web.json_response(connection.serialize())
+
+
+@docs(
+    tags=["connection"],
+    summary="Accept a stored connection invitation",
+    parameters=[
+        {
+            "name": "my_endpoint",
+            "in": "query",
+            "schema": {"type": "string"},
+            "required": False,
+        },
+        {
+            "name": "my_label",
+            "in": "query",
+            "schema": {"type": "string"},
+            "required": False,
+        },
+    ],
+)
+@response_schema(ConnectionRecordSchema(), 200)
+async def connections_accept_invitation(request: web.BaseRequest):
+    """
+    Request handler for accepting a stored connection invitation.
+
+    Args:
+        request: aiohttp request object
+
+    Returns:
+        The resulting connection record details
+
+    """
+    context = request["context"]
+    outbound_handler = request.app["outbound_message_router"]
+    connection_id = request.match_info["id"]
+    try:
+        connection = await ConnectionRecord.retrieve_by_id(
+            context, connection_id)
+    except StorageNotFoundError:
+        raise web.HTTPNotFound()
+    connection_mgr = ConnectionManager(context)
+    my_label = request.query.get("my_label") or None
+    my_endpoint = request.query.get("my_endpoint") or None
+
+    wallet_handler: WalletHandler = await context.inject(WalletHandler)
+    wallet: BaseWallet = await context.inject(BaseWallet)
+
+    did_info = await wallet.create_local_did()
+    connection.my_did = did_info.did
+
+    if not my_endpoint:
+        path = await wallet_handler.generate_path_mapping(
+            wallet.name, did=did_info.did)
+        my_endpoint = context.settings.get("default_endpoint") + "/" + path
+    else:
+        raise web.HTTPNotImplemented(
+            reason="Self defined endpoints not implemented yet.")
+
+    request = await connection_mgr.create_request(
+        connection, my_label, my_endpoint)
+
+    await outbound_handler(request, connection_id=connection.connection_id)
+    return web.json_response(connection.serialize())
+
+
+@docs(
+    tags=["connection"],
+    summary="Accept a stored connection request",
+    parameters=[
+        {
+            "name": "my_endpoint",
+            "in": "query",
+            "schema": {"type": "string"},
+            "required": False,
+        }
+    ],
+)
+@response_schema(ConnectionRecordSchema(), 200)
+async def connections_accept_request(request: web.BaseRequest):
+    """
+    Request handler for accepting a stored connection request.
+
+    Args:
+        request: aiohttp request object
+
+    Returns:
+        The resulting connection record details
+
+    """
+    context = request["context"]
+    outbound_handler = request.app["outbound_message_router"]
+    connection_id = request.match_info["id"]
+    try:
+        connection = await ConnectionRecord.retrieve_by_id(context, connection_id)
+    except StorageNotFoundError:
+        raise web.HTTPNotFound()
+    wallet: BaseWallet = await context.inject(BaseWallet)
+    did_info = await wallet.create_local_did()
+    connection.my_did = did_info.did
+    my_endpoint = request.query.get("my_endpoint") or None
+    # TODO: handle user specified endpoints.
+    wallet_handler: WalletHandler = await context.inject(WalletHandler)
+    if not my_endpoint:
+        handle = await wallet_handler.generate_path_mapping(
+            wallet.name, did=did_info.did)
+        my_endpoint = context.settings.get("default_endpoint") + "/" + handle
+    else:
+        raise web.HTTPNotImplemented(
+            reason="Self defined endpoints not implemented yet.")
+
+    connection_mgr = ConnectionManager(context)
+    response = await connection_mgr.create_response(connection, my_endpoint)
+
+    await outbound_handler(response, connection_id=connection.connection_id)
+    return web.json_response(connection.serialize())
+
+
+async def register(app: web.Application):
+    """Register routes."""
+
+    app.add_routes(
+        [
+            web.get("/wallet", wallet_handler_get_wallets),
+            web.post("/wallet", wallet_handler_add_wallet),
+            web.post("/wallet/{id}/remove", wallet_handler_remove_wallet),
+            web.post("/connections/invite-with-endpoint",
+                     connections_create_invitation),
+            web.post("/connections/receive-invitation-with-endpoint",
+                     connections_receive_invitation),
+            web.post("/connections/{id}/accept-invitation-with-endpoint",
+                     connections_accept_invitation),
+            web.post("/connections/{id}/accept-request-with-endpoint",
+                     connections_accept_request),
+        ]
+    )

--- a/aries_cloudagent/wallet_handler/setup.py
+++ b/aries_cloudagent/wallet_handler/setup.py
@@ -1,0 +1,39 @@
+"""Module setup."""
+
+from ..config.injection_context import InjectionContext
+from ..utils.classloader import ClassLoader
+from .handler import WalletHandler
+from ..wallet.base import BaseWallet
+
+HANDLER_CLASS = "aries_cloudagent.wallet_handler.handler.WalletHandler"
+HANDLED_CLASSES = {
+    "base": "aries_cloudagent.wallet.base.BaseWallet",
+    "indy": "aries_cloudagent.wallet.Indy.IndyWallet",
+    "basic": "aries_cloudagent.wallet.basic.BasicWallet",
+}
+HANDLED_CLASS = BaseWallet
+
+
+async def setup(context: InjectionContext):
+    """Set up wallet handler."""
+
+    # TODO: get necessary config from context
+    settings = context.settings
+
+    wallet_cfg = {}
+    if "wallet.key" in settings:
+        wallet_cfg["key"] = settings["wallet.key"]
+    if "wallet.name" in settings:
+        wallet_cfg["name"] = settings["wallet.name"]
+    if "wallet.storage_type" in settings:
+        wallet_cfg["storage_type"] = settings["wallet.storage_type"]
+    # storage.config and storage.creds are required if using postgres plugin
+    if "wallet.storage_config" in settings:
+        wallet_cfg["storage_config"] = settings["wallet.storage_config"]
+    if "wallet.storage_creds" in settings:
+        wallet_cfg["storage_creds"] = settings["wallet.storage_creds"]
+
+    handeled_provider = context.injector._providers[HANDLED_CLASS]
+
+    handler = ClassLoader.load_class(HANDLER_CLASS)(handeled_provider, wallet_cfg)
+    context.injector.bind_instance(WalletHandler, handler)

--- a/aries_cloudagent/wallet_handler/tests/test_handler.py
+++ b/aries_cloudagent/wallet_handler/tests/test_handler.py
@@ -1,0 +1,127 @@
+import pytest
+
+from aries_cloudagent.wallet_handler.handler import WalletHandler
+from aries_cloudagent.config.provider import DynamicProvider, StatsProvider
+from aries_cloudagent.wallet.provider import WalletProvider
+from aries_cloudagent.wallet.base import BaseWallet
+from aries_cloudagent.config.injection_context import InjectionContext
+from aries_cloudagent.storage.base import BaseStorage
+from aries_cloudagent.storage.provider import StorageProvider
+
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
+
+TEST_CONFIG = {}
+
+
+@pytest.fixture()
+async def wallet_handler():
+    provider = DynamicProvider(
+                WalletProvider(),
+                "wallet.name"
+            )
+    wallet_handler = WalletHandler(provider, TEST_CONFIG)
+    yield wallet_handler
+
+
+class TestWalletHandler(AsyncTestCase):
+    def setUp(self):
+        self.context = InjectionContext(enforce_typing=False)
+        self.context.injector.bind_provider(
+            BaseWallet,
+            DynamicProvider(
+                StatsProvider(
+                    WalletProvider(),
+                    (
+                        "sign_message",
+                        "verify_message",
+                        # "pack_message",
+                        # "unpack_message",
+                        "get_local_did",
+                    ),
+                ),
+                'wallet.name'
+            ),
+        )
+        self.context.injector.bind_provider(
+            BaseStorage,
+            #CachedProvider(
+            StatsProvider(
+                StorageProvider(), ("add_record", "get_record", "search_records")
+            )
+            #),
+        )
+        self.wallet = async_mock.create_autospec(BaseWallet)
+        handeled_provider = self.context.injector._providers[BaseWallet]
+
+        #self.context.injector.bind_instance(BaseWallet, self.wallet)
+        self.wallet_handler = WalletHandler(handeled_provider, {})
+
+        self.test_wallet_cfg = {
+            "type": "indy",
+            "key": "123456",
+            "name": "Wallet1",
+            "seed": "cccccccccccccccccccccccccccccccc"
+        }
+        self.test_wallet_cfg2 = {
+            "type": "indy",
+            "key": "123456",
+            "name": "Wallet2",
+            "seed": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+
+    def test_one(self):
+        x = "this"
+        assert "h" in x
+
+    def test_properties(self):
+        assert self.wallet_handler.WALLET_TYPE == 'indy'
+
+    @pytest.mark.asyncio
+    async def test_get_instances(self):
+        instances = await self.wallet_handler.get_instances()
+
+        assert instances == []
+
+    @pytest.mark.asyncio
+    async def test_handle_instances(self):
+        """Test handling of wallets by wallet handler.
+
+        Tests the following functionallities:
+        - Adding multiple wallets to the handler.
+        - Removing a wallet from the handler.
+
+        """
+        await self.wallet_handler.add_instance(self.test_wallet_cfg, self.context)
+        await self.wallet_handler.add_instance(self.test_wallet_cfg2, self.context)
+        wallets = await self.wallet_handler.get_instances()
+
+        assert wallets == [
+            self.test_wallet_cfg.get('name'),
+            self.test_wallet_cfg2.get('name')
+        ]
+
+        await self.wallet_handler.delete_instance(self.test_wallet_cfg2.get('name'))
+        wallets = await self.wallet_handler.get_instances()
+
+        assert wallets == [
+            self.test_wallet_cfg.get('name')
+        ]
+
+        await self.wallet_handler.delete_instance(self.test_wallet_cfg.get('name'))
+
+    @pytest.mark.asyncio
+    async def test_create_dids_for_wallets(self):
+        await self.wallet_handler.add_instance(self.test_wallet_cfg, self.context)
+        await self.wallet_handler.add_instance(self.test_wallet_cfg2, self.context)
+
+        await self.wallet_handler.set_instance(self.test_wallet_cfg.get('name'))
+        wallet1: BaseWallet = await self.context.inject(BaseWallet)
+        assert wallet1.name == self.test_wallet_cfg.get('name')
+
+        await self.wallet_handler.set_instance(self.test_wallet_cfg2.get('name'))
+        wallet2: BaseWallet = await self.context.inject(BaseWallet)
+        assert wallet2.name == self.test_wallet_cfg2.get('name')
+
+        await self.wallet_handler.delete_instance(self.test_wallet_cfg.get('name'))
+        await self.wallet_handler.delete_instance(self.test_wallet_cfg2.get('name'))

--- a/demo/ngrok-wait.sh
+++ b/demo/ngrok-wait.sh
@@ -4,11 +4,11 @@
 
 # if a tails network is specified, there should be an associated ngrok as well ...
 if ! [ -z "$TAILS_NGROK_NAME" ]; then
-    echo "ngrok end point [$TAILS_NGROK_NAME]"
+    echo "ngrok tails service name [$TAILS_NGROK_NAME]"
     NGROK_ENDPOINT=null
     while [ -z "$NGROK_ENDPOINT" ] || [ "$NGROK_ENDPOINT" = "null" ]
     do
-        echo "Fetching end point from ngrok service"
+        echo "Fetching endpoint from ngrok service"
         NGROK_ENDPOINT=$(curl --silent $TAILS_NGROK_NAME:4040/api/tunnels | ./jq -r '.tunnels[0].public_url')
 
         if [ -z "$NGROK_ENDPOINT" ] || [ "$NGROK_ENDPOINT" = "null" ]; then
@@ -18,10 +18,10 @@ if ! [ -z "$TAILS_NGROK_NAME" ]; then
     done
 
     export PUBLIC_TAILS_URL=$NGROK_ENDPOINT
-    echo "fetched tails server end point [$PUBLIC_TAILS_URL]"
+    echo "Fetched ngrok tails server endpoint [$PUBLIC_TAILS_URL]"
 fi
 
 export AGENT_NAME=$1
 shift
-echo "Starting [$AGENT_NAME] agent ... with args [$@]"
+echo "Starting [$AGENT_NAME] agent with args [$@]"
 python -m demo.runners.$AGENT_NAME $@

--- a/demo/run_demo
+++ b/demo/run_demo
@@ -27,7 +27,7 @@ do
   fi
   case $i in
   --events)
-    if [[ "${AGENT}" == "performance" ]] ; then
+    if [ "${AGENT}" = "performance" ]; then
       echo -e "\nIgnoring the \"--events\" option when running the ${AGENT} agent.\n"
     else
       EVENTS=1
@@ -80,7 +80,7 @@ do
     continue
   ;;
   --bg)
-    if [[ "${AGENT}" == "alice" ]] || [[ "${AGENT}" == "faber" ]] || [[ "${AGENT}" == "acme" ]]; then
+    if [ "${AGENT}" = "alice" ] || [ "${AGENT}" = "faber" ] || [ "${AGENT}" = "acme" ]; then
       DOCKER_OPTS="-d"
       echo -e "\nRunning in ${AGENT} in the background. Note that you cannot use the command line console in this mode."
       echo To see the logs use: \"docker logs ${AGENT}\".
@@ -163,15 +163,19 @@ fi
 
 # check if ngrok is running on our $AGENT_PORT (don't override if AGENT_ENDPOINT is already set)
 if [ -z "$AGENT_ENDPOINT" ] && [ "$RUNMODE" == "docker" ]; then
-    echo "Checking for Agent end point from ngrok service"
-    NGROK_ENDPOINT=$(curl --silent localhost:4040/api/tunnels | jq -r '.tunnels[0].public_url')
-
+  echo "Trying to detect ngrok service endpoint"
+  JQ=${JQ:-`which jq`}
+  if [ -x "$JQ" ]; then
+    NGROK_ENDPOINT=$(curl --silent localhost:4040/api/tunnels | $JQ -r '.tunnels[0].public_url')
     if [ -z "$NGROK_ENDPOINT" ] || [ "$NGROK_ENDPOINT" = "null" ]; then
-        echo "ngrok not running for Agent endpoint ...."
+      echo "ngrok not detected for agent endpoint"
     else
-        export AGENT_ENDPOINT=$NGROK_ENDPOINT
-        echo "fetched Agent end point [$AGENT_ENDPOINT]"
+      export AGENT_ENDPOINT=$NGROK_ENDPOINT
+      echo "Detected ngrok agent endpoint [$AGENT_ENDPOINT]"
     fi
+  else
+    echo "jq not found"
+  fi
 fi
 
 echo $DOCKERHOST
@@ -217,7 +221,7 @@ if ! [ -z "$TAILS_FILE_COUNT" ]; then
   DOCKER_ENV="${DOCKER_ENV} -e TAILS_FILE_COUNT=${TAILS_FILE_COUNT}"
 fi
 
-if ! [[ -z "${ENABLE_PYDEVD_PYCHARM}" ]]; then
+if ! [ -z "${ENABLE_PYDEVD_PYCHARM}" ]; then
   DOCKER_ENV="${DOCKER_ENV} -e ENABLE_PYDEVD_PYCHARM=${ENABLE_PYDEVD_PYCHARM} -e PYDEVD_PYCHARM_CONTROLLER_PORT=${PYDEVD_PYCHARM_CONTROLLER_PORT} -e PYDEVD_PYCHARM_AGENT_PORT=${PYDEVD_PYCHARM_AGENT_PORT}"
 fi
 
@@ -227,7 +231,6 @@ if [ "$OSTYPE" = "msys" ]; then
 fi
 DOCKER=${DOCKER:-docker}
 
-echo "Starting $AGENT..."
 $DOCKER run --name $AGENT --rm -it ${DOCKER_OPTS} \
   --network=${DOCKER_NET} \
   -p 0.0.0.0:$AGENT_PORT_RANGE:$AGENT_PORT_RANGE \

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -4,10 +4,9 @@ ENV ENABLE_PTVSD 0
 ENV ENABLE_PYDEVD_PYCHARM 0
 ENV PYDEVD_PYCHARM_HOST "host.docker.internal"
 
-USER root
-ADD https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 ./jq
-RUN chmod +x ./jq
-USER $user
+RUN mkdir bin && curl -L -o bin/jq \
+	https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+	chmod ug+x bin/jq
 
 # Add and install Indy Agent code
 ADD requirements*.txt ./
@@ -29,7 +28,5 @@ ADD demo/requirements.txt ./demo/requirements.txt
 RUN pip3 install --no-cache-dir -r demo/requirements.txt
 
 ADD demo ./demo
-COPY demo/ngrok-wait.sh ngrok-wait.sh
-RUN chmod +x ./ngrok-wait.sh
 
-ENTRYPOINT ["./ngrok-wait.sh"]
+ENTRYPOINT ["bash", "-c", "demo/ngrok-wait.sh \"$@\"", "--"]


### PR DESCRIPTION
This PR enables ACA-Py to handle multiple wallets for issuing, holding and verifying. 

## Running ACA-Py as Multi Wallet Agent

to start the agent in a multi wallet setup you need to pass the following flags during start:

`-it http_custodial`

`--plugin aries_cloudagent.wallet_handler`


### Admin API

To be able to use the admin API with multiple wallets each request might need to use a different wallet. To prevent that one requests overwrites the wallet inside another request which is waiting for some async coroutine each request needs it's individual local context with a different wallet requested in the `DynamicProvider` for the wallet class. To accomplish that a middleware checks the authorisation in the header of the request and obtains (somehow - best with a plugable authorization module -) the corresponding wallet for that request. Than the global context is copied and the `requested_instance` of the wallet provider is set according to the authorization. The request can than be handled as for the one-wallet-agent.

### Inbound Messages

To enable the agent to associate an inbound message with the correct wallet, for communication a new inbound path `default_endpoint/sha256(wallet_name+num(connections))` is created and passed to the agent which participates in that communication. If the agent receives a message he uses the endpoint to which the message is posted to check (by querying the `wallet_handler`) with what wallet the message can be received. In `create_session()` of the inbound manager the global context is copied, adapted for the correct wallet and passed to the session which handles the incoming message.

### Outbound Messages

Outbound messages are always associated to a specific connection. The `wallet_handler` keeps a mapping of connections to wallets so that it can return the correct wallet for any connection. Similar as for inbound messages the `outbound_manager` uses this functionallity to adapt a copied context with the correct wallet inside `perform_encode()` and pass it to the `queued` object. The following functionallity than picks up the correct wallet during injection and works as always.

### Persistance

If postgres is used as storage everything is persistent (credentials, connection, etc). However to get the data back from a wallet stored in the storage after the agent is restarted it needs to be opened again with `POST /wallet` by providing the same information as for the initial creation. This is because currently the list of handled wallets is not persisted by the agent.

## ToDo
- [ ] Make inbound message handling use key in message instead of endpoint
- [ ] Create larger test setup
- [ ] Production ready authorization setup
- [ ] Persist wallet  list