### PR TITLE
send-bound-request: do not insist on unused request, identify connect…

### DIFF
--- a/aries_cloudagent/protocols/present_proof/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/tests/test_routes.py
@@ -635,13 +635,7 @@ class TestProofRoutes(AsyncTestCase):
                 await test_module.presentation_exchange_send_free_request(self.request)
 
     async def test_presentation_exchange_send_bound_request(self):
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "connection_id": "dummy",
-                "comment": "dummy",
-                "proof_request": {},
-            }
-        )
+        self.request.json = async_mock.CoroutineMock(return_value={"trace": False})
         self.request.match_info = {"pres_ex_id": "dummy"}
 
         self.session_inject[BaseLedger] = async_mock.MagicMock(
@@ -669,13 +663,15 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
             autospec=True,
         ) as mock_attach_decorator, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            "aries_cloudagent.protocols.present_proof.v1_0."
+            "models.presentation_exchange.V10PresentationExchange",
             autospec=True,
         ) as mock_presentation_exchange:
 
             # Since we are mocking import
             importlib.reload(test_module)
 
+            mock_presentation_exchange.connection_id = "dummy"
             mock_presentation_exchange.state = (
                 test_module.V10PresentationExchange.STATE_PROPOSAL_RECEIVED
             )
@@ -707,13 +703,7 @@ class TestProofRoutes(AsyncTestCase):
                 )
 
     async def test_presentation_exchange_send_bound_request_not_found(self):
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "connection_id": "dummy",
-                "comment": "dummy",
-                "proof_request": {},
-            }
-        )
+        self.request.json = async_mock.CoroutineMock(return_value={"trace": False})
         self.request.match_info = {"pres_ex_id": "dummy"}
 
         with async_mock.patch(
@@ -740,6 +730,7 @@ class TestProofRoutes(AsyncTestCase):
             # Since we are mocking import
             importlib.reload(test_module)
 
+            mock_presentation_exchange.connection_id = "dummy"
             mock_presentation_exchange.state = (
                 test_module.V10PresentationExchange.STATE_PROPOSAL_RECEIVED
             )
@@ -754,13 +745,7 @@ class TestProofRoutes(AsyncTestCase):
                 await test_module.presentation_exchange_send_bound_request(self.request)
 
     async def test_presentation_exchange_send_bound_request_not_ready(self):
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "connection_id": "dummy",
-                "comment": "dummy",
-                "proof_request": {},
-            }
-        )
+        self.request.json = async_mock.CoroutineMock(return_value={"trace": False})
         self.request.match_info = {"pres_ex_id": "dummy"}
 
         with async_mock.patch(
@@ -787,6 +772,7 @@ class TestProofRoutes(AsyncTestCase):
             # Since we are mocking import
             importlib.reload(test_module)
 
+            mock_presentation_exchange.connection_id = "dummy"
             mock_presentation_exchange.state = (
                 test_module.V10PresentationExchange.STATE_PROPOSAL_RECEIVED
             )
@@ -803,13 +789,7 @@ class TestProofRoutes(AsyncTestCase):
                 await test_module.presentation_exchange_send_bound_request(self.request)
 
     async def test_presentation_exchange_send_bound_request_bad_state(self):
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "connection_id": "dummy",
-                "comment": "dummy",
-                "proof_request": {},
-            }
-        )
+        self.request.json = async_mock.CoroutineMock(return_value={"trace": False})
         self.request.match_info = {"pres_ex_id": "dummy"}
 
         with async_mock.patch(
@@ -820,6 +800,7 @@ class TestProofRoutes(AsyncTestCase):
             # Since we are mocking import
             importlib.reload(test_module)
 
+            mock_presentation_exchange.connection_id = "dummy"
             mock_presentation_exchange.retrieve_by_id = async_mock.CoroutineMock(
                 return_value=async_mock.MagicMock(
                     state=mock_presentation_exchange.STATE_PRESENTATION_ACKED
@@ -829,13 +810,7 @@ class TestProofRoutes(AsyncTestCase):
                 await test_module.presentation_exchange_send_bound_request(self.request)
 
     async def test_presentation_exchange_send_bound_request_x(self):
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "connection_id": "dummy",
-                "comment": "dummy",
-                "proof_request": {},
-            }
-        )
+        self.request.json = async_mock.CoroutineMock(return_value={"trace": False})
         self.request.match_info = {"pres_ex_id": "dummy"}
 
         with async_mock.patch(
@@ -862,6 +837,7 @@ class TestProofRoutes(AsyncTestCase):
             # Since we are mocking import
             importlib.reload(test_module)
 
+            mock_presentation_exchange.connection_id = "dummy"
             mock_presentation_exchange.state = (
                 test_module.V10PresentationExchange.STATE_PROPOSAL_RECEIVED
             )


### PR DESCRIPTION
…ion from proposal in pres ex rec

As wip-abramson noticed, send-bound took a whole required proof request in the web request, and then the processing ignored it and built a proof req from the proposal in question anyway, as the 'bound' API call name suggests.

Signed-off-by: sklump <srklump@hotmail.com>