### PR TITLE
feat(conn_record): add arbitrary metadata key-value storage

### DIFF
--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -367,8 +367,8 @@ class ConnRecord(BaseRecord):
         await self.clear_cached_key(session, cache_key)
 
     async def metadata_get(
-        self, session: ProfileSession, key: str, default: str = None
-    ) -> str:
+        self, session: ProfileSession, key: str, default: dict = None
+    ) -> dict:
         """Retrieve arbitrary metadata associated with this connection."""
         assert self.connection_id
         storage: BaseStorage = session.inject(BaseStorage)
@@ -377,13 +377,14 @@ class ConnRecord(BaseRecord):
                 self.RECORD_TYPE_METADATA,
                 {"key": key, "connection_id": self.connection_id},
             )
-            return record.value
+            return json.loads(record.value)
         except StorageNotFoundError:
             return default
 
-    async def metadata_set(self, session: ProfileSession, key: str, value: str):
+    async def metadata_set(self, session: ProfileSession, key: str, value: dict):
         """Set arbitrary metadata associated with this connection."""
         assert self.connection_id
+        value = json.dumps(value)
         storage: BaseStorage = session.inject(BaseStorage)
         try:
             record = await storage.find_record(

--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -119,7 +119,7 @@ class ConnRecord(BaseRecord):
     RECORD_TYPE = "connection"
     RECORD_TYPE_INVITATION = "connection_invitation"
     RECORD_TYPE_REQUEST = "connection_request"
-    RECORD_TYPE_METADATA = 'connection_metadata'
+    RECORD_TYPE_METADATA = "connection_metadata"
 
     INVITATION_MODE_ONCE = "once"
     INVITATION_MODE_MULTI = "multi"
@@ -375,7 +375,7 @@ class ConnRecord(BaseRecord):
         try:
             record = await storage.find_record(
                 self.RECORD_TYPE_METADATA,
-                {"key": key, "connection_id": self.connection_id}
+                {"key": key, "connection_id": self.connection_id},
             )
             return record.value
         except StorageNotFoundError:
@@ -388,14 +388,14 @@ class ConnRecord(BaseRecord):
         try:
             record = await storage.find_record(
                 self.RECORD_TYPE_METADATA,
-                {"key": key, "connection_id": self.connection_id}
+                {"key": key, "connection_id": self.connection_id},
             )
             await storage.update_record(record, value, record.tags)
         except StorageNotFoundError:
             record = StorageRecord(
                 self.RECORD_TYPE_METADATA,
                 value,
-                {"key": key, "connection_id": self.connection_id}
+                {"key": key, "connection_id": self.connection_id},
             )
             await storage.add_record(record)
 

--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -26,6 +26,7 @@ from ...protocols.out_of_band.v1_0.messages.invitation import (
 )
 from ...storage.base import BaseStorage
 from ...storage.record import StorageRecord
+from ...storage.error import StorageNotFoundError
 
 
 class ConnRecord(BaseRecord):
@@ -118,6 +119,7 @@ class ConnRecord(BaseRecord):
     RECORD_TYPE = "connection"
     RECORD_TYPE_INVITATION = "connection_invitation"
     RECORD_TYPE_REQUEST = "connection_request"
+    RECORD_TYPE_METADATA = 'connection_metadata'
 
     INVITATION_MODE_ONCE = "once"
     INVITATION_MODE_MULTI = "multi"
@@ -363,6 +365,39 @@ class ConnRecord(BaseRecord):
         # clear cache key set by connection manager
         cache_key = f"connection_target::{self.connection_id}"
         await self.clear_cached_key(session, cache_key)
+
+    async def metadata_get(
+        self, session: ProfileSession, key: str, default: str = None
+    ) -> str:
+        """Retrieve arbitrary metadata associated with this connection."""
+        assert self.connection_id
+        storage: BaseStorage = session.inject(BaseStorage)
+        try:
+            record = await storage.find_record(
+                self.RECORD_TYPE_METADATA,
+                {"key": key, "connection_id": self.connection_id}
+            )
+            return record.value
+        except StorageNotFoundError:
+            return default
+
+    async def metadata_set(self, session: ProfileSession, key: str, value: str):
+        """Set arbitrary metadata associated with this connection."""
+        assert self.connection_id
+        storage: BaseStorage = session.inject(BaseStorage)
+        try:
+            record = await storage.find_record(
+                self.RECORD_TYPE_METADATA,
+                {"key": key, "connection_id": self.connection_id}
+            )
+            await storage.update_record(record, value, record.tags)
+        except StorageNotFoundError:
+            record = StorageRecord(
+                self.RECORD_TYPE_METADATA,
+                value,
+                {"key": key, "connection_id": self.connection_id}
+            )
+            await storage.add_record(record)
 
     def __eq__(self, other: Any) -> bool:
         """Comparison between records."""

--- a/aries_cloudagent/connections/models/tests/test_conn_record.py
+++ b/aries_cloudagent/connections/models/tests/test_conn_record.py
@@ -234,32 +234,30 @@ class TestConnRecord(AsyncTestCase):
             my_did=self.test_did,
         )
         await record.save(self.session)
