### PR TITLE
Storage search API updates

### DIFF
--- a/aries_cloudagent/cache/base.py
+++ b/aries_cloudagent/cache/base.py
@@ -71,7 +71,7 @@ class BaseCache(ABC):
             del self._key_locks[key]
 
     def __repr__(self) -> str:
-        """Human readable representation of `BaseStorageRecordSearch`."""
+        """Human readable representation of this instance."""
         return "<{}>".format(self.__class__.__name__)
 
 

--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -275,7 +275,7 @@ class ConnRecord(BaseRecord):
             invitation.to_json(),
             {"connection_id": self.connection_id},
         )
-        storage: BaseStorage = session.inject(BaseStorage)
+        storage = session.inject(BaseStorage)
         await storage.add_record(record)
 
     async def retrieve_invitation(
@@ -287,7 +287,7 @@ class ConnRecord(BaseRecord):
             session: The active profile session
         """
         assert self.connection_id
-        storage: BaseStorage = session.inject(BaseStorage)
+        storage = session.inject(BaseStorage)
         result = await storage.find_record(
             self.RECORD_TYPE_INVITATION, {"connection_id": self.connection_id}
         )

--- a/aries_cloudagent/indy/sdk/profile.py
+++ b/aries_cloudagent/indy/sdk/profile.py
@@ -11,7 +11,7 @@ from ...config.provider import ClassProvider
 from ...core.profile import Profile, ProfileManager, ProfileSession
 from ...ledger.base import BaseLedger
 from ...ledger.indy import IndySdkLedger, IndySdkLedgerPool
-from ...storage.base import BaseStorage
+from ...storage.base import BaseStorage, BaseStorageSearch
 from ...wallet.base import BaseWallet
 from ...wallet.indy import IndySdkWallet
 
@@ -71,6 +71,12 @@ class IndySdkProfile(Profile):
     def bind_providers(self):
         """Initialize the profile-level instance providers."""
         injector = self._context.injector
+
+        injector.bind_provider(
+            BaseStorageSearch,
+            ClassProvider("aries_cloudagent.storage.indy.IndySdkStorage", self.opened),
+        )
+
         injector.bind_provider(
             IndyHolder,
             ClassProvider(
@@ -129,7 +135,6 @@ class IndySdkProfileSession(ProfileSession):
 
     async def _setup(self):
         """Create the session or transaction connection, if needed."""
-        await super()._setup()
         injector = self._context.injector
         injector.bind_provider(
             BaseWallet, ClassProvider(IndySdkWallet, self.profile.opened)

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -1022,9 +1022,7 @@ class IndySdkLedger(BaseLedger):
         if not acceptance:
             storage = self.get_indy_storage()
             tag_filter = {"pool_name": self.pool.name}
-            found = await storage.search_records(
-                TAA_ACCEPTED_RECORD_TYPE, tag_filter
-            ).fetch_all()
+            found = await storage.find_all_records(TAA_ACCEPTED_RECORD_TYPE, tag_filter)
             if found:
                 records = list(json.loads(record.value) for record in found)
                 records.sort(key=lambda v: v["time"], reverse=True)

--- a/aries_cloudagent/ledger/tests/test_indy.py
+++ b/aries_cloudagent/ledger/tests/test_indy.py
@@ -23,7 +23,6 @@ from ...ledger.indy import (
     Role,
     TAA_ACCEPTED_RECORD_TYPE,
 )
-from ...storage.indy import IndySdkStorage
 from ...storage.record import StorageRecord
 from ...wallet.base import DIDInfo
 
@@ -149,7 +148,7 @@ class TestIndySdkLedger(AsyncTestCase):
             assert led.pool_handle == mock_open_ledger.return_value
 
         mock_close_pool.assert_called_once()
-        assert ledger.pool_handle == None
+        assert ledger.pool_handle is None
 
     @async_mock.patch("indy.pool.set_protocol_version")
     @async_mock.patch("indy.pool.open_pool_ledger")
@@ -177,7 +176,7 @@ class TestIndySdkLedger(AsyncTestCase):
 
         await asyncio.sleep(1.01)
         mock_close_pool.assert_called_once()
-        assert ledger.pool_handle == None
+        assert ledger.pool_handle is None
 
     @async_mock.patch("indy.pool.set_protocol_version")
     @async_mock.patch("indy.pool.open_pool_ledger")
@@ -963,14 +962,14 @@ class TestIndySdkLedger(AsyncTestCase):
         "aries_cloudagent.ledger.indy.IndySdkLedger.fetch_credential_definition"
     )
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedger._submit")
-    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.search_records")
+    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.find_all_records")
     @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.add_record")
     @async_mock.patch("indy.ledger.build_cred_def_request")
     async def test_send_credential_definition(
         self,
         mock_build_cred_def,
         mock_add_record,
-        mock_search_records,
+        mock_find_all_records,
         mock_submit,
         mock_fetch_cred_def,
         mock_close,
@@ -979,9 +978,7 @@ class TestIndySdkLedger(AsyncTestCase):
     ):
         mock_wallet = async_mock.MagicMock()
 
-        mock_search_records.return_value.fetch_all = async_mock.CoroutineMock(
-            return_value=[]
-        )
+        mock_find_all_records.return_value = []
 
         mock_get_schema.return_value = {"seqNo": 999}
         cred_def_id = f"{self.test_did}:3:CL:999:default"
@@ -1049,14 +1046,14 @@ class TestIndySdkLedger(AsyncTestCase):
         "aries_cloudagent.ledger.indy.IndySdkLedger.fetch_credential_definition"
     )
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedger._submit")
-    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.search_records")
+    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.find_all_records")
     @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.add_record")
     @async_mock.patch("indy.ledger.build_cred_def_request")
     async def test_send_credential_definition_exists_in_ledger_and_wallet(
         self,
         mock_build_cred_def,
         mock_add_record,
-        mock_search_records,
+        mock_find_all_records,
         mock_submit,
         mock_fetch_cred_def,
         mock_close,
@@ -1065,9 +1062,7 @@ class TestIndySdkLedger(AsyncTestCase):
     ):
         mock_wallet = async_mock.MagicMock()
 
-        mock_search_records.return_value.fetch_all = async_mock.CoroutineMock(
-            return_value=[]
-        )
+        mock_find_all_records.return_value = []
 
         mock_get_schema.return_value = {"seqNo": 999}
         cred_def_id = f"{self.test_did}:3:CL:999:default"
@@ -1162,14 +1157,14 @@ class TestIndySdkLedger(AsyncTestCase):
         "aries_cloudagent.ledger.indy.IndySdkLedger.fetch_credential_definition"
     )
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedger._submit")
-    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.search_records")
+    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.find_all_records")
     @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.add_record")
     @async_mock.patch("indy.ledger.build_cred_def_request")
     async def test_send_credential_definition_offer_exception(
         self,
         mock_build_cred_def,
         mock_add_record,
-        mock_search_records,
+        mock_find_all_records,
         mock_submit,
         mock_fetch_cred_def,
         mock_close,
@@ -1178,9 +1173,7 @@ class TestIndySdkLedger(AsyncTestCase):
     ):
         mock_wallet = async_mock.MagicMock()
 
-        mock_search_records.return_value.fetch_all = async_mock.CoroutineMock(
-            return_value=[]
-        )
+        mock_find_all_records.return_value = []
 
         mock_get_schema.return_value = {"seqNo": 999}
 
@@ -1461,14 +1454,14 @@ class TestIndySdkLedger(AsyncTestCase):
         "aries_cloudagent.ledger.indy.IndySdkLedger.fetch_credential_definition"
     )
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedger._submit")
-    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.search_records")
+    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.find_all_records")
     @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.add_record")
     @async_mock.patch("indy.ledger.build_cred_def_request")
     async def test_send_credential_definition_on_ledger_in_wallet(
         self,
         mock_build_cred_def,
         mock_add_record,
-        mock_search_records,
+        mock_find_all_records,
         mock_submit,
         mock_fetch_cred_def,
         mock_close,
@@ -1477,9 +1470,7 @@ class TestIndySdkLedger(AsyncTestCase):
     ):
         mock_wallet = async_mock.MagicMock()
 
-        mock_search_records.return_value.fetch_all = async_mock.CoroutineMock(
-            return_value=[]
-        )
+        mock_find_all_records.return_value = []
 
         mock_get_schema.return_value = {"seqNo": 999}
         cred_def_id = f"{self.test_did}:3:CL:999:default"
@@ -1545,14 +1536,14 @@ class TestIndySdkLedger(AsyncTestCase):
         "aries_cloudagent.ledger.indy.IndySdkLedger.fetch_credential_definition"
     )
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedger._submit")
-    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.search_records")
+    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.find_all_records")
     @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.add_record")
     @async_mock.patch("indy.ledger.build_cred_def_request")
     async def test_send_credential_definition_create_cred_def_exception(
         self,
         mock_build_cred_def,
         mock_add_record,
-        mock_search_records,
+        mock_find_all_records,
         mock_submit,
         mock_fetch_cred_def,
         mock_close,
@@ -1561,9 +1552,7 @@ class TestIndySdkLedger(AsyncTestCase):
     ):
         mock_wallet = async_mock.MagicMock()
 
-        mock_search_records.return_value.fetch_all = async_mock.CoroutineMock(
-            return_value=[]
-        )
+        mock_find_all_records.return_value = []
 
         mock_get_schema.return_value = {"seqNo": 999}
         cred_def_id = f"{self.test_did}:3:CL:999:default"
@@ -2800,9 +2789,9 @@ class TestIndySdkLedger(AsyncTestCase):
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_open")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_close")
     @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.add_record")
-    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.search_records")
+    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.find_all_records")
     async def test_accept_and_get_latest_txn_author_agreement(
-        self, mock_search_records, mock_add_record, mock_close, mock_open
+        self, mock_find_all_records, mock_add_record, mock_close, mock_open
     ):
         mock_wallet = async_mock.MagicMock()
 
@@ -2824,15 +2813,13 @@ class TestIndySdkLedger(AsyncTestCase):
             "time": accept_time,
         }
 
-        mock_search_records.return_value.fetch_all = async_mock.CoroutineMock(
-            return_value=[
-                StorageRecord(
-                    TAA_ACCEPTED_RECORD_TYPE,
-                    json.dumps(acceptance),
-                    {"pool_name": ledger.pool_name},
-                )
-            ]
-        )
+        mock_find_all_records.return_value = [
+            StorageRecord(
+                TAA_ACCEPTED_RECORD_TYPE,
+                json.dumps(acceptance),
+                {"pool_name": ledger.pool_name},
+            )
+        ]
 
         async with ledger:
             await ledger.accept_txn_author_agreement(
@@ -2848,9 +2835,9 @@ class TestIndySdkLedger(AsyncTestCase):
 
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_open")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_close")
-    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.search_records")
+    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.find_all_records")
     async def test_get_latest_txn_author_agreement_none(
-        self, mock_search_records, mock_close, mock_open
+        self, mock_find_all_records, mock_close, mock_open
     ):
         mock_wallet = async_mock.MagicMock()
 
@@ -2858,9 +2845,7 @@ class TestIndySdkLedger(AsyncTestCase):
             IndySdkLedgerPool("name", checked=True, cache=InMemoryCache()), mock_wallet
         )
 
-        mock_search_records.return_value.fetch_all = async_mock.CoroutineMock(
-            return_value=[]
-        )
+        mock_find_all_records.return_value = []
 
         async with ledger:
             await ledger.pool.cache.clear(

--- a/aries_cloudagent/messaging/credential_definitions/tests/test_routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/tests/test_routes.py
@@ -34,18 +34,14 @@ class TestCredentialDefinitionRoutes(AsyncTestCase):
         self.ledger.get_credential_definition = async_mock.CoroutineMock(
             return_value={"cred": "def"}
         )
-        self.session_inject[BaseLedger] = self.ledger
+        self.context.injector.bind_instance(BaseLedger, self.ledger)
 
         self.issuer = async_mock.create_autospec(IndyIssuer)
-        self.session_inject[IndyIssuer] = self.issuer
+        self.context.injector.bind_instance(IndyIssuer, self.issuer)
 
         self.storage = async_mock.create_autospec(BaseStorage)
-        self.storage.search_records = async_mock.MagicMock(
-            return_value=async_mock.MagicMock(
-                fetch_all=async_mock.CoroutineMock(
-                    return_value=[async_mock.MagicMock(value=CRED_DEF_ID)]
-                )
-            )
+        self.storage.find_all_records = async_mock.CoroutineMock(
+            return_value=[async_mock.MagicMock(value=CRED_DEF_ID)]
         )
         self.session_inject[BaseStorage] = self.storage
 
@@ -226,7 +222,7 @@ class TestCredentialDefinitionRoutes(AsyncTestCase):
             }
         )
 
-        self.session_inject[BaseLedger] = None
+        self.context.injector.clear_binding(BaseLedger)
         with self.assertRaises(test_module.web.HTTPForbidden):
             await test_module.credential_definitions_send_credential_definition(
                 self.request
@@ -274,7 +270,7 @@ class TestCredentialDefinitionRoutes(AsyncTestCase):
     async def test_get_credential_definition_no_ledger(self):
         self.request.match_info = {"cred_def_id": CRED_DEF_ID}
 
-        self.session_inject[BaseLedger] = None
+        self.context.injector.clear_binding(BaseLedger)
         with self.assertRaises(test_module.web.HTTPForbidden):
             await test_module.credential_definitions_get_credential_definition(
                 self.request

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -218,14 +218,13 @@ class BaseRecord(BaseModel):
                 with sequence values specifying alternatives to match (hit any)
         """
         storage = session.inject(BaseStorage)
-        query = storage.search_records(
+        rows = await storage.find_all_records(
             cls.RECORD_TYPE,
             cls.prefix_tag_filter(tag_filter),
-            None,
-            {"retrieveTags": False},
+            options={"retrieveTags": False},
         )
         found = None
-        async for record in query:
+        for record in rows:
             vals = json.loads(record.value)
             if match_post_filter(vals, post_filter, alt=False):
                 if found:
@@ -266,14 +265,13 @@ class BaseRecord(BaseModel):
                 values in post_filter
         """
         storage = session.inject(BaseStorage)
-        query = storage.search_records(
+        rows = await storage.find_all_records(
             cls.RECORD_TYPE,
             cls.prefix_tag_filter(tag_filter),
-            None,
-            {"retrieveTags": False},
+            options={"retrieveTags": False},
         )
         result = []
-        async for record in query:
+        for record in rows:
             vals = json.loads(record.value)
             if match_post_filter(
                 vals,

--- a/aries_cloudagent/messaging/models/tests/test_base_record.py
+++ b/aries_cloudagent/messaging/models/tests/test_base_record.py
@@ -167,10 +167,10 @@ class TestBaseRecord(AsyncTestCase):
             BaseRecordImpl.RECORD_TYPE, json.dumps(record_value), {}, record_id
         )
 
-        mock_storage.search_records.return_value.__aiter__.return_value = [stored]
+        mock_storage.find_all_records.return_value = [stored]
         result = await BaseRecordImpl.query(session, tag_filter)
-        mock_storage.search_records.assert_called_once_with(
-            BaseRecordImpl.RECORD_TYPE, tag_filter, None, {"retrieveTags": False}
+        mock_storage.find_all_records.assert_awaited_once_with(
+            BaseRecordImpl.RECORD_TYPE, tag_filter, options={"retrieveTags": False}
         )
         assert result and isinstance(result[0], BaseRecordImpl)
         assert result[0]._id == record_id
@@ -193,17 +193,16 @@ class TestBaseRecord(AsyncTestCase):
             {"code": "red"},
             record_id,
         )
-        mock_storage.search_records.return_value.__aiter__.return_value = [stored]
+        mock_storage.find_all_records.return_value = [stored]
 
         # positive match
         result = await ARecordImpl.query(
             session, tag_filter, post_filter_positive={"a": "one"}
         )
-        mock_storage.search_records.assert_called_once_with(
+        mock_storage.find_all_records.assert_awaited_once_with(
             ARecordImpl.RECORD_TYPE,
             tag_filter,
-            None,
-            {"retrieveTags": False},
+            options={"retrieveTags": False},
         )
         assert result and isinstance(result[0], ARecordImpl)
         assert result[0]._id == record_id

--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -122,15 +122,14 @@ async def schemas_send_schema(request: web.BaseRequest):
     schema_version = body.get("schema_version")
     attributes = body.get("attributes")
 
-    session = await context.session()
-    ledger = session.inject(BaseLedger, required=False)
+    ledger = context.inject(BaseLedger, required=False)
     if not ledger:
         reason = "No ledger available"
-        if not session.settings.get_value("wallet.type"):
+        if not context.settings.get_value("wallet.type"):
             reason += ": missing wallet-type?"
         raise web.HTTPForbidden(reason=reason)
 
-    issuer = session.inject(IndyIssuer)
+    issuer = context.inject(IndyIssuer)
     async with ledger:
         try:
             schema_id, schema_def = await shield(
@@ -165,12 +164,12 @@ async def schemas_created(request: web.BaseRequest):
 
     session = await context.session()
     storage = session.inject(BaseStorage)
-    found = await storage.search_records(
+    found = await storage.find_all_records(
         type_filter=SCHEMA_SENT_RECORD_TYPE,
         tag_query={
             tag: request.query[tag] for tag in SCHEMA_TAGS if tag in request.query
         },
-    ).fetch_all()
+    )
 
     return web.json_response({"schema_ids": [record.value for record in found]})
 
@@ -193,11 +192,10 @@ async def schemas_get_schema(request: web.BaseRequest):
 
     schema_id = request.match_info["schema_id"]
 
-    session = await context.session()
-    ledger = session.inject(BaseLedger, required=False)
+    ledger = context.inject(BaseLedger, required=False)
     if not ledger:
         reason = "No ledger available"
-        if not session.settings.get_value("wallet.type"):
+        if not context.settings.get_value("wallet.type"):
             reason += ": missing wallet-type?"
         raise web.HTTPForbidden(reason=reason)
 

--- a/aries_cloudagent/messaging/schemas/tests/test_routes.py
+++ b/aries_cloudagent/messaging/schemas/tests/test_routes.py
@@ -32,18 +32,14 @@ class TestSchemaRoutes(AsyncTestCase):
         self.ledger.get_schema = async_mock.CoroutineMock(
             return_value={"schema": "def"}
         )
-        self.session_inject[BaseLedger] = self.ledger
+        self.context.injector.bind_instance(BaseLedger, self.ledger)
 
         self.issuer = async_mock.create_autospec(IndyIssuer)
-        self.session_inject[IndyIssuer] = self.issuer
+        self.context.injector.bind_instance(IndyIssuer, self.issuer)
 
         self.storage = async_mock.create_autospec(BaseStorage)
-        self.storage.search_records = async_mock.MagicMock(
-            return_value=async_mock.MagicMock(
-                fetch_all=async_mock.CoroutineMock(
-                    return_value=[async_mock.MagicMock(value=SCHEMA_ID)]
-                )
-            )
+        self.storage.find_all_records = async_mock.CoroutineMock(
+            return_value=[async_mock.MagicMock(value=SCHEMA_ID)]
         )
         self.session_inject[BaseStorage] = self.storage
 
@@ -72,7 +68,7 @@ class TestSchemaRoutes(AsyncTestCase):
             }
         )
 
-        self.session_inject[BaseLedger] = None
+        self.context.injector.clear_binding(BaseLedger)
         with self.assertRaises(test_module.web.HTTPForbidden):
             await test_module.schemas_send_schema(self.request)
 
@@ -121,7 +117,7 @@ class TestSchemaRoutes(AsyncTestCase):
             side_effect=test_module.LedgerError("Down for routine maintenance")
         )
 
-        self.session_inject[BaseLedger] = None
+        self.context.injector.clear_binding(BaseLedger)
         with self.assertRaises(test_module.web.HTTPForbidden):
             await test_module.schemas_get_schema(self.request)
 

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -932,11 +932,7 @@ class ConnectionManager:
             did: The DID to remove keys for
         """
         storage = self._session.inject(BaseStorage)
-        keys = await storage.search_records(
-            self.RECORD_TYPE_DID_KEY, {"did": did}
-        ).fetch_all()
-        for record in keys:
-            await storage.delete_record(record)
+        await storage.delete_all_records(self.RECORD_TYPE_DID_KEY, {"did": did})
 
     async def get_connection_targets(
         self, *, connection_id: str = None, connection: ConnRecord = None

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -699,11 +699,7 @@ class DIDXManager:
             did: The DID for which to remove keys
         """
         storage = self._session.inject(BaseStorage)
-        keys = await storage.search_records(
-            DIDXManager.RECORD_TYPE_DID_KEY, {"did": did}
-        ).fetch_all()
-        for record in keys:
-            await storage.delete_record(record)
+        await storage.delete_all_records(DIDXManager.RECORD_TYPE_DID_KEY, {"did": did})
 
     async def verify_diddoc(
         self,

--- a/aries_cloudagent/protocols/introduction/v0_1/demo_service.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/demo_service.py
@@ -111,10 +111,10 @@ class DemoIntroductionService(BaseIntroductionService):
         tag_filter = {"target_connection_id": target_connection_id}
         session = await self._context.session()
         storage = session.inject(BaseStorage)
-        records = await storage.search_records(
+        records = await storage.find_all_records(
             DemoIntroductionService.RECORD_TYPE,
             tag_filter,
-        ).fetch_all()
+        )
 
         found = False
         for row in records:

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -65,9 +65,9 @@ class CredentialManager:
 
         async with self._profile.session() as session:
             storage = session.inject(BaseStorage)
-            found = await storage.search_records(
+            found = await storage.find_all_records(
                 type_filter=CRED_DEF_SENT_RECORD_TYPE, tag_query=tag_query
-            ).fetch_all()
+            )
         if not found:
             raise CredentialManagerError(
                 f"Issuer has no operable cred def for proposal spec {tag_query}"

--- a/aries_cloudagent/protocols/routing/v1_0/manager.py
+++ b/aries_cloudagent/protocols/routing/v1_0/manager.py
@@ -118,7 +118,9 @@ class RoutingManager:
 
         results = []
         storage = self._session.inject(BaseStorage)
-        async for record in storage.search_records(RoutingManager.RECORD_TYPE, filters):
+        for record in await storage.find_all_records(
+            RoutingManager.RECORD_TYPE, filters
+        ):
             value = json.loads(record.value)
             value.update(record.tags)
             results.append(RouteRecord(**value))

--- a/aries_cloudagent/revocation/models/tests/test_issuer_cred_rev_record.py
+++ b/aries_cloudagent/revocation/models/tests/test_issuer_cred_rev_record.py
@@ -1,10 +1,7 @@
-import json
-
-from asynctest import TestCase as AsyncTestCase, mock as async_mock
+from asynctest import TestCase as AsyncTestCase
 
 from ....core.in_memory import InMemoryProfile
 from ....storage.base import StorageNotFoundError
-from ....wallet.base import DIDInfo
 
 from .. import issuer_cred_rev_record as test_module
 from ..issuer_cred_rev_record import IssuerCredRevRecord
@@ -14,7 +11,7 @@ CRED_DEF_ID = f"{TEST_DID}:3:CL:1234:default"
 REV_REG_ID = f"{TEST_DID}:4:{CRED_DEF_ID}:CL_ACCUM:0"
 
 
-class TestRecord(AsyncTestCase):
+class TestIssuerCredRevRecord(AsyncTestCase):
     def setUp(self):
         self.session = InMemoryProfile.test_session()
 

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -374,10 +374,10 @@ async def create_rev_reg(request: web.BaseRequest):
     # check we published this cred def
     storage = session.inject(BaseStorage)
 
-    found = await storage.search_records(
+    found = await storage.find_all_records(
         type_filter=CRED_DEF_SENT_RECORD_TYPE,
         tag_query={"cred_def_id": credential_definition_id},
-    ).fetch_all()
+    )
     if not found:
         raise web.HTTPNotFound(
             reason=f"Not issuer of credential definition id {credential_definition_id}"

--- a/aries_cloudagent/revocation/tests/test_routes.py
+++ b/aries_cloudagent/revocation/tests/test_routes.py
@@ -211,15 +211,13 @@ class TestRevocationRoutes(AsyncTestCase):
         )
 
         with async_mock.patch.object(
-            InMemoryStorage, "search_records", autospec=True
-        ) as mock_search, async_mock.patch.object(
+            InMemoryStorage, "find_all_records", autospec=True
+        ) as mock_find, async_mock.patch.object(
             test_module, "IndyRevocation", autospec=True
         ) as mock_indy_revoc, async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as mock_json_response:
-            mock_search.return_value.fetch_all = async_mock.CoroutineMock(
-                return_value=True
-            )
+            mock_find.return_value = True
             mock_indy_revoc.return_value = async_mock.MagicMock(
                 init_issuer_registry=async_mock.CoroutineMock(
                     return_value=async_mock.MagicMock(
@@ -243,13 +241,11 @@ class TestRevocationRoutes(AsyncTestCase):
         )
 
         with async_mock.patch.object(
-            InMemoryStorage, "search_records", autospec=True
-        ) as mock_search, async_mock.patch.object(
+            InMemoryStorage, "find_all_records", autospec=True
+        ) as mock_find, async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as mock_json_response:
-            mock_search.return_value.fetch_all = async_mock.CoroutineMock(
-                return_value=False
-            )
+            mock_find.return_value = False
 
             with self.assertRaises(HTTPNotFound):
                 result = await test_module.create_rev_reg(self.request)
@@ -265,15 +261,13 @@ class TestRevocationRoutes(AsyncTestCase):
         )
 
         with async_mock.patch.object(
-            InMemoryStorage, "search_records", autospec=True
-        ) as mock_search, async_mock.patch.object(
+            InMemoryStorage, "find_all_records", autospec=True
+        ) as mock_find, async_mock.patch.object(
             test_module, "IndyRevocation", autospec=True
         ) as mock_indy_revoc, async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as mock_json_response:
-            mock_search.return_value.fetch_all = async_mock.CoroutineMock(
-                return_value=True
-            )
+            mock_find = True
             mock_indy_revoc.return_value = async_mock.MagicMock(
                 init_issuer_registry=async_mock.CoroutineMock(
                     side_effect=test_module.RevocationNotSupportedError(

--- a/aries_cloudagent/storage/base.py
+++ b/aries_cloudagent/storage/base.py
@@ -95,13 +95,32 @@ class BaseStorage(ABC):
         return results[0]
 
     @abstractmethod
+    async def find_all_records(
+        self,
+        type_filter: str,
+        tag_query: Mapping = None,
+        options: Mapping = None,
+    ):
+        """Retrieve all records matching a particular type filter and tag query."""
+
+    @abstractmethod
+    async def delete_all_records(
+        self,
+        type_filter: str,
+        tag_query: Mapping = None,
+    ):
+        """Remove all records matching a particular type filter and tag query."""
+
+
+class BaseStorageSearch(ABC):
+    @abstractmethod
     def search_records(
         self,
         type_filter: str,
         tag_query: Mapping = None,
         page_size: int = None,
         options: Mapping = None,
-    ) -> "BaseStorageRecordSearch":
+    ) -> "BaseStorageSearchSession":
         """
         Create a new record query.
 
@@ -112,7 +131,7 @@ class BaseStorage(ABC):
             options: Dictionary of backend-specific options
 
         Returns:
-            An instance of `BaseStorageRecordSearch`
+            An instance of `BaseStorageSearchSession`
 
         """
 
@@ -121,7 +140,7 @@ class BaseStorage(ABC):
         return "<{}>".format(self.__class__.__name__)
 
 
-class BaseStorageRecordSearch(ABC):
+class BaseStorageSearchSession(ABC):
     """Represent an active stored records search."""
 
     @abstractmethod
@@ -157,14 +176,14 @@ class BaseStorageRecordSearch(ABC):
         return IterSearch(self)
 
     def __repr__(self) -> str:
-        """Human readable representation of `BaseStorageRecordSearch`."""
+        """Human readable representation of this instance."""
         return "<{}>".format(self.__class__.__name__)
 
 
 class IterSearch:
     """A generic record search async iterator."""
 
-    def __init__(self, search: BaseStorageRecordSearch, page_size: int = None):
+    def __init__(self, search: BaseStorageSearchSession, page_size: int = None):
         """Instantiate a new `IterSearch` instance."""
         self._buffer = None
         self._page_size = page_size

--- a/aries_cloudagent/storage/base.py
+++ b/aries_cloudagent/storage/base.py
@@ -23,7 +23,7 @@ def validate_record(record: StorageRecord, *, delete=False):
 
 
 class BaseStorage(ABC):
-    """Abstract Non-Secrets interface."""
+    """Abstract stored records interface."""
 
     @abstractmethod
     async def add_record(self, record: StorageRecord):
@@ -113,6 +113,8 @@ class BaseStorage(ABC):
 
 
 class BaseStorageSearch(ABC):
+    """Abstract stored records search interface."""
+
     @abstractmethod
     def search_records(
         self,
@@ -141,7 +143,7 @@ class BaseStorageSearch(ABC):
 
 
 class BaseStorageSearchSession(ABC):
-    """Represent an active stored records search."""
+    """Abstract stored records search session interface."""
 
     @abstractmethod
     async def fetch(self, max_count: int = None) -> Sequence[StorageRecord]:
@@ -156,17 +158,6 @@ class BaseStorageSearchSession(ABC):
             A list of `StorageRecord` instances
 
         """
-
-    async def fetch_all(self) -> Sequence[StorageRecord]:
-        """Fetch all records from the query."""
-        results = []
-        while True:
-            buf = await self.fetch()
-            if buf:
-                results.extend(buf)
-            else:
-                break
-        return results
 
     async def close(self):
         """Dispose of the search query."""

--- a/aries_cloudagent/storage/indy.py
+++ b/aries_cloudagent/storage/indy.py
@@ -175,9 +175,15 @@ class IndySdkStorage(BaseStorage, BaseStorageSearch):
         options: Mapping = None,
     ):
         """Retrieve all records matching a particular type filter and tag query."""
-        return await self.search_records(
-            type_filter, tag_query, options=options
-        ).fetch_all()
+        results = []
+        search = self.search_records(type_filter, tag_query, options=options)
+        while True:
+            buf = await search.fetch()
+            if buf:
+                results.extend(buf)
+            else:
+                break
+        return results
 
     async def delete_all_records(
         self,

--- a/aries_cloudagent/storage/indy.py
+++ b/aries_cloudagent/storage/indy.py
@@ -11,7 +11,8 @@ from indy.error import IndyError, ErrorCode
 from .base import (
     DEFAULT_PAGE_SIZE,
     BaseStorage,
-    BaseStorageRecordSearch,
+    BaseStorageSearch,
+    BaseStorageSearchSession,
     validate_record,
 )
 from .error import (
@@ -26,7 +27,7 @@ from ..indy.sdk.wallet_setup import IndyOpenWallet
 LOGGER = logging.getLogger(__name__)
 
 
-class IndySdkStorage(BaseStorage):
+class IndySdkStorage(BaseStorage, BaseStorageSearch):
     """Indy Non-Secrets interface."""
 
     def __init__(self, wallet: IndyOpenWallet):
@@ -167,6 +168,28 @@ class IndySdkStorage(BaseStorage):
                 raise StorageNotFoundError(f"Record not found: {record.id}")
             raise StorageError(str(x_indy))
 
+    async def find_all_records(
+        self,
+        type_filter: str,
+        tag_query: Mapping = None,
+        options: Mapping = None,
+    ):
+        """Retrieve all records matching a particular type filter and tag query."""
+        return await self.search_records(
+            type_filter, tag_query, options=options
+        ).fetch_all()
+
+    async def delete_all_records(
+        self,
+        type_filter: str,
+        tag_query: Mapping = None,
+    ):
+        """Remove all records matching a particular type filter and tag query."""
+        async for row in self.search_records(
+            type_filter, tag_query, options={"retrieveTags": False}
+        ):
+            await self.delete_record(row)
+
     def search_records(
         self,
         type_filter: str,
@@ -190,7 +213,7 @@ class IndySdkStorage(BaseStorage):
         return IndySdkStorageSearch(self, type_filter, tag_query, page_size, options)
 
 
-class IndySdkStorageSearch(BaseStorageRecordSearch):
+class IndySdkStorageSearch(BaseStorageSearchSession):
     """Represent an active stored records search."""
 
     def __init__(

--- a/aries_cloudagent/storage/tests/test_in_memory_storage.py
+++ b/aries_cloudagent/storage/tests/test_in_memory_storage.py
@@ -23,6 +23,12 @@ def store():
     yield InMemoryStorage(profile)
 
 
+@pytest.fixture()
+def store_search():
+    profile = InMemoryProfile.test_profile()
+    yield InMemoryStorage(profile)
+
+
 def test_record(tags={}):
     return StorageRecord(type="TYPE", value="TEST", tags=tags)
 
@@ -102,42 +108,17 @@ class TestInMemoryStorage:
             await store.update_record(missing, missing.value, {})
 
     @pytest.mark.asyncio
-    async def test_search(self, store):
+    async def test_find_record(self, store):
         record = test_record()
         await store.add_record(record)
 
-        # search
-        search = store.search_records(record.type, {}, None)
-        assert search.__class__.__name__ in str(search)
-        rows = await search.fetch(100)
-        assert len(rows) == 1
-        found = rows[0]
+        # search with find_record
+        found = await store.find_record(record.type, {}, None)
+        assert found
         assert found.id == record.id
         assert found.type == record.type
         assert found.value == record.value
         assert found.tags == record.tags
-        more = await search.fetch(100)
-        assert len(more) == 0
-
-        # search again with fetch-all
-        search = store.search_records(record.type, {}, None)
-        rows = await search.fetch_all()
-        assert len(rows) == 1
-
-        # search again with with iterator mystery error
-        search = store.search_records(record.type, {}, None)
-        with async_mock.patch.object(
-            search, "fetch", async_mock.CoroutineMock()
-        ) as mock_fetch:
-            mock_fetch.return_value = async_mock.MagicMock(
-                pop=async_mock.MagicMock(side_effect=IndexError())
-            )
-            async for row in search:
-                pytest.fail("Should not arrive here")
-
-        # search with find_record
-        row = await store.find_record(record.type, {}, None)
-        assert row
 
         # search again with find_record on no rows
         with pytest.raises(StorageNotFoundError):
@@ -150,11 +131,72 @@ class TestInMemoryStorage:
             await store.find_record(record.type, {}, None)
 
     @pytest.mark.asyncio
-    async def test_iter_search(self, store):
+    async def test_find_all(self, store):
         record = test_record()
         await store.add_record(record)
+
+        # search
+        rows = await store.find_all_records(record.type, {}, None)
+        assert len(rows) == 1
+        found = rows[0]
+        assert found.id == record.id
+        assert found.type == record.type
+        assert found.value == record.value
+        assert found.tags == record.tags
+
+    @pytest.mark.asyncio
+    async def test_delete_all(self, store):
+        record = test_record({"tag": "one"})
+        await store.add_record(record)
+
+        await store.delete_all_records(record.type, {"tag": "two"})
+        assert await store.find_record(record.type, {}, None)
+
+        await store.delete_all_records(record.type, {"tag": "one"})
+        with pytest.raises(StorageNotFoundError):
+            await store.find_record(record.type, {}, None)
+
+
+class TestInMemoryStorageSearch:
+    @pytest.mark.asyncio
+    async def test_search(self, store_search):
+        record = test_record()
+        await store_search.add_record(record)
+
+        # search
+        search = store_search.search_records(record.type, {}, None)
+        assert search.__class__.__name__ in str(search)
+        rows = await search.fetch(100)
+        assert len(rows) == 1
+        found = rows[0]
+        assert found.id == record.id
+        assert found.type == record.type
+        assert found.value == record.value
+        assert found.tags == record.tags
+        more = await search.fetch(100)
+        assert len(more) == 0
+
+        # search again with fetch-all
+        rows = await store_search.find_all_records(record.type, {}, None)
+        assert len(rows) == 1
+
+        # search again with with iterator mystery error
+        search = store_search.search_records(record.type, {}, None)
+        with async_mock.patch.object(
+            search, "fetch", async_mock.CoroutineMock()
+        ) as mock_fetch:
+            mock_fetch.return_value = async_mock.MagicMock(
+                pop=async_mock.MagicMock(side_effect=IndexError())
+            )
+            async for row in search:
+                pytest.fail("Should not arrive here")
+
+    @pytest.mark.asyncio
+    async def test_iter_search(self, store_search):
+        record = test_record()
+        await store_search.add_record(record)
         count = 0
-        search = store.search_records(record.type, {}, None)
+        search = store_search.search_records(record.type, {}, None)
         async for found in search:
             assert found.id == record.id
             assert found.type == record.type
@@ -164,12 +206,14 @@ class TestInMemoryStorage:
         assert count == 1
 
     @pytest.mark.asyncio
-    async def test_closed_search(self, store):
-        search = store.search_records("TYPE", {}, None)
+    async def test_closed_search(self, store_search):
+        search = store_search.search_records("TYPE", {}, None)
         _rows = await search.fetch_all()
         with pytest.raises(StorageSearchError):
             await search.fetch(100)
 
+
+class TestInMemoryTagQuery:
     @pytest.mark.asyncio
     async def test_tag_value_match(self, store):
         TAGS = {"a": "aardvark", "b": "bear", "z": "0"}

--- a/aries_cloudagent/storage/tests/test_in_memory_storage.py
+++ b/aries_cloudagent/storage/tests/test_in_memory_storage.py
@@ -208,7 +208,7 @@ class TestInMemoryStorageSearch:
     @pytest.mark.asyncio
     async def test_closed_search(self, store_search):
         search = store_search.search_records("TYPE", {}, None)
-        _rows = await search.fetch_all()
+        _rows = await search.fetch()
         with pytest.raises(StorageSearchError):
             await search.fetch(100)
 

--- a/aries_cloudagent/storage/tests/test_indy_storage.py
+++ b/aries_cloudagent/storage/tests/test_indy_storage.py
@@ -296,7 +296,7 @@ class TestIndySdkStorage(test_in_memory_storage.TestInMemoryStorage):
                 mock_indy_close_search.side_effect = test_module.IndyError("no close")
                 search = storage.search_records("connection")
                 with pytest.raises(StorageSearchError):
-                    await search.fetch_all()
+                    await search.fetch()
 
     @pytest.mark.asyncio
     async def test_storage_del_close(self):


### PR DESCRIPTION
- Add `find_all_records`, `delete_all_records` to `BaseStorage` interface for both convenience and optimization under Askar backend
- Move `search_records` to `BaseStorageSearch` interface, provided at profile level
- Fixes for session usage in `credential_definition`, `schema` routes
