### PR TITLE
cover easy modules 100%

### DIFF
--- a/aries_cloudagent/core/tests/test_in_memory.py
+++ b/aries_cloudagent/core/tests/test_in_memory.py
@@ -17,3 +17,7 @@ class TestInMemoryWallet:
 
         assert "InMemoryProfile" in str(profile)
         assert profile.created
+
+    @pytest.mark.asyncio
+    async def test_profile_clear(self):
+        InMemoryProfile.test_profile(settings=None, bind={"a": None})

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_mediation_manager.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_mediation_manager.py
@@ -250,12 +250,18 @@ class TestMediationManager:  # pylint: disable=R0904,W0621
         await manager._set_default_mediator_id("test", session)
         assert await manager.get_default_mediator_id() == "test"
 
-    async def test_set_set_get_default_mediator_by_id(
+    async def test_set_set_get_default_mediator_id(
         self, manager: MediationManager, session
     ):
         await manager._set_default_mediator_id("test", session)
         await manager._set_default_mediator_id("updated", session)
         assert await manager.get_default_mediator_id() == "updated"
+
+    async def test_set_default_mediator_by_id(self, manager: MediationManager):
+        with async_mock.patch.object(
+            test_module.MediationRecord, "retrieve_by_id", async_mock.CoroutineMock()
+        ) as mock_retrieve:
+            await manager.set_default_mediator_by_id("test")
 
     async def test_clear_default_mediator(self, manager: MediationManager, session):
         await manager._set_default_mediator_id("test", session)

--- a/aries_cloudagent/protocols/present_proof/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/tests/test_routes.py
@@ -59,7 +59,10 @@ class TestProofRoutes(AsyncTestCase):
         }
 
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -90,7 +93,10 @@ class TestProofRoutes(AsyncTestCase):
         }
 
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -108,7 +114,10 @@ class TestProofRoutes(AsyncTestCase):
         self.request.match_info = {"pres_ex_id": "dummy"}
 
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -140,7 +149,10 @@ class TestProofRoutes(AsyncTestCase):
         )
 
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -172,7 +184,10 @@ class TestProofRoutes(AsyncTestCase):
         )
 
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -200,14 +215,17 @@ class TestProofRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             IndyHolder,
             async_mock.MagicMock(
-                get_credentials_for_presentation_request_by_referent=async_mock.CoroutineMock(
-                    return_value=returned_credentials
+                get_credentials_for_presentation_request_by_referent=(
+                    async_mock.CoroutineMock(return_value=returned_credentials)
                 )
             ),
         )
 
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -228,7 +246,10 @@ class TestProofRoutes(AsyncTestCase):
         self.request.match_info = {"pres_ex_id": "dummy"}
 
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_pres_ex:
 
@@ -252,7 +273,10 @@ class TestProofRoutes(AsyncTestCase):
         self.request.match_info = {"pres_ex_id": "dummy"}
 
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_pres_ex:
 
@@ -274,7 +298,10 @@ class TestProofRoutes(AsyncTestCase):
             connection_id="abc123", thread_id="thid123"
         )
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_pres_ex:
 
@@ -301,7 +328,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.protocols.present_proof.v1_0.manager.PresentationManager",
             autospec=True,
         ) as mock_presentation_manager, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.messages.inner.presentation_preview.PresentationPreview",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "messages.inner.presentation_preview.PresentationPreview"
+            ),
             autospec=True,
         ) as mock_preview:
 
@@ -349,10 +379,16 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.connections.models.conn_record.ConnRecord",
             autospec=True,
         ) as mock_connection_record, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.messages.inner.presentation_preview.PresentationPreview",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "messages.inner.presentation_preview.PresentationPreview"
+            ),
             autospec=True,
         ) as mock_preview, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.messages.presentation_proposal.PresentationProposal",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "messages.presentation_proposal.PresentationProposal"
+            ),
             autospec=True,
         ) as mock_proposal:
 
@@ -375,7 +411,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.protocols.present_proof.v1_0.manager.PresentationManager",
             autospec=True,
         ) as mock_presentation_manager, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.messages.inner.presentation_preview.PresentationPreview",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "messages.inner.presentation_preview.PresentationPreview"
