### PR TITLE
OutOfBand Test Coverage Improvement, Fixes and cleanup

### DIFF
--- a/aries_cloudagent/protocols/out_of_band/v1_0/handlers/tests/test_problem_report_handler.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/handlers/tests/test_problem_report_handler.py
@@ -1,18 +1,21 @@
+"""Test Problem Report Handler."""
 import pytest
+
 from asynctest import mock as async_mock
 
 from ......connections.models import connection_target
 from ......connections.models.conn_record import ConnRecord
 from ......connections.models.diddoc import DIDDoc, PublicKey, PublicKeyType, Service
+from ......core.profile import ProfileSession
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
-from ......transport.inbound.receipt import MessageReceipt
 from ......storage.base import BaseStorage
 from ......storage.error import StorageNotFoundError
+from ......transport.inbound.receipt import MessageReceipt
+
 from ...handlers import problem_report_handler as handler
 from ...manager import OutOfBandManagerError, OutOfBandManager
 from ...messages.problem_report import ProblemReport, ProblemReportReason
-from ......core.profile import ProfileSession
 
 
 @pytest.fixture()

--- a/aries_cloudagent/protocols/out_of_band/v1_0/handlers/tests/test_reuse_accept_handler.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/handlers/tests/test_reuse_accept_handler.py
@@ -1,19 +1,22 @@
+"""Test Reuse Accept Message Handler."""
 import pytest
+
 from asynctest import mock as async_mock
 
 from ......connections.models import connection_target
 from ......connections.models.conn_record import ConnRecord
 from ......connections.models.diddoc import DIDDoc, PublicKey, PublicKeyType, Service
+from ......core.profile import ProfileSession
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
-from ......transport.inbound.receipt import MessageReceipt
 from ......storage.base import BaseStorage
 from ......storage.error import StorageNotFoundError
+from ......transport.inbound.receipt import MessageReceipt
+
 from ...handlers import reuse_accept_handler as handler
 from ...manager import OutOfBandManagerError, OutOfBandManager
 from ...messages.reuse import HandshakeReuse
 from ...messages.reuse_accept import HandshakeReuseAccept
-from ......core.profile import ProfileSession
 
 
 @pytest.fixture()

--- a/aries_cloudagent/protocols/out_of_band/v1_0/handlers/tests/test_reuse_handler.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/handlers/tests/test_reuse_handler.py
@@ -1,19 +1,22 @@
+"""Test Reuse Message Handler."""
 import pytest
+
 from asynctest import mock as async_mock
 
 from ......connections.models import connection_target
 from ......connections.models.conn_record import ConnRecord
 from ......connections.models.diddoc import DIDDoc, PublicKey, PublicKeyType, Service
+from ......core.profile import ProfileSession
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
-from ......transport.inbound.receipt import MessageReceipt
 from ......storage.base import BaseStorage
 from ......storage.error import StorageNotFoundError
+from ......transport.inbound.receipt import MessageReceipt
+
 from ...handlers import reuse_handler as handler
 from ...manager import OutOfBandManagerError, OutOfBandManager
 from ...messages.reuse import HandshakeReuse
 from ...messages.reuse_accept import HandshakeReuseAccept
-from ......core.profile import ProfileSession
 
 
 @pytest.fixture()

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -1,49 +1,46 @@
 """Classes to manage connections."""
 
-import logging
 import asyncio
 import json
+import logging
 
 from typing import Mapping, Sequence, Optional
 
 from ....connections.models.conn_record import ConnRecord
+from ....connections.base_manager import BaseConnectionManager
 from ....core.error import BaseError
 from ....core.profile import ProfileSession
+from ....indy.holder import IndyHolder
+from ....messaging.responder import BaseResponder
+from ....messaging.decorators.attach_decorator import AttachDecorator
 from ....multitenant.manager import MultitenantManager
+from ....ledger.base import BaseLedger
 from ....storage.error import StorageNotFoundError
+from ....transport.inbound.receipt import MessageReceipt
 from ....wallet.base import BaseWallet
 from ....wallet.util import naked_to_did_key, b64_to_bytes, did_key_to_naked
 
-from ...didexchange.v1_0.message_types import ARIES_PROTOCOL as DIDX_PROTO
+from ...connections.v1_0.messages.connection_invitation import ConnectionInvitation
+from ...connections.v1_0.manager import ConnectionManager
 from ...connections.v1_0.message_types import ARIES_PROTOCOL as CONN_PROTO
-from ...didexchange.v1_0.manager import DIDXManager
 from ...didcomm_prefix import DIDCommPrefix
+from ...didexchange.v1_0.message_types import ARIES_PROTOCOL as DIDX_PROTO
+from ...didexchange.v1_0.manager import DIDXManager
+from ...issue_credential.v2_0.messages.cred_offer import V20CredOffer
 from ...issue_credential.v1_0.models.credential_exchange import V10CredentialExchange
 from ...issue_credential.v2_0.models.cred_ex_record import V20CredExRecord
-from ...issue_credential.v2_0.messages.cred_offer import V20CredOffer
+from ...present_proof.v1_0.manager import PresentationManager
 from ...present_proof.v1_0.message_types import PRESENTATION_REQUEST
+from ...present_proof.v1_0.messages.presentation_proposal import PresentationProposal
 from ...present_proof.v1_0.models.presentation_exchange import V10PresentationExchange
+from ...present_proof.v1_0.util.indy import indy_proof_req_preview2indy_requested_creds
 
 from .messages.invitation import InvitationMessage
+from .messages.problem_report import ProblemReportReason, ProblemReport
 from .messages.reuse import HandshakeReuse
 from .messages.reuse_accept import HandshakeReuseAccept
-from .messages.problem_report import ProblemReportReason, ProblemReport
-from ....connections.base_manager import BaseConnectionManager
-from ....transport.inbound.receipt import MessageReceipt
-
 from .messages.service import Service as ServiceMessage
 from .models.invitation import InvitationRecord
-
-from ...connections.v1_0.manager import ConnectionManager
-from ...present_proof.v1_0.manager import PresentationManager
-
-from ...connections.v1_0.messages.connection_invitation import ConnectionInvitation
-from ....ledger.base import BaseLedger
-from ....messaging.responder import BaseResponder
-from ...present_proof.v1_0.messages.presentation_proposal import PresentationProposal
-from ...present_proof.v1_0.util.indy import indy_proof_req_preview2indy_requested_creds
-from ....indy.holder import IndyHolder
-from ....messaging.decorators.attach_decorator import AttachDecorator
 
 
 class OutOfBandManagerError(BaseError):

--- a/aries_cloudagent/protocols/out_of_band/v1_0/messages/tests/test_problem_report.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/messages/tests/test_problem_report.py
@@ -1,7 +1,8 @@
+"""Test Problem Report Message."""
 import pytest
 
-from unittest import mock, TestCase
 from asynctest import TestCase as AsyncTestCase
+from unittest import mock, TestCase
 
 from ......messaging.models.base import BaseModelError
 

--- a/aries_cloudagent/protocols/out_of_band/v1_0/messages/tests/test_reuse.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/messages/tests/test_reuse.py
@@ -1,7 +1,8 @@
+"""Test Reuse Message."""
 import pytest
 
-from unittest import mock, TestCase
 from asynctest import TestCase as AsyncTestCase
+from unittest import mock, TestCase
 
 from ......messaging.models.base import BaseModelError
 

--- a/aries_cloudagent/protocols/out_of_band/v1_0/messages/tests/test_reuse_accept.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/messages/tests/test_reuse_accept.py
@@ -1,7 +1,8 @@
+"""Test Reuse Accept Message."""
 import pytest
 
-from unittest import mock, TestCase
 from asynctest import TestCase as AsyncTestCase
+from unittest import mock, TestCase
 
 from ......messaging.models.base import BaseModelError
 

--- a/aries_cloudagent/protocols/out_of_band/v1_0/routes.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/routes.py
@@ -64,7 +64,7 @@ class InvitationCreateRequestSchema(OpenAPISchema):
         _type = fields.Str(
             data_key="type",
             description="Attachment type",
-            example="credential-offer",
+            example="present-proof",
         )
 
     attachments = fields.Nested(

--- a/aries_cloudagent/protocols/out_of_band/v1_0/routes.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/routes.py
@@ -42,7 +42,9 @@ class InvitationCreateQueryStringSchema(OpenAPISchema):
         required=False,
     )
     use_connections_rfc160 = fields.Boolean(
-        description="Use the RFC 0160 over did-exchange",
+        description=(
+            "Use RFC 0160 connection invitation over RFC 0023 did exchange protocol"
+        ),
         required=False,
         default=False,
     )

--- a/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
@@ -4,6 +4,7 @@ import json
 from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
 from datetime import datetime, timezone
+from copy import deepcopy
 
 from .....connections.models.conn_record import ConnRecord
 from .....connections.models.diddoc import DIDDoc, PublicKey, PublicKeyType, Service
@@ -15,6 +16,9 @@ from .....messaging.util import str_to_datetime, str_to_epoch
 from .....multitenant.manager import MultitenantManager
 from .....protocols.didexchange.v1_0.manager import DIDXManager
 from .....protocols.connections.v1_0.manager import ConnectionManager
