### PR TITLE
feature/Connection Invitation with routingKeys

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -75,6 +75,8 @@ class ConnectionManager:
         public: bool = False,
         multi_use: bool = False,
         alias: str = None,
+        routing_keys: Sequence[str] = None,
+        recipient_keys: Sequence[str] = None,
     ) -> Tuple[ConnectionRecord, ConnectionInvitation]:
         """
         Generate new connection invitation.
@@ -101,8 +103,9 @@ class ConnectionManager:
                 "@type": "https://didcomm.org/connections/1.0/invitation",
                 "label": "Alice",
                 "did": "did:peer:oiSqsNYhMrjHiqZDTUthsw",
-                "recipientKeys": ["8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"],
-                "serviceEndpoint": "https://example.com/endpoint"
+                "recipient_keys": ["8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"],
+                "service_endpoint": "https://example.com/endpoint"
+                "routing_keys": ["9EH5gYEeNc3z7PYXmd53d5x6qAfCNrqQqEB4nS7Zfu6K"],
             }
 
         Currently, only peer DID is supported.
@@ -164,13 +167,18 @@ class ConnectionManager:
             else ConnectionRecord.ACCEPT_MANUAL
         )
 
-        # Create and store new invitation key
-        connection_key = await wallet.create_signing_key()
-
+        if recipient_keys:
+            # TODO: check that recipient keys are in wallet
+            invitation_key = recipient_keys[0]
+        else:
+            # Create and store new invitation key
+            invitation_signing_key = await wallet.create_signing_key()
+            invitation_key = invitation_signing_key.verkey
+            recipient_keys = [invitation_key]
         # Create connection record
         connection = ConnectionRecord(
             initiator=ConnectionRecord.INITIATOR_SELF,
-            invitation_key=connection_key.verkey,
+            invitation_key=invitation_key,  # TODO: determine correct key to use
             their_role=their_role,
             state=ConnectionRecord.STATE_INVITATION,
             accept=accept,
@@ -184,7 +192,8 @@ class ConnectionManager:
         # Note: Need to split this into two stages to support inbound routing of invites
         # Would want to reuse create_did_document and convert the result
         invitation = ConnectionInvitation(
-            label=my_label, recipient_keys=[connection_key.verkey], endpoint=my_endpoint
+            label=my_label, recipient_keys=recipient_keys,
+            endpoint=my_endpoint, routing_keys=routing_keys
         )
         await connection.attach_invitation(self.context, invitation)
 

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -192,8 +192,10 @@ class ConnectionManager:
         # Note: Need to split this into two stages to support inbound routing of invites
         # Would want to reuse create_did_document and convert the result
         invitation = ConnectionInvitation(
-            label=my_label, recipient_keys=recipient_keys,
-            endpoint=my_endpoint, routing_keys=routing_keys
+            label=my_label,
+            recipient_keys=recipient_keys,
+            endpoint=my_endpoint,
+            routing_keys=routing_keys,
         )
         await connection.attach_invitation(self.context, invitation)
 

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -353,9 +353,13 @@ async def connections_create_invitation(request: web.BaseRequest):
     connection_mgr = ConnectionManager(context)
     try:
         (connection, invitation) = await connection_mgr.create_invitation(
-            auto_accept=auto_accept, public=public, multi_use=multi_use,
-            alias=alias, recipient_keys=recipient_keys, my_endpoint=service_endpoint,
-            routing_keys=routing_keys
+            auto_accept=auto_accept,
+            public=public,
+            multi_use=multi_use,
+            alias=alias,
+            recipient_keys=recipient_keys,
+            my_endpoint=service_endpoint,
+            routing_keys=routing_keys,
         )
 
         result = {

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -53,6 +53,26 @@ class ReceiveInvitationRequestSchema(ConnectionInvitationSchema):
         """Bypass middleware field validation."""
 
 
+class InvitationConnectionTargetRequestSchema(OpenAPISchema):
+    """Request schema for invitation connection target."""
+
+    recipient_keys = fields.List(
+        fields.Str(description="Recipient public key", **INDY_RAW_PUBLIC_KEY),
+        required=False,
+        description="List of recipient keys",
+    )
+    service_endpoint = fields.Str(
+        required=False,
+        description="Connection endpoint",
+        example="http://192.168.56.102:8020",
+    )
+    routing_keys = fields.List(
+        fields.Str(description="Routing key", **INDY_RAW_PUBLIC_KEY),
+        required=False,
+        description="List of routing keys",
+    )
+
+
 class InvitationResultSchema(OpenAPISchema):
     """Result schema for a new connection invitation."""
 
@@ -301,6 +321,7 @@ async def connections_retrieve(request: web.BaseRequest):
     summary="Create a new connection invitation",
 )
 @querystring_schema(CreateInvitationQueryStringSchema())
+@request_schema(InvitationConnectionTargetRequestSchema())
 @response_schema(InvitationResultSchema(), 200)
 async def connections_create_invitation(request: web.BaseRequest):
     """
