### PR TITLE
fix: connection req handler mediation metadata when no record

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/handlers/connection_request_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/connection_request_handler.py
@@ -31,7 +31,7 @@ class ConnectionRequestHandler(BaseHandler):
 
         if context.connection_record:
             mediation_metadata = await context.connection_record.metadata_get(
-                session, "mediation"
+                session, "mediation", {}
             )
         else:
             mediation_metadata = {}

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/connection_request_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/connection_request_handler.py
@@ -28,16 +28,19 @@ class ConnectionRequestHandler(BaseHandler):
 
         session = await context.session()
         mgr = ConnectionManager(session)
-        mediation_metadata = await context.connection_record.metadata_get(
-            session, "mediation"
-        )
+
+        if context.connection_record:
+            mediation_metadata = await context.connection_record.metadata_get(
+                session, "mediation"
+            )
+        else:
+            mediation_metadata = {}
+
         try:
             await mgr.receive_request(
                 context.message,
                 context.message_receipt,
-                mediation_id=None
-                if not mediation_metadata
-                else mediation_metadata["id"],
+                mediation_id=mediation_metadata.get("id"),
             )
         except ConnectionManagerError as e:
             self._logger.exception("Error receiving connection request")

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/tests/test_request_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/tests/test_request_handler.py
@@ -88,20 +88,22 @@ class TestRequestHandler:
     @pytest.mark.asyncio
     @async_mock.patch.object(handler, "ConnectionManager")
     async def test_connection_record_with_mediation_metadata(
-        self, mock_conn_mgr, request_context, session, connection_record
+        self, mock_conn_mgr, request_context, connection_record
     ):
         mock_conn_mgr.return_value.receive_request = async_mock.CoroutineMock()
         request_context.message = ConnectionRequest()
         with async_mock.patch.object(
-            connection_record, "metadata_get", async_mock.CoroutineMock(
-                return_value={"id": "test-mediation-id"}
-            )
+            connection_record,
+            "metadata_get",
+            async_mock.CoroutineMock(return_value={"id": "test-mediation-id"}),
         ) as mock_metadata_get:
             handler_inst = handler.ConnectionRequestHandler()
             responder = MockResponder()
             await handler_inst.handle(request_context, responder)
             mock_conn_mgr.return_value.receive_request.assert_called_once_with(
-                request_context.message, request_context.message_receipt, mediation_id="test-mediation-id"
+                request_context.message,
+                request_context.message_receipt,
+                mediation_id="test-mediation-id",
             )
             assert not responder.messages
 

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/tests/test_request_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/tests/test_request_handler.py
@@ -1,6 +1,7 @@
 import pytest
 from asynctest import mock as async_mock
 
+from ......core.profile import ProfileSession
 from ......connections.models import connection_target
 from ......connections.models.conn_record import ConnRecord
 from ......connections.models.diddoc import DIDDoc, PublicKey, PublicKeyType, Service
@@ -17,11 +18,21 @@ from ...models.connection_detail import ConnectionDetail
 @pytest.fixture()
 async def request_context() -> RequestContext:
     ctx = RequestContext.test_context()
-    session = await ctx.session()
     ctx.message_receipt = MessageReceipt()
-    ctx.connection_record = ConnRecord()
-    await ctx.connection_record.save(session)
     yield ctx
+
+
+@pytest.fixture()
+async def session(request_context) -> ProfileSession:
+    yield await request_context.session()
+
+
+@pytest.fixture()
+async def connection_record(request_context, session) -> ConnRecord:
+    record = ConnRecord()
+    request_context.connection_record = record
+    await record.save(session)
+    yield record
 
 
 TEST_DID = "55GkHamhTU1ZbTbV2ab9DE"
@@ -73,6 +84,26 @@ class TestRequestHandler:
             request_context.message, request_context.message_receipt, mediation_id=None
         )
         assert not responder.messages
+
+    @pytest.mark.asyncio
+    @async_mock.patch.object(handler, "ConnectionManager")
+    async def test_connection_record_with_mediation_metadata(
+        self, mock_conn_mgr, request_context, session, connection_record
+    ):
+        mock_conn_mgr.return_value.receive_request = async_mock.CoroutineMock()
+        request_context.message = ConnectionRequest()
+        with async_mock.patch.object(
+            connection_record, "metadata_get", async_mock.CoroutineMock(
+                return_value={"id": "test-mediation-id"}
+            )
+        ) as mock_metadata_get:
+            handler_inst = handler.ConnectionRequestHandler()
+            responder = MockResponder()
+            await handler_inst.handle(request_context, responder)
+            mock_conn_mgr.return_value.receive_request.assert_called_once_with(
+                request_context.message, request_context.message_receipt, mediation_id="test-mediation-id"
+            )
+            assert not responder.messages
 
     @pytest.mark.asyncio
     @async_mock.patch.object(handler, "ConnectionManager")


### PR DESCRIPTION
Checking was not very graceful originally, resulting in errors under the right circumstances. Added/modified tests to check those circumstances.