### PR TITLE
Rename duplicate MessageParseError, add trust_env to ClientSession

### DIFF
--- a/aries_cloudagent/core/tests/test_protocol_registry.py
+++ b/aries_cloudagent/core/tests/test_protocol_registry.py
@@ -1,7 +1,6 @@
 from asynctest import TestCase as AsyncTestCase, mock as async_mock
 
 from ...config.injection_context import InjectionContext
-from ...messaging.error import MessageParseError
 from ...utils.classloader import ClassLoader
 
 from ..protocol_registry import ProtocolRegistry

--- a/aries_cloudagent/tails/indy_tails_server.py
+++ b/aries_cloudagent/tails/indy_tails_server.py
@@ -1,6 +1,8 @@
 """Indy tails server interface class."""
 
-from ..utils.http import put, PutError
+from typing import Tuple
+
+from ..utils.http import put_file, PutError
 
 from .base import BaseTailsServer
 from .error import TailsServerNotConfiguredError
@@ -17,7 +19,7 @@ class IndyTailsServer(BaseTailsServer):
         interval: float = 1.0,
         backoff: float = 0.25,
         max_attempts: int = 5,
-    ) -> (bool, str):
+    ) -> Tuple[bool, str]:
         """Upload tails file to tails server.
 
         Args:
@@ -40,7 +42,7 @@ class IndyTailsServer(BaseTailsServer):
         try:
             return (
                 True,
-                await put(
+                await put_file(
                     f"{tails_server_upload_url}/{rev_reg_id}",
                     {"tails": tails_file_path},
                     {"genesis": genesis_transactions},

--- a/aries_cloudagent/tails/tests/test_indy.py
+++ b/aries_cloudagent/tails/tests/test_indy.py
@@ -28,7 +28,7 @@ class TestIndyTailsServer(AsyncTestCase):
         indy_tails = test_module.IndyTailsServer()
 
         with async_mock.patch.object(
-            test_module, "put", async_mock.CoroutineMock()
+            test_module, "put_file", async_mock.CoroutineMock()
         ) as mock_put:
             mock_put.return_value = "tails-hash"
             (ok, text) = await indy_tails.upload_tails_file(
@@ -49,7 +49,7 @@ class TestIndyTailsServer(AsyncTestCase):
         indy_tails = test_module.IndyTailsServer()
 
         with async_mock.patch.object(
-            test_module, "put", async_mock.CoroutineMock()
+            test_module, "put_file", async_mock.CoroutineMock()
         ) as mock_put:
             mock_put.side_effect = test_module.PutError("Server down for maintenance")
 

--- a/aries_cloudagent/transport/error.py
+++ b/aries_cloudagent/transport/error.py
@@ -11,14 +11,14 @@ class WireFormatError(TransportError):
     """Base class for wire-format errors."""
 
 
-class MessageParseError(WireFormatError):
-    """Message parse error."""
+class WireFormatParseError(WireFormatError):
+    """Parse error when unpacking the wire format."""
 
     error_code = "message_parse_error"
 
 
-class MessageEncodeError(WireFormatError):
-    """Message encoding error."""
+class WireFormatEncodeError(WireFormatError):
+    """Encoding error when packing the wire format."""
 
     error_code = "message_encode_error"
 

--- a/aries_cloudagent/transport/inbound/http.py
+++ b/aries_cloudagent/transport/inbound/http.py
@@ -6,6 +6,7 @@ from aiohttp import web
 
 from ...messaging.error import MessageParseError
 
+from ..error import WireFormatParseError
 from ..wire_format import DIDCOMM_V0_MIME_TYPE, DIDCOMM_V1_MIME_TYPE
 
 from .base import BaseInboundTransport, InboundTransportSetupError
@@ -93,7 +94,7 @@ class HttpTransport(BaseInboundTransport):
         async with session:
             try:
                 inbound = await session.receive(body)
-            except MessageParseError:
+            except (MessageParseError, WireFormatParseError):
                 raise web.HTTPBadRequest()
 
             if inbound.receipt.direct_response_requested:

--- a/aries_cloudagent/transport/inbound/tests/test_http_transport.py
+++ b/aries_cloudagent/transport/inbound/tests/test_http_transport.py
@@ -8,6 +8,7 @@ from asynctest import mock as async_mock
 from ....core.in_memory import InMemoryProfile
 from ....core.profile import Profile
 
+from ...error import WireFormatParseError
 from ...outbound.message import OutboundMessage
 from ...wire_format import JsonWireFormat
 
@@ -136,7 +137,7 @@ class TestHttpTransport(AioHTTPTestCase):
 
             mock_session.return_value = async_mock.MagicMock(
                 receive=async_mock.CoroutineMock(
-                    side_effect=test_module.MessageParseError()
+                    side_effect=test_module.WireFormatParseError()
                 ),
                 profile=InMemoryProfile.test_profile(),
             )

--- a/aries_cloudagent/transport/inbound/ws.py
+++ b/aries_cloudagent/transport/inbound/ws.py
@@ -7,6 +7,8 @@ from aiohttp import web, WSMessage, WSMsgType
 
 from ...messaging.error import MessageParseError
 
+from ..error import WireFormatParseError
+
 from .base import BaseInboundTransport, InboundTransportSetupError
 
 LOGGER = logging.getLogger(__name__)
@@ -106,7 +108,7 @@ class WsTransport(BaseInboundTransport):
                     if msg.type in (WSMsgType.TEXT, WSMsgType.BINARY):
                         try:
                             await session.receive(msg.data)
-                        except MessageParseError:
+                        except (MessageParseError, WireFormatParseError):
                             await ws.close(1003)  # unsupported data error
                     elif msg.type == WSMsgType.ERROR:
                         LOGGER.error(

--- a/aries_cloudagent/transport/outbound/http.py
+++ b/aries_cloudagent/transport/outbound/http.py
@@ -27,14 +27,16 @@ class HttpTransport(BaseOutboundTransport):
 
     async def start(self):
         """Start the transport."""
-        session_args = {}
         self.connector = TCPConnector(limit=200, limit_per_host=50)
+        session_args = {
+            "cookie_jar": DummyCookieJar(),
+            "connector": self.connector,
+            "trust_env": True,
+        }
         if self.collector:
             session_args["trace_configs"] = [
                 StatsTracer(self.collector, "outbound-http:")
             ]
-        session_args["cookie_jar"] = DummyCookieJar()
-        session_args["connector"] = self.connector
         self.client_session = ClientSession(**session_args)
         return self
 

--- a/aries_cloudagent/transport/outbound/ws.py
+++ b/aries_cloudagent/transport/outbound/ws.py
@@ -22,7 +22,7 @@ class WsTransport(BaseOutboundTransport):
 
     async def start(self):
         """Start the outbound transport."""
-        self.client_session = ClientSession(cookie_jar=DummyCookieJar())
+        self.client_session = ClientSession(cookie_jar=DummyCookieJar(), trust_env=True)
         return self
 
     async def stop(self):

--- a/aries_cloudagent/transport/pack_format.py
+++ b/aries_cloudagent/transport/pack_format.py
@@ -14,7 +14,7 @@ from ..utils.task_queue import TaskQueue
 from ..wallet.base import BaseWallet
 from ..wallet.error import WalletError
 
-from .error import MessageParseError, MessageEncodeError, RecipientKeysError
+from .error import WireFormatParseError, WireFormatEncodeError, RecipientKeysError
 from .inbound.receipt import MessageReceipt
 from .wire_format import BaseWireFormat
 
@@ -45,8 +45,8 @@ class PackWireFormat(BaseWireFormat):
             A tuple of the parsed message and a message receipt instance
 
         Raises:
-            MessageParseError: If the JSON parsing failed
-            MessageParseError: If a wallet is required but can't be located
+            WireFormatParseError: If the JSON parsing failed
+            WireFormatParseError: If a wallet is required but can't be located
 
         """
 
