### PR TITLE
Different upload-tail-file path

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -462,6 +462,13 @@ class GeneralGroup(ArgumentGroup):
             env_var="ACAPY_TAILS_SERVER_BASE_URL",
             help="Sets the base url of the tails server in use.",
         )
+        parser.add_argument(
+            "--tails-server-upload-url",
+            type=str,
+            metavar="<tails-server-upload-url>",
+            env_var="ACAPY_TAILS_SERVER_UPLOAD_URL",
+            help="Sets the upload url of the tails server.",
+        )
 
     def get_settings(self, args: Namespace) -> dict:
         """Extract general settings."""
@@ -483,6 +490,8 @@ class GeneralGroup(ArgumentGroup):
             settings["read_only_ledger"] = True
         if args.tails_server_base_url:
             settings["tails_server_base_url"] = args.tails_server_base_url
+        if args.tails_server_upload_url:
+            settings["tails_server_upload_url"] = args.tails_server_upload_url
         return settings
 
 

--- a/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
+++ b/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
@@ -149,7 +149,7 @@ class IssuerRevRegRecord(BaseRecord):
         issuer: BaseIssuer = await context.inject(BaseIssuer)
         tails_hopper_dir = indy_client_dir(join("tails", ".hopper"), create=True)
 
-        LOGGER.debug("create revocation registry with size:", self.max_cred_num)
+        LOGGER.debug("create revocation registry with size:" + str(self.max_cred_num))
 
         try:
             (

--- a/aries_cloudagent/tails/indy_tails_server.py
+++ b/aries_cloudagent/tails/indy_tails_server.py
@@ -30,18 +30,18 @@ class IndyTailsServer(BaseTailsServer):
         """
 
         genesis_transactions = context.settings.get("ledger.genesis_transactions")
-        tails_server_base_url = context.settings.get("tails_server_base_url")
+        tails_server_upload_url = context.settings.get("tails_server_upload_url")
 
-        if not tails_server_base_url:
+        if not tails_server_upload_url:
             raise TailsServerNotConfiguredError(
-                "tails_server_base_url setting is not set"
+                "tails_server_upload_url setting is not set"
             )
 
         try:
             return (
                 True,
                 await put(
-                    f"{tails_server_base_url}/{rev_reg_id}",
+                    f"{tails_server_upload_url}/{rev_reg_id}",
                     {"tails": tails_file_path},
                     {"genesis": genesis_transactions},
                     interval=interval,


### PR DESCRIPTION
Added support for having a different upload path than download path for the public tails file. This supports the case where the upload path is a restricted, internal route to a central file distribution server and the download path is a public interface for a static file download. In our case using dockers, the upload path is an internal docker-resolved path and the public path is the controller application that links to the cloud-agent application.