### PR TITLE
[Multi-tenancy] Fix incorrect responder profile

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -108,6 +108,16 @@ class AdminResponder(BaseResponder):
         """
         await self._webhook(self._profile, topic, payload)
 
+    @property
+    def send(self) -> Coroutine:
+        """Accessor for async function to send outbound message."""
+        return self._send
+
+    @property
+    def webhook(self) -> Coroutine:
+        """Accessor for the async function to dispatch a webhook."""
+        return self._webhook
+
 
 class WebhookTarget:
     """Class for managing webhook target information."""

--- a/aries_cloudagent/transport/inbound/session.py
+++ b/aries_cloudagent/transport/inbound/session.py
@@ -171,9 +171,15 @@ class InboundSession:
                     self.profile.context, wallet
                 )
 
-                # Update a responder profile with wallet profile
-                responder: AdminResponder = profile.inject(BaseResponder)
-                responder._profile = profile
+
+                base_responder: AdminResponder = profile.inject(BaseResponder)
+            
+                # Create new responder based on base responder
+                responder = AdminResponder(
+                    profile,
+                    base_responder._send,
+                    base_responder._webhook,
+                )
                 profile.context.injector.bind_instance(BaseResponder, responder)
 
                 # overwrite session profile with wallet profile

--- a/aries_cloudagent/transport/inbound/session.py
+++ b/aries_cloudagent/transport/inbound/session.py
@@ -171,14 +171,13 @@ class InboundSession:
                     self.profile.context, wallet
                 )
 
-
                 base_responder: AdminResponder = profile.inject(BaseResponder)
-            
+
                 # Create new responder based on base responder
                 responder = AdminResponder(
                     profile,
-                    base_responder._send,
-                    base_responder._webhook,
+                    base_responder.send,
+                    base_responder.webhook,
                 )
                 profile.context.injector.bind_instance(BaseResponder, responder)
 

--- a/aries_cloudagent/transport/inbound/session.py
+++ b/aries_cloudagent/transport/inbound/session.py
@@ -4,7 +4,9 @@ import asyncio
 import logging
 from typing import Callable, Sequence, Union
 
+from ...admin.server import AdminResponder
 from ...core.profile import Profile
+from ...messaging.responder import BaseResponder
 from ...multitenant.manager import MultitenantManager
 
 from ..error import WireFormatError
@@ -168,6 +170,11 @@ class InboundSession:
                 profile = await multitenant_mgr.get_wallet_profile(
                     self.profile.context, wallet
                 )
+
+                # Update a responder profile with wallet profile
+                responder: AdminResponder = profile.inject(BaseResponder)
+                responder._profile = profile
+                profile.context.injector.bind_instance(BaseResponder, responder)
 
                 # overwrite session profile with wallet profile
                 self.profile = profile

--- a/aries_cloudagent/transport/inbound/tests/test_session.py
+++ b/aries_cloudagent/transport/inbound/tests/test_session.py
@@ -124,9 +124,7 @@ class TestInboundSession(TestCase):
         )
         self.profile.context.update_settings({"multitenant.enabled": True})
         self.base_responder = async_mock.MagicMock(AdminResponder, autospec=True)
-        self.profile.context.injector.bind_instance(
-            BaseResponder, self.base_responder
-        )
+        self.profile.context.injector.bind_instance(BaseResponder, self.base_responder)
 
         sess = InboundSession(
             profile=self.profile,

--- a/aries_cloudagent/transport/inbound/tests/test_session.py
+++ b/aries_cloudagent/transport/inbound/tests/test_session.py
@@ -3,7 +3,9 @@ import pytest
 
 from asynctest import TestCase, mock as async_mock
 
+from ....admin.server import AdminResponder
 from ....core.in_memory import InMemoryProfile
+from ....messaging.responder import BaseResponder
 from ....multitenant.manager import MultitenantManager
 
 from ...error import WireFormatError
@@ -121,6 +123,10 @@ class TestInboundSession(TestCase):
             MultitenantManager, self.multitenant_mgr
         )
         self.profile.context.update_settings({"multitenant.enabled": True})
+        self.base_responder = async_mock.MagicMock(AdminResponder, autospec=True)
+        self.profile.context.injector.bind_instance(
+            BaseResponder, self.base_responder
+        )
 
         sess = InboundSession(
             profile=self.profile,


### PR DESCRIPTION
After aca-py restarts, there are two routes to load the sub wallet profile.

1. API call
2. inbound message

In case 1, the responder is updated with the loaded profile.
https://github.com/hyperledger/aries-cloudagent-python/blob/982a260ca327e0e9432a45dbb381b7b80c4c8ed2/aries_cloudagent/admin/server.py#L333

However, in case 2, since there is no such process as above, the responder is based on the profile of the base wallet.
We observed the problem that webhook message came to the webhook url of the base wallet, not the webhook url of the sub wallet.

This PR enable to update the responder with the loaded profile in case 2.