@@ -58,14 +58,14 @@ class PackWireFormat(BaseWireFormat):
         message_json = message_body
 
         if not message_json:
-            raise MessageParseError("Message body is empty")
+            raise WireFormatParseError("Message body is empty")
 
         try:
             message_dict = json.loads(message_json)
         except ValueError:
-            raise MessageParseError("Message JSON parsing failed")
+            raise WireFormatParseError("Message JSON parsing failed")
         if not isinstance(message_dict, dict):
-            raise MessageParseError("Message JSON result is not an object")
+            raise WireFormatParseError("Message JSON result is not an object")
 
         # packed messages are detected by the absence of @type
         if "@type" not in message_dict:
@@ -75,16 +75,16 @@ class PackWireFormat(BaseWireFormat):
                 message_json = await (
                     self.task_queue and self.task_queue.run(unpack) or unpack
                 )
-            except MessageParseError:
+            except WireFormatParseError:
                 LOGGER.debug("Message unpack failed, falling back to JSON")
             else:
                 receipt.raw_message = message_json
                 try:
                     message_dict = json.loads(message_json)
                 except ValueError:
-                    raise MessageParseError("Message JSON parsing failed")
+                    raise WireFormatParseError("Message JSON parsing failed")
                 if not isinstance(message_dict, dict):
