### PR TITLE
fix: wallet.name to wallet.opened.name in error msgs

### DIFF
--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -616,7 +616,7 @@ class IndySdkLedger(BaseLedger):
                         raise LedgerError(
                             f"Credential definition {credential_definition_id} is on "
                             f"ledger {self.pool.name} but not in wallet "
-                            f"{self.wallet.name}"
+                            f"{self.wallet.opened.name}"
                         )
                 except IndyIssuerError as err:
                     raise LedgerError(err.message) from err
@@ -629,7 +629,7 @@ class IndySdkLedger(BaseLedger):
                 ):
                     raise LedgerError(
                         f"Credential definition {credential_definition_id} is in "
-                        f"wallet {self.wallet.name} but not on ledger "
+                        f"wallet {self.wallet.opened.name} but not on ledger "
                         f"{self.pool.name}"
                     )
             except IndyIssuerError as err:
@@ -886,7 +886,7 @@ class IndySdkLedger(BaseLedger):
         public_info = await self.wallet.get_public_did()
         if not public_info:
             raise WalletNotFoundError(
-                f"Cannot register NYM to ledger: wallet {self.wallet.name} "
+                f"Cannot register NYM to ledger: wallet {self.wallet.opened.name} "
                 "has no public DID"
             )
 
@@ -953,7 +953,7 @@ class IndySdkLedger(BaseLedger):
         data = json.loads((json.loads(response_json))["result"]["data"])
         if not data:
             raise BadLedgerRequestError(
-                f"Ledger has no public DID for wallet {self.wallet.name}"
+                f"Ledger has no public DID for wallet {self.wallet.opened.name}"
             )
         seq_no = data["seqNo"]
 


### PR DESCRIPTION
Fix a couple of problems in exception messages in `ledger/indy.py` where `self.wallet.name` was used instead of `self.wallet.opened.name`.