-        await record.metadata_set(self.session, 'key', 'value')
-        retrieved = await record.metadata_get(self.session, 'key')
-        assert retrieved == 'value'
+        await record.metadata_set(self.session, "key", "value")
+        retrieved = await record.metadata_get(self.session, "key")
+        assert retrieved == "value"
 
     async def test_metadata_set_update_get(self):
         record = ConnRecord(
             my_did=self.test_did,
         )
         await record.save(self.session)
-        await record.metadata_set(self.session, 'key', 'value')
-        await record.metadata_set(self.session, 'key', 'updated')
-        retrieved = await record.metadata_get(self.session, 'key')
-        assert retrieved == 'updated'
+        await record.metadata_set(self.session, "key", "value")
+        await record.metadata_set(self.session, "key", "updated")
+        retrieved = await record.metadata_get(self.session, "key")
+        assert retrieved == "updated"
 
     async def test_metadata_get_without_set_is_none(self):
         record = ConnRecord(
             my_did=self.test_did,
         )
         await record.save(self.session)
-        assert await record.metadata_get(self.session, 'key') is None
+        assert await record.metadata_get(self.session, "key") is None
 
     async def test_metadata_get_default(self):
         record = ConnRecord(
             my_did=self.test_did,
         )
         await record.save(self.session)
-        assert await record.metadata_get(
-            self.session, 'key', 'default'
-        ) == "default"
+        assert await record.metadata_get(self.session, "key", "default") == "default"

--- a/aries_cloudagent/connections/models/tests/test_conn_record.py
+++ b/aries_cloudagent/connections/models/tests/test_conn_record.py
@@ -228,3 +228,38 @@ class TestConnRecord(AsyncTestCase):
         deser = ConnRecord.deserialize(ser)
         reser = deser.serialize()
         assert "initiator" not in reser
+
+    async def test_metadata_set_get(self):
+        record = ConnRecord(
+            my_did=self.test_did,
+        )
+        await record.save(self.session)
+        await record.metadata_set(self.session, 'key', 'value')
+        retrieved = await record.metadata_get(self.session, 'key')
+        assert retrieved == 'value'
+
+    async def test_metadata_set_update_get(self):
+        record = ConnRecord(
+            my_did=self.test_did,
+        )
+        await record.save(self.session)
+        await record.metadata_set(self.session, 'key', 'value')
+        await record.metadata_set(self.session, 'key', 'updated')
+        retrieved = await record.metadata_get(self.session, 'key')
+        assert retrieved == 'updated'
+
+    async def test_metadata_get_without_set_is_none(self):
+        record = ConnRecord(
+            my_did=self.test_did,
+        )
+        await record.save(self.session)
+        assert await record.metadata_get(self.session, 'key') is None
+
+    async def test_metadata_get_default(self):
+        record = ConnRecord(
+            my_did=self.test_did,
+        )
+        await record.save(self.session)
+        assert await record.metadata_get(
+            self.session, 'key', 'default'
+        ) == "default"

--- a/aries_cloudagent/connections/models/tests/test_conn_record.py
+++ b/aries_cloudagent/connections/models/tests/test_conn_record.py
@@ -234,19 +234,19 @@ class TestConnRecord(AsyncTestCase):
             my_did=self.test_did,
         )
         await record.save(self.session)
-        await record.metadata_set(self.session, "key", "value")
+        await record.metadata_set(self.session, "key", {"test": "value"})
         retrieved = await record.metadata_get(self.session, "key")
-        assert retrieved == "value"
+        assert retrieved == {"test": "value"}
 
     async def test_metadata_set_update_get(self):
         record = ConnRecord(
             my_did=self.test_did,
         )
         await record.save(self.session)
-        await record.metadata_set(self.session, "key", "value")
-        await record.metadata_set(self.session, "key", "updated")
+        await record.metadata_set(self.session, "key", {"test": "value"})
+        await record.metadata_set(self.session, "key", {"test": "updated"})
         retrieved = await record.metadata_get(self.session, "key")
-        assert retrieved == "updated"
+        assert retrieved == {"test": "updated"}
 
     async def test_metadata_get_without_set_is_none(self):
         record = ConnRecord(
@@ -260,4 +260,6 @@ class TestConnRecord(AsyncTestCase):
             my_did=self.test_did,
         )
         await record.save(self.session)
-        assert await record.metadata_get(self.session, "key", "default") == "default"
+        assert await record.metadata_get(self.session, "key", {"test": "default"}) == {
+            "test": "default"
+        }


### PR DESCRIPTION
After some brief discussion with @andrewwhitehead and @ianco on rocket chat about a need to be able to track info not strictly related to the connection protocol but still associated with the connection, I threw this together as a quick proof of concept. I get the feeling there might be a better optimized way to do this or other more elegant solutions but figured I'd get the conversation started with the obvious/simple choice.