### PR TITLE
Feature, default mediator admin api

### DIFF
--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/routes.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/routes.py
@@ -543,7 +543,9 @@ async def register(app: web.Application):
                 "/mediation/keylists/{mediation_id}/send-keylist-query",
                 send_keylist_query,
             ),
-            web.get("/mediation/default-mediator", get_default_mediator),
+            web.get(
+                "/mediation/default-mediator", get_default_mediator, allow_head=False
+            ),
             web.put("/mediation/{mediation_id}/default-mediator", set_default_mediator),
             web.delete("/mediation/default-mediator", clear_default_mediator),
         ]

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/routes.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/routes.py
@@ -478,7 +478,7 @@ async def get_default_mediator(request: web.BaseRequest):
         default_mediator = await MediationManager(
             session
         ).get_default_mediator()
-        results = default_mediator.serialize()
+        results = default_mediator.serialize() if default_mediator else {}
     except (StorageError, BaseModelError) as err:
         raise web.HTTPBadRequest(reason=err.roll_up) from err
     return web.json_response(results, status=200)
@@ -486,14 +486,14 @@ async def get_default_mediator(request: web.BaseRequest):
 
 @docs(tags=["mediation"], summary="Set default mediator")
 @match_info_schema(MediationIdMatchInfoSchema())
-@response_schema(MediationRecordSchema(), 200)
+@response_schema(MediationRecordSchema(), 201)
 async def set_default_mediator(request: web.BaseRequest):
     """Set default mediator."""
     context: AdminRequestContext = request["context"]
-    mediation_id = request.match_info["mediation_id"]
+    mediation_id = request.match_info.get("mediation_id")
     try:
         session = await context.session()
-        mediator_mgr = await MediationManager(session)
+        mediator_mgr = MediationManager(session)
         await mediator_mgr.set_default_mediator_by_id(
             mediation_id=mediation_id
         )
@@ -505,13 +505,13 @@ async def set_default_mediator(request: web.BaseRequest):
 
 
 @docs(tags=["mediation"], summary="Clear default mediator")
-@response_schema(MediationRecordSchema(), 200)
+@response_schema(MediationRecordSchema(), 201)
 async def clear_default_mediator(request: web.BaseRequest):
     """Clear set default mediator."""
     context: AdminRequestContext = request["context"]
     try:
         session = await context.session()
-        mediator_mgr = await MediationManager(session)
+        mediator_mgr = MediationManager(session)
         default_mediator = await mediator_mgr.get_default_mediator()
         await mediator_mgr.clear_default_mediator()
         results = default_mediator.serialize()

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/routes.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/routes.py
@@ -468,6 +468,58 @@ async def send_keylist_update(request: web.BaseRequest):
     return web.json_response(results, status=201)
 
 
+@docs(tags=["mediation"], summary="Get default mediator")
+@response_schema(MediationRecordSchema(), 200)
+async def get_default_mediator(request: web.BaseRequest):
+    """Get default mediator."""
+    context: AdminRequestContext = request["context"]
+    try:
+        session = await context.session()
+        default_mediator = await MediationManager(
+            session
+        ).get_default_mediator()
+        results = default_mediator.serialize()
+    except (StorageError, BaseModelError) as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
+    return web.json_response(results, status=200)
+
+
+@docs(tags=["mediation"], summary="Set default mediator")
+@match_info_schema(MediationIdMatchInfoSchema())
+@response_schema(MediationRecordSchema(), 200)
+async def set_default_mediator(request: web.BaseRequest):
+    """Set default mediator."""
+    context: AdminRequestContext = request["context"]
+    mediation_id = request.match_info["mediation_id"]
+    try:
+        session = await context.session()
+        mediator_mgr = await MediationManager(session)
+        await mediator_mgr.set_default_mediator_by_id(
+            mediation_id=mediation_id
+        )
+        default_mediator = await mediator_mgr.get_default_mediator()
+        results = default_mediator.serialize()
+    except (StorageError, BaseModelError) as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
+    return web.json_response(results, status=201)
+
+
+@docs(tags=["mediation"], summary="Clear default mediator")
+@response_schema(MediationRecordSchema(), 200)
+async def clear_default_mediator(request: web.BaseRequest):
+    """Clear set default mediator."""
+    context: AdminRequestContext = request["context"]
+    try:
+        session = await context.session()
+        mediator_mgr = await MediationManager(session)
+        default_mediator = await mediator_mgr.get_default_mediator()
+        await mediator_mgr.clear_default_mediator()
+        results = default_mediator.serialize()
+    except (StorageError, BaseModelError) as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
+    return web.json_response(results, status=201)
+
+
 async def register(app: web.Application):
     """Register routes."""
 
