### PR TITLE
store default endpoint in wallet in set public did

### DIFF
--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -309,9 +309,12 @@ async def wallet_set_public_did(request: web.BaseRequest):
         info = await wallet.set_public_did(did)
         if info:
             # Publish endpoint if necessary
-            endpoint = did_info.metadata.get(
-                "endpoint", session.settings.get("default_endpoint")
-            )
+            endpoint = did_info.metadata.get("endpoint")
+
+            if not endpoint:
+                endpoint = session.settings.get("default_endpoint")
+                await wallet.set_did_endpoint(info.did, endpoint, ledger)
+
             async with ledger:
                 await ledger.update_endpoint_for_did(info.did, endpoint)
     except WalletNotFoundError as err:

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -409,11 +409,52 @@ class TestWalletRoutes(AsyncTestCase):
             test_module.web, "json_response", async_mock.Mock()
         ) as json_response:
             self.wallet.set_public_did.return_value = DIDInfo(
-                self.test_did, self.test_verkey, DIDPosture.PUBLIC.metadata
+                self.test_did,
+                self.test_verkey,
+                {**DIDPosture.PUBLIC.metadata, "endpoint": "https://endpoint.com"},
             )
             result = await test_module.wallet_set_public_did(self.request)
             self.wallet.set_public_did.assert_awaited_once_with(
                 self.request.query["did"]
+            )
+            json_response.assert_called_once_with(
+                {
+                    "result": {
+                        "did": self.test_did,
+                        "verkey": self.test_verkey,
+                        "posture": DIDPosture.PUBLIC.moniker,
+                    }
+                }
+            )
+            assert result is json_response.return_value
+
+    async def test_set_public_did_update_endpoint_use_default_update_in_wallet(self):
+        self.request.query = {"did": self.test_did}
+        self.context.update_settings(
+            {"default_endpoint": "https://default_endpoint.com"}
+        )
+
+        Ledger = async_mock.MagicMock()
+        ledger = Ledger()
+        ledger.update_endpoint_for_did = async_mock.CoroutineMock()
+        ledger.get_key_for_did = async_mock.CoroutineMock()
+        ledger.__aenter__ = async_mock.CoroutineMock(return_value=ledger)
+        self.session_inject[BaseLedger] = ledger
+
+        with async_mock.patch.object(
+            test_module.web, "json_response", async_mock.Mock()
+        ) as json_response:
+            did_info = DIDInfo(
+                self.test_did, self.test_verkey, DIDPosture.PUBLIC.metadata
+            )
+            self.wallet.get_local_did.return_value = did_info
+            self.wallet.set_public_did.return_value = did_info
+            result = await test_module.wallet_set_public_did(self.request)
+            self.wallet.set_public_did.assert_awaited_once_with(
+                self.request.query["did"]
+            )
+            self.wallet.set_did_endpoint.assert_awaited_once_with(
+                did_info.did, "https://default_endpoint.com", ledger
             )
             json_response.assert_called_once_with(
                 {


### PR DESCRIPTION
When upgrading a local to public that has no endpoint, the default_endpoint will be registered on the ledger. However the endpoint is not stored in the wallet after this. So /wallet/get-did-endpoint returns null even though the endpoint is registered on the ledger

The issue from Rocket.chat:
> One thing that I noticed was that when I assign the public did: POST /wallet/did/public. GET /wallet/get-did-endpoint still returns null for the endpoint, but the endpoint is already on the ledger. I have to do a set-did-endpoint for this to change.

This is not specific to multitenancy, however it is now more noticeable because the flow is more common due to not being able to provide a seed to a multitenant wallet