### PR TITLE
Set liveliness status on fatal ledger error

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -51,7 +51,7 @@ class AdminStatusLivelinessSchema(Schema):
 
 
 class AdminStatusReadinessSchema(Schema):
-    """Schema for the liveliness endpoint."""
+    """Schema for the readiness endpoint."""
 
     ready = fields.Boolean(description="Readiness status", example=True)
 
@@ -295,6 +295,11 @@ class AdminServer(BaseAdminServer):
             app=app, title=agent_label, version=version_string, swagger_path="/api/doc"
         )
         app.on_startup.append(self.on_startup)
+
+        # ensure we always have status values
+        app._state["ready"] = False
+        app._state["alive"] = False
+
         return app
 
     async def start(self) -> None:
@@ -329,6 +334,7 @@ class AdminServer(BaseAdminServer):
         try:
             await self.site.start()
             self.app._state["ready"] = True
+            self.app._state["alive"] = True
         except OSError:
             raise AdminSetupError(
                 "Unable to start webserver with host "
@@ -338,6 +344,7 @@ class AdminServer(BaseAdminServer):
     async def stop(self) -> None:
         """Stop the webserver."""
         self.app._state["ready"] = False  # in case call does not come through OpenAPI
+        self.app._state["alive"] = False
         for queue in self.websocket_queues.values():
             queue.stop()
         if self.site:
@@ -429,7 +436,8 @@ class AdminServer(BaseAdminServer):
             The web response, always indicating True
 
         """
-        return web.json_response({"alive": True})
+        app_live = self.app._state["alive"]
+        return web.json_response({"alive": app_live})
 
     @docs(tags=["server"], summary="Readiness check")
     @response_schema(AdminStatusReadinessSchema(), 200)
@@ -444,7 +452,8 @@ class AdminServer(BaseAdminServer):
             The web response, indicating readiness for further calls
 
         """
-        return web.json_response({"ready": self.app._state["ready"]})
+        app_ready = self.app._state["ready"] and self.app._state["alive"]
+        return web.json_response({"ready": app_ready})
 
     @docs(tags=["server"], summary="Shut down server")
     async def shutdown_handler(self, request: web.BaseRequest):
@@ -463,6 +472,11 @@ class AdminServer(BaseAdminServer):
         asyncio.ensure_future(self.conductor_stop(), loop=loop)
 
         return web.json_response({})
+
+    def notify_fatal_error(self):
+        """Set our readiness flags to force a restart (openshift)."""
+        self.app._state["ready"] = False
+        self.app._state["alive"] = False
 
     async def websocket_handler(self, request):
         """Send notifications to admin client over websocket."""

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -18,10 +18,7 @@ from marshmallow import fields, Schema
 
 from ..config.injection_context import InjectionContext
 from ..core.plugin_registry import PluginRegistry
-from ..ledger.error import (
-    LedgerConfigError,
-    LedgerTransactionError
-)
+from ..ledger.error import LedgerConfigError, LedgerTransactionError
 from ..messaging.responder import BaseResponder
 from ..transport.queue.basic import BasicMessageQueue
 from ..transport.outbound.message import OutboundMessage

--- a/aries_cloudagent/admin/tests/test_admin_server.py
+++ b/aries_cloudagent/admin/tests/test_admin_server.py
@@ -266,3 +266,40 @@ class TestAdminServer(AsyncTestCase):
         ) as response:
             assert response.status == 200
         await server.stop()
+
+    async def test_server_health_state(self):
+        settings = {
+            "admin.admin_insecure_mode": True,
+        }
+        server = self.get_admin_server(settings)
+        await server.start()
+
+        async with self.client_session.get(
+            f"http://127.0.0.1:{self.port}/status/live", headers={}
+        ) as response:
+            assert response.status == 200
+            response_json = await response.json()
+            assert response_json["alive"]
+
+        async with self.client_session.get(
+            f"http://127.0.0.1:{self.port}/status/ready", headers={}
+        ) as response:
+            assert response.status == 200
+            response_json = await response.json()
+            assert response_json["ready"]
+
+        server.notify_fatal_error()
+        async with self.client_session.get(
+            f"http://127.0.0.1:{self.port}/status/live", headers={}
+        ) as response:
+            assert response.status == 200
+            response_json = await response.json()
+            assert not response_json["alive"]
+
+        async with self.client_session.get(
+            f"http://127.0.0.1:{self.port}/status/ready", headers={}
+        ) as response:
+            assert response.status == 200
+            response_json = await response.json()
+            assert not response_json["ready"]
+        await server.stop()