@@ -495,6 +547,12 @@ async def register(app: web.Application):
                 "/mediation/keylists/{mediation_id}/send-keylist-query",
                 send_keylist_query,
             ),
+            web.get("/mediation/default-mediator", get_default_mediator),
+            web.put(
+                "/mediation/{mediation_id}/default-mediator",
+                set_default_mediator
+            ),
+            web.delete("/mediation/default-mediator", clear_default_mediator),
         ]
     )
 

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/routes.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/routes.py
@@ -475,9 +475,7 @@ async def get_default_mediator(request: web.BaseRequest):
     context: AdminRequestContext = request["context"]
     try:
         session = await context.session()
-        default_mediator = await MediationManager(
-            session
-        ).get_default_mediator()
+        default_mediator = await MediationManager(session).get_default_mediator()
         results = default_mediator.serialize() if default_mediator else {}
     except (StorageError, BaseModelError) as err:
         raise web.HTTPBadRequest(reason=err.roll_up) from err
@@ -494,9 +492,7 @@ async def set_default_mediator(request: web.BaseRequest):
     try:
         session = await context.session()
         mediator_mgr = MediationManager(session)
-        await mediator_mgr.set_default_mediator_by_id(
-            mediation_id=mediation_id
-        )
+        await mediator_mgr.set_default_mediator_by_id(mediation_id=mediation_id)
         default_mediator = await mediator_mgr.get_default_mediator()
         results = default_mediator.serialize()
     except (StorageError, BaseModelError) as err:
@@ -548,10 +544,7 @@ async def register(app: web.Application):
                 send_keylist_query,
             ),
             web.get("/mediation/default-mediator", get_default_mediator),
-            web.put(
-                "/mediation/{mediation_id}/default-mediator",
-                set_default_mediator
-            ),
+            web.put("/mediation/{mediation_id}/default-mediator", set_default_mediator),
             web.delete("/mediation/default-mediator", clear_default_mediator),
         ]
     )

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_routes.py
@@ -574,24 +574,16 @@ class TestCoordinateMediationRoutes(AsyncTestCase):
         self.request.query = {}
         self.context.session = async_mock.CoroutineMock()
         with async_mock.patch.object(
-            test_module.MediationRecord,
-            "query",
-            async_mock.CoroutineMock(return_value=[self.mock_record]),
-        ) as mock_query, async_mock.patch.object(
             test_module.web, "json_response"
         ) as json_response, async_mock.patch.object(
-            BaseStorage, "get_record", async_mock.CoroutineMock()
-        ) as mock_get_record:
+            test_module.MediationManager,
+            "get_default_mediator",
+            async_mock.CoroutineMock(return_value=self.mock_record)
+        ) as mock_mgr_get_default_record:
             await test_module.get_default_mediator(self.request)
             json_response.assert_called_once_with(
-                self.mock_record.serialize.return_value
-            )
-            mock_query.assert_called_once_with(
-                self.context.session.return_value,
-                {
-                    "connection_id": "test-conn-id",
-                    "state": MediationRecord.STATE_GRANTED,
-                },
+                self.mock_record.serialize.return_value,
+                status=200,
             )
 
     async def test_set_default_mediator(self):

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_routes.py
@@ -7,7 +7,6 @@ from asynctest import mock as async_mock
 from aries_cloudagent.config.injection_context import InjectionContext
 from aries_cloudagent.messaging.request_context import RequestContext
 
-from .....storage.base import BaseStorage
 from .....admin.request_context import AdminRequestContext
 from .. import routes as test_module
 from ..manager import MediationManager

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_routes.py
@@ -578,7 +578,7 @@ class TestCoordinateMediationRoutes(AsyncTestCase):
         ) as json_response, async_mock.patch.object(
             test_module.MediationManager,
             "get_default_mediator",
-            async_mock.CoroutineMock(return_value=self.mock_record)
+            async_mock.CoroutineMock(return_value=self.mock_record),
         ) as mock_mgr_get_default_record:
             await test_module.get_default_mediator(self.request)
             json_response.assert_called_once_with(
@@ -594,7 +594,7 @@ class TestCoordinateMediationRoutes(AsyncTestCase):
         ) as json_response, async_mock.patch.object(
             test_module.MediationManager,
             "get_default_mediator",
-            async_mock.CoroutineMock(return_value=None)
+            async_mock.CoroutineMock(return_value=None),
         ) as mock_mgr_get_default_record:
             await test_module.get_default_mediator(self.request)
             json_response.assert_called_once_with(
@@ -610,25 +610,25 @@ class TestCoordinateMediationRoutes(AsyncTestCase):
         ) as json_response, async_mock.patch.object(
             test_module.MediationManager,
             "get_default_mediator",
-            async_mock.CoroutineMock(side_effect=test_module.StorageNotFoundError())
+            async_mock.CoroutineMock(side_effect=test_module.StorageNotFoundError()),
         ) as mock_mgr_get_default_record:
-            with self.assertRaises(test_module.web.HTTPBadRequest): 
+            with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.get_default_mediator(self.request)
 
     async def test_set_default_mediator(self):
-        self.request.match_info={
-                "mediation_id": "fake_id",
-            }
+        self.request.match_info = {
+            "mediation_id": "fake_id",
+        }
         self.request.query = {}
         self.context.session = async_mock.CoroutineMock()
         with async_mock.patch.object(
             test_module.MediationManager,
             "get_default_mediator",
-            async_mock.CoroutineMock(return_value=self.mock_record)
+            async_mock.CoroutineMock(return_value=self.mock_record),
         ) as mock_mgr_get_default_record, async_mock.patch.object(
             test_module.MediationManager,
             "set_default_mediator_by_id",
-            async_mock.CoroutineMock()
+            async_mock.CoroutineMock(),
         ) as mock_mgr_set_default_record_by_id, async_mock.patch.object(
             test_module.web, "json_response"
         ) as json_response:
@@ -639,23 +639,23 @@ class TestCoordinateMediationRoutes(AsyncTestCase):
             )
 
     async def test_set_default_mediator_storage_error(self):
-        self.request.match_info={
-                "mediation_id": "bad_id",
-            }
+        self.request.match_info = {
+            "mediation_id": "bad_id",
+        }
         self.request.query = {}
         self.context.session = async_mock.CoroutineMock()
         with async_mock.patch.object(
             test_module.MediationManager,
             "get_default_mediator",
-            async_mock.CoroutineMock(side_effect=test_module.StorageError())
+            async_mock.CoroutineMock(side_effect=test_module.StorageError()),
         ) as mock_mgr_get_default_record, async_mock.patch.object(
             test_module.MediationManager,
             "set_default_mediator_by_id",
-            async_mock.CoroutineMock(side_effect=test_module.StorageError())
+            async_mock.CoroutineMock(side_effect=test_module.StorageError()),
         ) as mock_mgr_set_default_record_by_id, async_mock.patch.object(
             test_module.web, "json_response"
         ) as json_response:
-            with self.assertRaises(test_module.web.HTTPBadRequest):    
+            with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.set_default_mediator(self.request)
 
     async def test_clear_default_mediator(self):
@@ -664,11 +664,11 @@ class TestCoordinateMediationRoutes(AsyncTestCase):
         with async_mock.patch.object(
             test_module.MediationManager,
             "get_default_mediator",
-            async_mock.CoroutineMock(return_value=self.mock_record)
+            async_mock.CoroutineMock(return_value=self.mock_record),
         ) as mock_mgr_get_default_record, async_mock.patch.object(
             test_module.MediationManager,
             "clear_default_mediator",
-            async_mock.CoroutineMock()
+            async_mock.CoroutineMock(),
         ) as mock_mgr_clear_default_record_by_id, async_mock.patch.object(
             test_module.web, "json_response"
         ) as json_response:
@@ -677,22 +677,22 @@ class TestCoordinateMediationRoutes(AsyncTestCase):
                 self.mock_record.serialize.return_value,
                 status=201,
             )
-    
+
     async def test_clear_default_mediator_storage_error(self):
         self.request.query = {}
         self.context.session = async_mock.CoroutineMock()
         with async_mock.patch.object(
             test_module.MediationManager,
             "get_default_mediator",
-            async_mock.CoroutineMock(side_effect=test_module.StorageError())
+            async_mock.CoroutineMock(side_effect=test_module.StorageError()),
         ) as mock_mgr_get_default_record, async_mock.patch.object(
             test_module.MediationManager,
             "clear_default_mediator",
-            async_mock.CoroutineMock()
+            async_mock.CoroutineMock(),
         ) as mock_mgr_clear_default_record_by_id, async_mock.patch.object(
             test_module.web, "json_response"
         ) as json_response:
-            with self.assertRaises(test_module.web.HTTPBadRequest): 
+            with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.clear_default_mediator(self.request)
 
     async def test_register(self):


### PR DESCRIPTION
get/set/clear default mediator admin API. This code provides admin API endpoints for the recently added  `default mediator` configuration.