+            ),
             autospec=True,
         ) as mock_preview:
 
@@ -399,7 +438,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.protocols.present_proof.v1_0.manager.PresentationManager",
             autospec=True,
         ) as mock_presentation_manager, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.messages.inner.presentation_preview.PresentationPreview",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "messages.inner.presentation_preview.PresentationPreview"
+            ),
             autospec=True,
         ) as mock_preview, async_mock.patch.object(
             test_module, "PresentationRequest", autospec=True
@@ -407,7 +449,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
             autospec=True,
         ) as mock_attach_decorator, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange, async_mock.patch(
             "aries_cloudagent.indy.util.generate_pr_nonce",
@@ -450,7 +495,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.protocols.present_proof.v1_0.manager.PresentationManager",
             autospec=True,
         ) as mock_presentation_manager, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.messages.inner.presentation_preview.PresentationPreview",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "messages.inner.presentation_preview.PresentationPreview"
+            ),
             autospec=True,
         ) as mock_preview, async_mock.patch.object(
             test_module, "PresentationRequest", autospec=True
@@ -458,7 +506,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
             autospec=True,
         ) as mock_attach_decorator, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange, async_mock.patch(
             "aries_cloudagent.indy.util.generate_pr_nonce",
@@ -501,7 +552,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.indy.util.generate_pr_nonce",
             autospec=True,
         ) as mock_generate_nonce, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.messages.inner.presentation_preview.PresentationPreview",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "messages.inner.presentation_preview.PresentationPreview"
+            ),
             autospec=True,
         ) as mock_preview, async_mock.patch.object(
             test_module, "PresentationRequest", autospec=True
@@ -509,7 +563,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
             autospec=True,
         ) as mock_attach_decorator, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -608,7 +665,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
             autospec=True,
         ) as mock_attach_decorator, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -733,7 +793,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
             autospec=True,
         ) as mock_attach_decorator, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -775,7 +838,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
             autospec=True,
         ) as mock_attach_decorator, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -798,12 +864,29 @@ class TestProofRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPForbidden):
                 await test_module.presentation_exchange_send_bound_request(self.request)
 
+    async def test_presentation_exchange_send_bound_request_px_rec_not_found(self):
+        self.request.json = async_mock.CoroutineMock(return_value={"trace": False})
+        self.request.match_info = {"pres_ex_id": "dummy"}
+
+        with async_mock.patch.object(
+            test_module.V10PresentationExchange,
+            "retrieve_by_id",
+            async_mock.CoroutineMock(),
+        ) as mock_retrieve:
+            mock_retrieve.side_effect = StorageNotFoundError("no such record")
+            with self.assertRaises(test_module.web.HTTPNotFound) as context:
+                await test_module.presentation_exchange_send_bound_request(self.request)
+            assert "no such record" in str(context.exception)
+
     async def test_presentation_exchange_send_bound_request_bad_state(self):
         self.request.json = async_mock.CoroutineMock(return_value={"trace": False})
         self.request.match_info = {"pres_ex_id": "dummy"}
 
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -840,7 +923,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
             autospec=True,
         ) as mock_attach_decorator, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -907,7 +993,10 @@ class TestProofRoutes(AsyncTestCase):
         ) as mock_presentation_manager, async_mock.patch.object(
             test_module, "PresentationPreview", autospec=True
         ) as mock_presentation_proposal, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -945,6 +1034,20 @@ class TestProofRoutes(AsyncTestCase):
                     mock_presentation_exchange.serialize.return_value
                 )
 
