### PR TITLE
allow for distinct upload and download tails server base URLs

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -452,6 +452,14 @@ class GeneralGroup(ArgumentGroup):
             env_var="ACAPY_TAILS_SERVER_BASE_URL",
             help="Sets the base url of the tails server in use.",
         )
+        parser.add_argument(
+            "--tails-server-upload-url",
+            type=str,
+            metavar="<tails-server-upload-url>",
+            env_var="ACAPY_TAILS_SERVER_UPLOAD_URL",
+            help="Sets the base url of the tails server for upload, defaulting to the\
+            tails server base url.",
+        )
 
     def get_settings(self, args: Namespace) -> dict:
         """Extract general settings."""
@@ -473,6 +481,9 @@ class GeneralGroup(ArgumentGroup):
             settings["read_only_ledger"] = True
         if args.tails_server_base_url:
             settings["tails_server_base_url"] = args.tails_server_base_url
+            settings["tails_server_upload_url"] = args.tails_server_base_url
+        if args.tails_server_upload_url:
+            settings["tails_server_upload_url"] = args.tails_server_upload_url
         return settings
 
 

--- a/aries_cloudagent/tails/indy_tails_server.py
+++ b/aries_cloudagent/tails/indy_tails_server.py
@@ -30,18 +30,18 @@ class IndyTailsServer(BaseTailsServer):
         """
 
         genesis_transactions = context.settings.get("ledger.genesis_transactions")
-        tails_server_base_url = context.settings.get("tails_server_base_url")
+        tails_server_upload_url = context.settings.get("tails_server_upload_url")
 
-        if not tails_server_base_url:
+        if not tails_server_upload_url:
             raise TailsServerNotConfiguredError(
-                "tails_server_base_url setting is not set"
+                "tails_server_upload_url setting is not set"
             )
 
         try:
             return (
                 True,
                 await put(
-                    f"{tails_server_base_url}/{rev_reg_id}",
+                    f"{tails_server_upload_url}/{rev_reg_id}",
                     {"tails": tails_file_path},
                     {"genesis": genesis_transactions},
                     interval=interval,

--- a/aries_cloudagent/tails/tests/test_indy.py
+++ b/aries_cloudagent/tails/tests/test_indy.py
@@ -11,7 +11,7 @@ REV_REG_ID = f"{TEST_DID}:4:{CRED_DEF_ID}:CL_ACCUM:0"
 
 
 class TestIndyTailsServer(AsyncTestCase):
-    async def test_upload_no_tails_base_url_x(self):
+    async def test_upload_no_tails_upload_url_x(self):
         context = InjectionContext(settings={"ledger.genesis_transactions": "dummy"})
         indy_tails = test_module.IndyTailsServer()
 
@@ -22,7 +22,7 @@ class TestIndyTailsServer(AsyncTestCase):
         context = InjectionContext(
             settings={
                 "ledger.genesis_transactions": "dummy",
-                "tails_server_base_url": "http://1.2.3.4:8088",
+                "tails_server_upload_url": "http://1.2.3.4:8088",
             }
         )
         indy_tails = test_module.IndyTailsServer()
@@ -43,7 +43,7 @@ class TestIndyTailsServer(AsyncTestCase):
         context = InjectionContext(
             settings={
                 "ledger.genesis_transactions": "dummy",
-                "tails_server_base_url": "http://1.2.3.4:8088",
+                "tails_server_upload_url": "http://1.2.3.4:8088",
             }
         )
         indy_tails = test_module.IndyTailsServer()


### PR DESCRIPTION
Implement distinct upload/download base URL for tails server in https://github.com/hyperledger/aries-cloudagent-python/pull/807; default upload to base.

Signed-off-by: sklump <srklump@hotmail.com>