### PR TITLE
Multiple Webhook targets w/ API Key in Header

### DIFF
--- a/aries_cloudagent/admin/base_server.py
+++ b/aries_cloudagent/admin/base_server.py
@@ -26,15 +26,16 @@ class BaseAdminServer(ABC):
     def add_webhook_target(
         self,
         target_url: str,
+        wallet_id: str,
         topic_filter: Sequence[str] = None,
         max_attempts: int = None,
     ):
         """Add a webhook target."""
 
     @abstractmethod
-    def remove_webhook_target(self, target_url: str):
+    def remove_webhook_target(self, target_url: str, wallet_id: str):
         """Remove a webhook target."""
 
     @abstractmethod
-    async def send_webhook(self, topic: str, payload: dict):
+    async def send_webhook(self, topic: str, payload: dict, wallet_id: str):
         """Add a webhook to the queue, to send to all registered targets."""

--- a/aries_cloudagent/admin/tests/test_admin_server.py
+++ b/aries_cloudagent/admin/tests/test_admin_server.py
@@ -188,6 +188,7 @@ class TestAdminServer(AsyncTestCase):
         test_attempts = 99
         server.add_webhook_target(
             target_url=test_url,
+            wallet_id=server.root_profile.name,
             topic_filter=["*"],  # cover vacuous filter
             max_attempts=test_attempts,
         )
@@ -205,12 +206,12 @@ class TestAdminServer(AsyncTestCase):
                 ]
             )
 
-            await server.responder.send_webhook(test_topic, test_payload)
+            await server.responder.send_webhook(test_topic, test_payload, server.root_profile.name)
             assert self.webhook_results == [
                 (test_topic, test_payload, test_url, test_attempts)
             ]
 
-        server.remove_webhook_target(target_url=test_url)
+        server.remove_webhook_target(target_url=test_url, wallet_id=server.root_profile.name)
         assert test_url not in server.webhook_targets
 
     async def test_import_routes(self):

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -140,10 +140,11 @@ class AdminGroup(ArgumentGroup):
         parser.add_argument(
             "--webhook-url",
             action="append",
-            metavar="<url>",
+            metavar="<url#api_key>",
             env_var="ACAPY_WEBHOOK_URL",
             help="Send webhooks containing internal state changes to the specified\
-            URL. This is useful for a controller to monitor agent events and respond\
+            URL. Append an API key if required separated by a hash [#] to be included in the header.\
+            This is useful for a controller to monitor agent events and respond\
             to those events using the admin API. If not specified, webhooks are not\
             published by the agent.",
         )

--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -292,13 +292,14 @@ class DispatcherResponder(BaseResponder):
         """
         await self._send(self._context.profile, message, self._inbound_message)
 
-    async def send_webhook(self, topic: str, payload: dict):
+    async def send_webhook(self, topic: str, payload: dict, wallet_id: str):
         """
         Dispatch a webhook.
 
         Args:
             topic: the webhook topic identifier
             payload: the webhook payload value
+            wallet_id: the wallet identifier currently in use
         """
         if self._webhook:
-            await self._webhook(topic, payload)
+            await self._webhook(topic, payload, wallet_id)

--- a/aries_cloudagent/core/tests/test_dispatcher.py
+++ b/aries_cloudagent/core/tests/test_dispatcher.py
@@ -348,7 +348,7 @@ class TestDispatcher(AsyncTestCase):
         assert json.loads(result.payload)["@type"] == DIDCommPrefix.qualify_current(
             StubAgentMessage.Meta.message_type
         )
-        await responder.send_webhook("topic", "payload")
+        await responder.send_webhook("topic", "payload", context.profile.name)
 
         context.default_endpoint = "http://agent.ca"
         assert context.default_endpoint == "http://agent.ca"

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -393,7 +393,8 @@ class BaseRecord(BaseModel):
                 return
         responder = session.inject(BaseResponder, required=False)
         if responder:
-            await responder.send_webhook(topic, payload)
+            wallet_id = session.profile.name
+            await responder.send_webhook(topic, payload, wallet_id)
 
     @classmethod
     def log_state(

--- a/aries_cloudagent/messaging/responder.py
+++ b/aries_cloudagent/messaging/responder.py
@@ -112,13 +112,14 @@ class BaseResponder(ABC):
         """
 
     @abstractmethod
-    async def send_webhook(self, topic: str, payload: dict):
+    async def send_webhook(self, topic: str, payload: dict, wallet_id: str):
         """
         Dispatch a webhook.
 
         Args:
             topic: the webhook topic identifier
             payload: the webhook payload value
+            wallet_id: Wallet identifier currently in use
         """
 
 
@@ -142,6 +143,6 @@ class MockResponder(BaseResponder):
         """Send an outbound message."""
         self.messages.append((message, None))
 
-    async def send_webhook(self, topic: str, payload: dict):
+    async def send_webhook(self, topic: str, payload: dict, wallet_id: str):
         """Send an outbound message."""
-        self.webhooks.append((topic, payload))
+        self.webhooks.append((topic, payload, wallet_id))

--- a/aries_cloudagent/protocols/actionmenu/v1_0/driver_service.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/driver_service.py
@@ -16,12 +16,13 @@ class DriverMenuService(BaseMenuService):
     """Driver-based action menu service."""
 
     async def get_active_menu(
-        self, connection: ConnRecord = None, thread_id: str = None
+        self, wallet_id: str, connection: ConnRecord = None, thread_id: str = None
     ) -> Menu:
         """
         Render the current menu.
 
         Args:
+            wallet_id: Wallet identifier currently in use
             connection: The active connection record
             thread_id: The thread identifier from the requesting message.
         """
