### PR TITLE
ptvsd debugger for pytest

### DIFF
--- a/DevReadMe.md
+++ b/DevReadMe.md
@@ -143,6 +143,18 @@ To run the ACA-Py test suite, use the following script:
 ./scripts/run_tests
 ```
 
+To run the ACA-Py test suite with ptvsd debugger enabled:
+
+```bash
+./scripts/run_tests --debug
+```
+
+To run specific tests pass parameters as defined by [pytest](https://docs.pytest.org/en/stable/usage.html#specifying-tests-selecting-tests):
+
+```bash
+./scripts/run_tests aries_cloudagent/protocols/connections
+```
+
 To run the tests including [Indy SDK](https://github.com/hyperledger/indy-sdk) and related dependencies, run the script:
 
 ```bash

--- a/conftest.py
+++ b/conftest.py
@@ -139,7 +139,6 @@ def pytest_sessionstart(session):
             import ptvsd
 
             ptvsd.enable_attach(address=("0.0.0.0", 5678))
-            
             print("ptvsd is running")
             print("=== Waiting for debugger to attach ===")
             # To pause execution until the debugger is attached:

--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,12 @@
 import os
 import sys
 from unittest import mock
-
 import pytest
 
 STUBS = {}
 
 POSTGRES_URL = None
+ENABLE_PTVSD = None
 
 
 class Stub:
@@ -131,7 +131,21 @@ def stub_indy_vdr() -> Stub:
 
 
 def pytest_sessionstart(session):
-    global STUBS, POSTGRES_URL
+    global STUBS, POSTGRES_URL, ENABLE_PTVSD
+    ENABLE_PTVSD = os.getenv("ENABLE_PTVSD", False)
+    # --debug-vs to use microsoft's visual studio remote debugger
+    if ENABLE_PTVSD or "--debug" in sys.argv:
+        try:
+            import ptvsd
+
+            ptvsd.enable_attach(address=("0.0.0.0", 5678))
+            
+            print("ptvsd is running")
+            print("=== Waiting for debugger to attach ===")
+            # To pause execution until the debugger is attached:
+            ptvsd.wait_for_attach()
+        except ImportError:
+            print("ptvsd library was not found")
 
     POSTGRES_URL = os.getenv("POSTGRES_URL")
 

--- a/scripts/run_docker
+++ b/scripts/run_docker
@@ -32,5 +32,5 @@ else
   DOCKER="docker"
 fi
 
-RAND_NAME=$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+RAND_NAME=$(od -vAn -N4 -tu < /dev/urandom | xargs)
 $DOCKER run --rm -ti --name "aries-cloudagent-runner_${RAND_NAME}" $ARGS aries-cloudagent-run "$@"

--- a/scripts/run_docker
+++ b/scripts/run_docker
@@ -32,5 +32,5 @@ else
   DOCKER="docker"
 fi
 
-RAND_NAME=$(od -vAn -N4 -tu < /dev/urandom | xargs)
+RAND_NAME=$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
 $DOCKER run --rm -ti --name "aries-cloudagent-runner_${RAND_NAME}" $ARGS aries-cloudagent-run "$@"

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -4,6 +4,19 @@ cd $(dirname $0)
 
 docker build -t aries-cloudagent-test -f ../docker/Dockerfile.test .. || exit 1
 
+DOCKER_ARGS=""
+PTVSD_PORT="5678"
+
+for arg in "$@"; do 
+  if [ "$arg" = "--debug" ]; then
+    ENABLE_PTVSD=1 # set ptvsd env
+    #shift # remove debug flag from pytest args.
+  fi
+done
+if [ ! -z "${ENABLE_PTVSD}" ]; then
+  DOCKER_ARGS="${DOCKER_ARGS} -e ENABLE_PTVSD=\"${ENABLE_PTVSD}\" -p $PTVSD_PORT:$PTVSD_PORT"
+fi
+
 if [ ! -d ../test-reports ]; then mkdir ../test-reports; fi
 
 # on Windows, docker run needs to be prefixed by winpty
@@ -15,4 +28,4 @@ fi
 
 $DOCKER run --rm -ti --name aries-cloudagent-runner \
 	-v "$(pwd)/../test-reports:/usr/src/app/test-reports" \
-	aries-cloudagent-test "$@"
+	$DOCKER_ARGS aries-cloudagent-test "$@"


### PR DESCRIPTION
This PR allows Visual Studio Code ptvsd to attach to the docker running pytest from the run_tests script. The `--debug` flag can now be used with run_tests, for example.
```bash
./scripts/run_tests --debug
```
The flag and any other arguments are then passed into the docker container directly to pytest, allowing calls like.
```bash
./scripts/run_tests --debug aries_cloudagent/protocols/connections
```