### PR TITLE
Enable to set custom web hook in demo

### DIFF
--- a/demo/AgentTracing.md
+++ b/demo/AgentTracing.md
@@ -95,4 +95,10 @@ DOCKER_NET=efk-stack_efk_net TRACE_TARGET_URL=fluentd:8088 ./run_demo faber --tr
 DOCKER_NET=efk-stack_efk_net TRACE_TARGET_URL=fluentd:8088 ./run_demo alice --trace-http
 ```
 
+## Hooking into event messaging
 
+ACA-PY supports sending events to web hooks, which allows the demo agents to display them in the CLI. To also send them to another end point, use the `--webhook-url` option, which requires the `WEBHOOK_URL` environment variable. Configure an end point running on the docker host system, port *8888*, use the following:
+
+```bash
+WEBHOOK_URL=host.docker.internal:8888 ./run_demo faber --webhook-url
+```

--- a/demo/run_demo
+++ b/demo/run_demo
@@ -15,6 +15,7 @@ if ! [ -z "$TRACE_TARGET_URL" ]; then
 else
   TRACE_TARGET=log
 fi
+WEBHOOK_TARGET=""
 if [ -z "$DOCKER_NET" ]; then
   DOCKER_NET="bridge"
 fi
@@ -48,6 +49,10 @@ do
       TRACE_ENABLED=1
       TRACE_TARGET=http://${TRACE_TARGET_URL}/
       TRACE_TAG=acapy.events
+      continue
+    ;;
+    --webhook-url)
+      WEBHOOK_TARGET=http://${WEBHOOK_URL}
       continue
     ;;
     --debug-ptvsd)
@@ -104,9 +109,10 @@ Usage:
       --events - display on the terminal the webhook events from the ACA-Py agent.
       --timing - at the end of the run, display timing; relevant to the "performance" agent.
       --bg - run the agent in the background; for use when using OpenAPI/Swagger interface
-          --trace-log - log events to the standard log file
-          --trace-http - log events to an http endmoint specified in env var TRACE_TARGET_URL
+          --trace-log - log trace events to the standard log file
+          --trace-http - log trace events to an http endpoint specified in env var TRACE_TARGET_URL
           --self-attested - include a self-attested attribute in the proof request/response
+          --webhook-url - send events to an http endpoint specified in env var WEBHOOK_URL
       debug options: --debug-pycharm-agent-port <port>; --debug-pycharm-controller-port <port>
                     --debug-pycharm; --debug-ptvsd
 
@@ -207,6 +213,9 @@ if ! [ -z "$TRACE_TARGET" ]; then
   DOCKER_ENV="${DOCKER_ENV} -e TRACE_TARGET=${TRACE_TARGET}"
   DOCKER_ENV="${DOCKER_ENV} -e TRACE_TAG=${TRACE_TAG}"
   DOCKER_ENV="${DOCKER_ENV} -e TRACE_ENABLED=${TRACE_ENABLED}"
+fi
+if ! [ -z "$WEBHOOK_TARGET" ]; then
+  DOCKER_ENV="${DOCKER_ENV} -e WEBHOOK_TARGET=${WEBHOOK_TARGET}"
 fi
 # if $TAILS_NETWORK is specified it will override any previously specified $DOCKER_NET
 if ! [ -z "$TAILS_NETWORK" ]; then

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -34,6 +34,8 @@ TRACE_TARGET = os.getenv("TRACE_TARGET")
 TRACE_TAG = os.getenv("TRACE_TAG")
 TRACE_ENABLED = os.getenv("TRACE_ENABLED")
 
+WEBHOOK_TARGET = os.getenv("WEBHOOK_TARGET")
+
 AGENT_ENDPOINT = os.getenv("AGENT_ENDPOINT")
 
 DEFAULT_POSTGRES = bool(os.getenv("POSTGRES"))
@@ -134,6 +136,7 @@ class DemoAgent:
         self.trace_enabled = TRACE_ENABLED
         self.trace_target = TRACE_TARGET
         self.trace_tag = TRACE_TAG
+        self.external_webhook_target = WEBHOOK_TARGET
 
         self.admin_url = f"http://{self.internal_host}:{admin_port}"
         if AGENT_ENDPOINT:
@@ -240,6 +243,8 @@ class DemoAgent:
             )
         if self.webhook_url:
             result.append(("--webhook-url", self.webhook_url))
+        if self.external_webhook_target:
+            result.append(("--webhook-url", self.external_webhook_target))
         if self.trace_enabled:
             result.extend(
                 [


### PR DESCRIPTION
Enhance `agent.py` to read env variable `WEBHOOK_TARGET`, which will be forwarded as a `--webhook-url` to aca-py.
`run_demo` received a new option `--webhook-url`, which (together with env variable `WEBHOOK_URL`) will forward the URL to the agent.

Example usage: `WEBHOOK_URL=host.docker.internal:8888 ./run_demo faber --webhook-url`