### PR TITLE
Ensure no attempt to publish endpoints is made when in read-only mode

### DIFF
--- a/aries_cloudagent/config/ledger.py
+++ b/aries_cloudagent/config/ledger.py
@@ -64,8 +64,10 @@ async def ledger_config(
         return False
 
     async with ledger:
+        read_only_ledger = context.settings.get("read_only_ledger")
+
         # Check transaction author agreement acceptance
-        if not context.settings.get("read_only_ledger"):
+        if not read_only_ledger:
             taa_info = await ledger.get_txn_author_agreement()
             if taa_info["taa_required"] and public_did:
                 taa_accepted = await ledger.get_latest_txn_author_acceptance()
@@ -87,9 +89,9 @@ async def ledger_config(
             except LedgerError as x_ledger:
                 raise ConfigError(x_ledger.message) from x_ledger  # e.g., read-only
 
-            # Publish profile endpoint
+            # Publish profile endpoint if ledger is NOT read-only
             profile_endpoint = context.settings.get("profile_endpoint")
-            if profile_endpoint:
+            if profile_endpoint and not read_only_ledger:
                 await ledger.update_endpoint_for_did(
                     public_did, profile_endpoint, EndpointType.PROFILE
                 )

--- a/aries_cloudagent/wallet/indy.py
+++ b/aries_cloudagent/wallet/indy.py
@@ -586,8 +586,9 @@ class IndyWallet(BaseWallet):
                 raise LedgerConfigError(
                     f"No ledger available but DID {did} is public: missing wallet-type?"
                 )
-            async with ledger:
-                await ledger.update_endpoint_for_did(did, endpoint, endpoint_type)
+            if not ledger.read_only:
+                async with ledger:
+                    await ledger.update_endpoint_for_did(did, endpoint, endpoint_type)
 
         await self.replace_local_did_metadata(did, metadata)
 


### PR DESCRIPTION
Addresses an error that would cause the agent to try publishing its endpoint when set to work in read-only mode, causing it to crash and exit.

@andrewwhitehead @sklump 