@@ -31,6 +32,7 @@ class DriverMenuService(BaseMenuService):
                 "connection_id": connection and connection.connection_id,
                 "thread_id": thread_id,
             },
+            wallet_id=wallet_id,
         )
         return None
 
@@ -38,6 +40,7 @@ class DriverMenuService(BaseMenuService):
         self,
         action_name: str,
         action_params: dict,
+        wallet_id: str,
         connection: ConnRecord = None,
         thread_id: str = None,
     ) -> AgentMessage:
@@ -47,6 +50,7 @@ class DriverMenuService(BaseMenuService):
         Args:
             action_name: The unique name of the action being performed
             action_params: A collection of parameters for the action
+            wallet_id: Wallet identifier currently in use
             connection: The active connection record
             thread_id: The thread identifier from the requesting message.
         """
@@ -58,11 +62,12 @@ class DriverMenuService(BaseMenuService):
                 "action_name": action_name,
                 "action_params": action_params,
             },
+            wallet_id=wallet_id,
         )
         return None
 
-    async def send_webhook(self, topic: str, payload: dict):
+    async def send_webhook(self, topic: str, payload: dict, wallet_id: str):
         """Dispatch a webhook through the registered responder."""
         responder = self._context.inject(BaseResponder, required=False)
         if responder:
-            await responder.send_webhook(topic, payload)
+            await responder.send_webhook(topic, payload, wallet_id)

--- a/aries_cloudagent/protocols/actionmenu/v1_0/tests/test_service.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/tests/test_service.py
@@ -25,7 +25,7 @@ class TestActionMenuService(AsyncTestCase):
         connection.connection_id = "connid"
         thread_id = "thid"
 
-        await self.menu_service.get_active_menu(connection, thread_id)
+        await self.menu_service.get_active_menu(self.context.profile.name, connection, thread_id)
 
         webhooks = self.responder.webhooks
         assert len(webhooks) == 1
@@ -51,7 +51,7 @@ class TestActionMenuService(AsyncTestCase):
         thread_id = "thid"
 
         await self.menu_service.perform_menu_action(
-            action_name, action_params, connection, thread_id
+            action_name, action_params, self.context.profile.name, connection, thread_id
         )
 
         webhooks = self.responder.webhooks

--- a/aries_cloudagent/protocols/actionmenu/v1_0/util.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/util.py
@@ -62,4 +62,5 @@ async def save_connection_menu(
                 "connection_id": connection_id,
                 "menu": menu.serialize() if menu else None,
             },
+            context.profile.name,
         )

--- a/aries_cloudagent/protocols/basicmessage/v1_0/handlers/basicmessage_handler.py
+++ b/aries_cloudagent/protocols/basicmessage/v1_0/handlers/basicmessage_handler.py
@@ -42,6 +42,7 @@ class BasicMessageHandler(BaseHandler):
                 "content": body,
                 "state": "received",
             },
+            context.profile.name,
         )
 
         reply = None

--- a/aries_cloudagent/protocols/problem_report/v1_0/handler.py
+++ b/aries_cloudagent/protocols/problem_report/v1_0/handler.py
@@ -30,4 +30,4 @@ class ProblemReportHandler(BaseHandler):
             context.message,
         )
 
-        await responder.send_webhook("problem_report", context.message.serialize())
+        await responder.send_webhook("problem_report", context.message.serialize(), context.profile.name)

--- a/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_handler.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_handler.py
@@ -52,4 +52,5 @@ class PingHandler(BaseHandler):
                     "state": "received",
                     "thread_id": context.message._thread_id,
                 },
+                context.profile.name,
             )

--- a/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_response_handler.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/handlers/ping_response_handler.py
@@ -38,6 +38,7 @@ class PingResponseHandler(BaseHandler):
                     "state": "response_received",
                     "thread_id": context.message._thread_id,
                 },
+                context.profile.name,
             )
 
         # Nothing to do, Connection should be automatically promoted to 'active'

--- a/aries_cloudagent/transport/outbound/http.py
+++ b/aries_cloudagent/transport/outbound/http.py
@@ -43,7 +43,7 @@ class HttpTransport(BaseOutboundTransport):
         self.client_session = None
 
     async def handle_message(
-        self, context: InjectionContext, payload: Union[str, bytes], endpoint: str
+        self, context: InjectionContext, payload: Union[str, bytes], endpoint: str, api_key: str = None
     ):
         """
         Handle message from queue.
@@ -60,6 +60,8 @@ class HttpTransport(BaseOutboundTransport):
             headers["Content-Type"] = "application/ssi-agent-wire"
         else:
             headers["Content-Type"] = "application/json"
+        if api_key is not None:
+            headers["x-api-key"] = api_key
         self.logger.debug(
             "Posting to %s; Data: %s; Headers: %s", endpoint, payload, headers
         )


### PR DESCRIPTION
- Optional API key which can be included in the request header when dispatching webhooks. This can be done by providing --webhook-url as hashlinks [# separated], with the first part being the endpoint and the second being the API key.
- The webhook_target dictionary key has been changed from target_url to (wallet_id, target_url), this is done to support multitenancy
- When routing webhooks, wallet_id [context.profile.name] is used so that only targets for that wallet are dispatched
- Multiple webhooks can now be configured by specifying multiple targets using --webhook-url CLI parameter.
Signed-off-by: Shaanjot <Gill>