### PR TITLE
Fixed description of Aries OpenAPI Demo parameter

### DIFF
--- a/demo/AriesOpenAPIDemo.md
+++ b/demo/AriesOpenAPIDemo.md
@@ -465,7 +465,7 @@ For the following fields, scroll on Faber's Swagger page to the listed endpoint,
 
 - `issuer_did` the Faber public DID (use **`GET /wallet/DID/public`**), 
 - `schema_id` the Id of the schema Faber created (use **`GET /schemas/created`**) and,
-- `cred_def_id` the Id of the schema Faber created (use **`GET /credential-definitions/created`**)
+- `cred_def_id` the Id of the credential definition Faber created (use **`GET /credential-definitions/created`**)
 
 For these items set the values as follows:
 


### PR DESCRIPTION
I think the correct name is 'credential definition' , not 'schema'.