### PR TITLE
feat: add argument for printing old connections style invites

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -229,8 +229,15 @@ class DebugGroup(ArgumentGroup):
             "--invite",
             action="store_true",
             env_var="ACAPY_INVITE",
-            help="After startup, generate and print a new connection invitation\
+            help="After startup, generate and print a new out-of-band connection invitation\
             URL. Default: false.",
+        )
+        parser.add_argument(
+            "--connections-invite",
+            action="store_true",
+            env_var="ACAPY_CONNECTIONS_INVITE",
+            help="After startup, generate and print a new connections protocol \
+            style invitation URL. Default: false.",
         )
         parser.add_argument(
             "--invite-label",
@@ -353,6 +360,8 @@ class DebugGroup(ArgumentGroup):
             settings["debug.seed"] = args.debug_seed
         if args.invite:
             settings["debug.print_invitation"] = True
+        if args.connections_invite:
+            settings["debug.print_connections_invitation"] = True
         if args.invite_label:
             settings["debug.invite_label"] = args.invite_label
         if args.invite_multi_use:

--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -242,6 +242,26 @@ class Conductor:
             except Exception:
                 LOGGER.exception("Error creating invitation")
 
+        # Print connections protocol invitation to the terminal
+        if context.settings.get("debug.print_connections_invitation"):
+            try:
+                async with self.root_profile.session() as session:
+                    mgr = ConnectionManager(session)
+                    _record, invite = await mgr.create_invitation(
+                        my_label=context.settings.get("debug.invite_label"),
+                        public=context.settings.get("debug.invite_public", False),
+                        multi_use=context.settings.get("debug.invite_multi_use", False),
+                        metadata=json.loads(
+                            context.settings.get("debug.invite_metadata_json", "{}")
+                        ),
+                    )
+                    base_url = context.settings.get("invite_base_url")
+                    print("Invitation URL (Connections protocol):")
+                    print(invite.to_url(base_url), flush=True)
+                    del mgr
+            except Exception:
+                LOGGER.exception("Error creating invitation")
+
     async def stop(self, timeout=1.0):
         """Stop the agent."""
         shutdown = TaskQueue()


### PR DESCRIPTION
This modification provides a much smoother transition period for the toolbox in supporting the up and coming 0.6.0 release of ACA-Py, as the toolbox does not yet support the new out of band protocol.