### PR TITLE
Add optional seed field when creating did

### DIFF
--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -56,7 +56,7 @@ class DIDCreateSchema(OpenAPISchema):
         description="Optional seed for did derivation",
         required=False,
         example="00000000000000000000000Endorser1",
-        validate=validate.Length(equal=32)
+        validate=validate.Length(equal=32),
     )
 
 


### PR DESCRIPTION
- This PR adds an optional `seed` field when creating DID, and the seed is used for did derivation.
- Especially in **multitenancy** situations, we may need to use the assigned DID. In our case, we need to use the steward DID to use registering nym.
- I know the seed is sensitive data, but the seed is not recorded in this API. So, we only need to be careful when calling the API.

@ianco @TimoGlastra

Signed-off-by: Ethan Sung <baegjae@gmail.com>