### PR TITLE
Conn rec rfc23 state

### DIFF
--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -114,11 +114,15 @@ class ConnRecord(BaseRecord):
 
             if self is ConnRecord.State.REQUEST:
                 return self.value[1] + (
-                    "-sent" if their_role is ConnRecord.Role.RESPONDER else "-received"
+                    "-sent"
+                    if ConnRecord.Role.get(their_role) is ConnRecord.Role.RESPONDER
+                    else "-received"
                 )
             else:
                 return self.value[1] + (
-                    "-received" if their_role is ConnRecord.Role.RESPONDER else "-sent"
+                    "-received"
+                    if ConnRecord.Role.get(their_role) is ConnRecord.Role.RESPONDER
+                    else "-sent"
                 )
 
         @classmethod

--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -77,7 +77,13 @@ class ConnRecord(BaseRecord):
             return self is ConnRecord.Role.get(other)
 
     class State(Enum):
-        """Collator for equivalent states between RFC 160 and RFC 23."""
+        """
+        Collator for equivalent states between RFC 160 and RFC 23.
+
+        On the connection record, the state has to serve for both RFCs.
+        Hence, internally, RFC23 requester/responder states collate to
+        their RFC160 condensed equivalent.
+        """
 
         INIT = ("init", "start")
         INVITATION = ("invitation", "invitation")
@@ -93,8 +99,27 @@ class ConnRecord(BaseRecord):
 
         @property
         def rfc23(self):
-            """Return RFC 23 (DID exchange protocol) nomenclature."""
+            """Return RFC 23 (DID exchange protocol) nomenclature to record logic."""
             return self.value[1]
+
+        def rfc23strict(self, their_role: "ConnRecord.Role"):
+            """Return RFC 23 (DID exchange protocol) nomenclature to role as per RFC."""
+
+            if not their_role or self in (
+                ConnRecord.State.INIT,
+                ConnRecord.State.COMPLETED,
+                ConnRecord.State.ABANDONED,
+            ):
+                return self.value[1]
+
+            if self is ConnRecord.State.REQUEST:
+                return self.value[1] + (
+                    "-sent" if their_role is ConnRecord.Role.RESPONDER else "-received"
+                )
+            else:
+                return self.value[1] + (
+                    "-received" if their_role is ConnRecord.Role.RESPONDER else "-sent"
+                )
 
         @classmethod
         def get(cls, label: Union[str, "ConnRecord.State"]):
@@ -183,6 +208,11 @@ class ConnRecord(BaseRecord):
     def connection_id(self) -> str:
         """Accessor for the ID associated with this connection."""
         return self._id
+
+    @property
+    def rfc23_state(self) -> str:
+        """RFC23 state per RFC text, potentially particular to role."""
+        return ConnRecord.State.get(self.state).rfc23strict(self.their_role)
 
     @property
     def record_value(self) -> dict:
@@ -488,6 +518,11 @@ class ConnRecordSchema(BaseRecordSchema):
             [label for role in ConnRecord.Role for label in role.value]
         ),
         example=ConnRecord.Role.REQUESTER.rfc23,
+    )
+    rfc23_state = fields.Str(
+        dump_only=True,
+        description="State per RFC 23",
+        example="invitation-sent",
     )
     inbound_connection_id = fields.Str(
         required=False,

--- a/aries_cloudagent/connections/models/tests/test_conn_record.py
+++ b/aries_cloudagent/connections/models/tests/test_conn_record.py
@@ -245,6 +245,15 @@ class TestConnRecord(AsyncTestCase):
         retrieved = await record.retrieve_request(self.session)
         assert isinstance(retrieved, ConnectionRequest)
 
+    async def test_ser_rfc23_state_present(self):
+        record = ConnRecord(
+            state=ConnRecord.State.INVITATION,
+            my_did=self.test_did,
+            their_role=ConnRecord.Role.REQUESTER,
+        )
+        ser = record.serialize()
+        assert ser["rfc23_state"] == f"{ConnRecord.State.INVITATION.value[1]}-sent"
+
     async def test_deser_old_style_record(self):
         record = ConnRecord(
             state=ConnRecord.State.INIT,

--- a/aries_cloudagent/connections/models/tests/test_conn_record.py
+++ b/aries_cloudagent/connections/models/tests/test_conn_record.py
@@ -33,6 +33,7 @@ class TestConnRecord(AsyncTestCase):
         )
         assert self.test_conn_record.their_role == ConnRecord.Role.REQUESTER.rfc160
         assert self.test_conn_record.state == ConnRecord.State.COMPLETED.rfc160
+        assert self.test_conn_record.rfc23_state == ConnRecord.State.COMPLETED.rfc23
 
     async def test_get_enums(self):
         assert ConnRecord.Role.get("Larry") is None
@@ -53,6 +54,33 @@ class TestConnRecord(AsyncTestCase):
         assert ConnRecord.Role.REQUESTER == ConnRecord.Role.REQUESTER.rfc160  # check ==
         assert ConnRecord.Role.REQUESTER == ConnRecord.Role.REQUESTER.rfc23
         assert ConnRecord.Role.REQUESTER != ConnRecord.Role.RESPONDER.rfc23
+
+    async def test_state_rfc23strict(self):
+        for state in (
+            ConnRecord.State.INIT,
+            ConnRecord.State.ABANDONED,
+            ConnRecord.State.COMPLETED,
+        ):
+            assert state.rfc23strict(their_role=None) == state.value[1]
+
+        for state in (ConnRecord.State.INVITATION, ConnRecord.State.RESPONSE):
+            assert (
+                state.rfc23strict(their_role=ConnRecord.Role.REQUESTER)
+                == f"{state.value[1]}-sent"
+            )
+            assert (
+                state.rfc23strict(their_role=ConnRecord.Role.RESPONDER)
+                == f"{state.value[1]}-received"
+            )
+
+        assert (
+            ConnRecord.State.REQUEST.rfc23strict(their_role=ConnRecord.Role.REQUESTER)
+            == f"{ConnRecord.State.REQUEST.value[1]}-received"
+        )
+        assert (
+            ConnRecord.State.REQUEST.rfc23strict(their_role=ConnRecord.Role.RESPONDER)
+            == f"{ConnRecord.State.REQUEST.value[1]}-sent"
+        )
 
     async def test_save_retrieve_compare(self):
         record = ConnRecord(my_did=self.test_did)


### PR DESCRIPTION
Dump rfc23 state strictly to match RFC text, rather than for internal conn record state machine logic, for clients that require such (e.g., test harness)