### PR TITLE
Add wallet type to agent runners, other fixes

### DIFF
--- a/aries_cloudagent/protocols/out_of_band/v1_0/messages/invitation.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/messages/invitation.py
@@ -130,7 +130,7 @@ class InvitationMessageSchema(AgentMessageSchema):
     label = fields.Str(required=False, description="Optional label", example="Bob")
     handshake_protocols = fields.List(fields.String, required=False, many=True)
     request_attach = fields.Nested(
-        AttachDecoratorSchema, required=True, many=True, data_key="request~attach"
+        AttachDecoratorSchema, required=False, many=True, data_key="request~attach"
     )
 
     service_blocks = fields.Nested(ServiceSchema, many=True)
@@ -191,5 +191,8 @@ class InvitationMessageSchema(AgentMessageSchema):
 
         del data["service_dids"]
         del data["service_blocks"]
+
+        if "request~attach" in data and not data["request~attach"]:
+            del data["request~attach"]
 
         return data

--- a/aries_cloudagent/protocols/out_of_band/v1_0/messages/service.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/messages/service.py
@@ -2,7 +2,7 @@
 
 from typing import Sequence
 
-from marshmallow import EXCLUDE, fields
+from marshmallow import EXCLUDE, fields, post_dump
 
 from .....messaging.models.base import BaseModel, BaseModelSchema
 from .....messaging.valid import INDY_DID, DID_KEY
@@ -78,3 +78,12 @@ class ServiceSchema(BaseModelSchema):
         description="Service endpoint at which to reach this agent",
         example="http://192.168.56.101:8020",
     )
+
+    @post_dump
+    def post_dump(self, data, **kwargs):
+        """Post dump hook."""
+
+        if "routingKeys" in data and not data["routingKeys"]:
+            del data["routingKeys"]
+
+        return data

--- a/aries_cloudagent/protocols/out_of_band/v1_0/models/invitation.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/models/invitation.py
@@ -31,6 +31,7 @@ class InvitationRecord(BaseExchangeRecord):
         self,
         *,
         invitation_id: str = None,
+        invitation_url: str = None,
         state: str = None,
         invi_msg_id: str = None,
         invitation: dict = None,

--- a/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
@@ -99,7 +99,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             assert invi_rec.invitation["@type"] == DIDCommPrefix.qualify_current(
                 INVITATION
             )
-            assert not invi_rec.invitation["request~attach"]
+            assert not invi_rec.invitation.get("request~attach")
             assert invi_rec.invitation["label"] == "This guy"
             assert (
                 DIDCommPrefix.qualify_current(INVITATION)
@@ -221,7 +221,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
         )
 
         assert invi_rec.invitation["@type"] == DIDCommPrefix.qualify_current(INVITATION)
-        assert not invi_rec.invitation["request~attach"]
+        assert not invi_rec.invitation.get("request~attach")
         assert invi_rec.invitation["label"] == "That guy"
         assert (
             DIDCommPrefix.qualify_current(INVITATION)
@@ -231,7 +231,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
         assert service["id"] == "#inline"
         assert service["type"] == "did-communication"
         assert len(service["recipientKeys"]) == 1
-        assert not service["routingKeys"]
+        assert not service.get("routingKeys")
         assert service["serviceEndpoint"] == TestConfig.test_endpoint
 
     async def test_receive_invitation_service_block(self):

--- a/demo/runners/acme.py
+++ b/demo/runners/acme.py
@@ -6,8 +6,8 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))  # noqa
 
-from runners.support.agent import DemoAgent, default_genesis_txns
-from runners.support.utils import (
+from runners.support.agent import DemoAgent, default_genesis_txns  # noqa:E402
+from runners.support.utils import (  # noqa:E402
     log_msg,
     log_status,
     log_timer,

--- a/demo/runners/alice.py
+++ b/demo/runners/alice.py
@@ -188,6 +188,9 @@ async def input_invitation(agent):
             if query and "c_i=" in query:
                 pos = query.index("c_i=") + 4
                 b64_invite = query[pos:]
+            elif query and "oob=" in query:
+                pos = query.index("oob=") + 4
+                b64_invite = query[pos:]
             else:
                 b64_invite = details
         except ValueError:
@@ -213,7 +216,14 @@ async def input_invitation(agent):
                 log_msg("Invalid invitation:", str(e))
 
     with log_timer("Connect duration:"):
-        connection = await agent.admin_POST("/didexchange/receive-invitation", details)
+        if "/out-of-band/" in details["@type"]:
+            connection = await agent.admin_POST(
+                "/didexchange/receive-invitation", details
+            )
+        else:
+            connection = await agent.admin_POST(
+                "/connections/receive-invitation", details
+            )
         agent.connection_id = connection["connection_id"]
         log_json(connection, label="Invitation response:")
 

--- a/demo/runners/alice.py
+++ b/demo/runners/alice.py
@@ -7,10 +7,12 @@ import os
 import sys
 from urllib.parse import urlparse
 
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))  # noqa
+from aiohttp import ClientError
 
