### PR TITLE
Multi-tenancy merge fix

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -478,12 +478,14 @@ class ConnectionManager:
             connection.my_did = my_info.did
 
         # Create connection response message
+        my_endpoints = []
         if not my_endpoint:
-            my_endpoints = []
             default_endpoint = self.context.settings.get("default_endpoint")
             if default_endpoint:
                 my_endpoints.append(default_endpoint)
             my_endpoints.extend(self.context.settings.get("additional_endpoints", []))
+        else:
+            my_endpoints.append(my_endpoint)
         did_doc = await self.create_did_document(
             my_info, connection.inbound_connection_id, my_endpoints
         )

--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -444,7 +444,7 @@ class OutboundTransportManager:
         """Kick off delivery of a queued message."""
         transport = self.get_transport_instance(queued.transport_id)
         queued.task = self.task_queue.run(
-            transport.handle_message(queued.payload, queued.endpoint),
+            transport.handle_message(queued.context, queued.payload, queued.endpoint),
             lambda completed: self.finished_deliver(queued, completed),
         )
         return queued.task

--- a/scripts/run_docker
+++ b/scripts/run_docker
@@ -2,7 +2,12 @@
 
 cd $(dirname $0)
 
-docker build -t aries-cloudagent-run -f ../docker/Dockerfile.run .. || exit 1
+# Checking if proxy is configured in environment.
+if [ -z ${http_proxy+x} ]; then
+  docker build -t aries-cloudagent-run -f ../docker/Dockerfile.run .. || exit 1
+else
+  docker build --build-arg HTTP_PROXY=$http_proxy --build-arg HTTPS_PROXY=$https_proxy -t aries-cloudagent-run -f ../docker/Dockerfile.run .. || exit 1
+fi
 
 ARGS=""
 for PORT in $PORTS; do


### PR DESCRIPTION
Fixed two issues from merge with latest aca-py version creating problems in connection protocol
- context not passed to `handle_message` in outbound manager
- passed endpoint to `create_response` in connection manager not considered

*note*: `run_docker` script changed to be able to build the container in environments behind a proxy