+from .....protocols.issue_credential.v1_0.message_types import (
+    CREDENTIAL_OFFER,
+)
 from .....protocols.present_proof.v1_0.manager import PresentationManager
 from .....protocols.present_proof.v1_0.message_types import (
     PRESENTATION_REQUEST,
@@ -42,6 +46,7 @@ from .....protocols.present_proof.v1_0.models.presentation_exchange import (
 from .....wallet.base import DIDInfo, KeyInfo
 from .....wallet.in_memory import InMemoryWallet
 from .....wallet.util import did_key_to_naked
+from .....storage.error import StorageError, StorageNotFoundError
 from .....indy.holder import IndyHolder
 from ....didcomm_prefix import DIDCommPrefix
 from .. import manager as test_module
@@ -71,6 +76,105 @@ class TestConfig:
     test_endpoint = "http://localhost"
     test_target_did = "GbuDUYXaUZRfHD2jeDuQuP"
     their_public_did = "55GkHamhTU1ZbTbV2ab9DE"
+    NOW_8601 = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(" ", "seconds")
+    NOW_EPOCH = str_to_epoch(NOW_8601)
+    CD_ID = "GMm4vMw8LLrLJjp81kRRLp:3:CL:12:tag"
+    INDY_PROOF_REQ = json.loads(
+        f"""{{
+        "name": "proof-req",
+        "version": "1.0",
+        "nonce": "12345",
+        "requested_attributes": {{
+            "0_player_uuid": {{
+                "name": "player",
+                "restrictions": [
+                    {{
+                        "cred_def_id": "{CD_ID}"
+                    }}
+                ],
+                "non_revoked": {{
+                    "from": {NOW_EPOCH},
+                    "to": {NOW_EPOCH}
+                }}
+            }},
+            "0_screencapture_uuid": {{
+                "name": "screenCapture",
+                "restrictions": [
+                    {{
+                        "cred_def_id": "{CD_ID}"
+                    }}
+                ],
+                "non_revoked": {{
+                    "from": {NOW_EPOCH},
+                    "to": {NOW_EPOCH}
+                }}
+            }}
+        }},
+        "requested_predicates": {{
+            "0_highscore_GE_uuid": {{
+                "name": "highScore",
+                "p_type": ">=",
+                "p_value": 1000000,
+                "restrictions": [
+                    {{
+                        "cred_def_id": "{CD_ID}"
+                    }}
+                ],
+                "non_revoked": {{
+                    "from": {NOW_EPOCH},
+                    "to": {NOW_EPOCH}
+                }}
+            }}
+        }}
+    }}"""
+    )
+
+    PRES_PREVIEW = PresentationPreview(
+        attributes=[
+            PresAttrSpec(name="player", cred_def_id=CD_ID, value="Richie Knucklez"),
+            PresAttrSpec(
+                name="screenCapture",
+                cred_def_id=CD_ID,
+                mime_type="image/png",
+                value="aW1hZ2luZSBhIHNjcmVlbiBjYXB0dXJl",
+            ),
+        ],
+        predicates=[
+            PresPredSpec(
+                name="highScore", cred_def_id=CD_ID, predicate=">=", threshold=1000000
+            )
+        ],
+    )
+
+    PRES_REQ = PresentationRequest(
+        comment="Test",
+        request_presentations_attach=[
+            AttachDecorator.from_indy_dict(
+                indy_dict=INDY_PROOF_REQ,
+                ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+            )
+        ],
+    )
+
+    pres_req_dict = PRES_REQ.request_presentations_attach[0].serialize()
+    req_attach = {
+        "@id": "request-0",
+        "mime-type": "application/json",
+        "data": {
+            "json": {
+                "@type": DIDCommPrefix.qualify_current(PRESENTATION_REQUEST),
+                "@id": "12345678-1234-5678-1234-567812345678",
+                "comment": "some comment",
+                "request_presentations~attach": [pres_req_dict],
+            }
+        },
+    }
+
+    indy_cred_req = {
+        "schema_id": f"{test_did}:2:bc-reg:1.0",
+        "cred_def_id": f"{test_did}:3:CL:12:tag1",
+    }
+    cred_req_meta = {}
 
     def make_did_doc(self, did, verkey):
         doc = DIDDoc(did=did)
@@ -714,12 +818,23 @@ class TestOOBManager(AsyncTestCase, TestConfig):
         assert conn_record == None
 
         post_filter["their_public_did"] = self.their_public_did
-        post_filter["state"] = "active"
         conn_record = await self.manager.find_existing_connection(
             tag_filter, post_filter
         )
         assert conn_record == test_conn_rec
         await test_conn_rec.delete_record(self.session)
+
+    async def test_find_existing_connection_no_active(self):
+        self.test_conn_rec.invitation_msg_id = "test_123"
+        self.test_conn_rec.state = ConnRecord.State.REQUEST.rfc160
+        await self.test_conn_rec.save(self.session)
+        tag_filter = {}
+        post_filter = {}
+        post_filter["invitation_msg_id"] = "test_123"
+        conn_record = await self.manager.find_existing_connection(
+            tag_filter, post_filter
+        )
+        assert conn_record is None
 
     async def test_check_reuse_msg_state(self):
         await self.test_conn_rec.save(self.session)
@@ -767,7 +882,36 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 == "initial"
             )
 
-    async def test_recieve_reuse_message_existing_found(self):
+    async def test_create_handshake_reuse_msg_catch_exception(self):
+        self.session.context.update_settings({"public_invites": True})
+        await self.test_conn_rec.save(self.session)
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            DIDXManager, "receive_invitation", autospec=True
+        ) as didx_mgr_receive_invitation, async_mock.patch(
+            "aries_cloudagent.protocols.out_of_band.v1_0.manager.InvitationMessage",
+            autospec=True,
+        ) as inv_message_cls, async_mock.patch.object(
+            OutOfBandManager,
+            "fetch_connection_targets",
+            autospec=True,
+        ) as oob_mgr_fetch_conn:
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+            oob_mgr_fetch_conn.side_effect = StorageNotFoundError()
+            oob_invi = InvitationMessage()
+            with self.assertRaises(OutOfBandManagerError) as context:
+                await self.manager.create_handshake_reuse_message(
+                    oob_invi, self.test_conn_rec
+                )
+                assert "Error on creating and sending a handshake reuse message" in str(
+                    context.exception
+                )
+
+    async def test_receive_reuse_message_existing_found(self):
         self.session.context.update_settings({"public_invites": True})
         receipt = MessageReceipt(
             recipient_did=TestConfig.test_did,
@@ -824,7 +968,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 == 1
             )
 
-    async def test_recieve_reuse_message_existing_not_found(self):
+    async def test_receive_reuse_message_existing_not_found(self):
         self.session.context.update_settings({"public_invites": True})
         receipt = MessageReceipt(
             recipient_did=TestConfig.test_did,
@@ -850,10 +994,6 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             "fetch_connection_targets",
             autospec=True,
         ) as oob_mgr_fetch_conn, async_mock.patch.object(
-            ConnRecord,
-            "query",
-            autospec=True,
-        ) as conn_rec_query, async_mock.patch.object(
             InvitationRecord,
             "retrieve_by_tag_filter",
             autospec=True,
@@ -864,7 +1004,6 @@ class TestOOBManager(AsyncTestCase, TestConfig):
         ) as oob_mgr_find_existing_conn:
             mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
             mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
-            conn_rec_query.return_value = [self.test_conn_rec]
             oob_mgr_find_existing_conn.return_value = None
             oob_mgr_fetch_conn.return_value = ConnectionTarget(
                 did=TestConfig.test_did,
@@ -874,9 +1013,84 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             )
             oob_invi = InvitationMessage()
             retrieve_invi_rec.return_value = InvitationRecord(invi_msg_id="test_123")
+            with self.assertRaises(OutOfBandManagerError) as context:
+                await self.manager.receive_reuse_message(reuse_msg, receipt)
+                assert "No existing ConnRecord found" in str(context.exception)
+
+    async def test_receive_reuse_message_storage_not_found(self):
+        self.session.context.update_settings({"public_invites": True})
+        receipt = MessageReceipt(
+            recipient_did=TestConfig.test_did,
+            recipient_did_public=False,
+            sender_did="test_did",
+        )
+        reuse_msg = HandshakeReuse()
+        reuse_msg.assign_thread_id(thid="test_123", pthid="test_123")
+
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            DIDXManager, "receive_invitation", autospec=True
+        ) as didx_mgr_receive_invitation, async_mock.patch(
+            "aries_cloudagent.protocols.out_of_band.v1_0.manager.InvitationMessage",
+            autospec=True,
+        ) as inv_message_cls, async_mock.patch.object(
+            OutOfBandManager,
+            "fetch_connection_targets",
+            autospec=True,
+        ) as oob_mgr_fetch_conn, async_mock.patch.object(
+            InvitationRecord,
+            "retrieve_by_tag_filter",
+            autospec=True,
+        ) as retrieve_invi_rec, async_mock.patch.object(
+            OutOfBandManager,
+            "find_existing_connection",
+            autospec=True,
+        ) as oob_mgr_find_existing_conn:
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+            oob_mgr_find_existing_conn.side_effect = StorageNotFoundError()
+            with self.assertRaises(OutOfBandManagerError) as context:
+                await self.manager.receive_reuse_message(reuse_msg, receipt)
+                assert "No existing ConnRecord found for OOB Invitee" in str(
+                    context.exception
+                )
+
+    async def test_receive_reuse_message_problem_report_logic(self):
+        self.session.context.update_settings({"public_invites": True})
+        receipt = MessageReceipt(
+            recipient_did=TestConfig.test_did,
+            recipient_did_public=False,
+            sender_did="test_did",
+        )
+        reuse_msg = HandshakeReuse()
+        reuse_msg.assign_thread_id(thid="test_123", pthid="test_123")
+        self.test_conn_rec.invitation_msg_id = "test_456"
+        self.test_conn_rec.their_did = "test_did"
+        self.test_conn_rec.state = ConnRecord.State.COMPLETED.rfc160
+        await self.test_conn_rec.save(self.session)
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            OutOfBandManager,
+            "fetch_connection_targets",
+            autospec=True,
+        ) as oob_mgr_fetch_conn:
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+            oob_mgr_fetch_conn.return_value = ConnectionTarget(
+                did=TestConfig.test_did,
+                endpoint=TestConfig.test_endpoint,
+                recipient_keys=TestConfig.test_verkey,
+                sender_key=TestConfig.test_verkey,
+            )
             await self.manager.receive_reuse_message(reuse_msg, receipt)
 
-    async def test_recieve_reuse_accepeted(self):
+    async def test_receive_reuse_accepted(self):
         self.session.context.update_settings({"public_invites": True})
         receipt = MessageReceipt(
             recipient_did=TestConfig.test_did,
@@ -917,7 +1131,48 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 == "accepted"
             )
 
-    async def test_recieve_reuse_accepeted_invalid_conn(self):
+    async def test_receive_reuse_accepted(self):
+        self.session.context.update_settings({"public_invites": True})
+        receipt = MessageReceipt(
+            recipient_did=TestConfig.test_did,
+            recipient_did_public=False,
+            sender_did="test_did",
+        )
+        reuse_msg_accepted = HandshakeReuseAccept()
+        reuse_msg_accepted.assign_thread_id(thid="test_123", pthid="test_123")
+        self.test_conn_rec.invitation_msg_id = "test_123"
+        self.test_conn_rec.state = ConnRecord.State.COMPLETED.rfc160
+        await self.test_conn_rec.save(self.session)
+        await self.test_conn_rec.metadata_set(self.session, "reuse_msg_id", "test_123")
+        await self.test_conn_rec.metadata_set(
+            self.session, "reuse_msg_state", "initial"
+        )
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            DIDXManager, "receive_invitation", autospec=True
+        ) as didx_mgr_receive_invitation, async_mock.patch(
+            "aries_cloudagent.protocols.out_of_band.v1_0.manager.InvitationMessage",
+            autospec=True,
+        ) as inv_message_cls, async_mock.patch.object(
+            OutOfBandManager,
+            "fetch_connection_targets",
+            autospec=True,
+        ) as oob_mgr_fetch_conn:
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+
+            await self.manager.receive_reuse_accepted_message(
+                reuse_msg_accepted, receipt, self.test_conn_rec
+            )
+            assert (
+                await self.test_conn_rec.metadata_get(self.session, "reuse_msg_state")
+                == "accepted"
+            )
+
+    async def test_receive_reuse_accepted_invalid_conn(self):
         self.session.context.update_settings({"public_invites": True})
         receipt = MessageReceipt(
             recipient_did=TestConfig.test_did,
@@ -948,9 +1203,48 @@ class TestOOBManager(AsyncTestCase, TestConfig):
         ) as oob_mgr_fetch_conn:
             mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
             mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