-from runners.support.agent import DemoAgent, default_genesis_txns
-from runners.support.utils import (
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from runners.support.agent import DemoAgent, default_genesis_txns  # noqa:E402
+from runners.support.utils import (  # noqa:E402
     log_json,
     log_msg,
     log_status,
@@ -20,7 +22,7 @@ from runners.support.utils import (
     require_indy,
 )
 
-
+logging.basicConfig(level=logging.WARNING)
 LOGGER = logging.getLogger(__name__)
 
 
@@ -121,54 +123,57 @@ class AliceAgent(DemoAgent):
             self_attested = {}
             predicates = {}
 
-            # select credentials to provide for the proof
-            credentials = await self.admin_GET(
-                f"/present-proof/records/{presentation_exchange_id}/credentials"
-            )
-            if credentials:
-                for row in sorted(
-                    credentials,
-                    key=lambda c: int(c["cred_info"]["attrs"]["timestamp"]),
-                    reverse=True,
-                ):
-                    for referent in row["presentation_referents"]:
-                        if referent not in credentials_by_reft:
-                            credentials_by_reft[referent] = row
+            try:
+                # select credentials to provide for the proof
+                credentials = await self.admin_GET(
+                    f"/present-proof/records/{presentation_exchange_id}/credentials"
+                )
+                if credentials:
+                    for row in sorted(
+                        credentials,
+                        key=lambda c: int(c["cred_info"]["attrs"]["timestamp"]),
+                        reverse=True,
+                    ):
+                        for referent in row["presentation_referents"]:
+                            if referent not in credentials_by_reft:
+                                credentials_by_reft[referent] = row
 
-            for referent in presentation_request["requested_attributes"]:
-                if referent in credentials_by_reft:
-                    revealed[referent] = {
-                        "cred_id": credentials_by_reft[referent]["cred_info"][
-                            "referent"
-                        ],
-                        "revealed": True,
-                    }
-                else:
-                    self_attested[referent] = "my self-attested value"
+                for referent in presentation_request["requested_attributes"]:
+                    if referent in credentials_by_reft:
+                        revealed[referent] = {
+                            "cred_id": credentials_by_reft[referent]["cred_info"][
+                                "referent"
+                            ],
+                            "revealed": True,
+                        }
+                    else:
+                        self_attested[referent] = "my self-attested value"
 
-            for referent in presentation_request["requested_predicates"]:
-                if referent in credentials_by_reft:
-                    predicates[referent] = {
-                        "cred_id": credentials_by_reft[referent]["cred_info"][
-                            "referent"
-                        ]
-                    }
+                for referent in presentation_request["requested_predicates"]:
+                    if referent in credentials_by_reft:
+                        predicates[referent] = {
+                            "cred_id": credentials_by_reft[referent]["cred_info"][
+                                "referent"
+                            ]
+                        }
 
-            log_status("#25 Generate the proof")
-            request = {
-                "requested_predicates": predicates,
-                "requested_attributes": revealed,
-                "self_attested_attributes": self_attested,
-            }
+                log_status("#25 Generate the proof")
+                request = {
+                    "requested_predicates": predicates,
+                    "requested_attributes": revealed,
+                    "self_attested_attributes": self_attested,
+                }
 
-            log_status("#26 Send the proof to X")
-            await self.admin_POST(
-                (
-                    "/present-proof/records/"
-                    f"{presentation_exchange_id}/send-presentation"
-                ),
-                request,
-            )
+                log_status("#26 Send the proof to X")
+                await self.admin_POST(
+                    (
+                        "/present-proof/records/"
+                        f"{presentation_exchange_id}/send-presentation"
+                    ),
+                    request,
+                )
+            except ClientError:
+                pass
 
     async def handle_basicmessages(self, message):
         self.log("Received message:", message["content"])
@@ -215,7 +220,12 @@ async def input_invitation(agent):
         await agent.detect_connection()
 
 
-async def main(start_port: int, no_auto: bool = False, show_timing: bool = False):
+async def main(
+    start_port: int,
+    no_auto: bool = False,
+    show_timing: bool = False,
+    wallet_type: str = None,
+):
 
     genesis = await default_genesis_txns()
     if not genesis:
@@ -225,13 +235,17 @@ async def main(start_port: int, no_auto: bool = False, show_timing: bool = False
     agent = None
 
     try:
-        log_status("#7 Provision an agent and wallet, get back configuration details")
+        log_status(
+            "#7 Provision an agent and wallet, get back configuration details"
+            + (f" (Wallet type: {wallet_type})" if wallet_type else "")
+        )
         agent = AliceAgent(
             start_port,
             start_port + 1,
             genesis_data=genesis,
             no_auto=no_auto,
             timing=show_timing,
+            wallet_type=wallet_type,
         )
         await agent.listen_webhooks(start_port + 2)
 
@@ -303,6 +317,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--timing", action="store_true", help="Enable timing information"
     )
+    parser.add_argument(
+        "--wallet-type",
+        type=str,
+        metavar="<wallet-type>",
+        help="Set the agent wallet type",
+    )
     args = parser.parse_args()
 
     ENABLE_PYDEVD_PYCHARM = os.getenv("ENABLE_PYDEVD_PYCHARM", "").lower()
@@ -337,7 +357,7 @@ if __name__ == "__main__":
 
     try:
         asyncio.get_event_loop().run_until_complete(
-            main(args.port, args.no_auto, args.timing)
+            main(args.port, args.no_auto, args.timing, args.wallet_type)
         )
     except KeyboardInterrupt:
         os._exit(1)

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -431,9 +431,8 @@ class DemoAgent:
         )
 
     async def handle_revocation_registry(self, message):
-        self.log(
-            f"Revocation registry: {message['revoc_reg_id']} state: {message['state']}"
-        )
+        reg_id = message.get("revoc_reg_id", "(undetermined)")
+        self.log(f"Revocation registry: {reg_id} state: {message['state']}")
 
     async def admin_request(
         self, method, path, data=None, text=False, params=None


### PR DESCRIPTION
- Add wallet-type to alice, faber, performance agents
- Enable basic logger for execution errors
- Check revocation option and tails-server-base option are consistent in performance demo
- In the performance demo, fetch the credential definition on alice's side before starting the credential exchange to reduce the initial delay (more accurate numbers)