### PR TITLE
Updates to correctly reference the default branch after renaming.

### DIFF
--- a/.github/workflows/blackformat.yml
+++ b/.github/workflows/blackformat.yml
@@ -3,7 +3,7 @@ name: Black Code Formatter Check
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   lint:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ For significant changes, please open an issue first to discuss the proposed chan
 
 (If you are new to GitHub, you might start with a [basic tutorial](https://help.github.com/articles/set-up-git) and check out a more detailed guide to [pull requests](https://help.github.com/articles/using-pull-requests/).)
 
-Pull requests will be evaluated by the repository guardians on a schedule and if deemed beneficial will be committed to the master. Pull requests should have a descriptive name and include an summary of all changes made in the pull request description.
+Pull requests will be evaluated by the repository guardians on a schedule and if deemed beneficial will be committed to the `main` branch. Pull requests should have a descriptive name and include an summary of all changes made in the pull request description.
 
 If you would like to propose a significant change, please open an issue first to discuss the work with the community.
 

--- a/DevReadMe.md
+++ b/DevReadMe.md
@@ -176,7 +176,7 @@ To run the tests including [Indy SDK](https://github.com/hyperledger/indy-sdk) a
 
 You can run a full suite of integration tests using the [Aries Agent Test Harness (AATH)](https://github.com/hyperledger/aries-agent-test-harness).
 
-Check out and run AATH tests as follows (this tests the aca-py `master` branch):
+Check out and run AATH tests as follows (this tests the aca-py `main` branch):
 
 ```bash
 git clone https://github.com/hyperledger/aries-agent-test-harness.git

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,6 +1,6 @@
 # How to Publish a New Version
 
-0. The code to be published should be in the `master` branch.
+0. The code to be published should be in the `main` branch.
 
 1. Update CHANGELOG.md to include details of the closed PRs included in this release.
 


### PR DESCRIPTION
- GitHub will automatically redirect links to the old branch name, however the URLs should eventually be updated once all of the repositories have been updated.

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>