-            with self.assertRaises(AssertionError) as context:
+            with self.assertRaises(OutOfBandManagerError) as context:
                 await self.manager.receive_reuse_accepted_message(
                     reuse_msg_accepted, receipt, test_invalid_conn
+                )
+                assert "Error processing reuse accepted message" in str(
+                    context.exception
+                )
+
+    async def test_receive_reuse_accepted_message_catch_exception(self):
+        self.session.context.update_settings({"public_invites": True})
+        receipt = MessageReceipt(
+            recipient_did=TestConfig.test_did,
+            recipient_did_public=False,
+            sender_did="test_did",
+        )
+        reuse_msg_accepted = HandshakeReuseAccept()
+        reuse_msg_accepted.assign_thread_id(thid="test_123", pthid="test_123")
+        self.test_conn_rec.invitation_msg_id = "test_123"
+        self.test_conn_rec.state = ConnRecord.State.COMPLETED.rfc160
+        await self.test_conn_rec.save(self.session)
+        await self.test_conn_rec.metadata_set(self.session, "reuse_msg_id", "test_123")
+        await self.test_conn_rec.metadata_set(
+            self.session, "reuse_msg_state", "initial"
+        )
+
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            self.test_conn_rec,
+            "metadata_set",
+            async_mock.CoroutineMock(side_effect=StorageNotFoundError),
+        ):
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+            with self.assertRaises(OutOfBandManagerError) as context:
+                await self.manager.receive_reuse_accepted_message(
+                    reuse_msg_accepted, receipt, self.test_conn_rec
+                )
+                assert "Error processing reuse accepted message" in str(
+                    context.exception
                 )
 
     async def test_problem_report_received_not_active(self):
@@ -1076,9 +1370,12 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
             mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
 
-            with self.assertRaises(AssertionError) as context:
+            with self.assertRaises(OutOfBandManagerError) as context:
                 await self.manager.receive_problem_report(
                     problem_report, receipt, test_invalid_conn
+                )
+                assert "Error processing problem report message" in str(
+                    context.exception
                 )
 
     async def test_existing_conn_record_public_did(self):
@@ -1428,7 +1725,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             )
             assert retrieved_conn_records[0].state == ConnRecord.State.ABANDONED.rfc160
 
-    async def test_req_attach_presentation_existing_conn_no_auto_present(self):
+    async def test_existing_conn_record_public_did_timeout_no_handshake_protocol(self):
         self.session.context.update_settings({"public_invites": True})
         test_exist_conn = ConnRecord(
             my_did=TestConfig.test_did,
@@ -1446,83 +1743,57 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             sender_did=TestConfig.test_target_did,
         )
 
-        NOW_8601 = (
-            datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(" ", "seconds")
-        )
-        NOW_EPOCH = str_to_epoch(NOW_8601)
-        CD_ID = "GMm4vMw8LLrLJjp81kRRLp:3:CL:12:tag"
-        INDY_PROOF_REQ = json.loads(
-            f"""{{
-            "name": "proof-req",
-            "version": "1.0",
-            "nonce": "12345",
-            "requested_attributes": {{
-                "0_player_uuid": {{
-                    "name": "player",
-                    "restrictions": [
-                        {{
-                            "cred_def_id": "{CD_ID}"
-                        }}
-                    ],
-                    "non_revoked": {{
-                        "from": {NOW_EPOCH},
-                        "to": {NOW_EPOCH}
-                    }}
-                }},
-                "0_screencapture_uuid": {{
-                    "name": "screenCapture",
-                    "restrictions": [
-                        {{
-                            "cred_def_id": "{CD_ID}"
-                        }}
-                    ],
-                    "non_revoked": {{
-                        "from": {NOW_EPOCH},
-                        "to": {NOW_EPOCH}
-                    }}
-                }}
-            }},
-            "requested_predicates": {{
-                "0_highscore_GE_uuid": {{
-                    "name": "highScore",
-                    "p_type": ">=",
-                    "p_value": 1000000,
-                    "restrictions": [
-                        {{
-                            "cred_def_id": "{CD_ID}"
-                        }}
-                    ],
-                    "non_revoked": {{
-                        "from": {NOW_EPOCH},
-                        "to": {NOW_EPOCH}
-                    }}
-                }}
-            }}
-        }}"""
-        )
-
-        PRES_REQ = PresentationRequest(
-            comment="Test",
-            request_presentations_attach=[
-                AttachDecorator.from_indy_dict(
-                    indy_dict=INDY_PROOF_REQ,
-                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            DIDXManager, "receive_invitation", autospec=True
+        ) as didx_mgr_receive_invitation, async_mock.patch(
+            "aries_cloudagent.protocols.out_of_band.v1_0.manager.InvitationMessage",
+            autospec=True,
+        ) as inv_message_cls, async_mock.patch.object(
+            OutOfBandManager,
+            "fetch_connection_targets",
+            autospec=True,
+        ) as oob_mgr_fetch_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "find_existing_connection",
+            autospec=True,
+        ) as oob_mgr_find_existing_conn:
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+            oob_mgr_find_existing_conn.return_value = test_exist_conn
+            mock_oob_invi = async_mock.MagicMock(
+                handshake_protocols=[],
+                service_dids=[TestConfig.test_target_did],
+                service_blocks=[],
+                request_attach=[{"having": "attachment", "is": "no", "good": "here"}],
+            )
+            inv_message_cls.deserialize.return_value = mock_oob_invi
+            with self.assertRaises(OutOfBandManagerError) as context:
+                result = await self.manager.receive_invitation(
+                    mock_oob_invi, use_existing_connection=False
                 )
-            ],
+                assert "No existing connection exists and " in str(context.exception)
+
+    async def test_req_attach_presentation_existing_conn_no_auto_present(self):
+        self.session.context.update_settings({"public_invites": True})
+        test_exist_conn = ConnRecord(
+            my_did=TestConfig.test_did,
+            their_did=TestConfig.test_target_did,
+            their_public_did=TestConfig.test_target_did,
+            invitation_msg_id="12345678-1234-5678-1234-567812345678",
+            their_role=ConnRecord.Role.REQUESTER,
         )
-        pres_req_dict = PRES_REQ.request_presentations_attach[0].serialize()
-        req_attach = {
-            "@id": "request-0",
-            "mime-type": "application/json",
-            "data": {
-                "json": {
-                    "@type": DIDCommPrefix.qualify_current(PRESENTATION_REQUEST),
-                    "@id": "12345678-1234-5678-1234-567812345678",
-                    "comment": "some comment",
-                    "request_presentations~attach": [pres_req_dict],
-                }
-            },
-        }
+        await test_exist_conn.save(self.session)
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_state", "initial")
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_id", "test_123")
+        receipt = MessageReceipt(
+            recipient_did=TestConfig.test_did,
+            recipient_did_public=False,
+            sender_did=TestConfig.test_target_did,
+        )
 
         exchange_rec = V10PresentationExchange()
 
@@ -1577,7 +1848,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 ],
                 service_dids=[TestConfig.test_target_did],
                 service_blocks=[],
-                request_attach=[AttachDecorator.deserialize(req_attach)],
+                request_attach=[AttachDecorator.deserialize(TestConfig.req_attach)],
             )
 
             inv_message_cls.deserialize.return_value = mock_oob_invi
@@ -1611,94 +1882,14 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             sender_did=TestConfig.test_target_did,
         )
 
-        NOW_8601 = (
-            datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(" ", "seconds")
-        )
-        NOW_EPOCH = str_to_epoch(NOW_8601)
-        CD_ID = "GMm4vMw8LLrLJjp81kRRLp:3:CL:12:tag"
-        INDY_PROOF_REQ = json.loads(
-            f"""{{
-            "name": "proof-req",
-            "version": "1.0",
-            "nonce": "12345",
-            "requested_attributes": {{
-                "0_player_uuid": {{
-                    "name": "player",
-                    "restrictions": [
-                        {{
-                            "cred_def_id": "{CD_ID}"
-                        }}
-                    ],
-                    "non_revoked": {{
-                        "from": {NOW_EPOCH},
-                        "to": {NOW_EPOCH}
-                    }}
-                }},
-                "0_screencapture_uuid": {{
-                    "name": "screenCapture",
-                    "restrictions": [
-                        {{
-                            "cred_def_id": "{CD_ID}"
-                        }}
-                    ],
-                    "non_revoked": {{
-                        "from": {NOW_EPOCH},
-                        "to": {NOW_EPOCH}
-                    }}
-                }}
-            }},
-            "requested_predicates": {{
-                "0_highscore_GE_uuid": {{
-                    "name": "highScore",
-                    "p_type": ">=",
-                    "p_value": 1000000,
-                    "restrictions": [
-                        {{
-                            "cred_def_id": "{CD_ID}"
-                        }}
-                    ],
-                    "non_revoked": {{
-                        "from": {NOW_EPOCH},
-                        "to": {NOW_EPOCH}
-                    }}
-                }}
-            }}
-        }}"""
-        )
-
-        PRES_REQ = PresentationRequest(
-            comment="Test",
-            request_presentations_attach=[
-                AttachDecorator.from_indy_dict(
-                    indy_dict=INDY_PROOF_REQ,
-                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
-                )
-            ],
-        )
-        pres_req_dict = PRES_REQ.request_presentations_attach[0].serialize()
-        req_attach = {
-            "@id": "request-0",
-            "mime-type": "application/json",
-            "data": {
-                "json": {
-                    "@type": DIDCommPrefix.qualify_current(PRESENTATION_REQUEST),
-                    "@id": "12345678-1234-5678-1234-567812345678",
-                    "comment": "some comment",
-                    "request_presentations~attach": [pres_req_dict],
-                }
-            },
-        }
-
-        indy_cred_req = {
-            "schema_id": f"{TestConfig.test_did}:2:bc-reg:1.0",
-            "cred_def_id": f"{TestConfig.test_did}:3:CL:12:tag1",
-        }
-        cred_req_meta = {}
-
         exchange_rec = V10PresentationExchange()
         exchange_rec.auto_present = True
