### PR TITLE
feat: transfer metadata from multi-use invitations to connections

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -495,6 +495,14 @@ class ConnectionManager:
                     self._session,
                     reason="Received connection request from multi-use invitation DID",
                 )
+
+                # Transfer metadata from multi-use to new connection
+                # Must come after save so there's an ID to associate with metadata
+                for key, value in (
+                    await connection.metadata_get_all(self._session)
+                ).items():
+                    await new_connection.metadata_set(self._session, key, value)
+
                 connection = new_connection
             else:
                 # remove key from mediator keylist

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -297,6 +297,14 @@ class DIDXManager:
                     self._session,
                     reason="Received connection request from multi-use invitation DID",
                 )
+
+                # Transfer metadata from multi-use to new connection
+                # Must come after save so there's an ID to associate with metadata
+                for key, value in (
+                    await conn_rec.metadata_get_all(self._session)
+                ).items():
+                    await new_conn_rec.metadata_set(self._session, key, value)
+
                 conn_rec = new_conn_rec
 
         if not (request.did_doc_attach and request.did_doc_attach.data):

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -507,6 +507,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             save=async_mock.CoroutineMock(),
             attach_request=async_mock.CoroutineMock(),
             accept=ConnRecord.ACCEPT_MANUAL,
+            metadata_get_all=async_mock.CoroutineMock(return_value={"test": "value"}),
         )
         mock_conn_rec_state_request = ConnRecord.State.REQUEST
 
@@ -536,6 +537,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
                 attach_request=async_mock.CoroutineMock(),
                 retrieve_request=async_mock.CoroutineMock(),
                 save=async_mock.CoroutineMock(),
+                metadata_set=async_mock.CoroutineMock(),
             )
             mock_oob_invi_rec_retrieve.return_value = async_mock.MagicMock(
                 auto_accept=False,
@@ -555,6 +557,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
 
             conn_rec = await self.manager.receive_request(mock_request, receipt)
             assert conn_rec
+            mock_conn_rec.return_value.metadata_set.assert_called()
 
         assert not self.responder.messages
 


### PR DESCRIPTION
This PR adds transfering of metadata from multi-use invitations to the connections created by receiving a request through that invitation.