+    async def test_presentation_exchange_send_presentation_px_rec_not_found(self):
+        self.request.json = async_mock.CoroutineMock(return_value={"trace": False})
+        self.request.match_info = {"pres_ex_id": "dummy"}
+
+        with async_mock.patch.object(
+            test_module.V10PresentationExchange,
+            "retrieve_by_id",
+            async_mock.CoroutineMock(),
+        ) as mock_retrieve:
+            mock_retrieve.side_effect = StorageNotFoundError("no such record")
+            with self.assertRaises(test_module.web.HTTPNotFound) as context:
+                await test_module.presentation_exchange_send_presentation(self.request)
+            assert "no such record" in str(context.exception)
+
     async def test_presentation_exchange_send_presentation_not_found(self):
         self.request.json = async_mock.CoroutineMock()
         self.request.match_info = {"pres_ex_id": "dummy"}
@@ -966,7 +1069,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
             autospec=True,
         ) as mock_attach_decorator, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -1008,7 +1114,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
             autospec=True,
         ) as mock_attach_decorator, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -1035,7 +1144,10 @@ class TestProofRoutes(AsyncTestCase):
         self.request.match_info = {"pres_ex_id": "dummy"}
 
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -1078,7 +1190,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
             autospec=True,
         ) as mock_attach_decorator, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -1124,7 +1239,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.indy.util.generate_pr_nonce",
             autospec=True,
         ) as mock_generate_nonce, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.messages.inner.presentation_preview.PresentationPreview",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "messages.inner.presentation_preview.PresentationPreview"
+            ),
             autospec=True,
         ) as mock_preview, async_mock.patch.object(
             test_module, "PresentationRequest", autospec=True
@@ -1132,7 +1250,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
             autospec=True,
         ) as mock_attach_decorator, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -1168,6 +1289,22 @@ class TestProofRoutes(AsyncTestCase):
                 )
                 mock_response.assert_called_once_with({"thread_id": "sample-thread-id"})
 
+    async def test_presentation_exchange_verify_presentation_px_rec_not_found(self):
+        self.request.json = async_mock.CoroutineMock(return_value={"trace": False})
+        self.request.match_info = {"pres_ex_id": "dummy"}
+
+        with async_mock.patch.object(
+            test_module.V10PresentationExchange,
+            "retrieve_by_id",
+            async_mock.CoroutineMock(),
+        ) as mock_retrieve:
+            mock_retrieve.side_effect = StorageNotFoundError("no such record")
+            with self.assertRaises(test_module.web.HTTPNotFound) as context:
+                await test_module.presentation_exchange_verify_presentation(
+                    self.request
+                )
+            assert "no such record" in str(context.exception)
+
     async def test_presentation_exchange_verify_presentation_not_found(self):
         self.request.match_info = {"pres_ex_id": "dummy"}
         self.profile.context.injector.bind_instance(
@@ -1191,7 +1328,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.protocols.present_proof.v1_0.manager.PresentationManager",
             autospec=True,
         ) as mock_presentation_manager, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -1224,7 +1364,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.protocols.present_proof.v1_0.manager.PresentationManager",
             autospec=True,
         ) as mock_presentation_manager, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -1253,7 +1396,10 @@ class TestProofRoutes(AsyncTestCase):
         self.request.match_info = {"pres_ex_id": "dummy"}
 
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -1293,7 +1439,10 @@ class TestProofRoutes(AsyncTestCase):
             "aries_cloudagent.protocols.present_proof.v1_0.manager.PresentationManager",
             autospec=True,
         ) as mock_presentation_manager, async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -1331,7 +1480,10 @@ class TestProofRoutes(AsyncTestCase):
         self.request.match_info = {"pres_ex_id": "dummy"}
 
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -1357,7 +1509,10 @@ class TestProofRoutes(AsyncTestCase):
         self.request.match_info = {"pres_ex_id": "dummy"}
 
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 
@@ -1376,7 +1531,10 @@ class TestProofRoutes(AsyncTestCase):
         self.request.match_info = {"pres_ex_id": "dummy"}
 
         with async_mock.patch(
-            "aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange.V10PresentationExchange",
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
             autospec=True,
         ) as mock_presentation_exchange:
 


### PR DESCRIPTION
@TimoGlastra is there meant to be a separation between `wallet_webhook_urls` values of `[]` (empty list) vs. `None` (multitenant/admin/routes.py lines 355-370)? Please advise.

Signed-off-by: sklump <srklump@hotmail.com>