### PR TITLE
allow (but exclude) extra fields in protocols and messages where conc…

### DIFF
--- a/aries_cloudagent/connections/models/connection_target.py
+++ b/aries_cloudagent/connections/models/connection_target.py
@@ -2,7 +2,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from ...messaging.models.base import BaseModel, BaseModelSchema
 from ...messaging.valid import INDY_DID, INDY_RAW_PUBLIC_KEY
@@ -51,6 +51,7 @@ class ConnectionTargetSchema(BaseModelSchema):
         """ConnectionTargetSchema metadata."""
 
         model_class = ConnectionTarget
+        unknown = EXCLUDE
 
     did = fields.Str(required=False, description="", **INDY_DID)
     endpoint = fields.Str(

--- a/aries_cloudagent/connections/models/tests/test_connection_target.py
+++ b/aries_cloudagent/connections/models/tests/test_connection_target.py
@@ -1,0 +1,29 @@
+from asynctest import TestCase as AsyncTestCase
+
+from ..connection_target import ConnectionTarget
+
+TEST_DID = "55GkHamhTU1ZbTbV2ab9DE"
+TEST_VERKEY = "3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"
+TEST_ENDPOINT = "http://localhost"
+
+
+class TestConnectionTarget(AsyncTestCase):
+    def test_deser(self):
+        target = ConnectionTarget(
+            did=TEST_DID,
+            endpoint=TEST_ENDPOINT,
+            label="a label",
+            recipient_keys=[TEST_VERKEY],
+            routing_keys=[TEST_VERKEY],
+            sender_key=TEST_VERKEY,
+        )
+        serial = target.serialize()
+        serial["extra-stuff"] = "to exclude"
+        deser = ConnectionTarget.deserialize(serial)
+
+        assert deser.did == target.did
+        assert deser.endpoint == target.endpoint
+        assert deser.label == target.label
+        assert deser.recipient_keys == target.recipient_keys
+        assert deser.routing_keys == target.routing_keys
+        assert deser.sender_key == target.sender_key

--- a/aries_cloudagent/core/tests/test_dispatcher.py
+++ b/aries_cloudagent/core/tests/test_dispatcher.py
@@ -3,6 +3,8 @@ import json
 
 from asynctest import TestCase as AsyncTestCase, mock as async_mock
 
+from marshmallow import EXCLUDE
+
 from ...config.injection_context import InjectionContext
 from ...connections.models.connection_record import ConnectionRecord
 from ...core.protocol_registry import ProtocolRegistry
@@ -56,6 +58,7 @@ class StubAgentMessage(AgentMessage):
 class StubAgentMessageSchema(AgentMessageSchema):
     class Meta:
         model_class = StubAgentMessage
+        unknown = EXCLUDE
 
 
 class StubAgentMessageHandler:
@@ -73,6 +76,7 @@ class StubV1_2AgentMessage(AgentMessage):
 class StubV1_2AgentMessageSchema(AgentMessageSchema):
     class Meta:
         model_class = StubV1_2AgentMessage
+        unknonw = EXCLUDE
 
 
 class StubV1_2AgentMessageHandler:

--- a/aries_cloudagent/holder/routes.py
+++ b/aries_cloudagent/holder/routes.py
@@ -4,9 +4,10 @@ import json
 
 from aiohttp import web
 from aiohttp_apispec import docs, match_info_schema, querystring_schema, response_schema
-from marshmallow import fields, Schema
+from marshmallow import fields
 
 from .base import BaseHolder, HolderError
+from ..messaging.models.openapi import OpenAPISchema
 from ..messaging.valid import (
     INDY_CRED_DEF_ID,
     INDY_REV_REG_ID,
@@ -19,11 +20,11 @@ from ..messaging.valid import (
 from ..wallet.error import WalletNotFoundError
 
 
-class AttributeMimeTypesResultSchema(Schema):
+class AttributeMimeTypesResultSchema(OpenAPISchema):
     """Result schema for credential attribute MIME type."""
 
 
-class RawEncCredAttrSchema(Schema):
+class RawEncCredAttrSchema(OpenAPISchema):
     """Credential attribute schema."""
 
     raw = fields.Str(description="Raw value", example="Alex")
@@ -33,7 +34,7 @@ class RawEncCredAttrSchema(Schema):
     )
 
 
-class RevRegSchema(Schema):
+class RevRegSchema(OpenAPISchema):
     """Revocation registry schema."""
 
     accum = fields.Str(
@@ -42,7 +43,7 @@ class RevRegSchema(Schema):
     )
 
 
-class WitnessSchema(Schema):
+class WitnessSchema(OpenAPISchema):
     """Witness schema."""
 
     omega = fields.Str(
@@ -51,7 +52,7 @@ class WitnessSchema(Schema):
     )
 
 
-class CredentialSchema(Schema):
+class CredentialSchema(OpenAPISchema):
     """Result schema for a credential query."""
 
     schema_id = fields.Str(description="Schema identifier", **INDY_SCHEMA_ID)
@@ -72,13 +73,13 @@ class CredentialSchema(Schema):
     witness = fields.Nested(WitnessSchema)
 
 
-class CredentialsListSchema(Schema):
+class CredentialsListSchema(OpenAPISchema):
     """Result schema for a credential query."""
 
     results = fields.List(fields.Nested(CredentialSchema()))
 
 
-class CredentialsListQueryStringSchema(Schema):
+class CredentialsListQueryStringSchema(OpenAPISchema):
     """Parameters and validators for query string in credentials list query."""
 
     start = fields.Int(description="Start index", required=False, **WHOLE_NUM,)
@@ -88,7 +89,7 @@ class CredentialsListQueryStringSchema(Schema):
     wql = fields.Str(description="(JSON) WQL query", required=False, **INDY_WQL,)
 
 
-class CredIdMatchInfoSchema(Schema):
+class CredIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking credential id."""
 
     credential_id = fields.Str(

--- a/aries_cloudagent/ledger/routes.py
+++ b/aries_cloudagent/ledger/routes.py
@@ -3,8 +3,9 @@
 from aiohttp import web
 from aiohttp_apispec import docs, querystring_schema, request_schema, response_schema
 
-from marshmallow import fields, Schema, validate
+from marshmallow import fields, validate
 
+from ..messaging.models.openapi import OpenAPISchema
 from ..messaging.valid import INDY_DID, INDY_RAW_PUBLIC_KEY
 from ..storage.error import StorageError
 from ..wallet.error import WalletError
@@ -13,7 +14,7 @@ from .indy import Role
 from .error import BadLedgerRequestError, LedgerError, LedgerTransactionError
 
 
-class AMLRecordSchema(Schema):
+class AMLRecordSchema(OpenAPISchema):
     """Ledger AML record."""
 
     version = fields.Str()
@@ -21,7 +22,7 @@ class AMLRecordSchema(Schema):
     amlContext = fields.Str()
 
 
-class TAARecordSchema(Schema):
+class TAARecordSchema(OpenAPISchema):
     """Ledger TAA record."""
 
     version = fields.Str()
@@ -29,14 +30,14 @@ class TAARecordSchema(Schema):
     digest = fields.Str()
 
 
-class TAAAcceptanceSchema(Schema):
+class TAAAcceptanceSchema(OpenAPISchema):
     """TAA acceptance record."""
 
     mechanism = fields.Str()
     time = fields.Int()
 
 
-class TAAInfoSchema(Schema):
+class TAAInfoSchema(OpenAPISchema):
     """Transaction author agreement info."""
 
     aml_record = fields.Nested(AMLRecordSchema())
@@ -45,13 +46,13 @@ class TAAInfoSchema(Schema):
     taa_accepted = fields.Nested(TAAAcceptanceSchema())
 
 
-class TAAResultSchema(Schema):
+class TAAResultSchema(OpenAPISchema):
     """Result schema for a transaction author agreement."""
 
     result = fields.Nested(TAAInfoSchema())
 
 
-class TAAAcceptSchema(Schema):
+class TAAAcceptSchema(OpenAPISchema):
     """Input schema for accepting the TAA."""
 
     version = fields.Str()
@@ -59,7 +60,7 @@ class TAAAcceptSchema(Schema):
     mechanism = fields.Str()
 
 
-class RegisterLedgerNymQueryStringSchema(Schema):
+class RegisterLedgerNymQueryStringSchema(OpenAPISchema):
     """Query string parameters and validators for register ledger nym request."""
 
     did = fields.Str(description="DID to register", required=True, **INDY_DID,)
@@ -76,7 +77,7 @@ class RegisterLedgerNymQueryStringSchema(Schema):
     )
 
 
-class QueryStringDIDSchema(Schema):
+class QueryStringDIDSchema(OpenAPISchema):
     """Parameters and validators for query string with DID only."""
 
     did = fields.Str(description="DID of interest", required=True, **INDY_DID)

--- a/aries_cloudagent/messaging/ack/message.py
+++ b/aries_cloudagent/messaging/ack/message.py
@@ -1,6 +1,6 @@
 """Represents an explicit ack message as per Aries RFC 15."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from ..agent_message import AgentMessage, AgentMessageSchema
 
@@ -36,6 +36,7 @@ class AckSchema(AgentMessageSchema):
         """Ack schema metadata."""
 
         model_class = Ack
+        unknown = EXCLUDE
 
     status = fields.Constant(
         constant="OK",

--- a/aries_cloudagent/messaging/agent_message.py
+++ b/aries_cloudagent/messaging/agent_message.py
@@ -5,6 +5,7 @@ from typing import Mapping, Union
 import uuid
 
 from marshmallow import (
+    EXCLUDE,
     fields,
     pre_load,
     post_load,
@@ -390,6 +391,7 @@ class AgentMessageSchema(BaseModelSchema):
 
         model_class = None
         signed_fields = None
+        unknown = EXCLUDE
 
     # Avoid clobbering keywords
     _type = fields.Str(

--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -11,13 +11,14 @@ from aiohttp_apispec import (
     response_schema,
 )
 
-from marshmallow import fields, Schema
+from marshmallow import fields
 
 from ...issuer.base import BaseIssuer
 from ...ledger.base import BaseLedger
 from ...storage.base import BaseStorage
 from ...tails.base import BaseTailsServer
 
+from ..models.openapi import OpenAPISchema
 from ..valid import INDY_CRED_DEF_ID, INDY_SCHEMA_ID, INDY_VERSION
 
 from ...revocation.error import RevocationError, RevocationNotSupportedError
@@ -28,7 +29,7 @@ from ...ledger.error import LedgerError
 from .util import CredDefQueryStringSchema, CRED_DEF_TAGS, CRED_DEF_SENT_RECORD_TYPE
 
 
-class CredentialDefinitionSendRequestSchema(Schema):
+class CredentialDefinitionSendRequestSchema(OpenAPISchema):
     """Request schema for schema send request."""
 
     schema_id = fields.Str(description="Schema identifier", **INDY_SCHEMA_ID)
@@ -44,7 +45,7 @@ class CredentialDefinitionSendRequestSchema(Schema):
     )
 
 
-class CredentialDefinitionSendResultsSchema(Schema):
+class CredentialDefinitionSendResultsSchema(OpenAPISchema):
     """Results schema for schema send request."""
 
     credential_definition_id = fields.Str(
@@ -52,7 +53,7 @@ class CredentialDefinitionSendResultsSchema(Schema):
     )
 
 
-class CredentialDefinitionSchema(Schema):
+class CredentialDefinitionSchema(OpenAPISchema):
     """Credential definition schema."""
 
     ver = fields.Str(description="Node protocol version", **INDY_VERSION)
@@ -80,13 +81,13 @@ class CredentialDefinitionSchema(Schema):
     )
 
 
-class CredentialDefinitionGetResultsSchema(Schema):
+class CredentialDefinitionGetResultsSchema(OpenAPISchema):
     """Results schema for schema get request."""
 
     credential_definition = fields.Nested(CredentialDefinitionSchema)
 
 
-class CredentialDefinitionsCreatedResultsSchema(Schema):
+class CredentialDefinitionsCreatedResultsSchema(OpenAPISchema):
     """Results schema for cred-defs-created request."""
 
     credential_definition_ids = fields.List(
@@ -94,7 +95,7 @@ class CredentialDefinitionsCreatedResultsSchema(Schema):
     )
 
 
-class CredDefIdMatchInfoSchema(Schema):
+class CredDefIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking cred def id."""
 
     cred_def_id = fields.Str(

--- a/aries_cloudagent/messaging/credential_definitions/util.py
+++ b/aries_cloudagent/messaging/credential_definitions/util.py
@@ -1,7 +1,8 @@
 """Credential definition utilities."""
 
-from marshmallow import fields, Schema
+from marshmallow import fields
 
+from ..models.openapi import OpenAPISchema
 from ..valid import (
     INDY_CRED_DEF_ID,
     INDY_DID,
@@ -13,7 +14,7 @@ from ..valid import (
 CRED_DEF_SENT_RECORD_TYPE = "cred_def_sent"
 
 
-class CredDefQueryStringSchema(Schema):
+class CredDefQueryStringSchema(OpenAPISchema):
     """Query string parameters for credential definition searches."""
 
     schema_id = fields.Str(

--- a/aries_cloudagent/messaging/decorators/attach_decorator.py
+++ b/aries_cloudagent/messaging/decorators/attach_decorator.py
@@ -10,7 +10,7 @@ import uuid
 
 from typing import Any, Mapping, Sequence, Union
 
-from marshmallow import fields, pre_load
+from marshmallow import EXCLUDE, fields, pre_load
 
 from ...wallet.base import BaseWallet
 from ...wallet.util import (
@@ -62,6 +62,7 @@ class AttachDecoratorDataJWSHeaderSchema(BaseModelSchema):
         """Attach decorator data schema metadata."""
 
         model_class = AttachDecoratorDataJWSHeader
+        unknown = EXCLUDE
 
     kid = fields.Str(
         description="Key identifier, in W3C did:key or DID URL format",
@@ -108,6 +109,7 @@ class AttachDecoratorData1JWSSchema(BaseModelSchema):
         """Single attach decorator data JWS schema metadata."""
 
         model_class = AttachDecoratorData1JWS
+        unknown = EXCLUDE
 
     header = fields.Nested(AttachDecoratorDataJWSHeaderSchema, required=True)
     protected = fields.Str(
@@ -152,6 +154,7 @@ class AttachDecoratorDataJWSSchema(BaseModelSchema):
         """Metadata for schema for detached JWS for inclusion in attach deco data."""
 
         model_class = AttachDecoratorDataJWS
+        unknown = EXCLUDE
 
     @pre_load
     def validate_single_xor_multi_sig(self, data: Mapping, **kwargs):
@@ -454,6 +457,7 @@ class AttachDecoratorDataSchema(BaseModelSchema):
         """Attach decorator data schema metadata."""
 
         model_class = AttachDecoratorData
+        unknown = EXCLUDE
 
     @pre_load
     def validate_data_spec(self, data: Mapping, **kwargs):
@@ -632,6 +636,7 @@ class AttachDecoratorSchema(BaseModelSchema):
         """AttachDecoratorSchema metadata."""
 
         model_class = AttachDecorator
+        unknown = EXCLUDE
 
     ident = fields.Str(
         description="Attachment identifier",

--- a/aries_cloudagent/messaging/decorators/localization_decorator.py
+++ b/aries_cloudagent/messaging/decorators/localization_decorator.py
@@ -2,7 +2,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from ..models.base import BaseModel, BaseModelSchema
 
@@ -44,6 +44,7 @@ class LocalizationDecoratorSchema(BaseModelSchema):
         """LocalizationDecoratorSchema metadata."""
 
         model_class = LocalizationDecorator
+        unknown = EXCLUDE
 
     locale = fields.Str(required=True, description="Locale specifier", example="en-CA",)
     localizable = fields.List(

--- a/aries_cloudagent/messaging/decorators/please_ack_decorator.py
+++ b/aries_cloudagent/messaging/decorators/please_ack_decorator.py
@@ -2,7 +2,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from ..models.base import BaseModel, BaseModelSchema
 from ..valid import UUIDFour
@@ -39,6 +39,7 @@ class PleaseAckDecoratorSchema(BaseModelSchema):
         """PleaseAckDecoratorSchema metadata."""
 
         model_class = PleaseAckDecorator
+        unknown = EXCLUDE
 
     message_id = fields.Str(
         description="Message identifier",

--- a/aries_cloudagent/messaging/decorators/signature_decorator.py
+++ b/aries_cloudagent/messaging/decorators/signature_decorator.py
@@ -1,11 +1,10 @@
 """Model and schema for working with field signatures within message bodies."""
 
-
 import json
 import struct
 import time
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from ...wallet.base import BaseWallet
 from ...wallet.util import b64_to_bytes, bytes_to_b64
@@ -128,6 +127,7 @@ class SignatureDecoratorSchema(BaseModelSchema):
         """SignatureDecoratorSchema metadata."""
 
         model_class = SignatureDecorator
+        unknown = EXCLUDE
 
     signature_type = fields.Str(
         data_key="@type",

--- a/aries_cloudagent/messaging/decorators/tests/test_base.py
+++ b/aries_cloudagent/messaging/decorators/tests/test_base.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from time import time
 from unittest import TestCase
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from ....messaging.models.base import BaseModel, BaseModelSchema
 
@@ -33,6 +33,7 @@ class SampleDecoratorSchema(BaseModelSchema):
 
     class Meta:
         model_class = SampleDecorator
+        unknown = EXCLUDE
 
     score = fields.Int(required=True)
 

--- a/aries_cloudagent/messaging/decorators/tests/test_decorator_set.py
+++ b/aries_cloudagent/messaging/decorators/tests/test_decorator_set.py
@@ -1,5 +1,6 @@
-from marshmallow import fields
 from unittest import TestCase
+
+from marshmallow import EXCLUDE, fields
 
 from ...models.base import BaseModel, BaseModelSchema
 
@@ -20,6 +21,7 @@ class SimpleModel(BaseModel):
 class SimpleModelSchema(BaseModelSchema):
     class Meta:
         model_class = SimpleModel
+        unknown = EXCLUDE
 
     value = fields.Str(required=True)
     handled_decorator = fields.Str(required=False, data_key="handled~decorator")

--- a/aries_cloudagent/messaging/decorators/thread_decorator.py
+++ b/aries_cloudagent/messaging/decorators/thread_decorator.py
@@ -7,7 +7,7 @@ context from previous messages.
 
 from typing import Mapping
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from ..models.base import BaseModel, BaseModelSchema
 from ..valid import UUIDFour
@@ -117,6 +117,7 @@ class ThreadDecoratorSchema(BaseModelSchema):
         """ThreadDecoratorSchema metadata."""
 
         model_class = ThreadDecorator
+        unknown = EXCLUDE
 
     thid = fields.Str(
         required=False,

--- a/aries_cloudagent/messaging/decorators/timing_decorator.py
+++ b/aries_cloudagent/messaging/decorators/timing_decorator.py
@@ -8,7 +8,7 @@ and constrained.
 from datetime import datetime
 from typing import Union
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from ..models.base import BaseModel, BaseModelSchema
 from ..util import datetime_to_str
@@ -60,6 +60,7 @@ class TimingDecoratorSchema(BaseModelSchema):
         """TimingDecoratorSchema metadata."""
 
         model_class = TimingDecorator
+        unknown = EXCLUDE
 
     in_time = fields.Str(
         required=False, description="Time of message receipt", **INDY_ISO8601_DATETIME

--- a/aries_cloudagent/messaging/decorators/trace_decorator.py
+++ b/aries_cloudagent/messaging/decorators/trace_decorator.py
@@ -7,7 +7,7 @@ to record information on message processing events.
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from ..models.base import BaseModel, BaseModelSchema
 from ..valid import UUIDFour
@@ -234,6 +234,7 @@ class TraceReportSchema(BaseModelSchema):
         """TraceReportSchema metadata."""
 
         model_class = TraceReport
+        unknown = EXCLUDE
 
     msg_id = fields.Str(
         required=True,
@@ -292,6 +293,7 @@ class TraceDecoratorSchema(BaseModelSchema):
         """TraceDecoratorSchema metadata."""
 
         model_class = TraceDecorator
+        unknown = EXCLUDE
 
     target = fields.Str(
         required=True,

--- a/aries_cloudagent/messaging/decorators/transport_decorator.py
+++ b/aries_cloudagent/messaging/decorators/transport_decorator.py
@@ -4,7 +4,7 @@ The transport decorator (~transport).
 This decorator allows changes to agent response behaviour and queue status updates.
 """
 
-from marshmallow import fields, validate
+from marshmallow import EXCLUDE, fields, validate
 
 from ..models.base import BaseModel, BaseModelSchema
 from ..valid import UUIDFour, WHOLE_NUM
@@ -46,6 +46,7 @@ class TransportDecoratorSchema(BaseModelSchema):
         """TransportDecoratorSchema metadata."""
 
         model_class = TransportDecorator
+        unknown = EXCLUDE
 
     return_route = fields.Str(
         required=False,

--- a/aries_cloudagent/messaging/jsonld/create_verify_data.py
+++ b/aries_cloudagent/messaging/jsonld/create_verify_data.py
@@ -5,11 +5,10 @@ This file was ported from
 https://github.com/transmute-industries/Ed25519Signature2018/blob/master/src/createVerifyData/index.js
 """
 
-
 import datetime
+import hashlib
 
 from pyld import jsonld
-import hashlib
 
 
 def _canonize(data):

--- a/aries_cloudagent/messaging/jsonld/credential.py
+++ b/aries_cloudagent/messaging/jsonld/credential.py
@@ -1,6 +1,7 @@
 """Sign and verify functions for json-ld based credentials."""
 
 import json
+
 from ...wallet.util import (
     b58_to_bytes,
     b64_to_bytes,

--- a/aries_cloudagent/messaging/jsonld/routes.py
+++ b/aries_cloudagent/messaging/jsonld/routes.py
@@ -3,23 +3,21 @@
 from aiohttp import web
 from aiohttp_apispec import docs, request_schema, response_schema
 
-from ...messaging.jsonld.credential import (
-    sign_credential,
-    verify_credential,
-)
+from marshmallow import fields
+
 from ...wallet.base import BaseWallet
+from ..models.openapi import OpenAPISchema
+from .credential import sign_credential, verify_credential
 
-from marshmallow import fields, Schema
 
-
-class SignRequestSchema(Schema):
+class SignRequestSchema(OpenAPISchema):
     """Request schema for signing a jsonld doc."""
 
     verkey = fields.Str(required=True, description="verkey to use for signing")
     doc = fields.Dict(required=True, description="JSON-LD Doc to sign")
 
 
-class SignResponseSchema(Schema):
+class SignResponseSchema(OpenAPISchema):
     """Response schema for a signed jsonld doc."""
 
     signed_doc = fields.Dict(required=True)
@@ -60,14 +58,14 @@ async def sign(request: web.BaseRequest):
     return web.json_response(response)
 
 
-class VerifyRequestSchema(Schema):
+class VerifyRequestSchema(OpenAPISchema):
     """Request schema for signing a jsonld doc."""
 
     verkey = fields.Str(required=True, description="verkey to use for doc verification")
     doc = fields.Dict(required=True, description="JSON-LD Doc to verify")
 
 
-class VerifyResponseSchema(Schema):
+class VerifyResponseSchema(OpenAPISchema):
     """Response schema for verification result."""
 
     valid = fields.Bool(required=True)

--- a/aries_cloudagent/messaging/models/base.py
+++ b/aries_cloudagent/messaging/models/base.py
@@ -296,3 +296,12 @@ class BaseModelSchema(Schema):
         """
         skip_vals = resolve_meta_property(self, "skip_values", [])
         return {key: value for key, value in data.items() if value not in skip_vals}
+
+
+class OpenAPISchema(Schema):
+    """Schema for OpenAPI artifacts: excluding unknown fields, not raising exception."""
+
+    class Meta:
+        """BaseModelSchema metadata."""
+
+        unknown = EXCLUDE

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -475,6 +475,8 @@ class BaseRecordSchema(BaseModelSchema):
     class Meta:
         """BaseRecordSchema metadata."""
 
+        model_class = None
+
     state = fields.Str(
         required=False, description="Current record state", example="active"
     )

--- a/aries_cloudagent/messaging/models/openapi.py
+++ b/aries_cloudagent/messaging/models/openapi.py
@@ -1,0 +1,13 @@
+"""Base class for OpenAPI artifact schema."""
+
+from marshmallow import Schema, EXCLUDE
+
+
+class OpenAPISchema(Schema):
+    """Schema for OpenAPI artifacts: excluding unknown fields, not raising exception."""
+
+    class Meta:
+        """OpenAPISchema metadata."""
+
+        model_class = None
+        unknown = EXCLUDE

--- a/aries_cloudagent/messaging/models/tests/test_base.py
+++ b/aries_cloudagent/messaging/models/tests/test_base.py
@@ -2,7 +2,7 @@ import json
 
 from asynctest import TestCase as AsyncTestCase, mock as async_mock
 
-from marshmallow import fields, validates_schema, ValidationError
+from marshmallow import EXCLUDE, fields, validates_schema, ValidationError
 
 from ....cache.base import BaseCache
 from ....config.injection_context import InjectionContext
@@ -25,6 +25,7 @@ class ModelImpl(BaseModel):
 class SchemaImpl(BaseModelSchema):
     class Meta:
         model_class = ModelImpl
+        unknown = EXCLUDE
 
     attr = fields.String(required=True)
 

--- a/aries_cloudagent/messaging/models/tests/test_base_record.py
+++ b/aries_cloudagent/messaging/models/tests/test_base_record.py
@@ -1,7 +1,7 @@
 import json
 
 from asynctest import TestCase as AsyncTestCase, mock as async_mock
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from ....cache.base import BaseCache
 from ....config.injection_context import InjectionContext
@@ -25,6 +25,7 @@ class BaseRecordImpl(BaseRecord):
 class BaseRecordImplSchema(BaseRecordSchema):
     class Meta:
         model_class = BaseRecordImpl
+        unknown = EXCLUDE
 
 
 class ARecordImpl(BaseRecord):
@@ -50,6 +51,7 @@ class ARecordImpl(BaseRecord):
 class ARecordImplSchema(BaseRecordSchema):
     class Meta:
         model_class = BaseRecordImpl
+        unknown = EXCLUDE
 
     ident = fields.Str(attribute="_id")
     a = fields.Str()

--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -11,18 +11,19 @@ from aiohttp_apispec import (
     response_schema,
 )
 
-from marshmallow import fields, Schema
+from marshmallow import fields
 from marshmallow.validate import Regexp
 
 from ...issuer.base import BaseIssuer, IssuerError
 from ...ledger.base import BaseLedger
 from ...ledger.error import LedgerError
 from ...storage.base import BaseStorage
+from ..models.openapi import OpenAPISchema
 from ..valid import B58, NATURAL_NUM, INDY_SCHEMA_ID, INDY_VERSION
 from .util import SchemaQueryStringSchema, SCHEMA_SENT_RECORD_TYPE, SCHEMA_TAGS
 
 
-class SchemaSendRequestSchema(Schema):
+class SchemaSendRequestSchema(OpenAPISchema):
     """Request schema for schema send request."""
 
     schema_name = fields.Str(required=True, description="Schema name", example="prefs",)
@@ -36,7 +37,7 @@ class SchemaSendRequestSchema(Schema):
     )
 
 
-class SchemaSendResultsSchema(Schema):
+class SchemaSendResultsSchema(OpenAPISchema):
     """Results schema for schema send request."""
 
     schema_id = fields.Str(
@@ -45,7 +46,7 @@ class SchemaSendResultsSchema(Schema):
     schema = fields.Dict(description="Schema result", required=True)
 
 
-class SchemaSchema(Schema):
+class SchemaSchema(OpenAPISchema):
     """Content for returned schema."""
 
     ver = fields.Str(description="Node protocol version", **INDY_VERSION)
@@ -62,13 +63,13 @@ class SchemaSchema(Schema):
     seqNo = fields.Int(description="Schema sequence number", **NATURAL_NUM)
 
 
-class SchemaGetResultsSchema(Schema):
+class SchemaGetResultsSchema(OpenAPISchema):
     """Results schema for schema get request."""
 
     schema_json = fields.Nested(SchemaSchema())
 
 
-class SchemasCreatedResultsSchema(Schema):
+class SchemasCreatedResultsSchema(OpenAPISchema):
     """Results schema for a schemas-created request."""
 
     schema_ids = fields.List(
@@ -76,7 +77,7 @@ class SchemasCreatedResultsSchema(Schema):
     )
 
 
-class SchemaIdMatchInfoSchema(Schema):
+class SchemaIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking schema id."""
 
     schema_id = fields.Str(

--- a/aries_cloudagent/messaging/schemas/util.py
+++ b/aries_cloudagent/messaging/schemas/util.py
@@ -1,15 +1,12 @@
 """Schema utilities."""
 
-from marshmallow import fields, Schema
+from marshmallow import fields
 
-from ..valid import (
-    INDY_DID,
-    INDY_SCHEMA_ID,
-    INDY_VERSION,
-)
+from ..models.openapi import OpenAPISchema
+from ..valid import INDY_DID, INDY_SCHEMA_ID, INDY_VERSION
 
 
-class SchemaQueryStringSchema(Schema):
+class SchemaQueryStringSchema(OpenAPISchema):
     """Query string parameters for schema searches."""
 
     schema_id = fields.Str(

--- a/aries_cloudagent/messaging/tests/test_agent_message.py
+++ b/aries_cloudagent/messaging/tests/test_agent_message.py
@@ -1,6 +1,7 @@
-from asynctest import TestCase as AsyncTestCase
-from marshmallow import fields
 import json
+
+from asynctest import TestCase as AsyncTestCase
+from marshmallow import EXCLUDE, fields
 
 from ...wallet.basic import BasicWallet
 from ...wallet.util import bytes_to_b64
@@ -32,6 +33,7 @@ class SignedAgentMessageSchema(AgentMessageSchema):
     class Meta:
         model_class = SignedAgentMessage
         signed_fields = ("value",)
+        unknown = EXCLUDE
 
     value = fields.Str(required=True)
 
@@ -42,7 +44,7 @@ class BasicAgentMessage(AgentMessage):
     class Meta:
         """Meta data"""
 
-        schema_class = "AgentMessageSchema"
+        schema_class = AgentMessageSchema
         message_type = "basic-message"
 
 

--- a/aries_cloudagent/protocols/actionmenu/v1_0/messages/menu.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/messages/menu.py
@@ -2,7 +2,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -53,6 +53,7 @@ class MenuSchema(AgentMessageSchema):
         """Menu schema metadata."""
 
         model_class = Menu
+        unknown = EXCLUDE
 
     title = fields.Str(required=False, description="Menu title", example="My Menu")
     description = fields.Str(

--- a/aries_cloudagent/protocols/actionmenu/v1_0/messages/menu_request.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/messages/menu_request.py
@@ -1,5 +1,7 @@
 """Represents a request for an action menu."""
 
+from marshmallow import EXCLUDE
+
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import MENU_REQUEST, PROTOCOL_PACKAGE
@@ -29,3 +31,4 @@ class MenuRequestSchema(AgentMessageSchema):
         """MenuRequest schema metadata."""
 
         model_class = MenuRequest
+        unknown = EXCLUDE

--- a/aries_cloudagent/protocols/actionmenu/v1_0/messages/perform.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/messages/perform.py
@@ -2,7 +2,7 @@
 
 from typing import Mapping
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -41,6 +41,7 @@ class PerformSchema(AgentMessageSchema):
         """Perform schema metadata."""
 
         model_class = Perform
+        unknown = EXCLUDE
 
     name = fields.Str(required=True, description="Menu option name", example="Query",)
     params = fields.Dict(

--- a/aries_cloudagent/protocols/actionmenu/v1_0/models/menu_form.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/models/menu_form.py
@@ -2,7 +2,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.models.base import BaseModel, BaseModelSchema
 
@@ -47,6 +47,7 @@ class MenuFormSchema(BaseModelSchema):
         """MenuFormSchema metadata."""
 
         model_class = MenuForm
+        unknown = EXCLUDE
 
     title = fields.Str(
         required=False, description="Menu form title", example="Preferences",

--- a/aries_cloudagent/protocols/actionmenu/v1_0/models/menu_form_param.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/models/menu_form_param.py
@@ -1,6 +1,6 @@
 """Record used to represent a parameter in a menu form."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.models.base import BaseModel, BaseModelSchema
 
@@ -50,6 +50,7 @@ class MenuFormParamSchema(BaseModelSchema):
         """MenuFormParamSchema metadata."""
 
         model_class = MenuFormParam
+        unknown = EXCLUDE
 
     name = fields.Str(
         required=True, description="Menu parameter name", example="delay",

--- a/aries_cloudagent/protocols/actionmenu/v1_0/models/menu_option.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/models/menu_option.py
@@ -1,6 +1,6 @@
 """Record used to represent individual menu options in an action menu."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.models.base import BaseModel, BaseModelSchema
 
@@ -48,6 +48,7 @@ class MenuOptionSchema(BaseModelSchema):
         """MenuOptionSchema metadata."""
 
         model_class = MenuOption
+        unknown = EXCLUDE
 
     name = fields.Str(
         required=True,

--- a/aries_cloudagent/protocols/actionmenu/v1_0/routes.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/routes.py
@@ -5,10 +5,11 @@ import logging
 from aiohttp import web
 from aiohttp_apispec import docs, match_info_schema, request_schema
 
-from marshmallow import fields, Schema
+from marshmallow import fields
 
 from ....connections.models.connection_record import ConnectionRecord
 from ....messaging.models.base import BaseModelError
+from ....messaging.models.openapi import OpenAPISchema
 from ....messaging.valid import UUIDFour
 from ....storage.error import StorageError, StorageNotFoundError
 
@@ -21,7 +22,7 @@ from .util import MENU_RECORD_TYPE, retrieve_connection_menu, save_connection_me
 LOGGER = logging.getLogger(__name__)
 
 
-class PerformRequestSchema(Schema):
+class PerformRequestSchema(OpenAPISchema):
     """Request schema for performing a menu action."""
 
     name = fields.Str(description="Menu option name", example="Query")
@@ -33,7 +34,7 @@ class PerformRequestSchema(Schema):
     )
 
 
-class MenuJsonSchema(Schema):
+class MenuJsonSchema(OpenAPISchema):
     """Matches MenuSchema but without the inherited AgentMessage properties."""
 
     title = fields.Str(required=False, description="Menu title", example="My Menu",)
@@ -54,7 +55,7 @@ class MenuJsonSchema(Schema):
     )
 
 
-class SendMenuSchema(Schema):
+class SendMenuSchema(OpenAPISchema):
     """Request schema for sending a menu to a connection."""
 
     menu = fields.Nested(
@@ -62,7 +63,7 @@ class SendMenuSchema(Schema):
     )
 
 
-class ConnIdMatchInfoSchema(Schema):
+class ConnIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking connection id."""
 
     conn_id = fields.Str(

--- a/aries_cloudagent/protocols/basicmessage/v1_0/messages/basicmessage.py
+++ b/aries_cloudagent/protocols/basicmessage/v1_0/messages/basicmessage.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Union
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 from .....messaging.util import datetime_now, datetime_to_str
@@ -57,6 +57,7 @@ class BasicMessageSchema(AgentMessageSchema):
         """Basic message schema metadata."""
 
         model_class = BasicMessage
+        unknown = EXCLUDE
 
     sent_time = fields.Str(
         required=False,

--- a/aries_cloudagent/protocols/basicmessage/v1_0/routes.py
+++ b/aries_cloudagent/protocols/basicmessage/v1_0/routes.py
@@ -3,9 +3,10 @@
 from aiohttp import web
 from aiohttp_apispec import docs, match_info_schema, request_schema
 
-from marshmallow import fields, Schema
+from marshmallow import fields
 
 from ....connections.models.connection_record import ConnectionRecord
+from ....messaging.models.openapi import OpenAPISchema
 from ....messaging.valid import UUIDFour
 from ....storage.error import StorageNotFoundError
 
@@ -13,13 +14,13 @@ from .message_types import SPEC_URI
 from .messages.basicmessage import BasicMessage
 
 
-class SendMessageSchema(Schema):
+class SendMessageSchema(OpenAPISchema):
     """Request schema for sending a message."""
 
     content = fields.Str(description="Message content", example="Hello")
 
 
-class ConnIdMatchInfoSchema(Schema):
+class ConnIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking connection id."""
 
     conn_id = fields.Str(

--- a/aries_cloudagent/protocols/connections/v1_0/messages/connection_invitation.py
+++ b/aries_cloudagent/protocols/connections/v1_0/messages/connection_invitation.py
@@ -3,7 +3,7 @@
 from typing import Sequence
 from urllib.parse import parse_qs, urljoin, urlparse
 
-from marshmallow import ValidationError, fields, validates_schema
+from marshmallow import EXCLUDE, fields, validates_schema, ValidationError
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 from .....messaging.valid import INDY_DID, INDY_RAW_PUBLIC_KEY
@@ -97,6 +97,7 @@ class ConnectionInvitationSchema(AgentMessageSchema):
         """Connection invitation schema metadata."""
 
         model_class = ConnectionInvitation
+        unknown = EXCLUDE
 
     label = fields.Str(
         required=False, description="Optional label for connection", example="Bob"

--- a/aries_cloudagent/protocols/connections/v1_0/messages/connection_request.py
+++ b/aries_cloudagent/protocols/connections/v1_0/messages/connection_request.py
@@ -1,6 +1,6 @@
 """Represents a connection request message."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -51,6 +51,7 @@ class ConnectionRequestSchema(AgentMessageSchema):
         """Connection request schema metadata."""
 
         model_class = ConnectionRequest
+        unknown = EXCLUDE
 
     connection = fields.Nested(ConnectionDetailSchema, required=True)
     label = fields.Str(

--- a/aries_cloudagent/protocols/connections/v1_0/messages/connection_response.py
+++ b/aries_cloudagent/protocols/connections/v1_0/messages/connection_response.py
@@ -1,6 +1,6 @@
 """Represents a connection response message."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -43,5 +43,6 @@ class ConnectionResponseSchema(AgentMessageSchema):
 
         model_class = ConnectionResponse
         signed_fields = ("connection",)
+        unknown = EXCLUDE
 
     connection = fields.Nested(ConnectionDetailSchema, required=True)

--- a/aries_cloudagent/protocols/connections/v1_0/messages/problem_report.py
+++ b/aries_cloudagent/protocols/connections/v1_0/messages/problem_report.py
@@ -1,7 +1,7 @@
 """Represents a connection problem report message."""
 
 from enum import Enum
-from marshmallow import fields, validate
+from marshmallow import EXCLUDE, fields, validate
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -50,6 +50,7 @@ class ProblemReportSchema(AgentMessageSchema):
         """Metadata for problem report schema."""
 
         model_class = ProblemReport
+        unknown = EXCLUDE
 
     explain = fields.Str(
         required=False,

--- a/aries_cloudagent/protocols/connections/v1_0/models/connection_detail.py
+++ b/aries_cloudagent/protocols/connections/v1_0/models/connection_detail.py
@@ -1,6 +1,6 @@
 """An object for containing the connection request/response DID information."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....connections.models.diddoc import DIDDoc
 from .....messaging.models.base import BaseModel, BaseModelSchema
@@ -87,7 +87,8 @@ class ConnectionDetailSchema(BaseModelSchema):
     class Meta:
         """ConnectionDetailSchema metadata."""
 
-        model_class = "ConnectionDetail"
+        model_class = ConnectionDetail
+        unknown = EXCLUDE
 
     did = fields.Str(
         data_key="DID",

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -11,13 +11,14 @@ from aiohttp_apispec import (
     response_schema,
 )
 
-from marshmallow import fields, Schema, validate, validates_schema
+from marshmallow import fields, validate, validates_schema
 
 from ....connections.models.connection_record import (
     ConnectionRecord,
     ConnectionRecordSchema,
 )
 from ....messaging.models.base import BaseModelError
+from ....messaging.models.openapi import OpenAPISchema
 from ....messaging.valid import (
     ENDPOINT,
     INDY_DID,
@@ -35,7 +36,7 @@ from .messages.connection_invitation import (
 )
 
 
-class ConnectionListSchema(Schema):
+class ConnectionListSchema(OpenAPISchema):
     """Result schema for connection list."""
 
     results = fields.List(
@@ -52,7 +53,7 @@ class ReceiveInvitationRequestSchema(ConnectionInvitationSchema):
         """Bypass middleware field validation."""
 
 
-class InvitationResultSchema(Schema):
+class InvitationResultSchema(OpenAPISchema):
     """Result schema for a new connection invitation."""
 
     connection_id = fields.Str(
@@ -65,7 +66,7 @@ class InvitationResultSchema(Schema):
     )
 
 
-class ConnectionStaticRequestSchema(Schema):
+class ConnectionStaticRequestSchema(OpenAPISchema):
     """Request schema for a new static connection."""
 
     my_seed = fields.Str(description="Seed to use for the local DID", required=False)
@@ -89,7 +90,7 @@ class ConnectionStaticRequestSchema(Schema):
     alias = fields.Str(description="Alias to assign to this connection", required=False)
 
 
-class ConnectionStaticResultSchema(Schema):
+class ConnectionStaticResultSchema(OpenAPISchema):
     """Result schema for new static connection."""
 
     my_did = fields.Str(description="Local DID", required=True, **INDY_DID)
@@ -104,7 +105,7 @@ class ConnectionStaticResultSchema(Schema):
     record = fields.Nested(ConnectionRecordSchema, required=True)
 
 
-class ConnectionsListQueryStringSchema(Schema):
+class ConnectionsListQueryStringSchema(OpenAPISchema):
     """Parameters and validators for connections list request query string."""
 
     alias = fields.Str(description="Alias", required=False, example="Barry",)
@@ -136,7 +137,7 @@ class ConnectionsListQueryStringSchema(Schema):
     )
 
 
-class CreateInvitationQueryStringSchema(Schema):
+class CreateInvitationQueryStringSchema(OpenAPISchema):
     """Parameters and validators for create invitation request query string."""
 
     alias = fields.Str(description="Alias", required=False, example="Barry",)
@@ -152,7 +153,7 @@ class CreateInvitationQueryStringSchema(Schema):
     )
 
 
-class ReceiveInvitationQueryStringSchema(Schema):
+class ReceiveInvitationQueryStringSchema(OpenAPISchema):
     """Parameters and validators for receive invitation request query string."""
 
     alias = fields.Str(description="Alias", required=False, example="Barry",)
@@ -162,7 +163,7 @@ class ReceiveInvitationQueryStringSchema(Schema):
     )
 
 
-class AcceptInvitationQueryStringSchema(Schema):
+class AcceptInvitationQueryStringSchema(OpenAPISchema):
     """Parameters and validators for accept invitation request query string."""
 
     my_endpoint = fields.Str(description="My URL endpoint", required=False, **ENDPOINT)
@@ -171,13 +172,13 @@ class AcceptInvitationQueryStringSchema(Schema):
     )
 
 
-class AcceptRequestQueryStringSchema(Schema):
+class AcceptRequestQueryStringSchema(OpenAPISchema):
     """Parameters and validators for accept conn-request web-request query string."""
 
     my_endpoint = fields.Str(description="My URL endpoint", required=False, **ENDPOINT)
 
 
-class ConnIdMatchInfoSchema(Schema):
+class ConnIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking connection id."""
 
     conn_id = fields.Str(
@@ -185,7 +186,7 @@ class ConnIdMatchInfoSchema(Schema):
     )
 
 
-class ConnIdRefIdMatchInfoSchema(Schema):
+class ConnIdRefIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking connection and ref ids."""
 
     conn_id = fields.Str(

--- a/aries_cloudagent/protocols/discovery/v1_0/messages/disclose.py
+++ b/aries_cloudagent/protocols/discovery/v1_0/messages/disclose.py
@@ -2,7 +2,7 @@
 
 from typing import Mapping, Sequence
 
-from marshmallow import fields, Schema, validate
+from marshmallow import EXCLUDE, fields, Schema, validate
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -55,6 +55,7 @@ class DiscloseSchema(AgentMessageSchema):
         """DiscloseSchema metadata."""
 
         model_class = Disclose
+        unknown = EXCLUDE
 
     protocols = fields.List(
         fields.Nested(ProtocolDescriptorSchema()),

--- a/aries_cloudagent/protocols/discovery/v1_0/messages/query.py
+++ b/aries_cloudagent/protocols/discovery/v1_0/messages/query.py
@@ -1,10 +1,10 @@
 """Represents a feature discovery query message."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
-from ..message_types import QUERY, PROTOCOL_PACKAGE
+from ..message_types import PROTOCOL_PACKAGE, QUERY
 
 HANDLER_CLASS = f"{PROTOCOL_PACKAGE}.handlers.query_handler.QueryHandler"
 
@@ -42,6 +42,7 @@ class QuerySchema(AgentMessageSchema):
         """QuerySchema metadata."""
 
         model_class = Query
+        unknown = EXCLUDE
 
     query = fields.Str(required=True)
     comment = fields.Str(required=False, allow_none=True)

--- a/aries_cloudagent/protocols/discovery/v1_0/routes.py
+++ b/aries_cloudagent/protocols/discovery/v1_0/routes.py
@@ -2,14 +2,15 @@
 
 from aiohttp import web
 from aiohttp_apispec import docs, querystring_schema, response_schema
-from marshmallow import fields, Schema
+from marshmallow import fields
 
 from ....core.protocol_registry import ProtocolRegistry
+from ....messaging.models.openapi import OpenAPISchema
 
 from .message_types import SPEC_URI
 
 
-class QueryResultSchema(Schema):
+class QueryResultSchema(OpenAPISchema):
     """Result schema for the protocol list."""
 
     results = fields.Dict(
@@ -19,7 +20,7 @@ class QueryResultSchema(Schema):
     )
 
 
-class QueryFeaturesQueryStringSchema(Schema):
+class QueryFeaturesQueryStringSchema(OpenAPISchema):
     """Query string parameters for feature query."""
 
     query = fields.Str(description="Query", required=False, example="did:sov:*")

--- a/aries_cloudagent/protocols/introduction/v0_1/messages/invitation.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/messages/invitation.py
@@ -1,6 +1,6 @@
 """Represents an invitation returned to the introduction service."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 from .....protocols.connections.v1_0.messages.connection_invitation import (
@@ -46,6 +46,7 @@ class InvitationSchema(AgentMessageSchema):
         """Invitation request schema metadata."""
 
         model_class = Invitation
+        unknown = EXCLUDE
 
     invitation = fields.Nested(ConnectionInvitationSchema(), required=True)
     message = fields.Str(

--- a/aries_cloudagent/protocols/introduction/v0_1/messages/invitation_request.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/messages/invitation_request.py
@@ -1,6 +1,6 @@
 """Represents an request for an invitation from the introduction service."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -41,6 +41,7 @@ class InvitationRequestSchema(AgentMessageSchema):
         """Invitation request schema metadata."""
 
         model_class = InvitationRequest
+        unknown = EXCLUDE
 
     responder = fields.Str(
         required=True,

--- a/aries_cloudagent/protocols/introduction/v0_1/routes.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/routes.py
@@ -5,8 +5,9 @@ import logging
 from aiohttp import web
 from aiohttp_apispec import docs, match_info_schema, querystring_schema
 
-from marshmallow import fields, Schema
+from marshmallow import fields
 
+from ....messaging.models.openapi import OpenAPISchema
 from ....messaging.valid import UUIDFour
 from ....storage.error import StorageError
 
@@ -15,7 +16,7 @@ from .base_service import BaseIntroductionService, IntroductionError
 LOGGER = logging.getLogger(__name__)
 
 
-class IntroStartQueryStringSchema(Schema):
+class IntroStartQueryStringSchema(OpenAPISchema):
     """Query string parameters for request to start introduction."""
 
     target_connection_id = fields.Str(
@@ -28,7 +29,7 @@ class IntroStartQueryStringSchema(Schema):
     )
 
 
-class ConnIdMatchInfoSchema(Schema):
+class ConnIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking connection id."""
 
     conn_id = fields.Str(

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_ack.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_ack.py
@@ -1,8 +1,10 @@
 """A credential ack message."""
 
-from .....messaging.ack.message import Ack, AckSchema
-from ..message_types import CREDENTIAL_ACK, PROTOCOL_PACKAGE
+from marshmallow import EXCLUDE
 
+from .....messaging.ack.message import Ack, AckSchema
+
+from ..message_types import CREDENTIAL_ACK, PROTOCOL_PACKAGE
 
 HANDLER_CLASS = (
     f"{PROTOCOL_PACKAGE}.handlers.credential_ack_handler.CredentialAckHandler"
@@ -31,3 +33,4 @@ class CredentialAckSchema(AckSchema):
         """Schema metadata."""
 
         model_class = CredentialAck
+        unknown = EXCLUDE

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_issue.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_issue.py
@@ -2,7 +2,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 from .....messaging.decorators.attach_decorator import (
@@ -11,7 +11,6 @@ from .....messaging.decorators.attach_decorator import (
 )
 
 from ..message_types import ATTACH_DECO_IDS, CREDENTIAL_ISSUE, PROTOCOL_PACKAGE
-
 
 HANDLER_CLASS = (
     f"{PROTOCOL_PACKAGE}.handlers.credential_issue_handler.CredentialIssueHandler"
@@ -74,6 +73,7 @@ class CredentialIssueSchema(AgentMessageSchema):
         """Credential schema metadata."""
 
         model_class = CredentialIssue
+        unknown = EXCLUDE
 
     comment = fields.Str(
         description="Human-readable comment", required=False, allow_none=True

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_offer.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_offer.py
@@ -2,7 +2,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 from .....messaging.decorators.attach_decorator import (
@@ -12,7 +12,6 @@ from .....messaging.decorators.attach_decorator import (
 
 from ..message_types import ATTACH_DECO_IDS, CREDENTIAL_OFFER, PROTOCOL_PACKAGE
 from .inner.credential_preview import CredentialPreview, CredentialPreviewSchema
-
 
 HANDLER_CLASS = (
     f"{PROTOCOL_PACKAGE}.handlers.credential_offer_handler.CredentialOfferHandler"
@@ -78,6 +77,7 @@ class CredentialOfferSchema(AgentMessageSchema):
         """Credential offer schema metadata."""
 
         model_class = CredentialOffer
+        unknown = EXCLUDE
 
     comment = fields.Str(
         description="Human-readable comment", required=False, allow_none=True

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_proposal.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_proposal.py
@@ -1,6 +1,6 @@
 """A credential proposal content message."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 from .....messaging.valid import (
@@ -13,7 +13,6 @@ from .....messaging.valid import (
 from ..message_types import CREDENTIAL_PROPOSAL, PROTOCOL_PACKAGE
 
 from .inner.credential_preview import CredentialPreview, CredentialPreviewSchema
-
 
 HANDLER_CLASS = (
     f"{PROTOCOL_PACKAGE}.handlers."
@@ -76,6 +75,7 @@ class CredentialProposalSchema(AgentMessageSchema):
         """Credential proposal schema metadata."""
 
         model_class = CredentialProposal
+        unknown = EXCLUDE
 
     comment = fields.Str(
         description="Human-readable comment", required=False, allow_none=True

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_request.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_request.py
@@ -2,7 +2,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 from .....messaging.decorators.attach_decorator import (
@@ -11,7 +11,6 @@ from .....messaging.decorators.attach_decorator import (
 )
 
 from ..message_types import ATTACH_DECO_IDS, CREDENTIAL_REQUEST, PROTOCOL_PACKAGE
-
 
 HANDLER_CLASS = (
     f"{PROTOCOL_PACKAGE}.handlers."
@@ -75,6 +74,7 @@ class CredentialRequestSchema(AgentMessageSchema):
         """Credential request schema metadata."""
 
         model_class = CredentialRequest
+        unknown = EXCLUDE
 
     comment = fields.Str(
         description="Human-readable comment", required=False, allow_none=True

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/inner/credential_preview.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/inner/credential_preview.py
@@ -3,7 +3,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from ......messaging.models.base import BaseModel, BaseModelSchema
 from ......wallet.util import b64_to_str
@@ -74,6 +74,7 @@ class CredAttrSpecSchema(BaseModelSchema):
         """Attribute preview schema metadata."""
 
         model_class = CredAttrSpec
+        unknown = EXCLUDE
 
     name = fields.Str(
         description="Attribute name", required=True, example="favourite_drink"
@@ -163,6 +164,7 @@ class CredentialPreviewSchema(BaseModelSchema):
         """Credential preview schema metadata."""
 
         model_class = CredentialPreview
+        unknown = EXCLUDE
 
     _type = fields.Str(
         description="Message type identifier",

--- a/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
@@ -11,13 +11,13 @@ from aiohttp_apispec import (
     response_schema,
 )
 from json.decoder import JSONDecodeError
-from marshmallow import fields, Schema, validate
+from marshmallow import fields, validate
 
 from ....connections.models.connection_record import ConnectionRecord
 from ....issuer.base import IssuerError
 from ....ledger.error import LedgerError
 from ....messaging.credential_definitions.util import CRED_DEF_TAGS
-from ....messaging.models.base import BaseModelError
+from ....messaging.models.base import BaseModelError, OpenAPISchema
 from ....messaging.valid import (
     INDY_CRED_DEF_ID,
     INDY_CRED_REV_ID,
@@ -34,6 +34,7 @@ from ....storage.error import StorageError, StorageNotFoundError
 from ....wallet.base import BaseWallet
 from ....wallet.error import WalletError
 from ....utils.outofband import serialize_outofband
+from ....utils.tracing import trace_event, get_timer, AdminAPIMessageTracingSchema
 
 from ...problem_report.v1_0 import internal_error
 from ...problem_report.v1_0.message import ProblemReport
@@ -51,10 +52,8 @@ from .models.credential_exchange import (
     V10CredentialExchangeSchema,
 )
 
-from ....utils.tracing import trace_event, get_timer, AdminAPIMessageTracingSchema
 
-
-class V10CredentialExchangeListQueryStringSchema(Schema):
+class V10CredentialExchangeListQueryStringSchema(OpenAPISchema):
     """Parameters and validators for credential exchange list query."""
 
     connection_id = fields.UUID(
@@ -91,7 +90,7 @@ class V10CredentialExchangeListQueryStringSchema(Schema):
     )
 
 
-class V10CredentialExchangeListResultSchema(Schema):
+class V10CredentialExchangeListResultSchema(OpenAPISchema):
     """Result schema for Aries#0036 v1.0 credential exchange query."""
 
     results = fields.List(
@@ -100,7 +99,7 @@ class V10CredentialExchangeListResultSchema(Schema):
     )
 
 
-class V10CredentialStoreRequestSchema(Schema):
+class V10CredentialStoreRequestSchema(OpenAPISchema):
     """Request schema for sending a credential store admin message."""
 
     credential_id = fields.Str(required=False)
@@ -243,7 +242,7 @@ class V10CredentialOfferRequestSchema(AdminAPIMessageTracingSchema):
     )
 
 
-class V10CredentialIssueRequestSchema(Schema):
+class V10CredentialIssueRequestSchema(OpenAPISchema):
     """Request schema for sending credential issue admin message."""
 
     comment = fields.Str(
@@ -251,13 +250,13 @@ class V10CredentialIssueRequestSchema(Schema):
     )
 
 
-class V10CredentialProblemReportRequestSchema(Schema):
+class V10CredentialProblemReportRequestSchema(OpenAPISchema):
     """Request schema for sending problem report."""
 
     explain_ltxt = fields.Str(required=True)
 
 
-class V10PublishRevocationsSchema(Schema):
+class V10PublishRevocationsSchema(OpenAPISchema):
     """Request and result schema for revocation publication API call."""
 
     rrid2crid = fields.Dict(
@@ -272,7 +271,7 @@ class V10PublishRevocationsSchema(Schema):
     )
 
 
-class V10ClearPendingRevocationsRequestSchema(Schema):
+class V10ClearPendingRevocationsRequestSchema(OpenAPISchema):
     """Request schema for clear pending revocations API call."""
 
     purge = fields.Dict(
@@ -290,7 +289,7 @@ class V10ClearPendingRevocationsRequestSchema(Schema):
     )
 
 
-class RevokeQueryStringSchema(Schema):
+class RevokeQueryStringSchema(OpenAPISchema):
     """Parameters and validators for revocation request."""
 
     rev_reg_id = fields.Str(
@@ -308,7 +307,7 @@ class RevokeQueryStringSchema(Schema):
     )
 
 
-class CredIdMatchInfoSchema(Schema):
+class CredIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking credential id."""
 
     credential_id = fields.Str(
@@ -316,7 +315,7 @@ class CredIdMatchInfoSchema(Schema):
     )
 
 
-class CredExIdMatchInfoSchema(Schema):
+class CredExIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking credential exchange id."""
 
     cred_ex_id = fields.Str(

--- a/aries_cloudagent/protocols/out_of_band/v1_0/messages/invitation.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/messages/invitation.py
@@ -2,7 +2,14 @@
 
 from typing import Sequence, Text, Union
 
-from marshmallow import fields, validates_schema, ValidationError, pre_load, post_dump
+from marshmallow import (
+    EXCLUDE,
+    fields,
+    post_dump,
+    pre_load,
+    validates_schema,
+    ValidationError,
+)
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 from .....messaging.decorators.attach_decorator import (
@@ -83,6 +90,7 @@ class InvitationSchema(AgentMessageSchema):
         """Invitation schema metadata."""
 
         model_class = Invitation
+        unknown = EXCLUDE
 
     label = fields.Str(required=False, description="Optional label", example="Bob")
     handshake_protocols = fields.List(fields.String, required=False, many=True)

--- a/aries_cloudagent/protocols/out_of_band/v1_0/messages/service.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/messages/service.py
@@ -2,7 +2,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.models.base import BaseModel, BaseModelSchema
 from .....messaging.valid import INDY_DID, INDY_RAW_PUBLIC_KEY
@@ -52,6 +52,7 @@ class ServiceSchema(BaseModelSchema):
         """ServiceSchema metadata."""
 
         model_class = Service
+        unknown = EXCLUDE
 
     _id = fields.Str(required=True, description="", data_key="id")
     _type = fields.Str(required=True, description="", data_key="type")

--- a/aries_cloudagent/protocols/out_of_band/v1_0/routes.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/routes.py
@@ -5,9 +5,10 @@ import logging
 
 from aiohttp import web
 from aiohttp_apispec import docs, request_schema
-from marshmallow import fields, Schema
+from marshmallow import fields
 from marshmallow.exceptions import ValidationError
 
+from ....messaging.models.openapi import OpenAPISchema
 from ....storage.error import StorageNotFoundError
 
 from .manager import OutOfBandManager, OutOfBandManagerError
@@ -17,10 +18,10 @@ from .messages.invitation import InvitationSchema
 LOGGER = logging.getLogger(__name__)
 
 
-class InvitationCreateRequestSchema(Schema):
+class InvitationCreateRequestSchema(OpenAPISchema):
     """Invitation create request Schema."""
 
-    class AttachmentDefSchema(Schema):
+    class AttachmentDefSchema(OpenAPISchema):
         """Attachment Schema."""
 
         _id = fields.String(data_key="id")

--- a/aries_cloudagent/protocols/out_of_band/v1_0/routes.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/routes.py
@@ -32,7 +32,7 @@ class InvitationCreateRequestSchema(OpenAPISchema):
     use_public_did = fields.Boolean(default=False)
 
 
-class InvitationSchema(InvitationSchema):
+class InvitationReceiveRequestSchema(InvitationSchema):
     """Invitation Schema."""
 
     service = fields.Field()
@@ -79,7 +79,7 @@ async def invitation_create(request: web.BaseRequest):
 @docs(
     tags=["out-of-band"], summary="Create a new connection invitation",
 )
-@request_schema(InvitationSchema())
+@request_schema(InvitationReceiveRequestSchema())
 async def invitation_receive(request: web.BaseRequest):
     """
     Request handler for creating a new connection invitation.

--- a/aries_cloudagent/protocols/present_proof/v1_0/messages/presentation.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/messages/presentation.py
@@ -3,7 +3,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 from .....messaging.decorators.attach_decorator import (
@@ -12,7 +12,6 @@ from .....messaging.decorators.attach_decorator import (
 )
 
 from ..message_types import PRESENTATION, PROTOCOL_PACKAGE
-
 
 HANDLER_CLASS = f"{PROTOCOL_PACKAGE}.handlers.presentation_handler.PresentationHandler"
 
@@ -68,6 +67,7 @@ class PresentationSchema(AgentMessageSchema):
         """Presentation schema metadata."""
 
         model_class = Presentation
+        unknown = EXCLUDE
 
     comment = fields.Str(
         description="Human-readable comment", required=False, allow_none=True

--- a/aries_cloudagent/protocols/present_proof/v1_0/messages/presentation_ack.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/messages/presentation_ack.py
@@ -1,8 +1,9 @@
 """Represents an explicit RFC 15 ack message, adopted into present-proof protocol."""
 
+from marshmallow import EXCLUDE
+
 from .....messaging.ack.message import Ack, AckSchema
 from ..message_types import PRESENTATION_ACK, PROTOCOL_PACKAGE
-
 
 HANDLER_CLASS = (
     f"{PROTOCOL_PACKAGE}.handlers.presentation_ack_handler.PresentationAckHandler"
@@ -37,3 +38,4 @@ class PresentationAckSchema(AckSchema):
         """PresentationAck schema metadata."""
 
         model_class = PresentationAck
+        unknown = EXCLUDE

--- a/aries_cloudagent/protocols/present_proof/v1_0/messages/presentation_proposal.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/messages/presentation_proposal.py
@@ -1,13 +1,12 @@
 """A presentation proposal content message."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import PRESENTATION_PROPOSAL, PROTOCOL_PACKAGE
 
 from .inner.presentation_preview import PresentationPreview, PresentationPreviewSchema
-
 
 HANDLER_CLASS = (
     f"{PROTOCOL_PACKAGE}.handlers."
@@ -52,6 +51,7 @@ class PresentationProposalSchema(AgentMessageSchema):
         """Presentation proposal schema metadata."""
 
         model_class = PresentationProposal
+        unknown = EXCLUDE
 
     comment = fields.Str(
         description="Human-readable comment", required=False, allow_none=True

--- a/aries_cloudagent/protocols/present_proof/v1_0/messages/presentation_request.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/messages/presentation_request.py
@@ -3,7 +3,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 from .....messaging.decorators.attach_decorator import (
@@ -12,7 +12,6 @@ from .....messaging.decorators.attach_decorator import (
 )
 
 from ..message_types import PRESENTATION_REQUEST, PROTOCOL_PACKAGE
-
 
 HANDLER_CLASS = (
     f"{PROTOCOL_PACKAGE}.handlers."
@@ -71,6 +70,7 @@ class PresentationRequestSchema(AgentMessageSchema):
         """Presentation request schema metadata."""
 
         model_class = PresentationRequest
+        unknown = EXCLUDE
 
     comment = fields.Str(
         description="Human-readable comment", required=False, allow_none=True

--- a/aries_cloudagent/protocols/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/routes.py
@@ -10,7 +10,7 @@ from aiohttp_apispec import (
     request_schema,
     response_schema,
 )
-from marshmallow import fields, Schema, validate, validates_schema
+from marshmallow import fields, validate, validates_schema
 from marshmallow.exceptions import ValidationError
 
 from ....connections.models.connection_record import ConnectionRecord
@@ -18,6 +18,7 @@ from ....holder.base import BaseHolder, HolderError
 from ....ledger.error import LedgerError
 from ....messaging.decorators.attach_decorator import AttachDecorator
 from ....messaging.models.base import BaseModelError
+from ....messaging.models.openapi import OpenAPISchema
 from ....messaging.valid import (
     INDY_CRED_DEF_ID,
     INDY_DID,
@@ -53,7 +54,7 @@ from .models.presentation_exchange import (
 from ....utils.tracing import trace_event, get_timer, AdminAPIMessageTracingSchema
 
 
-class V10PresentationExchangeListQueryStringSchema(Schema):
+class V10PresentationExchangeListQueryStringSchema(OpenAPISchema):
     """Parameters and validators for presentation exchange list query."""
 
     connection_id = fields.UUID(
@@ -90,7 +91,7 @@ class V10PresentationExchangeListQueryStringSchema(Schema):
     )
 
 
-class V10PresentationExchangeListSchema(Schema):
+class V10PresentationExchangeListSchema(OpenAPISchema):
     """Result schema for an Aries RFC 37 v1.0 presentation exchange query."""
 
     results = fields.List(
@@ -124,7 +125,7 @@ class V10PresentationProposalRequestSchema(AdminAPIMessageTracingSchema):
     )
 
 
-class IndyProofReqPredSpecRestrictionsSchema(Schema):
+class IndyProofReqPredSpecRestrictionsSchema(OpenAPISchema):
     """Schema for restrictions in attr or pred specifier indy proof request."""
 
     schema_id = fields.String(
@@ -149,7 +150,7 @@ class IndyProofReqPredSpecRestrictionsSchema(Schema):
     )
 
 
-class IndyProofReqNonRevokedSchema(Schema):
+class IndyProofReqNonRevokedSchema(OpenAPISchema):
     """Non-revocation times specification in indy proof request."""
 
     fro = fields.Int(
@@ -182,7 +183,7 @@ class IndyProofReqNonRevokedSchema(Schema):
             )
 
 
-class IndyProofReqAttrSpecSchema(Schema):
+class IndyProofReqAttrSpecSchema(OpenAPISchema):
     """Schema for attribute specification in indy proof request."""
 
     name = fields.String(
@@ -245,7 +246,7 @@ class IndyProofReqAttrSpecSchema(Schema):
             )
 
 
-class IndyProofReqPredSpecSchema(Schema):
+class IndyProofReqPredSpecSchema(OpenAPISchema):
     """Schema for predicate specification in indy proof request."""
 
     name = fields.String(example="index", description="Attribute name", required=True)
@@ -263,7 +264,7 @@ class IndyProofReqPredSpecSchema(Schema):
     non_revoked = fields.Nested(IndyProofReqNonRevokedSchema(), required=False)
 
 
-class IndyProofRequestSchema(Schema):
+class IndyProofRequestSchema(OpenAPISchema):
     """Schema for indy proof request."""
 
     nonce = fields.String(description="Nonce", required=False, example="1234567890")
@@ -316,7 +317,7 @@ class V10PresentationSendRequestRequestSchema(
     )
 
 
-class IndyRequestedCredsRequestedAttrSchema(Schema):
+class IndyRequestedCredsRequestedAttrSchema(OpenAPISchema):
     """Schema for requested attributes within indy requested credentials structure."""
 
     cred_id = fields.Str(
@@ -336,7 +337,7 @@ class IndyRequestedCredsRequestedAttrSchema(Schema):
     )
 
 
-class IndyRequestedCredsRequestedPredSchema(Schema):
+class IndyRequestedCredsRequestedPredSchema(OpenAPISchema):
     """Schema for requested predicates within indy requested credentials structure."""
 
     cred_id = fields.Str(
@@ -393,7 +394,7 @@ class V10PresentationRequestSchema(AdminAPIMessageTracingSchema):
     )
 
 
-class CredentialsFetchQueryStringSchema(Schema):
+class CredentialsFetchQueryStringSchema(OpenAPISchema):
     """Parameters and validators for credentials fetch request query string."""
 
     referent = fields.Str(
@@ -412,7 +413,7 @@ class CredentialsFetchQueryStringSchema(Schema):
     )
 
 
-class PresExIdMatchInfoSchema(Schema):
+class PresExIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking presentation exchange id."""
 
     pres_ex_id = fields.Str(

--- a/aries_cloudagent/protocols/problem_report/v1_0/message.py
+++ b/aries_cloudagent/protocols/problem_report/v1_0/message.py
@@ -2,7 +2,7 @@
 
 from typing import Mapping, Sequence
 
-from marshmallow import fields, validate
+from marshmallow import EXCLUDE, fields, validate
 
 from ....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -77,6 +77,7 @@ class ProblemReportSchema(AgentMessageSchema):
         """Problem report schema metadata."""
 
         model_class = ProblemReport
+        unknown = EXCLUDE
 
     msg_catalog = fields.Str(
         data_key="@msg_catalog",

--- a/aries_cloudagent/protocols/routing/v1_0/messages/forward.py
+++ b/aries_cloudagent/protocols/routing/v1_0/messages/forward.py
@@ -4,7 +4,7 @@ import json
 
 from typing import Union
 
-from marshmallow import fields, pre_load
+from marshmallow import EXCLUDE, fields, pre_load
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -45,6 +45,7 @@ class ForwardSchema(AgentMessageSchema):
         """ForwardSchema metadata."""
 
         model_class = Forward
+        unknown = EXCLUDE
 
     @pre_load
     def handle_str_message(self, data, **kwargs):

--- a/aries_cloudagent/protocols/routing/v1_0/messages/route_query_request.py
+++ b/aries_cloudagent/protocols/routing/v1_0/messages/route_query_request.py
@@ -1,6 +1,6 @@
 """Query existing forwarding routes."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -42,6 +42,7 @@ class RouteQueryRequestSchema(AgentMessageSchema):
         """RouteQueryRequestSchema metadata."""
 
         model_class = RouteQueryRequest
+        unknown = EXCLUDE
 
     filter = fields.Dict(
         keys=fields.Str(description="field"),

--- a/aries_cloudagent/protocols/routing/v1_0/messages/route_query_response.py
+++ b/aries_cloudagent/protocols/routing/v1_0/messages/route_query_response.py
@@ -2,7 +2,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -52,6 +52,7 @@ class RouteQueryResponseSchema(AgentMessageSchema):
         """RouteQueryResponseSchema metadata."""
 
         model_class = RouteQueryResponse
+        unknown = EXCLUDE
 
     routes = fields.List(fields.Nested(RouteQueryResultSchema()), required=True)
     paginated = fields.Nested(PaginatedSchema(), required=False)

--- a/aries_cloudagent/protocols/routing/v1_0/messages/route_update_request.py
+++ b/aries_cloudagent/protocols/routing/v1_0/messages/route_update_request.py
@@ -2,7 +2,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -44,5 +44,6 @@ class RouteUpdateRequestSchema(AgentMessageSchema):
         """RouteUpdateRequestSchema metadata."""
 
         model_class = RouteUpdateRequest
+        unknown = EXCLUDE
 
     updates = fields.List(fields.Nested(RouteUpdateSchema()), required=True)

--- a/aries_cloudagent/protocols/routing/v1_0/messages/route_update_response.py
+++ b/aries_cloudagent/protocols/routing/v1_0/messages/route_update_response.py
@@ -2,7 +2,7 @@
 
 from typing import Sequence
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -44,5 +44,6 @@ class RouteUpdateResponseSchema(AgentMessageSchema):
         """RouteUpdateResponseSchema metadata."""
 
         model_class = RouteUpdateResponse
+        unknown = EXCLUDE
 
     updated = fields.List(fields.Nested(RouteUpdatedSchema()), required=True)

--- a/aries_cloudagent/protocols/routing/v1_0/models/paginate.py
+++ b/aries_cloudagent/protocols/routing/v1_0/models/paginate.py
@@ -1,6 +1,6 @@
 """An object for containing the request pagination information."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.models.base import BaseModel, BaseModelSchema
 
@@ -33,7 +33,8 @@ class PaginateSchema(BaseModelSchema):
     class Meta:
         """PaginateSchema metadata."""
 
-        model_class = "Paginate"
+        model_class = Paginate
+        unknown = EXCLUDE
 
     limit = fields.Int(required=False)
     offset = fields.Int(required=False)

--- a/aries_cloudagent/protocols/routing/v1_0/models/paginated.py
+++ b/aries_cloudagent/protocols/routing/v1_0/models/paginated.py
@@ -1,6 +1,6 @@
 """An object for containing the response pagination information."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.models.base import BaseModel, BaseModelSchema
 
@@ -45,7 +45,8 @@ class PaginatedSchema(BaseModelSchema):
     class Meta:
         """PaginatedSchema metadata."""
 
-        model_class = "Paginated"
+        model_class = Paginated
+        unknown = EXCLUDE
 
     start = fields.Int(required=False)
     end = fields.Int(required=False)

--- a/aries_cloudagent/protocols/routing/v1_0/models/route_query_result.py
+++ b/aries_cloudagent/protocols/routing/v1_0/models/route_query_result.py
@@ -1,6 +1,6 @@
 """An object for containing returned route information."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.models.base import BaseModel, BaseModelSchema
 
@@ -31,6 +31,7 @@ class RouteQueryResultSchema(BaseModelSchema):
     class Meta:
         """RouteQueryResultSchema metadata."""
 
-        model_class = "RouteQueryResult"
+        model_class = RouteQueryResult
+        unknown = EXCLUDE
 
     recipient_key = fields.Str(required=True)

--- a/aries_cloudagent/protocols/routing/v1_0/models/route_record.py
+++ b/aries_cloudagent/protocols/routing/v1_0/models/route_record.py
@@ -1,6 +1,6 @@
 """An object for containing information on an individual route."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.models.base import BaseModel, BaseModelSchema
 
@@ -44,7 +44,8 @@ class RouteRecordSchema(BaseModelSchema):
     class Meta:
         """RouteRecordSchema metadata."""
 
-        model_class = "RouteRecord"
+        model_class = RouteRecord
+        unknown = EXCLUDE
 
     record_id = fields.Str(required=False)
     connection_id = fields.Str(required=True)

--- a/aries_cloudagent/protocols/routing/v1_0/models/route_update.py
+++ b/aries_cloudagent/protocols/routing/v1_0/models/route_update.py
@@ -1,6 +1,6 @@
 """An object for containing route information to be updated."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.models.base import BaseModel, BaseModelSchema
 
@@ -36,7 +36,8 @@ class RouteUpdateSchema(BaseModelSchema):
     class Meta:
         """RouteUpdateSchema metadata."""
 
-        model_class = "RouteUpdate"
+        model_class = RouteUpdate
+        unknown = EXCLUDE
 
     recipient_key = fields.Str(required=True)
     action = fields.Str(required=True)

--- a/aries_cloudagent/protocols/routing/v1_0/models/route_updated.py
+++ b/aries_cloudagent/protocols/routing/v1_0/models/route_updated.py
@@ -1,6 +1,6 @@
 """An object for containing updated route information."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.models.base import BaseModel, BaseModelSchema
 
@@ -47,7 +47,8 @@ class RouteUpdatedSchema(BaseModelSchema):
     class Meta:
         """RouteUpdatedSchema metadata."""
 
-        model_class = "RouteUpdated"
+        model_class = RouteUpdated
+        unknown = EXCLUDE
 
     recipient_key = fields.Str(required=True)
     action = fields.Str(required=True)

--- a/aries_cloudagent/protocols/trustping/v1_0/messages/ping.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/messages/ping.py
@@ -1,6 +1,6 @@
 """Represents a trust ping message."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -43,6 +43,7 @@ class PingSchema(AgentMessageSchema):
         """PingSchema metadata."""
 
         model_class = Ping
+        unknown = EXCLUDE
 
     response_requested = fields.Bool(
         description="Whether response is requested (default True)",

--- a/aries_cloudagent/protocols/trustping/v1_0/messages/ping_response.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/messages/ping_response.py
@@ -1,6 +1,6 @@
 """Represents an response to a trust ping message."""
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -38,6 +38,7 @@ class PingResponseSchema(AgentMessageSchema):
         """PingResponseSchema metadata."""
 
         model_class = PingResponse
+        unknown = EXCLUDE
 
     comment = fields.Str(
         required=False,

--- a/aries_cloudagent/protocols/trustping/v1_0/routes.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/routes.py
@@ -3,9 +3,10 @@
 from aiohttp import web
 from aiohttp_apispec import docs, match_info_schema, request_schema, response_schema
 
-from marshmallow import fields, Schema
+from marshmallow import fields
 
 from ....connections.models.connection_record import ConnectionRecord
+from ....messaging.models.openapi import OpenAPISchema
 from ....messaging.valid import UUIDFour
 from ....storage.error import StorageNotFoundError
 
@@ -13,7 +14,7 @@ from .message_types import SPEC_URI
 from .messages.ping import Ping
 
 
-class PingRequestSchema(Schema):
+class PingRequestSchema(OpenAPISchema):
     """Request schema for performing a ping."""
 
     comment = fields.Str(
@@ -21,13 +22,13 @@ class PingRequestSchema(Schema):
     )
 
 
-class PingRequestResponseSchema(Schema):
+class PingRequestResponseSchema(OpenAPISchema):
     """Request schema for performing a ping."""
 
     thread_id = fields.Str(required=False, description="Thread ID of the ping message")
 
 
-class ConnIdMatchInfoSchema(Schema):
+class ConnIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking connection id."""
 
     conn_id = fields.Str(

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -13,9 +13,10 @@ from aiohttp_apispec import (
     response_schema,
 )
 
-from marshmallow import fields, Schema, validate
+from marshmallow import fields, validate
 
 from ..messaging.credential_definitions.util import CRED_DEF_SENT_RECORD_TYPE
+from ..messaging.models.openapi import OpenAPISchema
 from ..messaging.valid import INDY_CRED_DEF_ID, INDY_REV_REG_ID
 from ..storage.base import BaseStorage, StorageNotFoundError
 
@@ -23,11 +24,10 @@ from .error import RevocationError, RevocationNotSupportedError
 from .indy import IndyRevocation
 from .models.issuer_rev_reg_record import IssuerRevRegRecord, IssuerRevRegRecordSchema
 
-
 LOGGER = logging.getLogger(__name__)
 
 
-class RevRegCreateRequestSchema(Schema):
+class RevRegCreateRequestSchema(OpenAPISchema):
     """Request schema for revocation registry creation request."""
 
     credential_definition_id = fields.Str(
@@ -38,13 +38,13 @@ class RevRegCreateRequestSchema(Schema):
     )
 
 
-class RevRegCreateResultSchema(Schema):
+class RevRegCreateResultSchema(OpenAPISchema):
     """Result schema for revocation registry creation request."""
 
     result = IssuerRevRegRecordSchema()
 
 
-class RevRegsCreatedSchema(Schema):
+class RevRegsCreatedSchema(OpenAPISchema):
     """Result schema for request for revocation registries created."""
 
     rev_reg_ids = fields.List(
@@ -52,7 +52,7 @@ class RevRegsCreatedSchema(Schema):
     )
 
 
-class RevRegUpdateTailsFileUriSchema(Schema):
+class RevRegUpdateTailsFileUriSchema(OpenAPISchema):
     """Request schema for updating tails file URI."""
 
     tails_public_uri = fields.Url(
@@ -65,7 +65,7 @@ class RevRegUpdateTailsFileUriSchema(Schema):
     )
 
 
-class RevRegsCreatedQueryStringSchema(Schema):
+class RevRegsCreatedQueryStringSchema(OpenAPISchema):
     """Query string parameters and validators for rev regs created request."""
 
     cred_def_id = fields.Str(
@@ -86,7 +86,7 @@ class RevRegsCreatedQueryStringSchema(Schema):
     )
 
 
-class RevRegIdMatchInfoSchema(Schema):
+class RevRegIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking rev reg id."""
 
     rev_reg_id = fields.Str(
@@ -94,7 +94,7 @@ class RevRegIdMatchInfoSchema(Schema):
     )
 
 
-class CredDefIdMatchInfoSchema(Schema):
+class CredDefIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking cred def id."""
 
     cred_def_id = fields.Str(

--- a/aries_cloudagent/utils/tracing.py
+++ b/aries_cloudagent/utils/tracing.py
@@ -6,7 +6,7 @@ import time
 import datetime
 import requests
 
-from marshmallow import fields, Schema
+from marshmallow import fields
 
 from ..transport.inbound.message import InboundMessage
 from ..transport.outbound.message import OutboundMessage
@@ -17,13 +17,14 @@ from ..messaging.decorators.trace_decorator import (
     TRACE_LOG_TARGET,
 )
 from ..messaging.models.base_record import BaseExchangeRecord
+from ..messaging.models.openapi import OpenAPISchema
 
 
 LOGGER = logging.getLogger(__name__)
 DT_FMT = "%Y-%m-%d %H:%M:%S.%f%z"
 
 
-class AdminAPIMessageTracingSchema(Schema):
+class AdminAPIMessageTracingSchema(OpenAPISchema):
     """
     Request/result schema including agent message tracing.
 

--- a/aries_cloudagent/wallet/crypto.py
+++ b/aries_cloudagent/wallet/crypto.py
@@ -1,13 +1,15 @@
 """Cryptography functions used by BasicWallet."""
 
-from collections import OrderedDict
 import json
+
+from collections import OrderedDict
 from typing import Callable, Optional, Sequence, Tuple
 
-from marshmallow import fields, Schema, ValidationError
 import nacl.bindings
 import nacl.exceptions
 import nacl.utils
+
+from marshmallow import fields, Schema, ValidationError
 
 from .error import WalletError
 from .util import bytes_to_b58, bytes_to_b64, b64_to_bytes, b58_to_bytes

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -11,17 +11,18 @@ from aiohttp_apispec import (
     response_schema,
 )
 
-from marshmallow import fields, Schema
+from marshmallow import fields
 
 from ..ledger.base import BaseLedger
 from ..ledger.error import LedgerConfigError, LedgerError
+from ..messaging.models.openapi import OpenAPISchema
 from ..messaging.valid import ENDPOINT, INDY_CRED_DEF_ID, INDY_DID, INDY_RAW_PUBLIC_KEY
 
 from .base import DIDInfo, BaseWallet
 from .error import WalletError, WalletNotFoundError
 
 
-class DIDSchema(Schema):
+class DIDSchema(OpenAPISchema):
     """Result schema for a DID."""
 
     did = fields.Str(description="DID of interest", **INDY_DID)
@@ -29,19 +30,19 @@ class DIDSchema(Schema):
     public = fields.Boolean(description="Whether DID is public", example=False)
 
 
-class DIDResultSchema(Schema):
+class DIDResultSchema(OpenAPISchema):
     """Result schema for a DID."""
 
     result = fields.Nested(DIDSchema())
 
 
-class DIDListSchema(Schema):
+class DIDListSchema(OpenAPISchema):
     """Result schema for connection list."""
 
     results = fields.List(fields.Nested(DIDSchema()), description="DID list")
 
 
-class DIDEndpointSchema(Schema):
+class DIDEndpointSchema(OpenAPISchema):
     """Request schema to set DID endpoint; response schema to get DID endpoint."""
 
     did = fields.Str(description="DID of interest", required=True, **INDY_DID)
@@ -50,7 +51,7 @@ class DIDEndpointSchema(Schema):
     )
 
 
-class DIDListQueryStringSchema(Schema):
+class DIDListQueryStringSchema(OpenAPISchema):
     """Parameters and validators for DID list request query string."""
 
     did = fields.Str(description="DID of interest", required=False, **INDY_DID)
@@ -62,13 +63,13 @@ class DIDListQueryStringSchema(Schema):
     public = fields.Boolean(description="Whether DID is on the ledger", required=False)
 
 
-class DIDQueryStringSchema(Schema):
+class DIDQueryStringSchema(OpenAPISchema):
     """Parameters and validators for set public DID request query string."""
 
     did = fields.Str(description="DID of interest", required=True, **INDY_DID)
 
 
-class CredDefIdMatchInfoSchema(Schema):
+class CredDefIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking credential definition id."""
 
     cred_def_id = fields.Str(


### PR DESCRIPTION
…eivably OK

I (used to) fundamentally disagree with this approach: I believe standards should be exclusive to ensure the tightest possible profile for interop, but I concede that embrace-and-extend is the zeitgeist of the day. Also, allowing extra fields and ignoring them by default puts us on a more error-resistant posture when it comes time to jockey multiple versions of a protocol.

This work allows extra fields (which aca-py discards) on protocols and messages without blowing up.

~I'm also working on a less invasive approach which might not suffice in the end. I'd rather not see this one merged until I fully exhaust that possibility.~ _update: it's cute but no better; prefer this approach_

For these two reasons I will mark this PR as draft for the moment.
_update_: I've made it ready to merge and am satisfied with the work if the group is.

Signed-off-by: sklump <srklump@hotmail.com>