-                    raise MessageParseError("Message JSON result is not an object")
+                    raise WireFormatParseError("Message JSON result is not an object")
 
         # parse thread ID
         thread_dec = message_dict.get("~thread")
@@ -110,7 +110,7 @@ class PackWireFormat(BaseWireFormat):
         """Look up the wallet instance and perform the message unpack."""
         wallet = session.inject(BaseWallet, required=False)
         if not wallet:
-            raise MessageParseError("Wallet not defined in profile session")
+            raise WireFormatParseError("Wallet not defined in profile session")
 
         try:
             unpacked = await wallet.unpack_message(message_body)
@@ -121,7 +121,7 @@ class PackWireFormat(BaseWireFormat):
             ) = unpacked
             return message_json
         except WalletError as e:
-            raise MessageParseError("Message unpack failed") from e
+            raise WireFormatParseError("Message unpack failed") from e
 
     async def encode_message(
         self,
@@ -168,18 +168,18 @@ class PackWireFormat(BaseWireFormat):
     ):
         """Look up the wallet instance and perform the message pack."""
         if not sender_key or not recipient_keys:
-            raise MessageEncodeError("Cannot pack message without associated keys")
+            raise WireFormatEncodeError("Cannot pack message without associated keys")
 
         wallet = session.inject(BaseWallet, required=False)
         if not wallet:
-            raise MessageEncodeError("No wallet instance")
+            raise WireFormatEncodeError("No wallet instance")
 
         try:
             message = await wallet.pack_message(
                 message_json, recipient_keys, sender_key
             )
         except WalletError as e:
-            raise MessageEncodeError("Message pack failed") from e
+            raise WireFormatEncodeError("Message pack failed") from e
 
         if routing_keys:
             recip_keys = recipient_keys
@@ -191,7 +191,7 @@ class PackWireFormat(BaseWireFormat):
                 try:
                     message = await wallet.pack_message(fwd_msg.to_json(), recip_keys)
                 except WalletError as e:
-                    raise MessageEncodeError("Forward message pack failed") from e
+                    raise WireFormatEncodeError("Forward message pack failed") from e
         return message
 
     def get_recipient_keys(self, message_body: Union[str, bytes]) -> List[str]:

--- a/aries_cloudagent/transport/tests/test_pack_format.py
+++ b/aries_cloudagent/transport/tests/test_pack_format.py
@@ -9,7 +9,7 @@ from ...protocols.didcomm_prefix import DIDCommPrefix
 from ...wallet.base import BaseWallet
 from ...wallet.error import WalletError
 
-from ..error import MessageEncodeError, MessageParseError, RecipientKeysError
+from ..error import WireFormatEncodeError, WireFormatParseError, RecipientKeysError
 from ..pack_format import PackWireFormat
 from .. import pack_format as test_module
 
@@ -38,7 +38,7 @@ class TestPackWireFormat(AsyncTestCase):
         bad_values = [None, "", "1", "[]", "{..."]
 
         for message_json in bad_values:
-            with self.assertRaises(MessageParseError):
+            with self.assertRaises(WireFormatParseError):
                 message_dict, delivery = await serializer.parse_message(
                     self.session, message_json
                 )
@@ -55,7 +55,7 @@ class TestPackWireFormat(AsyncTestCase):
             serializer, "unpack", async_mock.CoroutineMock()
         ) as mock_unpack:
             mock_unpack.return_value = "{missing-brace"