@@ -318,6 +339,10 @@ async def connections_create_invitation(request: web.BaseRequest):
     alias = request.query.get("alias")
     public = json.loads(request.query.get("public", "false"))
     multi_use = json.loads(request.query.get("multi_use", "false"))
+    body = await request.json()
+    recipient_keys = body.get("recipient_keys")
+    service_endpoint = body.get("service_endpoint")
+    routing_keys = body.get("routing_keys")
 
     if public and not context.settings.get("public_invites"):
         raise web.HTTPForbidden(
@@ -328,7 +353,9 @@ async def connections_create_invitation(request: web.BaseRequest):
     connection_mgr = ConnectionManager(context)
     try:
         (connection, invitation) = await connection_mgr.create_invitation(
-            auto_accept=auto_accept, public=public, multi_use=multi_use, alias=alias
+            auto_accept=auto_accept, public=public, multi_use=multi_use,
+            alias=alias, recipient_keys=recipient_keys, my_endpoint=service_endpoint,
+            routing_keys=routing_keys
         )
 
         result = {

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
@@ -196,6 +196,31 @@ class TestConnectionManager(AsyncTestCase, TestConfig):
 
         await self.manager.receive_request(requestB, receipt)
 
+    async def test_create_invitation_recipient_routing_endpoint(self):
+        wallet: BaseWallet = await self.context.inject(BaseWallet)
+        await wallet.create_local_did(
+            seed=self.test_seed, did=self.test_did, metadata=None
+        )
+        connect_record, connect_invite = await self.manager.create_invitation(
+            my_endpoint=self.test_endpoint,
+            recipient_keys=[self.test_verkey],
+            routing_keys=[self.test_verkey]
+        )
+
+        receipt = MessageReceipt(recipient_verkey=connect_record.invitation_key)
+
+        requestA = ConnectionRequest(
+            connection=ConnectionDetail(
+                did=self.test_target_did,
+                did_doc=self.make_did_doc(
+                    self.test_target_did, self.test_target_verkey
+                ),
+            ),
+            label="InviteRequestA",
+        )
+
+        await self.manager.receive_request(requestA, receipt)
+
     async def test_receive_invitation(self):
         (_, connect_invite) = await self.manager.create_invitation(
             my_endpoint="testendpoint"

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
@@ -204,7 +204,7 @@ class TestConnectionManager(AsyncTestCase, TestConfig):
         connect_record, connect_invite = await self.manager.create_invitation(
             my_endpoint=self.test_endpoint,
             recipient_keys=[self.test_verkey],
-            routing_keys=[self.test_verkey]
+            routing_keys=[self.test_verkey],
         )
 
         receipt = MessageReceipt(recipient_verkey=connect_record.invitation_key)

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
@@ -162,6 +162,7 @@ class TestConnectionRoutes(AsyncTestCase):
         mock_req.app = {
             "request_context": context,
         }
+        mock_req.json = async_mock.CoroutineMock()
         mock_req.query = {
             "auto_accept": "true",
             "alias": "alias",
@@ -204,6 +205,7 @@ class TestConnectionRoutes(AsyncTestCase):
         mock_req.app = {
             "request_context": context,
         }
+        mock_req.json = async_mock.CoroutineMock()
         mock_req.query = {
             "auto_accept": "true",
             "alias": "alias",
@@ -228,6 +230,7 @@ class TestConnectionRoutes(AsyncTestCase):
         mock_req.app = {
             "request_context": context,
         }
+        mock_req.json = async_mock.CoroutineMock()
         mock_req.query = {
             "auto_accept": "true",
             "alias": "alias",


### PR DESCRIPTION
This pr contains extended admin API to allow connection invitations to be created with routing and recipient keys as well as service endpoints. This functionality is needed for establishing connections using a mediator. 
Signed-off-by: Adam Burdett <burdettadam@gmail.com>