### PR TITLE
[multi-tenancy] throw error if key is provided but not required

### DIFF
--- a/aries_cloudagent/multitenant/admin/routes.py
+++ b/aries_cloudagent/multitenant/admin/routes.py
@@ -408,7 +408,8 @@ async def wallet_create_token(request: web.BaseRequest):
 
             if (not wallet_record.requires_external_key) and wallet_key:
                 raise web.HTTPBadRequest(
-                    reason=f"Wallet {wallet_id} doesn't require the wallet key to be provided"
+                    reason=f"Wallet {wallet_id} doesn't require"
+                    " the wallet key to be provided"
                 )
 
             token = multitenant_mgr.create_auth_token(wallet_record, wallet_key)
@@ -451,7 +452,8 @@ async def wallet_remove(request: web.BaseRequest):
 
             if (not wallet_record.requires_external_key) and wallet_key:
                 raise web.HTTPBadRequest(
-                    reason=f"Wallet {wallet_id} doesn't require the wallet key to be provided"
+                    reason=f"Wallet {wallet_id} doesn't require"
+                    " the wallet key to be provided"
                 )
 
             await multitenant_mgr.remove_wallet(wallet_id, wallet_key)

--- a/aries_cloudagent/multitenant/admin/routes.py
+++ b/aries_cloudagent/multitenant/admin/routes.py
@@ -406,6 +406,11 @@ async def wallet_create_token(request: web.BaseRequest):
             multitenant_mgr = session.inject(MultitenantManager)
             wallet_record = await WalletRecord.retrieve_by_id(session, wallet_id)
 
+            if (not wallet_record.requires_external_key) and wallet_key:
+                raise web.HTTPBadRequest(
+                    reason=f"Wallet {wallet_id} doesn't require the wallet key to be provided"
+                )
+
             token = multitenant_mgr.create_auth_token(wallet_record, wallet_key)
         except StorageNotFoundError as err:
             raise web.HTTPNotFound(reason=err.roll_up) from err
@@ -442,6 +447,13 @@ async def wallet_remove(request: web.BaseRequest):
     async with context.session() as session:
         try:
             multitenant_mgr = session.inject(MultitenantManager)
+            wallet_record = await WalletRecord.retrieve_by_id(session, wallet_id)
+
+            if (not wallet_record.requires_external_key) and wallet_key:
+                raise web.HTTPBadRequest(
+                    reason=f"Wallet {wallet_id} doesn't require the wallet key to be provided"
+                )
+
             await multitenant_mgr.remove_wallet(wallet_id, wallet_key)
         except StorageNotFoundError as err:
             raise web.HTTPNotFound(reason=err.roll_up) from err


### PR DESCRIPTION
Small update to throw an error when a wallet key is provided, but not required. This could be when running in managed mode, or using a local wallet.

Fixes issue posted in rocket.chat: https://chat.hyperledger.org/channel/aries-cloudagent-python?msg=wvdD5tb8RyFca5kX3