### PR TITLE
[multitenancy] Fix wallet error when getting wallet at inbound message handler

### DIFF
--- a/aries_cloudagent/transport/inbound/http_custodial.py
+++ b/aries_cloudagent/transport/inbound/http_custodial.py
@@ -102,7 +102,8 @@ class CustodialHttpTransport(BaseInboundTransport):
             wallet_ids = await wallet_handler.get_wallet_by_msg(body)
             session.context = session.context.copy()
             # FIXME: What if multiple recipients are handled by the agent?
-            session.context.settings.set_value("wallet.id", wallet_ids[0])
+            # prevent getting wallet without opening wallet
+            await wallet_handler.set_instance(wallet_ids[0], session.context)
 
         async with session:
 


### PR DESCRIPTION
**Problem:**
- I tested aca-py scaleout: two multitenancy aca-py servers (A and B) share a postgres wallet (storage).
- I found that when server A creates Alice and server B receives inbound message for Alice, an error occurs.
- The problem was that server B was trying to get Alice's wallet without opening the wallet.

This PR fixes the problem.

Signed-off-by: Ethan Sung <baegjae@gmail.com>