### PR TITLE
[multi-tenancy] unique taa cache key per wallet and ledger pool

### DIFF
--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -1048,12 +1048,25 @@ class IndySdkLedger(BaseLedger):
         storage = self.get_indy_storage()
         await storage.add_record(record)
         if self.pool.cache:
-            cache_key = TAA_ACCEPTED_RECORD_TYPE + "::" + self.pool.name
+            # TAA acceptance must be set for each wallet and pool combination
+            cache_key = (
+                TAA_ACCEPTED_RECORD_TYPE
+                + "::"
+                + self.wallet.opened.name
+                + "::"
+                + self.pool.name
+            )
             await self.pool.cache.set(cache_key, acceptance, self.pool.cache_duration)
 
     async def get_latest_txn_author_acceptance(self) -> dict:
         """Look up the latest TAA acceptance."""
-        cache_key = TAA_ACCEPTED_RECORD_TYPE + "::" + self.pool.name
+        cache_key = (
+            TAA_ACCEPTED_RECORD_TYPE
+            + "::"
+            + self.wallet.opened.name
+            + "::"
+            + self.pool.name
+        )
         acceptance = self.pool.cache and await self.pool.cache.get(cache_key)
         if not acceptance:
             storage = self.get_indy_storage()

--- a/aries_cloudagent/ledger/tests/test_indy.py
+++ b/aries_cloudagent/ledger/tests/test_indy.py
@@ -2902,6 +2902,7 @@ class TestIndySdkLedger(AsyncTestCase):
         self, mock_find_all_records, mock_add_record, mock_close, mock_open
     ):
         mock_wallet = async_mock.MagicMock()
+        mock_wallet.opened.name = "test_wallet"
 
         ledger = IndySdkLedger(
             IndySdkLedgerPool("name", checked=True, cache=InMemoryCache()), mock_wallet
@@ -2935,11 +2936,67 @@ class TestIndySdkLedger(AsyncTestCase):
             )
 
             await ledger.pool.cache.clear(
-                f"{TAA_ACCEPTED_RECORD_TYPE}::{ledger.pool_name}"
+                f"{TAA_ACCEPTED_RECORD_TYPE}::{mock_wallet.opened.name}::{ledger.pool_name}"
             )
             for i in range(2):  # populate, then get from, cache
                 response = await ledger.get_latest_txn_author_acceptance()
                 assert response == acceptance
+
+    @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_open")
+    @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_close")
+    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.add_record")
+    @async_mock.patch("aries_cloudagent.storage.indy.IndySdkStorage.find_all_records")
+    async def test_accept_and_get_latest_txn_author_agreement_multiple_wallets_same_pool(
+        self, mock_find_all_records, mock_add_record, mock_close, mock_open
+    ):
+        mock_wallet1 = async_mock.MagicMock()
+        mock_wallet1.opened.name = "test_wallet1"
+
+        mock_wallet2 = async_mock.MagicMock()
+        mock_wallet2.opened.name = "test_wallet2"
+
+        shared_pool = IndySdkLedgerPool("name", checked=True, cache=InMemoryCache())
+
+        ledger1 = IndySdkLedger(shared_pool, mock_wallet1)
+        ledger2 = IndySdkLedger(shared_pool, mock_wallet2)
+
+        accept_time = ledger1.taa_rough_timestamp()
+        taa_record = {
+            "text": "text",
+            "version": "1.0",
+            "digest": "abcd1234",
+        }
+        acceptance = {
+            "text": taa_record["text"],
+            "version": taa_record["version"],
+            "digest": taa_record["digest"],
+            "mechanism": "dummy",
+            "time": accept_time,
+        }
+
+        mock_find_all_records.return_value = [
+            StorageRecord(
+                TAA_ACCEPTED_RECORD_TYPE,
+                json.dumps(acceptance),
+                {"pool_name": shared_pool.name},
+            )
+        ]
+
+        async with ledger1, ledger2:
+            # Set cache for wallet1
+            await shared_pool.cache.set(
+                f"{TAA_ACCEPTED_RECORD_TYPE}::{mock_wallet1.opened.name}::{ledger1.pool_name}",
+                acceptance,
+            )
+
+            # Expect cache value returned
+            response = await ledger1.get_latest_txn_author_acceptance()
+            assert response == acceptance
+            mock_find_all_records.assert_not_called()
+
+            # Expect wallet2 value retrieved from stoage
+            response = await ledger2.get_latest_txn_author_acceptance()
+            mock_find_all_records.assert_called_once()
 
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_open")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_close")
@@ -2948,6 +3005,7 @@ class TestIndySdkLedger(AsyncTestCase):
         self, mock_find_all_records, mock_close, mock_open
     ):
         mock_wallet = async_mock.MagicMock()
+        mock_wallet.opened.name = "test_wallet"
 
         ledger = IndySdkLedger(
             IndySdkLedgerPool("name", checked=True, cache=InMemoryCache()), mock_wallet
@@ -2957,7 +3015,7 @@ class TestIndySdkLedger(AsyncTestCase):
 
         async with ledger:
             await ledger.pool.cache.clear(
-                f"{TAA_ACCEPTED_RECORD_TYPE}::{ledger.pool_name}"
+                f"{TAA_ACCEPTED_RECORD_TYPE}::{mock_wallet.opened.name} :: {ledger.pool_name}"
             )
             response = await ledger.get_latest_txn_author_acceptance()
             assert response == {}


### PR DESCRIPTION
This fixes a bug related to taa acceptance. The taa acceptance was cached in memory with only the ledger pool name, while multiple wallets share the same pool. This caches the taa acceptance based on pool name + wallet name which is always unique

@mat-work this fixes the bug you reported a while ago with TAA acceptance