### PR TITLE
Webhook - Optional API Key in Header

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -140,12 +140,13 @@ class AdminGroup(ArgumentGroup):
         parser.add_argument(
             "--webhook-url",
             action="append",
-            metavar="<url>",
+            metavar="<url#api_key>",
             env_var="ACAPY_WEBHOOK_URL",
             help="Send webhooks containing internal state changes to the specified\
-            URL. This is useful for a controller to monitor agent events and respond\
-            to those events using the admin API. If not specified, webhooks are not\
-            published by the agent.",
+            URL. Optional API key to be passed in the request body can be appended using\
+            a hash separator [#]. This is useful for a controller to monitor agent events\
+            and respond to those events using the admin API. If not specified, \
+            webhooks are not published by the agent.",
         )
 
     def get_settings(self, args: Namespace):

--- a/aries_cloudagent/transport/outbound/http.py
+++ b/aries_cloudagent/transport/outbound/http.py
@@ -48,6 +48,7 @@ class HttpTransport(BaseOutboundTransport):
         payload: Union[str, bytes],
         endpoint: str,
         metadata: dict = None,
+        api_key: str = None,
     ):
         """
         Handle message from queue.
@@ -61,9 +62,8 @@ class HttpTransport(BaseOutboundTransport):
         if not endpoint:
             raise OutboundTransportError("No endpoint provided")
         headers = metadata or {}
-        if len(endpoint.split('#'))>1:
-            endpoint_hash_split = endpoint.split('#')
-            headers["x-api-key"] = endpoint_hash_split[1]
+        if api_key is not None:
+            headers["x-api-key"] = api_key
         if isinstance(payload, bytes):
             headers["Content-Type"] = "application/ssi-agent-wire"
         else:

--- a/aries_cloudagent/transport/outbound/http.py
+++ b/aries_cloudagent/transport/outbound/http.py
@@ -61,6 +61,9 @@ class HttpTransport(BaseOutboundTransport):
         if not endpoint:
             raise OutboundTransportError("No endpoint provided")
         headers = metadata or {}
+        if len(endpoint.split('#'))>1:
+            endpoint_hash_split = endpoint.split('#')
+            headers["x-api-key"] = endpoint_hash_split[1]
         if isinstance(payload, bytes):
             headers["Content-Type"] = "application/ssi-agent-wire"
         else:

--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -284,7 +284,7 @@ class OutboundTransportManager:
         """
         transport_id = self.get_running_transport_for_endpoint(endpoint)
         queued = QueuedOutboundMessage(None, None, None, transport_id)
-        if len(endpoint.split('#'))>1:
+        if len(endpoint.split('#')) > 1:
             endpoint_hash_split = endpoint.split('#')
             endpoint = endpoint_hash_split[0]
             api_key = endpoint_hash_split[1]
@@ -449,7 +449,7 @@ class OutboundTransportManager:
         transport = self.get_transport_instance(queued.transport_id)
         queued.task = self.task_queue.run(
             transport.handle_message(
-                queued.profile, queued.payload, queued.endpoint, queued.metadata, queued.api_key
+                queued.profile, queued.payload, queued.endpoint, queued.metadata, queued.api_key,
             ),
             lambda completed: self.finished_deliver(queued, completed),
         )

--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -284,8 +284,8 @@ class OutboundTransportManager:
         """
         transport_id = self.get_running_transport_for_endpoint(endpoint)
         queued = QueuedOutboundMessage(None, None, None, transport_id)
-        if len(endpoint.split('#')) > 1:
-            endpoint_hash_split = endpoint.split('#')
+        if len(endpoint.split("#")) > 1:
+            endpoint_hash_split = endpoint.split("#")
             endpoint = endpoint_hash_split[0]
             api_key = endpoint_hash_split[1]
             queued.api_key = api_key
@@ -449,7 +449,11 @@ class OutboundTransportManager:
         transport = self.get_transport_instance(queued.transport_id)
         queued.task = self.task_queue.run(
             transport.handle_message(
-                queued.profile, queued.payload, queued.endpoint, queued.metadata, queued.api_key,
+                queued.profile,
+                queued.payload, 
+                queued.endpoint, 
+                queued.metadata, 
+                queued.api_key,
             ),
             lambda completed: self.finished_deliver(queued, completed),
         )

--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -450,9 +450,9 @@ class OutboundTransportManager:
         queued.task = self.task_queue.run(
             transport.handle_message(
                 queued.profile,
-                queued.payload, 
-                queued.endpoint, 
-                queued.metadata, 
+                queued.payload,
+                queued.endpoint,
+                queued.metadata,
                 queued.api_key,
             ),
             lambda completed: self.finished_deliver(queued, completed),

--- a/aries_cloudagent/transport/outbound/tests/test_http_transport.py
+++ b/aries_cloudagent/transport/outbound/tests/test_http_transport.py
@@ -52,13 +52,18 @@ class TestHttpTransport(AioHTTPTestCase):
     async def test_handle_message_api_key(self):
         server_addr = f"http://localhost:{self.server.port}"
         api_key = "test1234"
+
         async def send_message(transport, payload, endpoint, api_key):
             async with transport:
-                await transport.handle_message(self.context, payload, endpoint, api_key=api_key)
+                await transport.handle_message(
+                    self.context, payload, endpoint, api_key=api_key
+                )
 
         transport = HttpTransport()
 
-        await asyncio.wait_for(send_message(transport, "{}", endpoint=server_addr, api_key=api_key), 5.0)
+        await asyncio.wait_for(
+            send_message(transport, "{}", endpoint=server_addr, api_key=api_key), 5.0
+        )
         assert self.message_results == [{}]
         assert self.headers.get("x-api-key") == api_key
 

--- a/aries_cloudagent/transport/outbound/tests/test_manager.py
+++ b/aries_cloudagent/transport/outbound/tests/test_manager.py
@@ -101,6 +101,7 @@ class TestOutboundTransportManager(AsyncTestCase):
             transport.wire_format.encode_message.return_value,
             message.target.endpoint,
             None,
+            None,
         )
 
         with self.assertRaises(OutboundDeliveryError):


### PR DESCRIPTION
API Key can be sent as part of the request parameter [x-api-key], it is specified by appending it to the webhook URL and separate it using a hash [#].