-        exchange_rec.presentation_request = INDY_PROOF_REQ
-        exchange_rec.presentation_proposal_dict = {}
+        exchange_rec.presentation_request = TestConfig.INDY_PROOF_REQ
+
+        presentation_proposal = PresentationProposal(
+            comment="Hello World", presentation_proposal=TestConfig.PRES_PREVIEW
+        )
+        exchange_rec.presentation_proposal_dict = presentation_proposal.serialize()
 
         with async_mock.patch.object(
             self.ledger, "get_key_for_did", async_mock.CoroutineMock()
@@ -1768,7 +1959,10 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             )
             holder.get_credentials_for_presentation_request_by_referent = get_creds
             holder.create_credential_request = async_mock.CoroutineMock(
-                return_value=(json.dumps(indy_cred_req), json.dumps(cred_req_meta))
+                return_value=(
+                    json.dumps(TestConfig.indy_cred_req),
+                    json.dumps(TestConfig.cred_req_meta),
+                )
             )
             self.session.context.injector.bind_instance(IndyHolder, holder)
             mock_oob_invi = async_mock.MagicMock(
@@ -1777,7 +1971,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 ],
                 service_dids=[TestConfig.test_target_did],
                 service_blocks=[],
-                request_attach=[AttachDecorator.deserialize(req_attach)],
+                request_attach=[AttachDecorator.deserialize(TestConfig.req_attach)],
             )
 
             inv_message_cls.deserialize.return_value = mock_oob_invi
@@ -1811,93 +2005,9 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             sender_did=TestConfig.test_target_did,
         )
 
-        NOW_8601 = (
-            datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(" ", "seconds")
-        )
-        NOW_EPOCH = str_to_epoch(NOW_8601)
-        CD_ID = "GMm4vMw8LLrLJjp81kRRLp:3:CL:12:tag"
-        INDY_PROOF_REQ = json.loads(
-            f"""{{
-            "name": "proof-req",
-            "version": "1.0",
-            "nonce": "12345",
-            "requested_attributes": {{
-                "0_player_uuid": {{
-                    "name": "player",
-                    "restrictions": [
-                        {{
-                            "cred_def_id": "{CD_ID}"
-                        }}
-                    ],
-                    "non_revoked": {{
-                        "from": {NOW_EPOCH},
-                        "to": {NOW_EPOCH}
-                    }}
-                }},
-                "0_screencapture_uuid": {{
-                    "name": "screenCapture",
-                    "restrictions": [
-                        {{
-                            "cred_def_id": "{CD_ID}"
-                        }}
-                    ],
-                    "non_revoked": {{
-                        "from": {NOW_EPOCH},
-                        "to": {NOW_EPOCH}
-                    }}
-                }}
-            }},
-            "requested_predicates": {{
-                "0_highscore_GE_uuid": {{
-                    "name": "highScore",
-                    "p_type": ">=",
-                    "p_value": 1000000,
-                    "restrictions": [
-                        {{
-                            "cred_def_id": "{CD_ID}"
-                        }}
-                    ],
-                    "non_revoked": {{
-                        "from": {NOW_EPOCH},
-                        "to": {NOW_EPOCH}
-                    }}
-                }}
-            }}
-        }}"""
-        )
-
-        PRES_REQ = PresentationRequest(
-            comment="Test",
-            request_presentations_attach=[
-                AttachDecorator.from_indy_dict(
-                    indy_dict=INDY_PROOF_REQ,
-                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
-                )
-            ],
-        )
-        pres_req_dict = PRES_REQ.request_presentations_attach[0].serialize()
-        req_attach = {
-            "@id": "request-0",
-            "mime-type": "application/json",
-            "data": {
-                "json": {
-                    "@type": DIDCommPrefix.qualify_current(PRESENTATION_REQUEST),
-                    "@id": "12345678-1234-5678-1234-567812345678",
-                    "comment": "some comment",
-                    "request_presentations~attach": [pres_req_dict],
-                }
-            },
-        }
-
-        indy_cred_req = {
-            "schema_id": f"{TestConfig.test_did}:2:bc-reg:1.0",
-            "cred_def_id": f"{TestConfig.test_did}:3:CL:12:tag1",
-        }
-        cred_req_meta = {}
-
         exchange_rec = V10PresentationExchange()
         exchange_rec.auto_present = True
-        exchange_rec.presentation_request = INDY_PROOF_REQ
+        exchange_rec.presentation_request = TestConfig.INDY_PROOF_REQ
         exchange_rec.presentation_proposal_dict = {}
 
         with async_mock.patch.object(
@@ -1971,7 +2081,10 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             )
             holder.get_credentials_for_presentation_request_by_referent = get_creds
             holder.create_credential_request = async_mock.CoroutineMock(
-                return_value=(json.dumps(indy_cred_req), json.dumps(cred_req_meta))
+                return_value=(
+                    json.dumps(TestConfig.indy_cred_req),
+                    json.dumps(TestConfig.cred_req_meta),
+                )
             )
             self.session.context.injector.bind_instance(IndyHolder, holder)
             mock_oob_invi = async_mock.MagicMock(
@@ -1980,7 +2093,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 ],
                 service_dids=[TestConfig.test_target_did],
                 service_blocks=[],
-                request_attach=[AttachDecorator.deserialize(req_attach)],
+                request_attach=[AttachDecorator.deserialize(TestConfig.req_attach)],
             )
 
             inv_message_cls.deserialize.return_value = mock_oob_invi
@@ -1989,3 +2102,216 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 mock_oob_invi, use_existing_connection=True
             )
             assert result.get("comment") == "this is test"
+
+    async def test_req_attach_presentation_catch_value_error(self):
+        self.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings(
+            {"debug.auto_respond_presentation_request": True}
+        )
+        test_exist_conn = ConnRecord(
+            my_did=TestConfig.test_did,
+            their_did=TestConfig.test_target_did,
+            their_public_did=TestConfig.test_target_did,
+            invitation_msg_id="12345678-1234-5678-1234-567812345678",
+            their_role=ConnRecord.Role.REQUESTER,
+        )
+        await test_exist_conn.save(self.session)
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_state", "initial")
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_id", "test_123")
+        receipt = MessageReceipt(
+            recipient_did=TestConfig.test_did,
+            recipient_did_public=False,
+            sender_did=TestConfig.test_target_did,
+        )
+
+        exchange_rec = V10PresentationExchange()
+        exchange_rec.auto_present = True
+        exchange_rec.presentation_request = TestConfig.INDY_PROOF_REQ
+        exchange_rec.presentation_proposal_dict = {}
+
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            DIDXManager,
+            "receive_invitation",
+            autospec=True,
+        ) as didx_mgr_receive_invitation, async_mock.patch.object(
+            PresentationManager,
+            "receive_request",
+            autospec=True,
+        ) as proof_mgr_receive_request, async_mock.patch(
+            "aries_cloudagent.protocols.out_of_band.v1_0.manager.InvitationMessage",
+            autospec=True,
+        ) as inv_message_cls, async_mock.patch.object(
+            OutOfBandManager,
+            "fetch_connection_targets",
+            autospec=True,
+        ) as oob_mgr_fetch_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "find_existing_connection",
+            autospec=True,
+        ) as oob_mgr_find_existing_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "check_reuse_msg_state",
+            autospec=True,
+        ) as oob_mgr_check_reuse_state, async_mock.patch.object(
+            OutOfBandManager,
+            "create_handshake_reuse_message",
+            autospec=True,
+        ) as oob_mgr_create_reuse_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_reuse_message",
+            autospec=True,
+        ) as oob_mgr_receive_reuse_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_reuse_accepted_message",
+            autospec=True,
+        ) as oob_mgr_receive_accept_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_problem_report",
+            autospec=True,
+        ) as oob_mgr_receive_problem_report, async_mock.patch.object(
+            PresentationManager,
+            "create_presentation",
+            autospec=True,
+        ) as proof_mgr_create_presentation, async_mock.patch.object(
+            PresentationProposal,
+            "deserialize",
+            autospec=True,
+        ) as present_proposal_deserialize:
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+            oob_mgr_find_existing_conn.return_value = test_exist_conn
+            proof_mgr_receive_request.return_value = exchange_rec
+            proof_mgr_create_presentation.return_value = (
+                exchange_rec,
+                Presentation(comment="this is test"),
+            )
+            present_proposal_deserialize.return_value = PresentationProposal()
+            holder = async_mock.MagicMock(IndyHolder, autospec=True)
+            get_creds = async_mock.CoroutineMock(return_value=())
+            holder.get_credentials_for_presentation_request_by_referent = get_creds
+            holder.create_credential_request = async_mock.CoroutineMock(
+                return_value=(
+                    json.dumps(TestConfig.indy_cred_req),
+                    json.dumps(TestConfig.cred_req_meta),
+                )
+            )
+            self.session.context.injector.bind_instance(IndyHolder, holder)
+            mock_oob_invi = async_mock.MagicMock(
+                handshake_protocols=[
+                    pfx.qualify(test_module.DIDX_PROTO) for pfx in DIDCommPrefix
+                ],
+                service_dids=[TestConfig.test_target_did],
+                service_blocks=[],
+                request_attach=[AttachDecorator.deserialize(TestConfig.req_attach)],
+            )
+
+            inv_message_cls.deserialize.return_value = mock_oob_invi
+            result = await self.manager.receive_invitation(
+                mock_oob_invi, use_existing_connection=True
+            )
+            assert result is None
+
+    async def test_req_attach_presentation_cred_offer(self):
+        self.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings(
+            {"debug.auto_respond_presentation_request": True}
+        )
+        test_exist_conn = ConnRecord(
+            my_did=TestConfig.test_did,
+            their_did=TestConfig.test_target_did,
+            their_public_did=TestConfig.test_target_did,
+            invitation_msg_id="12345678-1234-5678-1234-567812345678",
+            their_role=ConnRecord.Role.REQUESTER,
+        )
+        await test_exist_conn.save(self.session)
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_state", "initial")
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_id", "test_123")
+
+        receipt = MessageReceipt(
+            recipient_did=TestConfig.test_did,
+            recipient_did_public=False,
+            sender_did=TestConfig.test_target_did,
+        )
+        req_attach = deepcopy(TestConfig.req_attach)
+        req_attach["data"]["json"]["@type"] = DIDCommPrefix.qualify_current(
+            CREDENTIAL_OFFER
+        )
+
+        exchange_rec = V10PresentationExchange()
+        exchange_rec.auto_present = True
+        exchange_rec.presentation_request = TestConfig.INDY_PROOF_REQ
+        exchange_rec.presentation_proposal_dict = {}
+
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            DIDXManager,
+            "receive_invitation",
+            autospec=True,
+        ) as didx_mgr_receive_invitation, async_mock.patch.object(
+            PresentationManager,
+            "receive_request",
+            autospec=True,
+        ) as proof_mgr_receive_request, async_mock.patch(
+            "aries_cloudagent.protocols.out_of_band.v1_0.manager.InvitationMessage",
+            autospec=True,
+        ) as inv_message_cls, async_mock.patch.object(
+            OutOfBandManager,
+            "fetch_connection_targets",
+            autospec=True,
+        ) as oob_mgr_fetch_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "find_existing_connection",
+            autospec=True,
+        ) as oob_mgr_find_existing_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "check_reuse_msg_state",
+            autospec=True,
+        ) as oob_mgr_check_reuse_state, async_mock.patch.object(
+            OutOfBandManager,
+            "create_handshake_reuse_message",
+            autospec=True,
+        ) as oob_mgr_create_reuse_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_reuse_message",
+            autospec=True,
+        ) as oob_mgr_receive_reuse_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_reuse_accepted_message",
+            autospec=True,
+        ) as oob_mgr_receive_accept_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_problem_report",
+            autospec=True,
+        ) as oob_mgr_receive_problem_report, async_mock.patch.object(
+            PresentationManager,
+            "create_presentation",
+            autospec=True,
+        ) as proof_mgr_create_presentation:
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+            oob_mgr_find_existing_conn.return_value = test_exist_conn
+            proof_mgr_create_presentation.return_value = (
+                exchange_rec,
+                Presentation(comment="this is test"),
+            )
+            mock_oob_invi = async_mock.MagicMock(
+                handshake_protocols=[
+                    pfx.qualify(test_module.DIDX_PROTO) for pfx in DIDCommPrefix
+                ],
+                service_dids=[TestConfig.test_target_did],
+                service_blocks=[],
+                request_attach=[AttachDecorator.deserialize(req_attach)],
+            )
+            inv_message_cls.deserialize.return_value = mock_oob_invi
+            with self.assertRaises(OutOfBandManagerError) as context:
+                result = await self.manager.receive_invitation(
+                    mock_oob_invi, use_existing_connection=True
+                )
+                assert "Unsupported request~attach type," in str(context.exception)

