### PR TITLE
simplify non-revoc tweak at verifier for non-revocable creds

### DIFF
--- a/aries_cloudagent/verifier/tests/test_indy.py
+++ b/aries_cloudagent/verifier/tests/test_indy.py
@@ -481,7 +481,7 @@ class TestIndyVerifier(AsyncTestCase):
             ],
         }
 
-        self.verifier.non_revoc_intervals(big_pres_req, big_pres, True)
+        self.verifier.non_revoc_intervals(big_pres_req, big_pres)
 
         assert "non_revoked" not in big_pres_req
         for spec in big_pres_req["requested_attributes"].values():


### PR DESCRIPTION
Method doesn't need last parameter: it can take it from absence of timestamps
Signed-off-by: sklump <srklump@hotmail.com>