### PR TITLE
Profiles follow-up

### DIFF
--- a/aries_cloudagent/admin/request_context.py
+++ b/aries_cloudagent/admin/request_context.py
@@ -7,7 +7,7 @@ A request context provided by the admin server to admin route handlers.
 from typing import Mapping, Optional, Type
 
 from ..core.profile import Profile, ProfileSession
-from ..config.injector import Injector, InjectorError, InjectType
+from ..config.injector import Injector, InjectionError, InjectType
 from ..config.injection_context import InjectionContext
 from ..config.settings import Settings
 from ..utils.classloader import DeferLoad
@@ -26,7 +26,7 @@ class AdminRequestContext:
         settings: Mapping[str, object] = None
     ):
         """Initialize an instance of AdminRequestContext."""
-        self._context = context or profile.context.start_scope("admin", settings)
+        self._context = (context or profile.context).start_scope("admin", settings)
         self._profile = profile
 
     @property
@@ -98,7 +98,7 @@ class AdminRequestContext:
             if session._active and base_cls in self.session_inject:
                 ret = self.session_inject[base_cls]
                 if ret is None and required:
-                    raise InjectorError(
+                    raise InjectionError(
                         "No instance provided for class: {}".format(base_cls.__name__)
                     )
                 return ret

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -64,7 +64,7 @@ class AdminResponder(BaseResponder):
 
     def __init__(
         self,
-        context: InjectionContext,
+        profile: Profile,
         send: Coroutine,
         webhook: Coroutine,
         **kwargs,
@@ -77,7 +77,7 @@ class AdminResponder(BaseResponder):
 
         """
         super().__init__(**kwargs)
-        self._context = context
+        self._profile = profile
         self._send = send
         self._webhook = webhook
 
@@ -88,7 +88,7 @@ class AdminResponder(BaseResponder):
         Args:
             message: The `OutboundMessage` to be sent
         """
-        await self._send(self._context, message)
+        await self._send(self._profile, message)
 
     async def send_webhook(self, topic: str, payload: dict):
         """
@@ -230,7 +230,7 @@ class AdminServer(BaseAdminServer):
         self.site = None
 
         self.responder = AdminResponder(
-            self.context,
+            self.root_profile,
             self.outbound_message_router,
             self.send_webhook,
         )

--- a/aries_cloudagent/admin/tests/test_admin_server.py
+++ b/aries_cloudagent/admin/tests/test_admin_server.py
@@ -180,7 +180,7 @@ class TestAdminServer(AsyncTestCase):
         message = OutboundMessage(payload="{}")
         server = self.get_admin_server()
         await server.responder.send_outbound(message)
-        assert self.message_results == [(server.context, message)]
+        assert self.message_results == [(server.root_profile, message)]
 
     async def test_responder_webhook(self):
         server = self.get_admin_server()

--- a/aries_cloudagent/config/base.py
+++ b/aries_cloudagent/config/base.py
@@ -100,8 +100,8 @@ class BaseSettings(Mapping[str, object]):
         return "<{}({})>".format(self.__class__.__name__, ", ".join(items))
 
 
-class InjectorError(ConfigError):
-    """The base exception raised by `BaseInjector` implementations."""
+class InjectionError(ConfigError):
+    """The base exception raised by Injector and Provider implementations."""
 
 
 class BaseInjector(ABC):
@@ -130,10 +130,6 @@ class BaseInjector(ABC):
     @abstractmethod
     def copy(self) -> "BaseInjector":
         """Produce a copy of the injector instance."""
-
-
-class ProviderError(ConfigError):
-    """The base exception raised by `BaseProvider` implementations."""
 
 
 class BaseProvider(ABC):

--- a/aries_cloudagent/config/injection_context.py
+++ b/aries_cloudagent/config/injection_context.py
@@ -4,14 +4,14 @@ from collections import namedtuple
 import copy
 from typing import Mapping, Optional, Type
 
-from .base import BaseInjector, InjectorError
+from .base import BaseInjector, InjectionError
 from .injector import Injector, InjectType
 from .settings import Settings
 
 Scope = namedtuple("Scope", "name injector")
 
 
-class InjectionContextError(InjectorError):
+class InjectionContextError(InjectionError):
     """Base class for issues in the injection context."""
 
 

--- a/aries_cloudagent/config/injector.py
+++ b/aries_cloudagent/config/injector.py
@@ -2,7 +2,7 @@
 
 from typing import Mapping, Optional, Type
 
-from .base import BaseProvider, BaseInjector, InjectorError, InjectType
+from .base import BaseProvider, BaseInjector, InjectionError, InjectType
 from .provider import InstanceProvider, CachedProvider
 from .settings import Settings
 
@@ -70,7 +70,7 @@ class Injector(BaseInjector):
 
         """
         if not base_cls:
-            raise InjectorError("No base class provided for lookup")
+            raise InjectionError("No base class provided for lookup")
         provider = self._providers.get(base_cls)
         if settings:
             ext_settings = self.settings.extend(settings)
@@ -82,11 +82,11 @@ class Injector(BaseInjector):
             result = None
         if result is None:
             if required:
-                raise InjectorError(
+                raise InjectionError(
                     "No instance provided for class: {}".format(base_cls.__name__)
                 )
         elif not isinstance(result, base_cls) and self.enforce_typing:
-            raise InjectorError(
+            raise InjectionError(
                 "Provided instance does not implement the base class: {}".format(
                     base_cls.__name__
                 )

--- a/aries_cloudagent/config/provider.py
+++ b/aries_cloudagent/config/provider.py
@@ -1,11 +1,12 @@
 """Service provider implementations."""
 
 from typing import Sequence, Union
+from weakref import ReferenceType
 
-from ..utils.classloader import ClassLoader
+from ..utils.classloader import DeferLoad
 from ..utils.stats import Collector
 
-from .base import BaseProvider, BaseSettings, BaseInjector
+from .base import BaseProvider, BaseSettings, BaseInjector, InjectionError
 
 
 class InstanceProvider(BaseProvider):
@@ -13,13 +14,18 @@ class InstanceProvider(BaseProvider):
 
     def __init__(self, instance):
         """Initialize the instance provider."""
-        if not instance:
+        if instance is None:
             raise ValueError("Class instance binding must be non-empty")
         self._instance = instance
 
     def provide(self, config: BaseSettings, injector: BaseInjector):
         """Provide the object instance given a config and injector."""
-        return self._instance
+        inst = self._instance
+        if isinstance(inst, ReferenceType):
+            inst = inst()
+            if inst is None:
+                raise InjectionError("Weakref instance expired")
+        return inst
 
 
 class ClassProvider(BaseProvider):
@@ -43,25 +49,31 @@ class ClassProvider(BaseProvider):
         self._ctor_args = ctor_args
         self._ctor_kwargs = ctor_kwargs
         self._init_method = init_method
+        if isinstance(instance_cls, str):
+            instance_cls = DeferLoad(instance_cls)
         self._instance_cls = instance_cls
 
     def provide(self, config: BaseSettings, injector: BaseInjector):
         """Provide the object instance given a config and injector."""
-        instance_cls = self._instance_cls
-        if isinstance(instance_cls, str):
-            instance_cls = ClassLoader.load_class(instance_cls)
-            self._instance_cls = instance_cls
         args = []
         for arg in self._ctor_args:
-            if isinstance(arg, self.Inject):
+            if isinstance(arg, ClassProvider.Inject):
                 arg = injector.inject(arg.base_class)
+            elif isinstance(arg, ReferenceType):
+                arg = arg()
+                if arg is None:
+                    raise InjectionError("Weakref instance expired")
             args.append(arg)
         kwargs = {}
         for arg_name, arg in self._ctor_kwargs.items():
-            if isinstance(arg, self.Inject):
+            if isinstance(arg, ClassProvider.Inject):
                 arg = injector.inject(arg.base_class)
+            elif isinstance(arg, ReferenceType):
+                arg = arg()
+                if arg is None:
+                    raise InjectionError("Weakref instance expired")
             kwargs[arg_name] = arg
-        instance = instance_cls(*args, **kwargs)
+        instance = (self._instance_cls)(*args, **kwargs)
         if self._init_method:
             getattr(instance, self._init_method)()
         return instance

--- a/aries_cloudagent/config/tests/test_injection_context.py
+++ b/aries_cloudagent/config/tests/test_injection_context.py
@@ -1,6 +1,6 @@
 from asynctest import TestCase as AsyncTestCase
 
-from ..base import BaseInjector, InjectorError
+from ..base import InjectionError
 from ..injection_context import InjectionContext, InjectionContextError
 
 
@@ -48,7 +48,7 @@ class TestInjectionContext(AsyncTestCase):
     async def test_inject_simple(self):
         """Test a basic injection."""
         assert self.test_instance.inject(str, required=False) is None
-        with self.assertRaises(InjectorError):
+        with self.assertRaises(InjectionError):
             self.test_instance.inject(str)
         self.test_instance.injector.bind_instance(str, self.test_value)
         assert self.test_instance.inject(str) is self.test_value
@@ -65,3 +65,4 @@ class TestInjectionContext(AsyncTestCase):
         assert self.test_instance.inject(str, required=False) is None
         root = context.injector_for_scope(context.ROOT_SCOPE)
         assert root.inject(str, required=False) is None
+        assert self.test_instance.inject(str, required=False) is None

--- a/aries_cloudagent/config/tests/test_injector.py
+++ b/aries_cloudagent/config/tests/test_injector.py
@@ -1,6 +1,6 @@
 from asynctest import TestCase as AsyncTestCase
 
-from ..base import BaseProvider, BaseInjector, BaseSettings, InjectorError
+from ..base import BaseProvider, BaseInjector, BaseSettings, InjectionError
 from ..injector import Injector
 from ..provider import ClassProvider, CachedProvider
 
@@ -43,7 +43,7 @@ class TestInjector(AsyncTestCase):
     def test_inject_simple(self):
         """Test a basic injection."""
         assert self.test_instance.inject(str, required=False) is None
-        with self.assertRaises(InjectorError):
+        with self.assertRaises(InjectionError):
             self.test_instance.inject(str)
         with self.assertRaises(ValueError):
             self.test_instance.bind_instance(str, None)
@@ -52,7 +52,7 @@ class TestInjector(AsyncTestCase):
 
     def test_inject_x(self):
         """Test injection failure on null base class."""
-        with self.assertRaises(InjectorError):
+        with self.assertRaises(InjectionError):
             self.test_instance.inject(None)
 
     def test_inject_provider(self):
@@ -72,13 +72,13 @@ class TestInjector(AsyncTestCase):
     def test_bad_provider(self):
         """Test empty and invalid provider results."""
         self.test_instance.bind_provider(str, MockProvider(None))
-        with self.assertRaises(InjectorError):
+        with self.assertRaises(InjectionError):
             self.test_instance.inject(str)
         self.test_instance.inject(str, required=False)
         self.test_instance.bind_provider(str, MockProvider(1))
         self.test_instance.clear_binding(str)
         assert self.test_instance.get_provider(str) is None
-        with self.assertRaises(InjectorError):
+        with self.assertRaises(InjectionError):
             self.test_instance.inject(str)
 
     def test_inject_class(self):
@@ -118,7 +118,7 @@ class TestInjector(AsyncTestCase):
         self.test_instance.clear_binding(int)
         self.test_instance.clear_binding(str)
         self.test_instance.bind_instance(str, test_int)
-        with self.assertRaises(InjectorError):
+        with self.assertRaises(InjectionError):
             self.test_instance.inject(str)
 
     def test_inject_cached(self):

--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -127,11 +127,12 @@ class Dispatcher:
         """
         r_time = get_timer()
 
-        session = await self.profile.session()
-        connection_mgr = ConnectionManager(session)
-        connection = await connection_mgr.find_inbound_connection(
-            inbound_message.receipt
-        )
+        async with self.profile.session() as session:
+            connection_mgr = ConnectionManager(session)
+            connection = await connection_mgr.find_inbound_connection(
+                inbound_message.receipt
+            )
+            del connection_mgr
         if connection:
             inbound_message.connection_id = connection.connection_id
 
@@ -146,7 +147,7 @@ class Dispatcher:
             message = None
 
         trace_event(
-            session.settings,
+            self.profile.settings,
             message,
             outcome="Dispatcher.handle_message.START",
         )
@@ -180,7 +181,7 @@ class Dispatcher:
         await handler(context, responder)
 
         trace_event(
-            session.settings,
+            self.profile.settings,
             context.message,
             outcome="Dispatcher.handle_message.END",
             perf_counter=r_time,
@@ -289,7 +290,7 @@ class DispatcherResponder(BaseResponder):
         Args:
             message: The `OutboundMessage` to be sent
         """
-        await self._send(self._context, message, self._inbound_message)
+        await self._send(self._context.profile, message, self._inbound_message)
 
     async def send_webhook(self, topic: str, payload: dict):
         """

--- a/aries_cloudagent/core/tests/test_conductor.py
+++ b/aries_cloudagent/core/tests/test_conductor.py
@@ -321,7 +321,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             connection_id = "connection_id"
             message = OutboundMessage(payload=payload, connection_id=connection_id)
 
-            await conductor.outbound_message_router(conductor.context, message)
+            await conductor.outbound_message_router(conductor.root_profile, message)
 
             conn_mgr.return_value.get_connection_targets.assert_awaited_once_with(
                 connection_id=connection_id
@@ -332,7 +332,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             )
 
             mock_outbound_mgr.return_value.enqueue_message.assert_called_once_with(
-                conductor.context, message
+                conductor.root_profile, message
             )
 
     async def test_outbound_message_handler_with_verkey_no_target(self):
@@ -383,7 +383,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
 
             await conductor.setup()
 
-            conductor.handle_not_returned(conductor.context, message)
+            conductor.handle_not_returned(conductor.root_profile, message)
 
             with async_mock.patch.object(
                 test_module, "ConnectionManager"
@@ -394,14 +394,14 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
                     async_mock.CoroutineMock()
                 )
                 mock_run_task.side_effect = test_module.ConnectionManagerError()
-                await conductor.queue_outbound(conductor.context, message)
+                await conductor.queue_outbound(conductor.root_profile, message)
                 mock_outbound_mgr.return_value.enqueue_message.assert_not_called()
 
                 message.connection_id = None
                 mock_outbound_mgr.return_value.enqueue_message.side_effect = (
                     test_module.OutboundDeliveryError()
                 )
-                await conductor.queue_outbound(conductor.context, message)
+                await conductor.queue_outbound(conductor.root_profile, message)
                 mock_run_task.assert_called_once()
 
     async def test_handle_not_returned_ledger_x(self):
@@ -429,7 +429,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             )
 
             with self.assertRaises(test_module.LedgerConfigError):
-                conductor.handle_not_returned(conductor.context, message)
+                conductor.handle_not_returned(conductor.root_profile, message)
 
             mock_dispatch_run.assert_called_once()
             mock_notify.assert_called_once()
@@ -460,7 +460,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             )
 
             with self.assertRaises(test_module.LedgerConfigError):
-                await conductor.queue_outbound(conductor.context, message)
+                await conductor.queue_outbound(conductor.root_profile, message)
 
             mock_dispatch_run.assert_called_once()
             mock_notify.assert_called_once()

--- a/aries_cloudagent/indy/sdk/holder.py
+++ b/aries_cloudagent/indy/sdk/holder.py
@@ -25,7 +25,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class IndySdkHolder(IndyHolder):
-    """Indy holder class."""
+    """Indy-SDK holder implementation."""
 
     def __init__(self, wallet: IndyOpenWallet):
         """

--- a/aries_cloudagent/indy/sdk/issuer.py
+++ b/aries_cloudagent/indy/sdk/issuer.py
@@ -28,14 +28,14 @@ LOGGER = logging.getLogger(__name__)
 
 
 class IndySdkIssuer(IndyIssuer):
-    """Indy issuer class."""
+    """Indy-SDK issuer implementation."""
 
     def __init__(self, profile: IndySdkProfile):
         """
         Initialize an IndyIssuer instance.
 
         Args:
-            wallet: IndySdkProfile instance
+            profile: IndySdkProfile instance
 
         """
         self.profile = profile

--- a/aries_cloudagent/indy/sdk/tests/test_holder.py
+++ b/aries_cloudagent/indy/sdk/tests/test_holder.py
@@ -8,12 +8,6 @@ from asynctest import mock as async_mock
 import indy.anoncreds
 from indy.error import IndyError, ErrorCode
 
-from ....storage.error import StorageError
-from ....storage.record import StorageRecord
-from ....protocols.issue_credential.v1_0.messages.inner.credential_preview import (
-    CredentialPreview,
-)
-
 from ...holder import IndyHolder
 
 from .. import holder as test_module

--- a/aries_cloudagent/indy/sdk/verifier.py
+++ b/aries_cloudagent/indy/sdk/verifier.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class IndySdkVerifier(IndyVerifier):
-    """Indy verifier class."""
+    """Indy-SDK verifier implementation."""
 
     def __init__(self, ledger: IndySdkLedger):
         """

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -212,7 +212,7 @@ class IndySdkLedger(BaseLedger):
 
         Args:
             pool: The pool instance handling the raw ledger connection
-            wallet: The session IndySdkWallet instance
+            wallet: The IndySdkWallet instance
         """
         self.pool = pool
         self.wallet = wallet

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -198,15 +198,11 @@ class BaseRecord(BaseModel):
             session: The profile session to use
             record_id: The ID of the record to find
         """
-        vals = None
-
-        if not vals:
-            storage = session.inject(BaseStorage)
-            result = await storage.get_record(
-                cls.RECORD_TYPE, record_id, {"retrieveTags": False}
-            )
-            vals = json.loads(result.value)
-
+        storage = session.inject(BaseStorage)
+        result = await storage.get_record(
+            cls.RECORD_TYPE, record_id, {"retrieveTags": False}
+        )
+        vals = json.loads(result.value)
         return cls.from_storage(record_id, vals)
 
     @classmethod

--- a/aries_cloudagent/messaging/request_context.py
+++ b/aries_cloudagent/messaging/request_context.py
@@ -33,7 +33,7 @@ class RequestContext:
         """Initialize an instance of RequestContext."""
         self._connection_ready = False
         self._connection_record = None
-        self._context = context or profile.context.start_scope("request", settings)
+        self._context = (context or profile.context).start_scope("request", settings)
         self._message = None
         self._message_receipt = None
         self._profile = profile

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -13,7 +13,7 @@ from ....connections.models.diddoc import (
     PublicKeyType,
     Service,
 )
-from ....config.base import InjectorError
+from ....config.base import InjectionError
 from ....core.error import BaseError
 from ....core.profile import ProfileSession
 from ....ledger.base import BaseLedger
@@ -283,7 +283,7 @@ class ConnectionManager:
             A new `ConnectionRequest` message to send to the other agent
 
         """
-        wallet: BaseWallet = self._session.inject(BaseWallet)
+        wallet = self._session.inject(BaseWallet)
         if connection.my_did:
             my_info = await wallet.get_local_did(connection.my_did)
         else:
@@ -494,7 +494,7 @@ class ConnectionManager:
         response.assign_thread_from(request)
         response.assign_trace_from(request)
         # Sign connection field using the invitation key
-        wallet: BaseWallet = self._session.inject(BaseWallet)
+        wallet = self._session.inject(BaseWallet)
         await response.sign_field("connection", connection.invitation_key, wallet)
 
         # Update connection state
@@ -767,14 +767,14 @@ class ConnectionManager:
 
         if receipt.recipient_verkey:
             try:
-                wallet: BaseWallet = self._session.inject(BaseWallet)
+                wallet = self._session.inject(BaseWallet)
                 my_info = await wallet.get_local_did_for_verkey(
                     receipt.recipient_verkey
                 )
                 receipt.recipient_did = my_info.did
                 if "public" in my_info.metadata and my_info.metadata["public"] is True:
                     receipt.recipient_did_public = True
-            except InjectorError:
+            except InjectionError:
                 self._logger.warning(
                     "Cannot resolve recipient verkey, no wallet defined by "
                     "context: %s",

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
@@ -3,7 +3,7 @@ from asynctest import mock as async_mock
 
 from .....cache.base import BaseCache
 from .....cache.in_memory import InMemoryCache
-from .....config.base import InjectorError
+from .....config.base import InjectionError
 from .....connections.models.conn_record import ConnRecord
 from .....connections.models.connection_target import ConnectionTarget
 from .....connections.models.diddoc import (
@@ -747,7 +747,7 @@ class TestConnectionManager(AsyncTestCase):
         ) as mock_wallet_get_local_did_for_verkey, async_mock.patch.object(
             self.manager, "find_connection", async_mock.CoroutineMock()
         ) as mock_mgr_find_conn:
-            mock_wallet_get_local_did_for_verkey.side_effect = InjectorError()
+            mock_wallet_get_local_did_for_verkey.side_effect = InjectionError()
             mock_mgr_find_conn.return_value = mock_conn
 
             assert await self.manager.resolve_inbound_connection(receipt)

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_ack_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_ack_handler.py
@@ -36,8 +36,7 @@ class CredentialAckHandler(BaseHandler):
         if not context.connection_ready:
             raise HandlerException("No connection established for credential ack")
 
-        session = await context.session()
-        credential_manager = CredentialManager(session)
+        credential_manager = CredentialManager(context.profile)
         await credential_manager.receive_credential_ack(
             context.message, context.connection_record.connection_id
         )

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_issue_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_issue_handler.py
@@ -36,8 +36,7 @@ class CredentialIssueHandler(BaseHandler):
         if not context.connection_ready:
             raise HandlerException("No connection established for credential request")
 
-        session = await context.session()
-        credential_manager = CredentialManager(session)
+        credential_manager = CredentialManager(context.profile)
         cred_ex_record = await credential_manager.receive_credential(
             context.message, context.connection_record.connection_id
         )

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_offer_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_offer_handler.py
@@ -37,8 +37,7 @@ class CredentialOfferHandler(BaseHandler):
         if not context.connection_ready:
             raise HandlerException("No connection established for credential offer")
 
-        session = await context.session()
-        credential_manager = CredentialManager(session)
+        credential_manager = CredentialManager(context.profile)
         cred_ex_record = await credential_manager.receive_offer(
             context.message, context.connection_record.connection_id
         )

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_proposal_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_proposal_handler.py
@@ -37,8 +37,7 @@ class CredentialProposalHandler(BaseHandler):
         if not context.connection_ready:
             raise HandlerException("No connection established for credential proposal")
 
-        session = await context.session()
-        credential_manager = CredentialManager(session)
+        credential_manager = CredentialManager(context.profile)
         cred_ex_record = await credential_manager.receive_proposal(
             context.message, context.connection_record.connection_id
         )

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_request_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_request_handler.py
@@ -37,8 +37,7 @@ class CredentialRequestHandler(BaseHandler):
         if not context.connection_ready:
             raise HandlerException("No connection established for credential request")
 
-        session = await context.session()
-        credential_manager = CredentialManager(session)
+        credential_manager = CredentialManager(context.profile)
         cred_ex_record = await credential_manager.receive_request(
             context.message, context.connection_record.connection_id
         )

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_ack_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_ack_handler.py
@@ -1,4 +1,3 @@
-import pytest
 from asynctest import (
     mock as async_mock,
     TestCase as AsyncTestCase,
@@ -20,9 +19,7 @@ class TestCredentialAckHandler(AsyncTestCase):
 
         with async_mock.patch.object(
             handler, "CredentialManager", autospec=True
-        ) as mock_cred_mgr, async_mock.patch.object(
-            request_context, "session", async_mock.CoroutineMock()
-        ) as mock_session:
+        ) as mock_cred_mgr:
             mock_cred_mgr.return_value.receive_credential_ack = (
                 async_mock.CoroutineMock()
             )
@@ -32,7 +29,7 @@ class TestCredentialAckHandler(AsyncTestCase):
             responder = MockResponder()
             await handler_inst.handle(request_context, responder)
 
-        mock_cred_mgr.assert_called_once_with(mock_session.return_value)
+        mock_cred_mgr.assert_called_once_with(request_context.profile)
         mock_cred_mgr.return_value.receive_credential_ack.assert_called_once_with(
             request_context.message, request_context.connection_record.connection_id
         )

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_issue_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_issue_handler.py
@@ -1,4 +1,3 @@
-import pytest
 from asynctest import (
     mock as async_mock,
     TestCase as AsyncTestCase,
@@ -21,9 +20,7 @@ class TestCredentialIssueHandler(AsyncTestCase):
 
         with async_mock.patch.object(
             handler, "CredentialManager", autospec=True
-        ) as mock_cred_mgr, async_mock.patch.object(
-            request_context, "session", async_mock.CoroutineMock()
-        ) as mock_session:
+        ) as mock_cred_mgr:
             mock_cred_mgr.return_value.receive_credential = async_mock.CoroutineMock()
             request_context.message = CredentialIssue()
             request_context.connection_ready = True
@@ -31,7 +28,7 @@ class TestCredentialIssueHandler(AsyncTestCase):
             responder = MockResponder()
             await handler_inst.handle(request_context, responder)
 
-        mock_cred_mgr.assert_called_once_with(mock_session.return_value)
+        mock_cred_mgr.assert_called_once_with(request_context.profile)
         mock_cred_mgr.return_value.receive_credential.assert_called_once_with(
             request_context.message, request_context.connection_record.connection_id
         )
@@ -45,9 +42,7 @@ class TestCredentialIssueHandler(AsyncTestCase):
 
         with async_mock.patch.object(
             handler, "CredentialManager", autospec=True
-        ) as mock_cred_mgr, async_mock.patch.object(
-            request_context, "session", async_mock.CoroutineMock()
-        ) as mock_session:
+        ) as mock_cred_mgr:
             mock_cred_mgr.return_value.receive_credential = async_mock.CoroutineMock()
             mock_cred_mgr.return_value.store_credential = async_mock.CoroutineMock(
                 return_value=(None, "credential_ack_message")
@@ -58,7 +53,7 @@ class TestCredentialIssueHandler(AsyncTestCase):
             responder = MockResponder()
             await handler_inst.handle(request_context, responder)
 
-        mock_cred_mgr.assert_called_once_with(mock_session.return_value)
+        mock_cred_mgr.assert_called_once_with(request_context.profile)
         mock_cred_mgr.return_value.receive_credential.assert_called_once_with(
             request_context.message, request_context.connection_record.connection_id
         )

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_offer_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_offer_handler.py
@@ -1,4 +1,3 @@
-import pytest
 from asynctest import (
     mock as async_mock,
     TestCase as AsyncTestCase,
@@ -21,9 +20,7 @@ class TestCredentialOfferHandler(AsyncTestCase):
 
         with async_mock.patch.object(
             handler, "CredentialManager", autospec=True
-        ) as mock_cred_mgr, async_mock.patch.object(
-            request_context, "session", async_mock.CoroutineMock()
-        ) as mock_session:
+        ) as mock_cred_mgr:
             mock_cred_mgr.return_value.receive_offer = async_mock.CoroutineMock()
             request_context.message = CredentialOffer()
             request_context.connection_ready = True
@@ -31,7 +28,7 @@ class TestCredentialOfferHandler(AsyncTestCase):
             responder = MockResponder()
             await handler_inst.handle(request_context, responder)
 
-        mock_cred_mgr.assert_called_once_with(mock_session.return_value)
+        mock_cred_mgr.assert_called_once_with(request_context.profile)
         mock_cred_mgr.return_value.receive_offer.assert_called_once_with(
             request_context.message, request_context.connection_record.connection_id
         )
@@ -46,9 +43,7 @@ class TestCredentialOfferHandler(AsyncTestCase):
 
         with async_mock.patch.object(
             handler, "CredentialManager", autospec=True
-        ) as mock_cred_mgr, async_mock.patch.object(
-            request_context, "session", async_mock.CoroutineMock()
-        ) as mock_session:
+        ) as mock_cred_mgr:
             mock_cred_mgr.return_value.receive_offer = async_mock.CoroutineMock()
             mock_cred_mgr.return_value.create_request = async_mock.CoroutineMock(
                 return_value=(None, "credential_request_message")
@@ -59,7 +54,7 @@ class TestCredentialOfferHandler(AsyncTestCase):
             responder = MockResponder()
             await handler_inst.handle(request_context, responder)
 
-        mock_cred_mgr.assert_called_once_with(mock_session.return_value)
+        mock_cred_mgr.assert_called_once_with(request_context.profile)
         mock_cred_mgr.return_value.receive_offer.assert_called_once_with(
             request_context.message, request_context.connection_record.connection_id
         )

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_proposal_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_proposal_handler.py
@@ -1,4 +1,3 @@
-import pytest
 from asynctest import (
     mock as async_mock,
     TestCase as AsyncTestCase,
@@ -20,9 +19,7 @@ class TestCredentialProposalHandler(AsyncTestCase):
 
         with async_mock.patch.object(
             handler, "CredentialManager", autospec=True
-        ) as mock_cred_mgr, async_mock.patch.object(
-            request_context, "session", async_mock.CoroutineMock()
-        ) as mock_session:
+        ) as mock_cred_mgr:
             mock_cred_mgr.return_value.receive_proposal = async_mock.CoroutineMock(
                 return_value=async_mock.MagicMock()
             )
@@ -33,7 +30,7 @@ class TestCredentialProposalHandler(AsyncTestCase):
             responder = MockResponder()
             await handler_inst.handle(request_context, responder)
 
-        mock_cred_mgr.assert_called_once_with(mock_session.return_value)
+        mock_cred_mgr.assert_called_once_with(request_context.profile)
         mock_cred_mgr.return_value.receive_proposal.assert_called_once_with(
             request_context.message, request_context.connection_record.connection_id
         )
@@ -46,9 +43,7 @@ class TestCredentialProposalHandler(AsyncTestCase):
 
         with async_mock.patch.object(
             handler, "CredentialManager", autospec=True
-        ) as mock_cred_mgr, async_mock.patch.object(
-            request_context, "session", async_mock.CoroutineMock()
-        ) as mock_session:
+        ) as mock_cred_mgr:
             mock_cred_mgr.return_value.receive_proposal = async_mock.CoroutineMock(
                 return_value=async_mock.MagicMock()
             )
@@ -62,7 +57,7 @@ class TestCredentialProposalHandler(AsyncTestCase):
             responder = MockResponder()
             await handler_inst.handle(request_context, responder)
 
-        mock_cred_mgr.assert_called_once_with(mock_session.return_value)
+        mock_cred_mgr.assert_called_once_with(request_context.profile)
         mock_cred_mgr.return_value.receive_proposal.assert_called_once_with(
             request_context.message, request_context.connection_record.connection_id
         )

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_request_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_request_handler.py
@@ -1,4 +1,3 @@
-import pytest
 from asynctest import (
     mock as async_mock,
     TestCase as AsyncTestCase,
@@ -25,9 +24,7 @@ class TestCredentialRequestHandler(AsyncTestCase):
 
         with async_mock.patch.object(
             handler, "CredentialManager", autospec=True
-        ) as mock_cred_mgr, async_mock.patch.object(
-            request_context, "session", async_mock.CoroutineMock()
-        ) as mock_session:
+        ) as mock_cred_mgr:
             mock_cred_mgr.return_value.receive_request = async_mock.CoroutineMock(
                 return_value=async_mock.MagicMock()
             )
@@ -38,7 +35,7 @@ class TestCredentialRequestHandler(AsyncTestCase):
             responder = MockResponder()
             await handler_inst.handle(request_context, responder)
 
-        mock_cred_mgr.assert_called_once_with(mock_session.return_value)
+        mock_cred_mgr.assert_called_once_with(request_context.profile)
         mock_cred_mgr.return_value.receive_request.assert_called_once_with(
             request_context.message, request_context.connection_record.connection_id
         )
@@ -61,9 +58,7 @@ class TestCredentialRequestHandler(AsyncTestCase):
 
         with async_mock.patch.object(
             handler, "CredentialManager", autospec=True
-        ) as mock_cred_mgr, async_mock.patch.object(
-            request_context, "session", async_mock.CoroutineMock()
-        ) as mock_session:
+        ) as mock_cred_mgr:
             mock_cred_mgr.return_value.receive_request = async_mock.CoroutineMock(
                 return_value=cred_ex_rec
             )
@@ -80,7 +75,7 @@ class TestCredentialRequestHandler(AsyncTestCase):
                 cred_ex_record=cred_ex_rec, comment=None
             )
 
-        mock_cred_mgr.assert_called_once_with(mock_session.return_value)
+        mock_cred_mgr.assert_called_once_with(request_context.profile)
         mock_cred_mgr.return_value.receive_request.assert_called_once_with(
             request_context.message, request_context.connection_record.connection_id
         )
@@ -101,9 +96,7 @@ class TestCredentialRequestHandler(AsyncTestCase):
 
         with async_mock.patch.object(
             handler, "CredentialManager", autospec=True
-        ) as mock_cred_mgr, async_mock.patch.object(
-            request_context, "session", async_mock.CoroutineMock()
-        ) as mock_session:
+        ) as mock_cred_mgr:
             mock_cred_mgr.return_value.receive_request = async_mock.CoroutineMock(
                 return_value=cred_ex_rec
             )
@@ -119,7 +112,7 @@ class TestCredentialRequestHandler(AsyncTestCase):
             await handler_inst.handle(request_context, responder)
             mock_cred_mgr.return_value.issue_credential.assert_not_called()
 
-        mock_cred_mgr.assert_called_once_with(mock_session.return_value)
+        mock_cred_mgr.assert_called_once_with(request_context.profile)
         mock_cred_mgr.return_value.receive_request.assert_called_once_with(
             request_context.message, request_context.connection_record.connection_id
         )

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/inner/tests/test_credential_preview.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/inner/tests/test_credential_preview.py
@@ -7,7 +7,6 @@ from ....message_types import CREDENTIAL_PREVIEW
 from ..credential_preview import (
     CredAttrSpec,
     CredentialPreview,
-    CredentialPreviewSchema,
 )
 
 CRED_PREVIEW = CredentialPreview(

--- a/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
@@ -13,7 +13,7 @@ from marshmallow import fields, validate
 
 from ....admin.request_context import AdminRequestContext
 from ....connections.models.conn_record import ConnRecord
-from ....core.profile import ProfileSession
+from ....core.profile import Profile
 from ....indy.issuer import IndyIssuerError
 from ....ledger.error import LedgerError
 from ....messaging.credential_definitions.util import CRED_DEF_TAGS
@@ -352,12 +352,12 @@ async def credential_exchange_list(request: web.BaseRequest):
     }
 
     try:
-        session = await context.session()
-        records = await V10CredentialExchange.query(
-            session=session,
-            tag_filter=tag_filter,
-            post_filter_positive=post_filter,
-        )
+        async with context.session() as session:
+            records = await V10CredentialExchange.query(
+                session=session,
+                tag_filter=tag_filter,
+                post_filter_positive=post_filter,
+            )
         results = [record.serialize() for record in records]
     except (StorageError, BaseModelError) as err:
         raise web.HTTPBadRequest(reason=err.roll_up) from err
@@ -385,10 +385,10 @@ async def credential_exchange_retrieve(request: web.BaseRequest):
     credential_exchange_id = request.match_info["cred_ex_id"]
     cred_ex_record = None
     try:
-        session = await context.session()
-        cred_ex_record = await V10CredentialExchange.retrieve_by_id(
-            session, credential_exchange_id
-        )
+        async with context.session() as session:
+            cred_ex_record = await V10CredentialExchange.retrieve_by_id(
+                session, credential_exchange_id
+            )
         result = cred_ex_record.serialize()
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
@@ -451,8 +451,7 @@ async def credential_exchange_create(request: web.BaseRequest):
             outcome="credential_exchange_create.START",
         )
 
-        session = await context.session()
-        credential_manager = CredentialManager(session)
+        credential_manager = CredentialManager(context.profile)
 
         (
             credential_exchange_record,
@@ -515,10 +514,10 @@ async def credential_exchange_send(request: web.BaseRequest):
     cred_ex_record = None
     try:
         preview = CredentialPreview.deserialize(preview_spec)
-        session = await context.session()
-        connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
-        if not connection_record.is_ready:
-            raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
+        async with context.session() as session:
+            connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
+            if not connection_record.is_ready:
+                raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
 
         credential_proposal = CredentialProposal(
             comment=comment,
@@ -536,7 +535,7 @@ async def credential_exchange_send(request: web.BaseRequest):
             outcome="credential_exchange_send.START",
         )
 
-        credential_manager = CredentialManager(session)
+        credential_manager = CredentialManager(context.profile)
         (
             cred_ex_record,
             credential_offer_message,
@@ -546,6 +545,7 @@ async def credential_exchange_send(request: web.BaseRequest):
             auto_remove=auto_remove,
         )
         result = cred_ex_record.serialize()
+
     except (StorageError, BaseModelError, CredentialManagerError) as err:
         await internal_error(
             err,
@@ -599,12 +599,12 @@ async def credential_exchange_send_proposal(request: web.BaseRequest):
     cred_ex_record = None
     try:
         preview = CredentialPreview.deserialize(preview_spec) if preview_spec else None
-        session = await context.session()
-        connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
-        if not connection_record.is_ready:
-            raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
+        async with context.session() as session:
+            connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
+            if not connection_record.is_ready:
+                raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
 
-        credential_manager = CredentialManager(session)
+        credential_manager = CredentialManager(context.profile)
         cred_ex_record = await credential_manager.create_proposal(
             connection_id,
             comment=comment,
@@ -618,6 +618,7 @@ async def credential_exchange_send_proposal(request: web.BaseRequest):
             cred_ex_record.credential_proposal_dict
         )
         result = cred_ex_record.serialize()
+
     except (BaseModelError, StorageError) as err:
         await internal_error(
             err,
@@ -642,7 +643,7 @@ async def credential_exchange_send_proposal(request: web.BaseRequest):
 
 
 async def _create_free_offer(
-    session: ProfileSession,
+    profile: Profile,
     cred_def_id: str,
     connection_id: str = None,
     auto_issue: bool = False,
@@ -660,7 +661,7 @@ async def _create_free_offer(
         cred_def_id=cred_def_id,
     )
     credential_proposal.assign_trace_decorator(
-        session.settings,
+        profile.settings,
         trace_msg,
     )
     credential_proposal_dict = credential_proposal.serialize()
@@ -676,7 +677,7 @@ async def _create_free_offer(
         trace=trace_msg,
     )
 
-    credential_manager = CredentialManager(session)
+    credential_manager = CredentialManager(profile)
 
     (
         cred_ex_record,
@@ -729,31 +730,35 @@ async def credential_exchange_create_free_offer(request: web.BaseRequest):
     connection_id = body.get("connection_id")
     trace_msg = body.get("trace")
 
-    session = await context.session()
-    wallet = session.inject(BaseWallet)
-    if connection_id:
-        try:
-            connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
-            conn_did = await wallet.get_local_did(connection_record.my_did)
-        except (WalletError, StorageError) as err:
-            raise web.HTTPBadRequest(reason=err.roll_up) from err
-    else:
-        conn_did = await wallet.get_public_did()
-        if not conn_did:
-            raise web.HTTPBadRequest(reason="Wallet has no public DID")
-        connection_id = None
+    async with context.session() as session:
+        wallet = session.inject(BaseWallet)
+        if connection_id:
+            try:
+                connection_record = await ConnRecord.retrieve_by_id(
+                    session, connection_id
+                )
+                conn_did = await wallet.get_local_did(connection_record.my_did)
+            except (WalletError, StorageError) as err:
+                raise web.HTTPBadRequest(reason=err.roll_up) from err
+        else:
+            conn_did = await wallet.get_public_did()
+            if not conn_did:
+                raise web.HTTPBadRequest(reason="Wallet has no public DID")
+            connection_id = None
 
-    did_info = await wallet.get_public_did()
+        did_info = await wallet.get_public_did()
+        del wallet
+
     endpoint = did_info.metadata.get(
-        "endpoint", session.settings.get("default_endpoint")
+        "endpoint", context.settings.get("default_endpoint")
     )
     if not endpoint:
         raise web.HTTPBadRequest(reason="An endpoint for the public DID is required")
 
     cred_ex_record = None
     try:
-        (cred_ex_record, credential_offer_message,) = await _create_free_offer(
-            session,
+        (cred_ex_record, credential_offer_message) = await _create_free_offer(
+            context.profile,
             cred_def_id,
             connection_id,
             auto_issue,
@@ -772,6 +777,7 @@ async def credential_exchange_create_free_offer(request: web.BaseRequest):
 
         oob_url = serialize_outofband(credential_offer_message, conn_did, endpoint)
         result = cred_ex_record.serialize()
+
     except (BaseModelError, CredentialManagerError, LedgerError) as err:
         await internal_error(
             err,
@@ -830,13 +836,13 @@ async def credential_exchange_send_free_offer(request: web.BaseRequest):
     cred_ex_record = None
     connection_record = None
     try:
-        session = await context.session()
-        connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
-        if not connection_record.is_ready:
-            raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
+        async with context.session() as session:
+            connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
+            if not connection_record.is_ready:
+                raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
 
         (cred_ex_record, credential_offer_message,) = await _create_free_offer(
-            session,
+            context.profile,
             cred_def_id,
             connection_id,
             auto_issue,
@@ -846,6 +852,7 @@ async def credential_exchange_send_free_offer(request: web.BaseRequest):
             trace_msg,
         )
         result = cred_ex_record.serialize()
+
     except (
         StorageNotFoundError,
         BaseModelError,
@@ -897,37 +904,39 @@ async def credential_exchange_send_bound_offer(request: web.BaseRequest):
     outbound_handler = request.app["outbound_message_router"]
 
     credential_exchange_id = request.match_info["cred_ex_id"]
-    session = await context.session()
-    try:
-        cred_ex_record = await V10CredentialExchange.retrieve_by_id(
-            session, credential_exchange_id
-        )
-    except StorageNotFoundError as err:
-        raise web.HTTPNotFound(reason=err.roll_up) from err
-
+    cred_ex_record = None
     connection_record = None
-    connection_id = cred_ex_record.connection_id
     try:
-        if cred_ex_record.state != (
-            V10CredentialExchange.STATE_PROPOSAL_RECEIVED
-        ):  # check state here: manager call creates free offers too
-            raise CredentialManagerError(
-                f"Credential exchange {cred_ex_record.credential_exchange_id} "
-                f"in {cred_ex_record.state} state "
-                f"(must be {V10CredentialExchange.STATE_PROPOSAL_RECEIVED})"
-            )
+        async with context.session() as session:
+            try:
+                cred_ex_record = await V10CredentialExchange.retrieve_by_id(
+                    session, credential_exchange_id
+                )
+            except StorageNotFoundError as err:
+                raise web.HTTPNotFound(reason=err.roll_up) from err
 
-        connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
-        if not connection_record.is_ready:
-            raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
+            connection_id = cred_ex_record.connection_id
+            if cred_ex_record.state != (
+                V10CredentialExchange.STATE_PROPOSAL_RECEIVED
+            ):  # check state here: manager call creates free offers too
+                raise CredentialManagerError(
+                    f"Credential exchange {cred_ex_record.credential_exchange_id} "
+                    f"in {cred_ex_record.state} state "
+                    f"(must be {V10CredentialExchange.STATE_PROPOSAL_RECEIVED})"
+                )
 
-        credential_manager = CredentialManager(session)
+            connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
+            if not connection_record.is_ready:
+                raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
+
+        credential_manager = CredentialManager(context.profile)
         (
             cred_ex_record,
             credential_offer_message,
         ) = await credential_manager.create_offer(cred_ex_record, comment=None)
 
         result = cred_ex_record.serialize()
+
     except (StorageError, BaseModelError, CredentialManagerError, LedgerError) as err:
         await internal_error(
             err,
@@ -968,22 +977,24 @@ async def credential_exchange_send_request(request: web.BaseRequest):
     outbound_handler = request.app["outbound_message_router"]
 
     credential_exchange_id = request.match_info["cred_ex_id"]
-    session = await context.session()
-    try:
-        cred_ex_record = await V10CredentialExchange.retrieve_by_id(
-            session, credential_exchange_id
-        )
-    except StorageNotFoundError as err:
-        raise web.HTTPNotFound(reason=err.roll_up) from err
-    connection_id = cred_ex_record.connection_id
 
+    cred_ex_record = None
     connection_record = None
     try:
-        connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
-        if not connection_record.is_ready:
-            raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
+        async with context.session() as session:
+            try:
+                cred_ex_record = await V10CredentialExchange.retrieve_by_id(
+                    session, credential_exchange_id
+                )
+            except StorageNotFoundError as err:
+                raise web.HTTPNotFound(reason=err.roll_up) from err
+            connection_id = cred_ex_record.connection_id
 
-        credential_manager = CredentialManager(session)
+            connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
+            if not connection_record.is_ready:
+                raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
+
+        credential_manager = CredentialManager(context.profile)
         (
             cred_ex_record,
             credential_request_message,
@@ -992,6 +1003,7 @@ async def credential_exchange_send_request(request: web.BaseRequest):
         )
 
         result = cred_ex_record.serialize()
+
     except (StorageError, CredentialManagerError, BaseModelError) as err:
         await internal_error(
             err,
@@ -1036,28 +1048,31 @@ async def credential_exchange_issue(request: web.BaseRequest):
     comment = body.get("comment")
 
     credential_exchange_id = request.match_info["cred_ex_id"]
-    session = await context.session()
-    try:
-        cred_ex_record = await V10CredentialExchange.retrieve_by_id(
-            session, credential_exchange_id
-        )
-    except StorageNotFoundError as err:
-        raise web.HTTPNotFound(reason=err.roll_up) from err
-    connection_id = cred_ex_record.connection_id
 
+    cred_ex_record = None
     connection_record = None
     try:
-        connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
-        if not connection_record.is_ready:
-            raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
+        async with context.session() as session:
+            try:
+                cred_ex_record = await V10CredentialExchange.retrieve_by_id(
+                    session, credential_exchange_id
+                )
+            except StorageNotFoundError as err:
+                raise web.HTTPNotFound(reason=err.roll_up) from err
+            connection_id = cred_ex_record.connection_id
 
-        credential_manager = CredentialManager(session)
+            connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
+            if not connection_record.is_ready:
+                raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
+
+        credential_manager = CredentialManager(context.profile)
         (
             cred_ex_record,
             credential_issue_message,
         ) = await credential_manager.issue_credential(cred_ex_record, comment=comment)
 
         result = cred_ex_record.serialize()
+
     except (
         BaseModelError,
         CredentialManagerError,
@@ -1110,28 +1125,31 @@ async def credential_exchange_store(request: web.BaseRequest):
         credential_id = None
 
     credential_exchange_id = request.match_info["cred_ex_id"]
-    session = await context.session()
-    try:
-        cred_ex_record = await V10CredentialExchange.retrieve_by_id(
-            session, credential_exchange_id
-        )
-    except StorageNotFoundError as err:
-        raise web.HTTPNotFound(reason=err.roll_up) from err
 
+    cred_ex_record = None
     connection_record = None
-    connection_id = cred_ex_record.connection_id
     try:
-        connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
-        if not connection_record.is_ready:
-            raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
+        async with context.session() as session:
+            try:
+                cred_ex_record = await V10CredentialExchange.retrieve_by_id(
+                    session, credential_exchange_id
+                )
+            except StorageNotFoundError as err:
+                raise web.HTTPNotFound(reason=err.roll_up) from err
 
-        credential_manager = CredentialManager(session)
+            connection_id = cred_ex_record.connection_id
+            connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
+            if not connection_record.is_ready:
+                raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
+
+        credential_manager = CredentialManager(context.profile)
         (
             cred_ex_record,
             credential_stored_message,
         ) = await credential_manager.store_credential(cred_ex_record, credential_id)
 
         result = cred_ex_record.serialize()
+
     except (StorageError, CredentialManagerError, BaseModelError) as err:
         await internal_error(
             err,
@@ -1169,12 +1187,12 @@ async def credential_exchange_remove(request: web.BaseRequest):
 
     credential_exchange_id = request.match_info["cred_ex_id"]
     cred_ex_record = None
-    session = await context.session()
     try:
-        cred_ex_record = await V10CredentialExchange.retrieve_by_id(
-            session, credential_exchange_id
-        )
-        await cred_ex_record.delete_record(session)
+        async with context.session() as session:
+            cred_ex_record = await V10CredentialExchange.retrieve_by_id(
+                session, credential_exchange_id
+            )
+            await cred_ex_record.delete_record(session)
     except StorageNotFoundError as err:
         await internal_error(err, web.HTTPNotFound, cred_ex_record, outbound_handler)
     except StorageError as err:
@@ -1203,12 +1221,12 @@ async def credential_exchange_problem_report(request: web.BaseRequest):
 
     credential_exchange_id = request.match_info["cred_ex_id"]
     body = await request.json()
-    session = await context.session()
 
     try:
-        cred_ex_record = await V10CredentialExchange.retrieve_by_id(
-            session, credential_exchange_id
-        )
+        async with await context.session() as session:
+            cred_ex_record = await V10CredentialExchange.retrieve_by_id(
+                session, credential_exchange_id
+            )
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
 

--- a/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_ack_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_ack_handler.py
@@ -36,11 +36,12 @@ class PresentationAckHandler(BaseHandler):
         if not context.connection_ready:
             raise HandlerException("No connection established for presentation ack")
 
-        session = await context.session()
-        presentation_manager = PresentationManager(session)
-        await presentation_manager.receive_presentation_ack(
-            context.message, context.connection_record
-        )
+        async with context.session() as session:
+            presentation_manager = PresentationManager(session)
+            await presentation_manager.receive_presentation_ack(
+                context.message, context.connection_record
+            )
+            del presentation_manager
 
         trace_event(
             context.settings,

--- a/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_request_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_request_handler.py
@@ -53,7 +53,7 @@ class PresentationRequestHandler(BaseHandler):
             (
                 presentation_exchange_record
             ) = await V10PresentationExchange.retrieve_by_tag_filter(
-                context,
+                session,
                 {"thread_id": context.message._thread_id},
                 {"connection_id": context.connection_record.connection_id},
             )  # holder initiated via proposal

--- a/aries_cloudagent/protocols/present_proof/v1_0/handlers/tests/test_presentation_ack_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/handlers/tests/test_presentation_ack_handler.py
@@ -1,4 +1,3 @@
-import pytest
 from asynctest import (
     mock as async_mock,
     TestCase as AsyncTestCase,
@@ -16,12 +15,12 @@ class TestPresentationAckHandler(AsyncTestCase):
     async def test_called(self):
         request_context = RequestContext.test_context()
         request_context.message_receipt = MessageReceipt()
+        session = request_context.session()
+        setattr(request_context, "session", async_mock.MagicMock(return_value=session))
 
         with async_mock.patch.object(
             handler, "PresentationManager", autospec=True
-        ) as mock_pres_mgr, async_mock.patch.object(
-            request_context, "session", async_mock.CoroutineMock()
-        ) as mock_session:
+        ) as mock_pres_mgr:
             mock_pres_mgr.return_value.receive_presentation_ack = (
                 async_mock.CoroutineMock()
             )
@@ -32,7 +31,7 @@ class TestPresentationAckHandler(AsyncTestCase):
             responder = MockResponder()
             await handler_inst.handle(request_context, responder)
 
-        mock_pres_mgr.assert_called_once_with(mock_session.return_value)
+        mock_pres_mgr.assert_called_once_with(session)
         mock_pres_mgr.return_value.receive_presentation_ack.assert_called_once_with(
             request_context.message, request_context.connection_record
         )

--- a/aries_cloudagent/protocols/routing/v1_0/manager.py
+++ b/aries_cloudagent/protocols/routing/v1_0/manager.py
@@ -117,7 +117,7 @@ class RoutingManager:
                     )
 
         results = []
-        storage: BaseStorage = self._session.inject(BaseStorage)
+        storage = self._session.inject(BaseStorage)
         async for record in storage.search_records(RoutingManager.RECORD_TYPE, filters):
             value = json.loads(record.value)
             value.update(record.tags)

--- a/aries_cloudagent/transport/inbound/manager.py
+++ b/aries_cloudagent/transport/inbound/manager.py
@@ -6,7 +6,7 @@ import uuid
 from collections import OrderedDict
 from typing import Callable, Coroutine
 
-from ...config.injection_context import InjectionContext
+from ...core.profile import Profile
 from ...utils.classloader import ClassLoader, ModuleLoadError, ClassNotFoundError
 from ...utils.task_queue import CompletedTask, TaskQueue
 
@@ -31,12 +31,12 @@ class InboundTransportManager:
 
     def __init__(
         self,
-        context: InjectionContext,
+        profile: Profile,
         receive_inbound: Coroutine,
         return_inbound: Callable = None,
     ):
         """Initialize an `InboundTransportManager` instance."""
-        self.context = context
+        self.profile = profile
         self.max_message_size = 0
         self.receive_inbound = receive_inbound
         self.return_inbound = return_inbound
@@ -50,11 +50,13 @@ class InboundTransportManager:
     async def setup(self):
         """Perform setup operations."""
         # Load config settings
-        if self.context.settings.get("transport.max_message_size"):
-            self.max_message_size = self.context.settings["transport.max_message_size"]
+        if self.profile.context.settings.get("transport.max_message_size"):
+            self.max_message_size = self.profile.context.settings[
+                "transport.max_message_size"
+            ]
 
         inbound_transports = (
-            self.context.settings.get("transport.inbound_configs") or []
+            self.profile.context.settings.get("transport.inbound_configs") or []
         )
         for transport in inbound_transports:
             module, host, port = transport
@@ -63,7 +65,7 @@ class InboundTransportManager:
             )
 
         # Setup queue for undelivered messages
-        if self.context.settings.get("transport.enable_undelivered_queue"):
+        if self.profile.context.settings.get("transport.enable_undelivered_queue"):
             self.undelivered_queue = DeliveryQueue()
 
         # self.session_limit = asyncio.Semaphore(50)
@@ -163,9 +165,9 @@ class InboundTransportManager:
         if self.session_limit:
             await self.session_limit
         if not wire_format:
-            wire_format = self.context.inject(BaseWireFormat)
+            wire_format = self.profile.context.inject(BaseWireFormat)
         session = InboundSession(
-            context=self.context,
+            profile=self.profile,
             accept_undelivered=accept_undelivered,
             can_respond=can_respond,
             client_info=client_info,
@@ -196,7 +198,7 @@ class InboundTransportManager:
                 self.session_limit.release()
         if session.response_buffer:
             if self.return_inbound:
-                self.return_inbound(session.context, session.response_buffer)
+                self.return_inbound(session.profile, session.response_buffer)
             else:
                 LOGGER.warning("Message failed return delivery, will not be delivered")
 

--- a/aries_cloudagent/transport/inbound/session.py
+++ b/aries_cloudagent/transport/inbound/session.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from typing import Callable, Sequence, Union
 
-from ...config.injection_context import InjectionContext
+from ...core.profile import Profile
 
 from ..error import WireFormatError
 from ..outbound.message import OutboundMessage
@@ -35,7 +35,7 @@ class InboundSession:
     def __init__(
         self,
         *,
-        context: InjectionContext,
+        profile: Profile,
         inbound_handler: Callable,
         session_id: str,
         wire_format: BaseWireFormat,
@@ -49,7 +49,7 @@ class InboundSession:
         transport_type: str = None,
     ):
         """Initialize the inbound session."""
-        self.context = context
+        self.profile = profile
         self.inbound_handler = inbound_handler
         self.session_id = session_id
         self.wire_format = wire_format
@@ -164,9 +164,8 @@ class InboundSession:
 
     async def parse_inbound(self, payload_enc: Union[str, bytes]) -> InboundMessage:
         """Convert a message payload and to an inbound message."""
-        payload, receipt = await self.wire_format.parse_message(
-            self.context, payload_enc
-        )
+        session = await self.profile.session()
+        payload, receipt = await self.wire_format.parse_message(session, payload_enc)
         return InboundMessage(
             payload,
             receipt,
@@ -218,8 +217,9 @@ class InboundSession:
         if not outbound.reply_to_verkey:
             raise WireFormatError("No reply verkey available for encoding message")
 
+        session = await self.profile.session()
         return await self.wire_format.encode_message(
-            self.context,
+            session,
             outbound.payload,
             [outbound.reply_to_verkey],
             None,

--- a/aries_cloudagent/transport/inbound/tests/test_http_transport.py
+++ b/aries_cloudagent/transport/inbound/tests/test_http_transport.py
@@ -3,11 +3,12 @@ import pytest
 import json
 
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop, unused_port
-from aiohttp import web
 from asynctest import mock as async_mock
 
+from ....core.in_memory import InMemoryProfile
+
 from ...outbound.message import OutboundMessage
-from ...wire_format import BaseWireFormat, JsonWireFormat
+from ...wire_format import JsonWireFormat
 
 from ..http import HttpTransport
 from ..message import InboundMessage
@@ -39,7 +40,7 @@ class TestHttpTransport(AioHTTPTestCase):
     ):
         if not self.session:
             session = InboundSession(
-                context=None,
+                profile=InMemoryProfile.test_profile(),
                 can_respond=can_respond,
                 inbound_handler=self.receive_message,
                 session_id=None,

--- a/aries_cloudagent/transport/inbound/tests/test_session.py
+++ b/aries_cloudagent/transport/inbound/tests/test_session.py
@@ -3,7 +3,7 @@ import pytest
 
 from asynctest import TestCase, mock as async_mock
 
-from ....config.injection_context import InjectionContext
+from ....core.in_memory import InMemoryProfile
 
 from ...error import WireFormatError
 from ...outbound.message import OutboundMessage
@@ -14,8 +14,10 @@ from ..session import InboundSession
 
 
 class TestInboundSession(TestCase):
+    def setUp(self):
+        self.profile = InMemoryProfile.test_profile()
+
     def test_init(self):
-        test_ctx = InjectionContext()
         test_inbound = async_mock.MagicMock()
         test_session_id = "session-id"
         test_wire_format = async_mock.MagicMock()
@@ -26,7 +28,7 @@ class TestInboundSession(TestCase):
         test_reply_verkeys = {"3", "4"}
         test_transport_type = "transport-type"
         sess = InboundSession(
-            context=test_ctx,
+            profile=self.profile,
             inbound_handler=test_inbound,
             session_id=test_session_id,
             wire_format=test_wire_format,
@@ -38,7 +40,7 @@ class TestInboundSession(TestCase):
             transport_type=test_transport_type,
         )
 
-        assert sess.context is test_ctx
+        assert sess.profile is self.profile
         assert sess.session_id == test_session_id
         assert sess.wire_format is test_wire_format
         assert sess.client_info == test_client_info
@@ -58,9 +60,11 @@ class TestInboundSession(TestCase):
         assert sess.closed
 
     def test_setters(self):
-        test_ctx = InjectionContext()
         sess = InboundSession(
-            context=test_ctx, inbound_handler=None, session_id=None, wire_format=None
+            profile=self.profile,
+            inbound_handler=None,
+            session_id=None,
+            wire_format=None,
         )
 
         sess.reply_mode = MessageReceipt.REPLY_MODE_ALL
@@ -76,7 +80,6 @@ class TestInboundSession(TestCase):
         assert not sess.reply_thread_ids  # reset by setter method
 
     async def test_parse_inbound(self):
-        test_ctx = InjectionContext()
         test_session_id = "session-id"
         test_transport_type = "transport-type"
         test_wire_format = async_mock.MagicMock()
@@ -85,25 +88,27 @@ class TestInboundSession(TestCase):
         test_receipt = async_mock.MagicMock()
         test_wire_format.parse_message.return_value = (test_parsed, test_receipt)
         sess = InboundSession(
-            context=test_ctx,
+            profile=self.profile,
             inbound_handler=None,
             session_id=test_session_id,
             wire_format=test_wire_format,
             transport_type=test_transport_type,
         )
 
+        session = self.profile.session()
+        setattr(self.profile, "session", async_mock.MagicMock(return_value=session))
+
         test_payload = "{}"
         result = await sess.parse_inbound(test_payload)
-        test_wire_format.parse_message.assert_awaited_once_with(test_ctx, test_payload)
+        test_wire_format.parse_message.assert_awaited_once_with(session, test_payload)
         assert result.payload == test_parsed
         assert result.receipt is test_receipt
         assert result.session_id == test_session_id
         assert result.transport_type == test_transport_type
 
     async def test_receive(self):
-        test_ctx = InjectionContext()
         sess = InboundSession(
-            context=test_ctx,
+            profile=self.profile,
             inbound_handler=None,
             session_id=None,
             wire_format=None,
@@ -121,12 +126,11 @@ class TestInboundSession(TestCase):
             assert result is encode.return_value
 
     def test_process_inbound(self):
-        test_ctx = InjectionContext()
         test_session_id = "session-id"
         test_thread_id = "thread-id"
         test_verkey = "verkey"
         sess = InboundSession(
-            context=test_ctx,
+            profile=self.profile,
             inbound_handler=None,
             session_id=test_session_id,
             wire_format=None,
@@ -163,12 +167,11 @@ class TestInboundSession(TestCase):
         assert receipt.connection_id == "dummy"
 
     def test_select_outbound(self):
-        test_ctx = InjectionContext()
         test_session_id = "session-id"
         test_thread_id = "thread-id"
         test_verkey = "verkey"
         sess = InboundSession(
-            context=test_ctx,
+            profile=self.profile,
             inbound_handler=None,
             session_id=test_session_id,
             wire_format=None,
@@ -201,9 +204,8 @@ class TestInboundSession(TestCase):
         assert not sess.select_outbound(test_msg)
 
     async def test_wait_response(self):
-        test_ctx = InjectionContext()
         sess = InboundSession(
-            context=test_ctx,
+            profile=self.profile,
             inbound_handler=None,
             session_id=None,
             wire_format=None,
@@ -227,9 +229,8 @@ class TestInboundSession(TestCase):
         assert await asyncio.wait_for(sess.wait_response(), 0.1) is None
 
     async def test_wait_response_x(self):
-        test_ctx = InjectionContext()
         sess = InboundSession(
-            context=test_ctx,
+            profile=self.profile,
             inbound_handler=None,
             session_id=None,
             wire_format=None,
@@ -252,11 +253,10 @@ class TestInboundSession(TestCase):
         assert await asyncio.wait_for(sess.wait_response(), 0.1) is None
 
     async def test_encode_response(self):
-        test_ctx = InjectionContext()
         test_wire_format = async_mock.MagicMock()
         test_wire_format.encode_message = async_mock.CoroutineMock()
         sess = InboundSession(
-            context=test_ctx,
+            profile=self.profile,
             inbound_handler=None,
             session_id=None,
             wire_format=test_wire_format,
@@ -264,6 +264,9 @@ class TestInboundSession(TestCase):
         test_msg = OutboundMessage(payload=None)
         test_from_verkey = "from-verkey"
         test_to_verkey = "to-verkey"
+
+        session = self.profile.session()
+        setattr(self.profile, "session", async_mock.MagicMock(return_value=session))
 
         with self.assertRaises(WireFormatError):
             await sess.encode_outbound(test_msg)
@@ -276,7 +279,7 @@ class TestInboundSession(TestCase):
         assert result is test_wire_format.encode_message.return_value
 
         test_wire_format.encode_message.assert_awaited_once_with(
-            test_ctx,
+            session,
             test_msg.payload,
             [test_to_verkey],
             None,
@@ -284,9 +287,8 @@ class TestInboundSession(TestCase):
         )
 
     async def test_accept_response(self):
-        test_ctx = InjectionContext()
         sess = InboundSession(
-            context=test_ctx,
+            profile=self.profile,
             inbound_handler=None,
             session_id=None,
             wire_format=None,
@@ -309,9 +311,8 @@ class TestInboundSession(TestCase):
             assert accepted
 
     async def test_context_mgr(self):
-        test_ctx = InjectionContext()
         sess = InboundSession(
-            context=test_ctx,
+            profile=self.profile,
             inbound_handler=None,
             session_id=None,
             wire_format=None,

--- a/aries_cloudagent/transport/inbound/tests/test_ws_transport.py
+++ b/aries_cloudagent/transport/inbound/tests/test_ws_transport.py
@@ -3,8 +3,9 @@ import json
 import pytest
 
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop, unused_port
-from aiohttp import web
 from asynctest import mock as async_mock
+
+from ....core.in_memory import InMemoryProfile
 
 from ...outbound.message import OutboundMessage
 from ...wire_format import JsonWireFormat
@@ -36,7 +37,7 @@ class TestWsTransport(AioHTTPTestCase):
     ):
         if not self.session:
             session = InboundSession(
-                context=None,
+                profile=InMemoryProfile.test_profile(),
                 can_respond=can_respond,
                 inbound_handler=self.receive_message,
                 session_id=None,

--- a/aries_cloudagent/transport/pack_format.py
+++ b/aries_cloudagent/transport/pack_format.py
@@ -4,7 +4,6 @@ import json
 import logging
 from typing import Sequence, Tuple, Union
 
-from ..config.base import InjectorError
 from ..core.profile import ProfileSession
 
 from ..protocols.routing.v1_0.messages.forward import Forward
@@ -108,9 +107,8 @@ class PackWireFormat(BaseWireFormat):
         receipt: MessageReceipt,
     ):
         """Look up the wallet instance and perform the message unpack."""
-        try:
-            wallet: BaseWallet = session.inject(BaseWallet)
-        except InjectorError:
+        wallet = session.inject(BaseWallet, required=False)
+        if not wallet:
             raise MessageParseError("Wallet not defined in profile session")
 
         try:
@@ -171,7 +169,7 @@ class PackWireFormat(BaseWireFormat):
         if not sender_key or not recipient_keys:
             raise MessageEncodeError("Cannot pack message without associated keys")
 
-        wallet: BaseWallet = session.inject(BaseWallet, required=False)
+        wallet = session.inject(BaseWallet, required=False)
         if not wallet:
             raise MessageEncodeError("No wallet instance")
 


### PR DESCRIPTION
Update CredentialManager, InboundTransportManager, InboundSession to accept a Profile instance. Route outbound messages with a Profile rather than a context.

General refactoring: combine InjectorError and ProviderError into InjectionError.