--- a/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
@@ -1,20 +1,48 @@
 """Test OOB Manager."""
+import asyncio
+import json
 from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
+from datetime import datetime, timezone
 
 from .....connections.models.conn_record import ConnRecord
 from .....connections.models.diddoc import DIDDoc, PublicKey, PublicKeyType, Service
 from .....core.in_memory import InMemoryProfile
 from .....ledger.base import BaseLedger
 from .....messaging.responder import BaseResponder, MockResponder
+from .....messaging.decorators.attach_decorator import AttachDecorator
+from .....messaging.util import str_to_datetime, str_to_epoch
 from .....multitenant.manager import MultitenantManager
 from .....protocols.didexchange.v1_0.manager import DIDXManager
 from .....protocols.connections.v1_0.manager import ConnectionManager
 from .....protocols.present_proof.v1_0.manager import PresentationManager
-from .....protocols.present_proof.v1_0.message_types import PRESENTATION_REQUEST
+from .....protocols.present_proof.v1_0.message_types import (
+    PRESENTATION_REQUEST,
+    ATTACH_DECO_IDS,
+    PRESENTATION_PREVIEW,
+)
+from .....protocols.present_proof.v1_0.messages.presentation_proposal import (
+    PresentationProposal,
+)
+from .....protocols.present_proof.v1_0.messages.presentation import (
+    Presentation,
+)
+from .....protocols.present_proof.v1_0.messages.presentation_request import (
+    PresentationRequest,
+    PresentationRequestSchema,
+)
+from .....protocols.present_proof.v1_0.messages.inner.presentation_preview import (
+    PresAttrSpec,
+    PresentationPreview,
+    PresPredSpec,
+)
+from .....protocols.present_proof.v1_0.models.presentation_exchange import (
+    V10PresentationExchange,
+)
 from .....wallet.base import DIDInfo, KeyInfo
 from .....wallet.in_memory import InMemoryWallet
 from .....wallet.util import did_key_to_naked
+from .....indy.holder import IndyHolder
 from ....didcomm_prefix import DIDCommPrefix
 from .. import manager as test_module
 from ..messages.invitation import InvitationMessage, InvitationMessageSchema
