### PR TITLE
Initialize my_endpoints with my_endpoint

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -482,6 +482,8 @@ class ConnectionManager:
             if default_endpoint:
                 my_endpoints.append(default_endpoint)
             my_endpoints.extend(self.context.settings.get("additional_endpoints", []))
+        else:
+            my_endpoints = [my_endpoint]
         did_doc = await self.create_did_document(
             my_info, connection.inbound_connection_id, my_endpoints
         )

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -291,14 +291,14 @@ class ConnectionManager:
             connection.my_did = my_info.did
 
         # Create connection request message
-        if not my_endpoint:
+        if my_endpoint:
+            my_endpoints = [my_endpoint]
+        else:
             my_endpoints = []
             default_endpoint = self.context.settings.get("default_endpoint")
             if default_endpoint:
                 my_endpoints.append(default_endpoint)
             my_endpoints.extend(self.context.settings.get("additional_endpoints", []))
-        else:
-            my_endpoints = [my_endpoint]
         did_doc = await self.create_did_document(
             my_info, connection.inbound_connection_id, my_endpoints
         )
@@ -476,14 +476,14 @@ class ConnectionManager:
             connection.my_did = my_info.did
 
         # Create connection response message
-        if not my_endpoint:
+        if my_endpoint:
+            my_endpoints = [my_endpoint]
+        else:
             my_endpoints = []
             default_endpoint = self.context.settings.get("default_endpoint")
             if default_endpoint:
                 my_endpoints.append(default_endpoint)
             my_endpoints.extend(self.context.settings.get("additional_endpoints", []))
-        else:
-            my_endpoints = [my_endpoint]
         did_doc = await self.create_did_document(
             my_info, connection.inbound_connection_id, my_endpoints
         )


### PR DESCRIPTION
While I was trying to manually go through the invite/request process via Swagger I used the `/connections/{conn_id}/accept-request` endpoint and added My URL endpoint which resulted in an error 500.

```
Creating connection response
    connection_id: db0b89aa-df4c-4ec7-a99d-f11c1bcb18df

2020-09-09 12:32:12,290 aries_cloudagent.core.dispatcher ERROR Handler error: connections_accept_request
Traceback (most recent call last):
  File "/home/laurencedejong/.venv/aries-cloudagent-python/lib/python3.6/site-packages/aries_cloudagent/protocols/connections/v1_0/routes.py", line 435, in connections_accept_request
    response = await connection_mgr.create_response(connection, my_endpoint)
  File "/home/laurencedejong/.venv/aries-cloudagent-python/lib/python3.6/site-packages/aries_cloudagent/protocols/connections/v1_0/manager.py", line 488, in create_response
    my_info, connection.inbound_connection_id, my_endpoints
UnboundLocalError: local variable 'my_endpoints' referenced before assignment
2020-09-09 12:32:12,292 aries_cloudagent.admin.server ERROR Handler error with exception: local variable 'my_endpoints' referenced before assignment
2020-09-09 12:32:12,292 aiohttp.server ERROR Error handling request
Traceback (most recent call last):
  File "/home/laurencedejong/.venv/aries-cloudagent-python/lib/python3.6/site-packages/aiohttp/web_protocol.py", line 418, in start
    resp = await task
  File "/home/laurencedejong/.venv/aries-cloudagent-python/lib/python3.6/site-packages/aiohttp/web_app.py", line 458, in _handle
    resp = await handler(request)
  File "/home/laurencedejong/.venv/aries-cloudagent-python/lib/python3.6/site-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/home/laurencedejong/.venv/aries-cloudagent-python/lib/python3.6/site-packages/aries_cloudagent/admin/server.py", line 146, in ready_middleware
    raise e
  File "/home/laurencedejong/.venv/aries-cloudagent-python/lib/python3.6/site-packages/aries_cloudagent/admin/server.py", line 136, in ready_middleware
    return await handler(request)
  File "/home/laurencedejong/.venv/aries-cloudagent-python/lib/python3.6/site-packages/aries_cloudagent/admin/server.py", line 161, in debug_middleware
    return await handler(request)
  File "/home/laurencedejong/.venv/aries-cloudagent-python/lib/python3.6/site-packages/aiohttp_apispec/middlewares.py", line 45, in validation_middleware
    return await handler(request)
  File "/home/laurencedejong/.venv/aries-cloudagent-python/lib/python3.6/site-packages/aries_cloudagent/admin/server.py", line 253, in apply_limiter
    return await task
  File "/home/laurencedejong/.venv/aries-cloudagent-python/lib/python3.6/site-packages/aries_cloudagent/protocols/connections/v1_0/routes.py", line 435, in connections_accept_request
    response = await connection_mgr.create_response(connection, my_endpoint)
  File "/home/laurencedejong/.venv/aries-cloudagent-python/lib/python3.6/site-packages/aries_cloudagent/protocols/connections/v1_0/manager.py", line 488, in create_response
    my_info, connection.inbound_connection_id, my_endpoints
UnboundLocalError: local variable 'my_endpoints' referenced before assignment
```