-            with self.assertRaises(MessageParseError) as context:
+            with self.assertRaises(WireFormatParseError) as context:
                 await serializer.parse_message(self.session, json.dumps(x_message))
         assert "Message JSON parsing failed" in str(context.exception)
 
@@ -65,11 +65,11 @@ class TestPackWireFormat(AsyncTestCase):
             serializer, "unpack", async_mock.CoroutineMock()
         ) as mock_unpack:
             mock_unpack.return_value = json.dumps([1, 2, 3])
-            with self.assertRaises(MessageParseError) as context:
+            with self.assertRaises(WireFormatParseError) as context:
                 await serializer.parse_message(self.session, json.dumps(x_message))
         assert "Message JSON result is not an object" in str(context.exception)
 
-        with self.assertRaises(MessageParseError):
+        with self.assertRaises(WireFormatParseError):
             await serializer.unpack(
                 InMemoryProfile.test_session(bind={BaseWallet: None}), "...", None
             )
@@ -77,10 +77,10 @@ class TestPackWireFormat(AsyncTestCase):
     async def test_pack_x(self):
         serializer = PackWireFormat()
 
-        with self.assertRaises(MessageEncodeError):
+        with self.assertRaises(WireFormatEncodeError):
             await serializer.pack(self.session, None, None, None, None)
 
-        with self.assertRaises(MessageEncodeError):
+        with self.assertRaises(WireFormatEncodeError):
             await serializer.pack(
                 InMemoryProfile.test_session(bind={BaseWallet: None}),
                 None,
@@ -93,7 +93,7 @@ class TestPackWireFormat(AsyncTestCase):
             pack_message=async_mock.CoroutineMock(side_effect=WalletError())
         )
         session = InMemoryProfile.test_session(bind={BaseWallet: mock_wallet})
