### PR TITLE
Add a pause when only retries are in the queue

### DIFF
--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -392,6 +392,9 @@ class OutboundTransportManager:
             if self.outbound_buffer:
                 if (not new_pending) and (not retry_count):
                     await self.outbound_event.wait()
+                elif retry_count:
+                    # only retries - yield here so we don't hog resources
+                    await asyncio.sleep(0.05)
             else:
                 break
 


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Added a sleep() when there are *only* retries in the queue.

Was causing problems with aries-vcr on startup - when the request was sent to establish a self-connection, aca-py was hogging cpu and preventing the aries-vcr startup from continuing; aries-vcr was unable to respond to callbacks until aca-py retries had all failed and timed out.
