### PR TITLE
fix: minor tweaks to run scripts

### DIFF
--- a/scripts/run_docker
+++ b/scripts/run_docker
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-cd $(dirname $0)
+cd "$(dirname "$0")" || exit 1
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 
-docker build -t aries-cloudagent-run -f ../docker/Dockerfile.run .. || exit 1
+$CONTAINER_RUNTIME build -t aries-cloudagent-run -f ../docker/Dockerfile.run .. || exit 1
 
 ARGS=""
 for PORT in $PORTS; do
@@ -11,26 +12,25 @@ done
 
 PTVSD_PORT="${PTVSD_PORT-5678}"
 
-for arg in $@; do
+for arg in "$@"; do
   if [ "$arg" = "--debug" ]; then
     ENABLE_PTVSD=1
   fi
 done
-if [ ! -z "${ENABLE_PTVSD}" ]; then
+if [ -n "${ENABLE_PTVSD}" ]; then
   ARGS="${ARGS} -e ENABLE_PTVSD=\"${ENABLE_PTVSD}\" -p $PTVSD_PORT:$PTVSD_PORT"
 fi
 
 ARGS="${ARGS} -v $(pwd)/../logs:/home/indy/logs"
 
-if [ ! -z "${WEBHOOK_URL}" ]; then
+if [ -n "${WEBHOOK_URL}" ]; then
   ARGS="${ARGS} -e WEBHOOK_URL=\"${WEBHOOK_URL}\""
 fi
 
 if [ "$OSTYPE" == "msys" ]; then
-  DOCKER="winpty docker"
-else
-  DOCKER="docker"
+  CONTAINER_RUNTIME="winpty docker"
 fi
 
-RAND_NAME=$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
-$DOCKER run --rm -ti --name "aries-cloudagent-runner_${RAND_NAME}" $ARGS aries-cloudagent-run "$@"
+RAND_NAME=$(env LC_CTYPE=C tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 16 | head -n 1)
+$CONTAINER_RUNTIME run --rm -ti --name "aries-cloudagent-runner_${RAND_NAME}" \
+    $ARGS aries-cloudagent-run "$@"

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-cd $(dirname $0)
+cd "$(dirname "$0")" || exit
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 
-docker build -t aries-cloudagent-test -f ../docker/Dockerfile.test .. || exit 1
+$CONTAINER_RUNTIME build -t aries-cloudagent-test -f ../docker/Dockerfile.test .. || exit 1
 
 DOCKER_ARGS=""
 PTVSD_PORT="5678"
@@ -13,7 +14,7 @@ for arg in "$@"; do
     #shift # remove debug flag from pytest args.
   fi
 done
-if [ ! -z "${ENABLE_PTVSD}" ]; then
+if [ -n "${ENABLE_PTVSD}" ]; then
   DOCKER_ARGS="${DOCKER_ARGS} -e ENABLE_PTVSD=\"${ENABLE_PTVSD}\" -p $PTVSD_PORT:$PTVSD_PORT"
 fi
 
@@ -21,11 +22,9 @@ if [ ! -d ../test-reports ]; then mkdir ../test-reports; fi
 
 # on Windows, docker run needs to be prefixed by winpty
 if [ "$OSTYPE" == "msys" ]; then
-  DOCKER="winpty docker"
-else
-  DOCKER="docker"
+  CONTAINER_RUNTIME="winpty docker"
 fi
 
-$DOCKER run --rm -ti --name aries-cloudagent-runner \
-	-v "$(pwd)/../test-reports:/usr/src/app/test-reports" \
+$CONTAINER_RUNTIME run --rm -ti --name aries-cloudagent-runner \
+	-v "$(pwd)/../test-reports:/usr/src/app/test-reports:z" \
 	$DOCKER_ARGS aries-cloudagent-test "$@"

--- a/scripts/run_tests_indy
+++ b/scripts/run_tests_indy
@@ -1,32 +1,31 @@
 #!/bin/bash
 
-cd $(dirname $0)
+cd "$(dirname "$0")" || exit
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 
-docker build -t aries-cloudagent-test -f ../docker/Dockerfile.test-indy .. || exit 1
+$CONTAINER_RUNTIME build -t aries-cloudagent-test -f ../docker/Dockerfile.test-indy .. || exit 1
 
 if [ ! -d ../test-reports ]; then mkdir ../test-reports; fi
 
 # on Windows, docker run needs to be prefixed by winpty
 if [ "$OSTYPE" == "msys" ]; then
-  DOCKER="winpty docker"
-else
-  DOCKER="docker"
+  CONTAINER_RUNTIME="winpty docker"
 fi
 if [ -z "$DOCKER_NET" ]; then
     DOCKER_NET="bridge"
 fi
 
 if [ -z "$POSTGRES_URL" ]; then
-  if [ ! -z $(docker ps --filter name=indy-demo-postgres --quiet) ]; then
+  if [ -n "$($CONTAINER_RUNTIME ps --filter name=indy-demo-postgres --quiet)" ]; then
     DOCKER_ARGS="$DOCKER_ARGS --link indy-demo-postgres"
     POSTGRES_URL="indy-demo-postgres"
   fi
 fi
-if [ ! -z "$POSTGRES_URL" ]; then
+if [ -n "$POSTGRES_URL" ]; then
   DOCKER_ARGS="$DOCKER_ARGS -e POSTGRES_URL=$POSTGRES_URL"
 fi
 
-$DOCKER run --rm -ti --name aries-cloudagent-runner \
+$CONTAINER_RUNTIME run --rm -ti --name aries-cloudagent-runner \
   --network=${DOCKER_NET} \
   -v "$(pwd)/../test-reports:/home/indy/src/app/test-reports" \
   $DOCKER_ARGS \


### PR DESCRIPTION
These tweaks better support using docker-compatible container runtimes (i.e. podman, which is the default for RHEL based systems these days) for running tests by specifying an alternate runtime with the environment variable `CONTAINER_RUNTIME`. Additionally, I made changes as recommended by shellcheck.

I believe these changes should be pretty benign but I don't have a reliable way to test that for all environments.