### PR TITLE
Add OOB invitation_msg_id to connection record

### DIFF
--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -142,6 +142,7 @@ class ConnRecord(BaseRecord):
         their_label: str = None,
         their_role: Union[str, "ConnRecord.Role"] = None,
         invitation_key: str = None,
+        invitation_msg_id: str = None,
         request_id: str = None,
         state: Union[str, "ConnRecord.State"] = None,
         inbound_connection_id: str = None,
@@ -169,6 +170,7 @@ class ConnRecord(BaseRecord):
             else their_role.rfc160
         )
         self.invitation_key = invitation_key
+        self.invitation_msg_id = invitation_msg_id
         self.request_id = request_id
         self.error_msg = error_msg
         self.inbound_connection_id = inbound_connection_id
@@ -193,6 +195,7 @@ class ConnRecord(BaseRecord):
                 "routing_state",
                 "accept",
                 "invitation_mode",
+                "invitation_msg_id",
                 "alias",
                 "error_msg",
                 "their_label",
@@ -493,6 +496,11 @@ class ConnRecordSchema(BaseRecordSchema):
     )
     invitation_key = fields.Str(
         required=False, description="Public key for connection", **INDY_RAW_PUBLIC_KEY
+    )
+    invitation_msg_id = fields.Str(
+        required=False,
+        description="ID of out-of-band invitation message",
+        example=UUIDFour.EXAMPLE,
     )
     request_id = fields.Str(
         required=False,

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -120,6 +120,7 @@ class DIDXManager:
                 if invitation.service_blocks
                 else None
             ),
+            invitation_msg_id=invitation._id,
             their_label=invitation.label,
             their_role=ConnRecord.Role.RESPONDER.rfc23,
             state=ConnRecord.State.INVITATION.rfc23,

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -212,6 +212,7 @@ class OutOfBandManager:
             # Create connection record
             conn_rec = ConnRecord(
                 invitation_key=connection_key.verkey,
+                invitation_msg_id=invi_msg._id,
                 their_role=ConnRecord.Role.REQUESTER.rfc23,
                 state=ConnRecord.State.INVITATION.rfc23,
                 accept=ConnRecord.ACCEPT_AUTO if accept else ConnRecord.ACCEPT_MANUAL,

--- a/demo/runners/alice.py
+++ b/demo/runners/alice.py
@@ -222,7 +222,7 @@ async def input_invitation(agent):
                 log_msg("Invalid invitation:", str(e))
 
     with log_timer("Connect duration:"):
-        if "/out-of-band/" in details["@type"]:
+        if "/out-of-band/" in details.get("@type", ""):
             connection = await agent.admin_POST(
                 "/didexchange/receive-invitation", details
             )


### PR DESCRIPTION
This should allow the Aries agent test harness back channel to associate the invitation with the connection.

@nodlesh 