### PR TITLE
FIx description of the agent option

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -789,7 +789,7 @@ class WalletGroup(ArgumentGroup):
             metavar="<storage-type>",
             help="Specifies the type of Indy wallet backend to use.\
             Supported internal storage types are 'basic' (memory),\
-            'indy', and 'postgres_storage'.",
+            'default' (sqlite), and 'postgres_storage'.",
         )
         parser.add_argument(
             "--wallet-storage-config",

--- a/aries_cloudagent/protocols/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/manager.py
@@ -330,7 +330,7 @@ class PresentationManager:
 
         non_revoc_interval = {"from": 0, "to": epoch_now}
         non_revoc_interval.update(
-            presentation_exchange_record.presentation_request.get("non_revoked", {})
+            presentation_exchange_record.presentation_request.get("non_revoked") if presentation_exchange_record.presentation_request.get("non_revoked") else {}
         )
 
         revoc_reg_deltas = {}


### PR DESCRIPTION
Among the options for '--wallet-storage-type' that were not previously supported, 'indy' was modified to 'default'.

For this problem, if you follow the description of the option and set it to 'indy', you will receive an error of 'Unknown wallet storage type'.

This is received from the indy library and only handles the 'default' option as a map in the WalletService of the indy library, and does not add the 'indy' option.

So I modified & reinforced the description of '--wallet-storage-type'.