@@ -103,7 +131,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
         )
 
     async def test_create_invitation_handshake_succeeds(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
 
         with async_mock.patch.object(
             InMemoryWallet, "get_public_did", autospec=True
@@ -129,7 +157,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             assert invi_rec.invitation["service"] == [f"did:sov:{TestConfig.test_did}"]
 
     async def test_create_invitation_public_auto_accept_override_x(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
 
         with self.assertRaises(OutOfBandManagerError) as context:
             await self.manager.create_invitation(
@@ -141,7 +169,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
         assert "Cannot override auto-acceptance" in str(context.exception)
 
     async def test_create_invitation_multitenant_local(self):
-        self.manager.session.context.update_settings(
+        self.session.context.update_settings(
             {
                 "multitenant.enabled": True,
                 "wallet.id": "test_wallet",
@@ -167,7 +195,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             )
 
     async def test_create_invitation_multitenant_public(self):
-        self.manager.session.context.update_settings(
+        self.session.context.update_settings(
             {
                 "multitenant.enabled": True,
                 "wallet.id": "test_wallet",
@@ -204,7 +232,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             assert "Invitation must include" in str(context.exception)
 
     async def test_create_invitation_attachment_v1_0_cred_offer(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         with async_mock.patch.object(
             InMemoryWallet, "get_public_did", autospec=True
         ) as mock_wallet_get_public_did, async_mock.patch.object(
@@ -229,7 +257,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             assert isinstance(invi_rec, InvitationRecord)
 
     async def test_create_invitation_attachment_v1_0_cred_offer_no_handshake(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         with async_mock.patch.object(
             InMemoryWallet, "get_public_did", autospec=True
         ) as mock_wallet_get_public_did, async_mock.patch.object(
@@ -255,7 +283,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             assert not invi_rec.invitation["handshake_protocols"]
 
     async def test_create_invitation_attachment_v2_0_cred_offer(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         with async_mock.patch.object(
             InMemoryWallet, "get_public_did", autospec=True
         ) as mock_wallet_get_public_did, async_mock.patch.object(
@@ -355,7 +383,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
         )
 
     async def test_create_invitation_attachment_x(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         with async_mock.patch.object(
             InMemoryWallet, "get_public_did", autospec=True
         ) as mock_wallet_get_public_did:
@@ -373,7 +401,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             assert "Unknown attachment type" in str(context.exception)
 
     async def test_create_invitation_peer_did(self):
-        self.manager.session.context.update_settings(
+        self.session.context.update_settings(
             {
                 "multitenant.enabled": True,
                 "wallet.id": "my-wallet",
@@ -432,7 +460,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             assert "Cannot store metadata on public" in str(context.exception)
 
     async def test_receive_invitation_didx_service_block(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         with async_mock.patch.object(
             test_module, "DIDXManager", autospec=True
         ) as didx_mgr_cls, async_mock.patch.object(
@@ -461,7 +489,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             await self.manager.receive_invitation(mock_oob_invi)
 
     async def test_receive_invitation_connection_mock(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         with async_mock.patch.object(
             test_module, "ConnectionManager", autospec=True
         ) as conn_mgr_cls, async_mock.patch.object(
@@ -502,7 +530,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             assert result == self.test_conn_rec.serialize()
 
     async def test_receive_invitation_connection(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         oob_invi_rec = await self.manager.create_invitation(
             auto_accept=True,
             public=False,
@@ -523,7 +551,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
         )
 
     async def test_receive_invitation_no_service_blocks_nor_dids(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         with async_mock.patch.object(
             test_module, "InvitationMessage", async_mock.MagicMock()
         ) as invi_msg_cls:
@@ -536,7 +564,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 await self.manager.receive_invitation(mock_invi_msg)
 
     async def test_receive_invitation_service_did(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         with async_mock.patch.object(
             self.ledger, "get_key_for_did", async_mock.CoroutineMock()
         ) as mock_ledger_get_key_for_did, async_mock.patch.object(
@@ -567,7 +595,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             assert invi_rec.invitation["service"]
 
     async def test_receive_invitation_attachment_x(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         with async_mock.patch.object(
             self.ledger, "get_key_for_did", async_mock.CoroutineMock()
         ) as mock_ledger_get_key_for_did, async_mock.patch.object(
@@ -599,7 +627,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 )
 
     async def test_receive_invitation_req_pres_attachment_x(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         with async_mock.patch.object(
             self.ledger, "get_key_for_did", async_mock.CoroutineMock()
         ) as mock_ledger_get_key_for_did, async_mock.patch.object(
@@ -642,7 +670,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 )
 
     async def test_receive_invitation_invalid_request_type_x(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         with async_mock.patch.object(
             self.ledger, "get_key_for_did", async_mock.CoroutineMock()
         ) as mock_ledger_get_key_for_did, async_mock.patch.object(
@@ -701,7 +729,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
         assert await self.manager.check_reuse_msg_state(self.test_conn_rec) is None
 
     async def test_create_handshake_reuse_msg(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         await self.test_conn_rec.save(self.session)
         with async_mock.patch.object(
             self.ledger, "get_key_for_did", async_mock.CoroutineMock()
@@ -740,7 +768,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             )
 
     async def test_recieve_reuse_message_existing_found(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         receipt = MessageReceipt(
             recipient_did=TestConfig.test_did,
             recipient_did_public=False,
@@ -797,7 +825,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             )
 
     async def test_recieve_reuse_message_existing_not_found(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         receipt = MessageReceipt(
             recipient_did=TestConfig.test_did,
             recipient_did_public=False,
@@ -849,7 +877,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             await self.manager.receive_reuse_message(reuse_msg, receipt)
 
     async def test_recieve_reuse_accepeted(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         receipt = MessageReceipt(
             recipient_did=TestConfig.test_did,
             recipient_did_public=False,
@@ -890,7 +918,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             )
 
     async def test_recieve_reuse_accepeted_invalid_conn(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         receipt = MessageReceipt(
             recipient_did=TestConfig.test_did,
             recipient_did_public=False,
@@ -926,7 +954,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 )
 
     async def test_problem_report_received_not_active(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         receipt = MessageReceipt(
             recipient_did=TestConfig.test_did,
             recipient_did_public=False,
@@ -970,7 +998,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             )
 
     async def test_problem_report_received_not_exists(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         receipt = MessageReceipt(
             recipient_did=TestConfig.test_did,
             recipient_did_public=False,
@@ -1014,7 +1042,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             )
 
     async def test_problem_report_received_invalid_conn(self):
-        self.manager.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings({"public_invites": True})
         receipt = MessageReceipt(
             recipient_did=TestConfig.test_did,
             recipient_did_public=False,
@@ -1052,3 +1080,912 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 await self.manager.receive_problem_report(
                     problem_report, receipt, test_invalid_conn
                 )
+
+    async def test_existing_conn_record_public_did(self):
+        self.session.context.update_settings({"public_invites": True})
+        test_exist_conn = ConnRecord(
+            my_did=TestConfig.test_did,
+            their_did=TestConfig.test_target_did,
+            their_public_did=TestConfig.test_target_did,
+            invitation_msg_id="12345678-1234-5678-1234-567812345678",
+            their_role=ConnRecord.Role.REQUESTER,
+        )
+        await test_exist_conn.save(self.session)
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_state", "initial")
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_id", "test_123")
+        receipt = MessageReceipt(
+            recipient_did=TestConfig.test_did,
+            recipient_did_public=False,
+            sender_did=TestConfig.test_target_did,
+        )
+
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            DIDXManager, "receive_invitation", autospec=True
+        ) as didx_mgr_receive_invitation, async_mock.patch(
+            "aries_cloudagent.protocols.out_of_band.v1_0.manager.InvitationMessage",
+            autospec=True,
+        ) as inv_message_cls, async_mock.patch.object(
+            OutOfBandManager,
+            "fetch_connection_targets",
+            autospec=True,
+        ) as oob_mgr_fetch_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "find_existing_connection",
+            autospec=True,
+        ) as oob_mgr_find_existing_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "check_reuse_msg_state",
+            autospec=True,
+        ) as oob_mgr_check_reuse_state, async_mock.patch.object(
+            OutOfBandManager,
+            "create_handshake_reuse_message",
+            autospec=True,
+        ) as oob_mgr_create_reuse_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_reuse_message",
+            autospec=True,
+        ) as oob_mgr_receive_reuse_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_reuse_accepted_message",
+            autospec=True,
+        ) as oob_mgr_receive_accept_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_problem_report",
+            autospec=True,
+        ) as oob_mgr_receive_problem_report:
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+            oob_mgr_find_existing_conn.return_value = test_exist_conn
+            oob_mgr_check_reuse_state.return_value = None
+            oob_mgr_create_reuse_msg.return_value = None
+            oob_mgr_receive_reuse_msg.return_value = None
+            oob_mgr_receive_accept_msg.return_value = None
+            oob_mgr_receive_problem_report.return_value = None
+            await test_exist_conn.metadata_set(
+                self.session, "reuse_msg_state", "accepted"
+            )
+            mock_oob_invi = async_mock.MagicMock(
+                handshake_protocols=[
+                    pfx.qualify(test_module.DIDX_PROTO) for pfx in DIDCommPrefix
+                ],
+                service_dids=[TestConfig.test_target_did],
+                service_blocks=[],
+                request_attach=[],
+            )
+            inv_message_cls.deserialize.return_value = mock_oob_invi
+
+            result = await self.manager.receive_invitation(
+                mock_oob_invi, use_existing_connection=True
+            )
+            retrieved_conn_records = await ConnRecord.query(
+                session=self.session,
+                tag_filter={},
+                post_filter_positive={
+                    "invitation_msg_id": "12345678-1234-5678-1234-567812345678"
+                },
+                alt=True,
+            )
+            assert (
+                await retrieved_conn_records[0].metadata_get(
+                    self.session, "reuse_msg_id"
+                )
+                is None
+            )
+            assert (
+                await retrieved_conn_records[0].metadata_get(
+                    self.session, "reuse_msg_state"
+                )
+                is None
+            )
+            assert (
+                result.get("connection_id") == retrieved_conn_records[0].connection_id
+            )
+
+    async def test_existing_conn_record_public_did_not_accepted(self):
+        self.session.context.update_settings({"public_invites": True})
+        test_exist_conn = ConnRecord(
+            my_did=TestConfig.test_did,
+            their_did="did:sov:LjgpST2rjsoxYegQDRm7EL",
+            their_public_did="did:sov:LjgpST2rjsoxYegQDRm7EL",
+            invitation_msg_id="12345678-1234-5678-1234-567812345678",
+            their_role=ConnRecord.Role.REQUESTER,
+        )
+        await test_exist_conn.save(self.session)
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_id", "test_123")
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_state", "initial")
+
+        test_new_conn = ConnRecord(
+            my_did=TestConfig.test_did,
+            their_did="did:sov:LjgpST2rjsoxYegQDRm7EL",
+            their_public_did="did:sov:LjgpST2rjsoxYegQDRm7EL",
+            invitation_msg_id="12345678-1234-5678-1234-1234545454487",
+            their_role=ConnRecord.Role.REQUESTER,
+        )
+
+        receipt = MessageReceipt(
+            recipient_did=TestConfig.test_did,
+            recipient_did_public=False,
+            sender_did=TestConfig.test_target_did,
+        )
+
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            DIDXManager, "receive_invitation", autospec=True
+        ) as didx_mgr_receive_invitation, async_mock.patch(
+            "aries_cloudagent.protocols.out_of_band.v1_0.manager.InvitationMessage",
+            autospec=True,
+        ) as inv_message_cls, async_mock.patch.object(
+            OutOfBandManager,
+            "fetch_connection_targets",
+            autospec=True,
+        ) as oob_mgr_fetch_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "find_existing_connection",
+            autospec=True,
+        ) as oob_mgr_find_existing_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "check_reuse_msg_state",
+            autospec=True,
+        ) as oob_mgr_check_reuse_state, async_mock.patch.object(
+            OutOfBandManager,
+            "create_handshake_reuse_message",
+            autospec=True,
+        ) as oob_mgr_create_reuse_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_reuse_message",
+            autospec=True,
+        ) as oob_mgr_receive_reuse_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_reuse_accepted_message",
+            autospec=True,
+        ) as oob_mgr_receive_accept_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_problem_report",
+            autospec=True,
+        ) as oob_mgr_receive_problem_report:
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+            oob_mgr_find_existing_conn.return_value = test_exist_conn
+            oob_mgr_check_reuse_state.return_value = None
+            oob_mgr_create_reuse_msg.return_value = None
+            oob_mgr_receive_reuse_msg.return_value = None
+            oob_mgr_receive_accept_msg.return_value = None
+            oob_mgr_receive_problem_report.return_value = None
+            await test_exist_conn.metadata_set(
+                self.session, "reuse_msg_state", "not_accepted"
+            )
+            didx_mgr_receive_invitation.return_value = test_new_conn
+            mock_oob_invi = async_mock.MagicMock(
+                handshake_protocols=[
+                    pfx.qualify(test_module.DIDX_PROTO) for pfx in DIDCommPrefix
+                ],
+                service_dids=[TestConfig.test_target_did],
+                service_blocks=[],
+                request_attach=[],
+            )
+            inv_message_cls.deserialize.return_value = mock_oob_invi
+
+            result = await self.manager.receive_invitation(
+                mock_oob_invi, use_existing_connection=True
+            )
+            retrieved_conn_records = await ConnRecord.query(
+                session=self.session,
+                tag_filter={},
+                post_filter_positive={
+                    "invitation_msg_id": "12345678-1234-5678-1234-567812345678"
+                },
+                alt=True,
+            )
+            assert (
+                await retrieved_conn_records[0].metadata_get(
+                    self.session, "reuse_msg_state"
+                )
+                == "not_accepted"
+            )
+            assert (
+                result.get("connection_id") != retrieved_conn_records[0].connection_id
+            )
+
+    async def test_existing_conn_record_public_did_inverse_cases(self):
+        self.session.context.update_settings({"public_invites": True})
+        test_exist_conn = ConnRecord(
+            my_did=TestConfig.test_did,
+            their_did=TestConfig.test_target_did,
+            their_public_did=TestConfig.test_target_did,
+            invitation_msg_id="12345678-1234-5678-1234-567812345678",
+            their_role=ConnRecord.Role.REQUESTER,
+        )
+        await self.test_conn_rec.save(self.session)
+        await test_exist_conn.save(self.session)
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_state", "initial")
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_id", "test_123")
+        receipt = MessageReceipt(
+            recipient_did=TestConfig.test_did,
+            recipient_did_public=False,
+            sender_did=TestConfig.test_target_did,
+        )
+
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            DIDXManager, "receive_invitation", autospec=True
+        ) as didx_mgr_receive_invitation, async_mock.patch(
+            "aries_cloudagent.protocols.out_of_band.v1_0.manager.InvitationMessage",
+            autospec=True,
+        ) as inv_message_cls, async_mock.patch.object(
+            OutOfBandManager,
+            "fetch_connection_targets",
+            autospec=True,
+        ) as oob_mgr_fetch_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "find_existing_connection",
+            autospec=True,
+        ) as oob_mgr_find_existing_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "check_reuse_msg_state",
+            autospec=True,
+        ) as oob_mgr_check_reuse_state:
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+            oob_mgr_find_existing_conn.return_value = test_exist_conn
+            didx_mgr_receive_invitation.return_value = self.test_conn_rec
+            mock_oob_invi = async_mock.MagicMock(
+                handshake_protocols=[
+                    pfx.qualify(test_module.DIDX_PROTO) for pfx in DIDCommPrefix
+                ],
+                service_dids=[TestConfig.test_target_did],
+                service_blocks=[],
+                request_attach=[],
+            )
+            inv_message_cls.deserialize.return_value = mock_oob_invi
+
+            result = await self.manager.receive_invitation(
+                mock_oob_invi, use_existing_connection=False
+            )
+            retrieved_conn_records = await ConnRecord.query(
+                session=self.session,
+                tag_filter={},
+                post_filter_positive={
+                    "invitation_msg_id": "12345678-1234-5678-1234-567812345678"
+                },
+                alt=True,
+            )
+            assert (
+                result.get("connection_id") != retrieved_conn_records[0].connection_id
+            )
+
+    async def test_existing_conn_record_public_did_timeout(self):
+        self.session.context.update_settings({"public_invites": True})
+        test_exist_conn = ConnRecord(
+            my_did=TestConfig.test_did,
+            their_did=TestConfig.test_target_did,
+            their_public_did=TestConfig.test_target_did,
+            invitation_msg_id="12345678-1234-5678-1234-567812345678",
+            their_role=ConnRecord.Role.REQUESTER,
+        )
+        await test_exist_conn.save(self.session)
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_state", "initial")
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_id", "test_123")
+        receipt = MessageReceipt(
+            recipient_did=TestConfig.test_did,
+            recipient_did_public=False,
+            sender_did=TestConfig.test_target_did,
+        )
+
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            DIDXManager, "receive_invitation", autospec=True
+        ) as didx_mgr_receive_invitation, async_mock.patch(
+            "aries_cloudagent.protocols.out_of_band.v1_0.manager.InvitationMessage",
+            autospec=True,
+        ) as inv_message_cls, async_mock.patch.object(
+            OutOfBandManager,
+            "fetch_connection_targets",
+            autospec=True,
+        ) as oob_mgr_fetch_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "find_existing_connection",
+            autospec=True,
+        ) as oob_mgr_find_existing_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "check_reuse_msg_state",
+            autospec=True,
+        ) as oob_mgr_check_reuse_state:
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+            oob_mgr_find_existing_conn.return_value = test_exist_conn
+            oob_mgr_check_reuse_state.side_effect = asyncio.TimeoutError
+            mock_oob_invi = async_mock.MagicMock(
+                handshake_protocols=[
+                    pfx.qualify(test_module.DIDX_PROTO) for pfx in DIDCommPrefix
+                ],
+                service_dids=[TestConfig.test_target_did],
+                service_blocks=[],
+                request_attach=[],
+            )
+            inv_message_cls.deserialize.return_value = mock_oob_invi
+
+            result = await self.manager.receive_invitation(
+                mock_oob_invi, use_existing_connection=True
+            )
+            retrieved_conn_records = await ConnRecord.query(
+                session=self.session,
+                tag_filter={},
+                post_filter_positive={"their_public_did": TestConfig.test_target_did},
+                alt=True,
+            )
+            assert retrieved_conn_records[0].state == ConnRecord.State.ABANDONED.rfc160
+
+    async def test_req_attach_presentation_existing_conn_no_auto_present(self):
+        self.session.context.update_settings({"public_invites": True})
+        test_exist_conn = ConnRecord(
+            my_did=TestConfig.test_did,
+            their_did=TestConfig.test_target_did,
+            their_public_did=TestConfig.test_target_did,
+            invitation_msg_id="12345678-1234-5678-1234-567812345678",
+            their_role=ConnRecord.Role.REQUESTER,
+        )
+        await test_exist_conn.save(self.session)
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_state", "initial")
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_id", "test_123")
+        receipt = MessageReceipt(
+            recipient_did=TestConfig.test_did,
+            recipient_did_public=False,
+            sender_did=TestConfig.test_target_did,
+        )
+
+        NOW_8601 = (
+            datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(" ", "seconds")
+        )
+        NOW_EPOCH = str_to_epoch(NOW_8601)
+        CD_ID = "GMm4vMw8LLrLJjp81kRRLp:3:CL:12:tag"
+        INDY_PROOF_REQ = json.loads(
+            f"""{{
+            "name": "proof-req",
+            "version": "1.0",
+            "nonce": "12345",
+            "requested_attributes": {{
+                "0_player_uuid": {{
+                    "name": "player",
+                    "restrictions": [
+                        {{
+                            "cred_def_id": "{CD_ID}"
+                        }}
+                    ],
+                    "non_revoked": {{
+                        "from": {NOW_EPOCH},
+                        "to": {NOW_EPOCH}
+                    }}
+                }},
+                "0_screencapture_uuid": {{
+                    "name": "screenCapture",
+                    "restrictions": [
+                        {{
+                            "cred_def_id": "{CD_ID}"
+                        }}
+                    ],
+                    "non_revoked": {{
+                        "from": {NOW_EPOCH},
+                        "to": {NOW_EPOCH}
+                    }}
+                }}
+            }},
+            "requested_predicates": {{
+                "0_highscore_GE_uuid": {{
+                    "name": "highScore",
+                    "p_type": ">=",
+                    "p_value": 1000000,
+                    "restrictions": [
+                        {{
+                            "cred_def_id": "{CD_ID}"
+                        }}
+                    ],
+                    "non_revoked": {{
+                        "from": {NOW_EPOCH},
+                        "to": {NOW_EPOCH}
+                    }}
+                }}
+            }}
+        }}"""
+        )
+
+        PRES_REQ = PresentationRequest(
+            comment="Test",
+            request_presentations_attach=[
+                AttachDecorator.from_indy_dict(
+                    indy_dict=INDY_PROOF_REQ,
+                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+                )
+            ],
+        )
+        pres_req_dict = PRES_REQ.request_presentations_attach[0].serialize()
+        req_attach = {
+            "@id": "request-0",
+            "mime-type": "application/json",
+            "data": {
+                "json": {
+                    "@type": DIDCommPrefix.qualify_current(PRESENTATION_REQUEST),
+                    "@id": "12345678-1234-5678-1234-567812345678",
+                    "comment": "some comment",
+                    "request_presentations~attach": [pres_req_dict],
+                }
+            },
+        }
+
+        exchange_rec = V10PresentationExchange()
+
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            DIDXManager, "receive_invitation", autospec=True
+        ) as didx_mgr_receive_invitation, async_mock.patch.object(
+            PresentationManager, "receive_request", autospec=True
+        ) as proof_mgr_receive_request, async_mock.patch(
+            "aries_cloudagent.protocols.out_of_band.v1_0.manager.InvitationMessage",
+            autospec=True,
+        ) as inv_message_cls, async_mock.patch.object(
+            OutOfBandManager,
+            "fetch_connection_targets",
+            autospec=True,
+        ) as oob_mgr_fetch_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "find_existing_connection",
+            autospec=True,
+        ) as oob_mgr_find_existing_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "check_reuse_msg_state",
+            autospec=True,
+        ) as oob_mgr_check_reuse_state, async_mock.patch.object(
+            OutOfBandManager,
+            "create_handshake_reuse_message",
+            autospec=True,
+        ) as oob_mgr_create_reuse_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_reuse_message",
+            autospec=True,
+        ) as oob_mgr_receive_reuse_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_reuse_accepted_message",
+            autospec=True,
+        ) as oob_mgr_receive_accept_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_problem_report",
+            autospec=True,
+        ) as oob_mgr_receive_problem_report:
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+            oob_mgr_find_existing_conn.return_value = test_exist_conn
+            proof_mgr_receive_request.return_value = exchange_rec
+
+            mock_oob_invi = async_mock.MagicMock(
+                handshake_protocols=[
+                    pfx.qualify(test_module.DIDX_PROTO) for pfx in DIDCommPrefix
+                ],
+                service_dids=[TestConfig.test_target_did],
+                service_blocks=[],
+                request_attach=[AttachDecorator.deserialize(req_attach)],
+            )
+
+            inv_message_cls.deserialize.return_value = mock_oob_invi
+
+            with self.assertRaises(OutOfBandManagerError) as context:
+                result = await self.manager.receive_invitation(
+                    mock_oob_invi, use_existing_connection=True
+                )
+                assert "auto_present setting in configuration is" in str(
+                    context.exception
+                )
+
+    async def test_req_attach_presentation_existing_conn_auto_present_no_pres_msg(self):
+        self.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings(
+            {"debug.auto_respond_presentation_request": True}
+        )
+        test_exist_conn = ConnRecord(
+            my_did=TestConfig.test_did,
+            their_did=TestConfig.test_target_did,
+            their_public_did=TestConfig.test_target_did,
+            invitation_msg_id="12345678-1234-5678-1234-567812345678",
+            their_role=ConnRecord.Role.REQUESTER,
+        )
+        await test_exist_conn.save(self.session)
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_state", "initial")
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_id", "test_123")
+        receipt = MessageReceipt(
+            recipient_did=TestConfig.test_did,
+            recipient_did_public=False,
+            sender_did=TestConfig.test_target_did,
+        )
+
+        NOW_8601 = (
+            datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(" ", "seconds")
+        )
+        NOW_EPOCH = str_to_epoch(NOW_8601)
+        CD_ID = "GMm4vMw8LLrLJjp81kRRLp:3:CL:12:tag"
+        INDY_PROOF_REQ = json.loads(
+            f"""{{
+            "name": "proof-req",
+            "version": "1.0",
+            "nonce": "12345",
+            "requested_attributes": {{
+                "0_player_uuid": {{
+                    "name": "player",
+                    "restrictions": [
+                        {{
+                            "cred_def_id": "{CD_ID}"
+                        }}
+                    ],
+                    "non_revoked": {{
+                        "from": {NOW_EPOCH},
+                        "to": {NOW_EPOCH}
+                    }}
+                }},
+                "0_screencapture_uuid": {{
+                    "name": "screenCapture",
+                    "restrictions": [
+                        {{
+                            "cred_def_id": "{CD_ID}"
+                        }}
+                    ],
+                    "non_revoked": {{
+                        "from": {NOW_EPOCH},
+                        "to": {NOW_EPOCH}
+                    }}
+                }}
+            }},
+            "requested_predicates": {{
+                "0_highscore_GE_uuid": {{
+                    "name": "highScore",
+                    "p_type": ">=",
+                    "p_value": 1000000,
+                    "restrictions": [
+                        {{
+                            "cred_def_id": "{CD_ID}"
+                        }}
+                    ],
+                    "non_revoked": {{
+                        "from": {NOW_EPOCH},
+                        "to": {NOW_EPOCH}
+                    }}
+                }}
+            }}
+        }}"""
+        )
+
+        PRES_REQ = PresentationRequest(
+            comment="Test",
+            request_presentations_attach=[
+                AttachDecorator.from_indy_dict(
+                    indy_dict=INDY_PROOF_REQ,
+                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+                )
+            ],
+        )
+        pres_req_dict = PRES_REQ.request_presentations_attach[0].serialize()
+        req_attach = {
+            "@id": "request-0",
+            "mime-type": "application/json",
+            "data": {
+                "json": {
+                    "@type": DIDCommPrefix.qualify_current(PRESENTATION_REQUEST),
+                    "@id": "12345678-1234-5678-1234-567812345678",
+                    "comment": "some comment",
+                    "request_presentations~attach": [pres_req_dict],
+                }
+            },
+        }
+
+        indy_cred_req = {
+            "schema_id": f"{TestConfig.test_did}:2:bc-reg:1.0",
+            "cred_def_id": f"{TestConfig.test_did}:3:CL:12:tag1",
+        }
+        cred_req_meta = {}
+
+        exchange_rec = V10PresentationExchange()
+        exchange_rec.auto_present = True
+        exchange_rec.presentation_request = INDY_PROOF_REQ
+        exchange_rec.presentation_proposal_dict = {}
+
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            DIDXManager,
+            "receive_invitation",
+            autospec=True,
+        ) as didx_mgr_receive_invitation, async_mock.patch.object(
+            PresentationManager,
+            "receive_request",
+            autospec=True,
+        ) as proof_mgr_receive_request, async_mock.patch(
+            "aries_cloudagent.protocols.out_of_band.v1_0.manager.InvitationMessage",
+            autospec=True,
+        ) as inv_message_cls, async_mock.patch.object(
+            OutOfBandManager,
+            "fetch_connection_targets",
+            autospec=True,
+        ) as oob_mgr_fetch_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "find_existing_connection",
+            autospec=True,
+        ) as oob_mgr_find_existing_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "check_reuse_msg_state",
+            autospec=True,
+        ) as oob_mgr_check_reuse_state, async_mock.patch.object(
+            OutOfBandManager,
+            "create_handshake_reuse_message",
+            autospec=True,
+        ) as oob_mgr_create_reuse_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_reuse_message",
+            autospec=True,
+        ) as oob_mgr_receive_reuse_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_reuse_accepted_message",
+            autospec=True,
+        ) as oob_mgr_receive_accept_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_problem_report",
+            autospec=True,
+        ) as oob_mgr_receive_problem_report, async_mock.patch.object(
+            PresentationManager,
+            "create_presentation",
+            autospec=True,
+        ) as proof_mgr_create_presentation:
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+            oob_mgr_find_existing_conn.return_value = test_exist_conn
+            proof_mgr_receive_request.return_value = exchange_rec
+            proof_mgr_create_presentation.return_value = (exchange_rec, None)
+            holder = async_mock.MagicMock(IndyHolder, autospec=True)
+            get_creds = async_mock.CoroutineMock(
+                return_value=(
+                    {
+                        "cred_info": {"referent": "dummy_reft"},
+                        "attrs": {
+                            "player": "Richie Knucklez",
+                            "screenCapture": "aW1hZ2luZSBhIHNjcmVlbiBjYXB0dXJl",
+                            "highScore": "1234560",
+                        },
+                    },
+                )
+            )
+            holder.get_credentials_for_presentation_request_by_referent = get_creds
+            holder.create_credential_request = async_mock.CoroutineMock(
+                return_value=(json.dumps(indy_cred_req), json.dumps(cred_req_meta))
+            )
+            self.session.context.injector.bind_instance(IndyHolder, holder)
+            mock_oob_invi = async_mock.MagicMock(
+                handshake_protocols=[
+                    pfx.qualify(test_module.DIDX_PROTO) for pfx in DIDCommPrefix
+                ],
+                service_dids=[TestConfig.test_target_did],
+                service_blocks=[],
+                request_attach=[AttachDecorator.deserialize(req_attach)],
+            )
+
+            inv_message_cls.deserialize.return_value = mock_oob_invi
+
+            with self.assertRaises(OutOfBandManagerError) as context:
+                result = await self.manager.receive_invitation(
+                    mock_oob_invi, use_existing_connection=True
+                )
+                assert "No presentation for proof request nonce" in str(
+                    context.exception
+                )
+
+    async def test_req_attach_presentation_existing_conn_auto_present_pres_msg(self):
+        self.session.context.update_settings({"public_invites": True})
+        self.session.context.update_settings(
+            {"debug.auto_respond_presentation_request": True}
+        )
+        test_exist_conn = ConnRecord(
+            my_did=TestConfig.test_did,
+            their_did=TestConfig.test_target_did,
+            their_public_did=TestConfig.test_target_did,
+            invitation_msg_id="12345678-1234-5678-1234-567812345678",
+            their_role=ConnRecord.Role.REQUESTER,
+        )
+        await test_exist_conn.save(self.session)
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_state", "initial")
+        await test_exist_conn.metadata_set(self.session, "reuse_msg_id", "test_123")
+        receipt = MessageReceipt(
+            recipient_did=TestConfig.test_did,
+            recipient_did_public=False,
+            sender_did=TestConfig.test_target_did,
+        )
+
+        NOW_8601 = (
+            datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(" ", "seconds")
+        )
+        NOW_EPOCH = str_to_epoch(NOW_8601)
+        CD_ID = "GMm4vMw8LLrLJjp81kRRLp:3:CL:12:tag"
+        INDY_PROOF_REQ = json.loads(
+            f"""{{
+            "name": "proof-req",
+            "version": "1.0",
+            "nonce": "12345",
+            "requested_attributes": {{
+                "0_player_uuid": {{
+                    "name": "player",
+                    "restrictions": [
+                        {{
+                            "cred_def_id": "{CD_ID}"
+                        }}
+                    ],
+                    "non_revoked": {{
+                        "from": {NOW_EPOCH},
+                        "to": {NOW_EPOCH}
+                    }}
+                }},
+                "0_screencapture_uuid": {{
+                    "name": "screenCapture",
+                    "restrictions": [
+                        {{
+                            "cred_def_id": "{CD_ID}"
+                        }}
+                    ],
+                    "non_revoked": {{
+                        "from": {NOW_EPOCH},
+                        "to": {NOW_EPOCH}
+                    }}
+                }}
+            }},
+            "requested_predicates": {{
+                "0_highscore_GE_uuid": {{
+                    "name": "highScore",
+                    "p_type": ">=",
+                    "p_value": 1000000,
+                    "restrictions": [
+                        {{
+                            "cred_def_id": "{CD_ID}"
+                        }}
+                    ],
+                    "non_revoked": {{
+                        "from": {NOW_EPOCH},
+                        "to": {NOW_EPOCH}
+                    }}
+                }}
+            }}
+        }}"""
+        )
+
+        PRES_REQ = PresentationRequest(
+            comment="Test",
+            request_presentations_attach=[
+                AttachDecorator.from_indy_dict(
+                    indy_dict=INDY_PROOF_REQ,
+                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+                )
+            ],
+        )
+        pres_req_dict = PRES_REQ.request_presentations_attach[0].serialize()
+        req_attach = {
+            "@id": "request-0",
+            "mime-type": "application/json",
+            "data": {
+                "json": {
+                    "@type": DIDCommPrefix.qualify_current(PRESENTATION_REQUEST),
+                    "@id": "12345678-1234-5678-1234-567812345678",
+                    "comment": "some comment",
+                    "request_presentations~attach": [pres_req_dict],
+                }
+            },
+        }
+
+        indy_cred_req = {
+            "schema_id": f"{TestConfig.test_did}:2:bc-reg:1.0",
+            "cred_def_id": f"{TestConfig.test_did}:3:CL:12:tag1",
+        }
+        cred_req_meta = {}
+
+        exchange_rec = V10PresentationExchange()
+        exchange_rec.auto_present = True
+        exchange_rec.presentation_request = INDY_PROOF_REQ
+        exchange_rec.presentation_proposal_dict = {}
+
+        with async_mock.patch.object(
+            self.ledger, "get_key_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_key_for_did, async_mock.patch.object(
+            self.ledger, "get_endpoint_for_did", async_mock.CoroutineMock()
+        ) as mock_ledger_get_endpoint_for_did, async_mock.patch.object(
+            DIDXManager,
+            "receive_invitation",
+            autospec=True,
+        ) as didx_mgr_receive_invitation, async_mock.patch.object(
+            PresentationManager,
+            "receive_request",
+            autospec=True,
+        ) as proof_mgr_receive_request, async_mock.patch(
+            "aries_cloudagent.protocols.out_of_band.v1_0.manager.InvitationMessage",
+            autospec=True,
+        ) as inv_message_cls, async_mock.patch.object(
+            OutOfBandManager,
+            "fetch_connection_targets",
+            autospec=True,
+        ) as oob_mgr_fetch_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "find_existing_connection",
+            autospec=True,
+        ) as oob_mgr_find_existing_conn, async_mock.patch.object(
+            OutOfBandManager,
+            "check_reuse_msg_state",
+            autospec=True,
+        ) as oob_mgr_check_reuse_state, async_mock.patch.object(
+            OutOfBandManager,
+            "create_handshake_reuse_message",
+            autospec=True,
+        ) as oob_mgr_create_reuse_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_reuse_message",
+            autospec=True,
+        ) as oob_mgr_receive_reuse_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_reuse_accepted_message",
+            autospec=True,
+        ) as oob_mgr_receive_accept_msg, async_mock.patch.object(
+            OutOfBandManager,
+            "receive_problem_report",
+            autospec=True,
+        ) as oob_mgr_receive_problem_report, async_mock.patch.object(
+            PresentationManager,
+            "create_presentation",
+            autospec=True,
+        ) as proof_mgr_create_presentation:
+            mock_ledger_get_key_for_did.return_value = TestConfig.test_verkey
+            mock_ledger_get_endpoint_for_did.return_value = TestConfig.test_endpoint
+            oob_mgr_find_existing_conn.return_value = test_exist_conn
+            proof_mgr_receive_request.return_value = exchange_rec
+            proof_mgr_create_presentation.return_value = (
+                exchange_rec,
+                Presentation(comment="this is test"),
+            )
+            holder = async_mock.MagicMock(IndyHolder, autospec=True)
+            get_creds = async_mock.CoroutineMock(
+                return_value=(
+                    {
+                        "cred_info": {"referent": "dummy_reft"},
+                        "attrs": {
+                            "player": "Richie Knucklez",
+                            "screenCapture": "aW1hZ2luZSBhIHNjcmVlbiBjYXB0dXJl",
+                            "highScore": "1234560",
+                        },
+                    },
+                )
+            )
+            holder.get_credentials_for_presentation_request_by_referent = get_creds
+            holder.create_credential_request = async_mock.CoroutineMock(
+                return_value=(json.dumps(indy_cred_req), json.dumps(cred_req_meta))
+            )
+            self.session.context.injector.bind_instance(IndyHolder, holder)
+            mock_oob_invi = async_mock.MagicMock(
+                handshake_protocols=[
+                    pfx.qualify(test_module.DIDX_PROTO) for pfx in DIDCommPrefix
+                ],
+                service_dids=[TestConfig.test_target_did],
+                service_blocks=[],
+                request_attach=[AttachDecorator.deserialize(req_attach)],
+            )
+
+            inv_message_cls.deserialize.return_value = mock_oob_invi
+
+            result = await self.manager.receive_invitation(
+                mock_oob_invi, use_existing_connection=True
+            )
+            assert result.get("comment") == "this is test"

--- a/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
@@ -1017,9 +1017,8 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             )
             oob_invi = InvitationMessage()
             retrieve_invi_rec.return_value = InvitationRecord(invi_msg_id="test_123")
-            with self.assertRaises(OutOfBandManagerError) as context:
-                await self.manager.receive_reuse_message(reuse_msg, receipt)
-                assert "No existing ConnRecord found" in str(context.exception)
+            await self.manager.receive_reuse_message(reuse_msg, receipt)
+            assert len(self.responder.messages) == 0
 
     async def test_receive_reuse_message_storage_not_found(self):
         self.session.context.update_settings({"public_invites": True})


### PR DESCRIPTION
100% Test Coverage - Done

Following discussion with Andrew, changed pthid for reuse messages to the existing conn_record invitation_msg_id [original] instead of the received OOB invitation_msg_id [previous impl] - Done

Cleanup: reordering of import according to the convention - Done
