### PR TITLE
Also: underscores separate webhook topics and record types. Complete …

### DIFF
--- a/aries_cloudagent/protocols/actionmenu/v1_0/util.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/util.py
@@ -10,7 +10,7 @@ from ....storage.base import (
 
 from .messages.menu import Menu
 
-MENU_RECORD_TYPE = "connection-action-menu"
+MENU_RECORD_TYPE = "connection_action_menu"
 
 
 async def retrieve_connection_menu(

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_mediation_manager.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_mediation_manager.py
@@ -197,6 +197,9 @@ class TestMediationManager:  # pylint: disable=R0904,W0621
         assert record_0 != record_1
         assert record_0 != ValueError("not a mediation record")
 
+        with pytest.raises(ValueError):
+            record_0.state = "bad state"
+
     async def test_mediation_record_duplicate_means_exists(self, session):
         await MediationRecord(connection_id=TEST_CONN_ID, endpoint="abc").save(session)
         await MediationRecord(connection_id=TEST_CONN_ID, endpoint="def").save(session)

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -90,6 +90,12 @@ class OutOfBandManager:
             Invitation record
 
         """
+        if not (include_handshake or attachments):
+            raise OutOfBandManagerError(
+                "Invitation must include handshake protocols, "
+                "request attachments, or both"
+            )
+
         wallet = self._session.inject(BaseWallet)
 
         accept = bool(

--- a/aries_cloudagent/protocols/out_of_band/v1_0/models/invitation.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/models/invitation.py
@@ -18,9 +18,9 @@ class InvitationRecord(BaseExchangeRecord):
 
         schema_class = "InvitationRecordSchema"
 
-    RECORD_TYPE = "oob-invitation"
+    RECORD_TYPE = "oob_invitation"
     RECORD_ID_NAME = "invitation_id"
-    WEBHOOK_TOPIC = "oob-invitation"
+    WEBHOOK_TOPIC = "oob_invitation"
     TAG_NAMES = {"invi_msg_id"}
 
     STATE_INITIAL = "initial"

--- a/aries_cloudagent/protocols/out_of_band/v1_0/routes.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/routes.py
@@ -138,8 +138,6 @@ async def register(app: web.Application):
     """Register routes."""
     app.add_routes(
         [
-            # web.get("/out-of-band", invitation_list),
-            # web.get("/out-of-band/{id}", invitation_retrieve),
             web.post("/out-of-band/create-invitation", invitation_create),
             web.post("/out-of-band/receive-invitation", invitation_receive),
         ]


### PR DESCRIPTION
…unit test coverage for connection metadata.

Short circuit doomed out-of-band create-invitation to raise HTTPBadRequest before creating the Invitation record.

Signed-off-by: sklump <srklump@hotmail.com>