--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -263,10 +263,8 @@ class Conductor:
                 self.admin_server and self.admin_server.send_webhook,
                 lambda completed: self.dispatch_complete(message, completed),
             )
-        except LedgerConfigError:
-            self.admin_server.notify_fatal_error()
-            raise
-        except LedgerTransactionError:
+        except (LedgerConfigError, LedgerTransactionError) as e:
+            LOGGER.error("Shutdown with %s", str(e))
             self.admin_server.notify_fatal_error()
             raise
 
@@ -324,10 +322,8 @@ class Conductor:
         """Handle a message that failed delivery via an inbound session."""
         try:
             self.dispatcher.run_task(self.queue_outbound(context, outbound))
-        except LedgerConfigError:
-            self.admin_server.notify_fatal_error()
-            raise
-        except LedgerTransactionError:
+        except (LedgerConfigError, LedgerTransactionError) as e:
+            LOGGER.error("Shutdown with %s", str(e))
             self.admin_server.notify_fatal_error()
             raise
 
@@ -356,10 +352,8 @@ class Conductor:
             except ConnectionManagerError:
                 LOGGER.exception("Error preparing outbound message for transmission")
                 return
-            except LedgerConfigError:
-                self.admin_server.notify_fatal_error()
-                raise
-            except LedgerTransactionError:
+            except (LedgerConfigError, LedgerTransactionError) as e:
+                LOGGER.error("Shutdown with %s", str(e))
                 self.admin_server.notify_fatal_error()
                 raise
 

--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -18,10 +18,7 @@ from ..config.injection_context import InjectionContext
 from ..config.ledger import ledger_config
 from ..config.logging import LoggingConfigurator
 from ..config.wallet import wallet_config, BaseWallet
-from ..ledger.error import (
-    LedgerConfigError,
-    LedgerTransactionError
-)
+from ..ledger.error import LedgerConfigError, LedgerTransactionError
 from ..messaging.responder import BaseResponder
 from ..protocols.connections.v1_0.manager import (
     ConnectionManager,

--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -18,7 +18,10 @@ from ..config.injection_context import InjectionContext
 from ..config.ledger import ledger_config
 from ..config.logging import LoggingConfigurator
 from ..config.wallet import wallet_config, BaseWallet
-from ..ledger.error import LedgerConfigError
+from ..ledger.error import (
+    LedgerConfigError,
+    LedgerTransactionError
+)
 from ..messaging.responder import BaseResponder
 from ..protocols.connections.v1_0.manager import (
     ConnectionManager,
@@ -266,6 +269,9 @@ class Conductor:
         except LedgerConfigError:
             self.admin_server.notify_fatal_error()
             raise
+        except LedgerTransactionError:
+            self.admin_server.notify_fatal_error()
+            raise
 
     def dispatch_complete(self, message: InboundMessage, completed: CompletedTask):
         """Handle completion of message dispatch."""
@@ -324,6 +330,9 @@ class Conductor:
         except LedgerConfigError:
             self.admin_server.notify_fatal_error()
             raise
+        except LedgerTransactionError:
+            self.admin_server.notify_fatal_error()
+            raise
 
     async def queue_outbound(
         self,
@@ -351,6 +360,9 @@ class Conductor:
                 LOGGER.exception("Error preparing outbound message for transmission")
                 return
             except LedgerConfigError:
+                self.admin_server.notify_fatal_error()
+                raise
+            except LedgerTransactionError:
                 self.admin_server.notify_fatal_error()
                 raise
 


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

issue #638 

Set live check to False when we get a fatal ledger error