-        with self.assertRaises(MessageEncodeError):
+        with self.assertRaises(WireFormatEncodeError):
             await serializer.pack(session, None, ["key"], None, ["key"])
 
         mock_wallet = async_mock.MagicMock(
@@ -108,7 +108,7 @@ class TestPackWireFormat(AsyncTestCase):
             mock_forward.return_value = async_mock.MagicMock(
                 to_json=async_mock.MagicMock()
             )
-            with self.assertRaises(MessageEncodeError):
+            with self.assertRaises(WireFormatEncodeError):
                 await serializer.pack(session, None, ["key"], ["key"], ["key"])
 
     async def test_unpacked(self):

--- a/aries_cloudagent/transport/wire_format.py
+++ b/aries_cloudagent/transport/wire_format.py
@@ -10,7 +10,7 @@ from ..core.profile import ProfileSession
 from ..messaging.util import time_now
 
 from .inbound.receipt import MessageReceipt
-from .error import MessageParseError
+from .error import WireFormatParseError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class BaseWireFormat:
             A tuple of the parsed message and a message receipt instance
 
         Raises:
-            MessageParseError: If the message can't be parsed
+            WireFormatParseError: If the message can't be parsed
 
         """
 
@@ -109,7 +109,7 @@ class JsonWireFormat(BaseWireFormat):
             A tuple of the parsed message and a message receipt instance
 
         Raises:
-            MessageParseError: If the JSON parsing failed
+            WireFormatParseError: If the JSON parsing failed
 
         """
         receipt = MessageReceipt()
@@ -120,14 +120,14 @@ class JsonWireFormat(BaseWireFormat):
         message_json = message_body
 
         if not message_json:
-            raise MessageParseError("Message body is empty")
+            raise WireFormatParseError("Message body is empty")
 
         try:
             message_dict = json.loads(message_json)
         except ValueError:
-            raise MessageParseError("Message JSON parsing failed")
+            raise WireFormatParseError("Message JSON parsing failed")
         if not isinstance(message_dict, dict):
-            raise MessageParseError("Message JSON result is not an object")
+            raise WireFormatParseError("Message JSON result is not an object")
 
         # parse thread ID
         thread_dec = message_dict.get("~thread")

--- a/aries_cloudagent/utils/http.py
+++ b/aries_cloudagent/utils/http.py
@@ -47,7 +47,9 @@ async def fetch_stream(
     """
     limit = max_attempts if retry else 1
     if not session:
-        session = ClientSession(connector=connector, connector_owner=(not connector))
+        session = ClientSession(
+            connector=connector, connector_owner=(not connector), trust_env=True
+        )
     async with session:
         async for attempt in RepeatSequence(limit, interval, backoff):
             try:
@@ -94,7 +96,9 @@ async def fetch(
     """
     limit = max_attempts if retry else 1
     if not session:
-        session = ClientSession(connector=connector, connector_owner=(not connector))
+        session = ClientSession(
+            connector=connector, connector_owner=(not connector), trust_env=True
+        )
     async with session:
         async for attempt in RepeatSequence(limit, interval, backoff):
             try:
@@ -147,7 +151,9 @@ async def put(
     limit = max_attempts if retry else 1
 
     if not session:
-        session = ClientSession(connector=connector, connector_owner=(not connector))
+        session = ClientSession(
+            connector=connector, connector_owner=(not connector), trust_env=True
+        )
     async with session:
         async for attempt in RepeatSequence(limit, interval, backoff):
             try:

--- a/aries_cloudagent/utils/http.py
+++ b/aries_cloudagent/utils/http.py
@@ -115,7 +115,7 @@ async def fetch(
                     raise FetchError("Exceeded maximum fetch attempts") from e
 
 
-async def put(
+async def put_file(
     url: str,
     file_data: dict,
     extra_data: dict,

--- a/aries_cloudagent/utils/tests/test_http.py
+++ b/aries_cloudagent/utils/tests/test_http.py
@@ -1,8 +1,8 @@
 from aiohttp import web
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
-from asynctest import mock as async_mock
+from asynctest import mock as async_mock, mock_open
 
-from ..http import fetch, fetch_stream, FetchError, put, PutError
+from ..http import fetch, fetch_stream, FetchError, put_file, PutError
 
 
 class TestTransportUtils(AioHTTPTestCase):
@@ -90,10 +90,10 @@ class TestTransportUtils(AioHTTPTestCase):
         assert self.fail_calls == 2
 
     @unittest_run_loop
-    async def test_put(self):
+    async def test_put_file(self):
         server_addr = f"http://localhost:{self.server.port}"
-        with async_mock.patch("builtins.open", async_mock.MagicMock()) as mock_open:
-            result = await put(
+        with async_mock.patch("builtins.open", mock_open(read_data="data")):
+            result = await put_file(
                 f"{server_addr}/succeed",
                 {"tails": "/tmp/dummy/path"},
                 {"genesis": "..."},
@@ -104,10 +104,10 @@ class TestTransportUtils(AioHTTPTestCase):
         assert self.succeed_calls == 1
 
     @unittest_run_loop
-    async def test_put_default_client(self):
+    async def test_put_file_default_client(self):
         server_addr = f"http://localhost:{self.server.port}"
-        with async_mock.patch("builtins.open", async_mock.MagicMock()) as mock_open:
-            result = await put(
+        with async_mock.patch("builtins.open", mock_open(read_data="data")):
+            result = await put_file(
                 f"{server_addr}/succeed",
                 {"tails": "/tmp/dummy/path"},
                 {"genesis": "..."},
@@ -117,11 +117,11 @@ class TestTransportUtils(AioHTTPTestCase):
         assert self.succeed_calls == 1
 
     @unittest_run_loop
-    async def test_put_fail(self):
+    async def test_put_file_fail(self):
         server_addr = f"http://localhost:{self.server.port}"
-        with async_mock.patch("builtins.open", async_mock.MagicMock()) as mock_open:
+        with async_mock.patch("builtins.open", mock_open(read_data="data")):
             with self.assertRaises(PutError):
-                result = await put(
+                result = await put_file(
                     f"{server_addr}/fail",
                     {"tails": "/tmp/dummy/path"},
                     {"genesis": "..."},


### PR DESCRIPTION
Combined transport fixes. Adding `trust_env` to `ClientSession` causes it to respect the environment-defined transport settings. Renamed `MessageParseError` and `MessageEncodeError` in the transport module to avoid ambiguity. Supercedes #980 