### PR TITLE
Fix for handle_not_delivered being triggered when there is no message property

### DIFF
--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -340,7 +340,7 @@ class OutboundTransportManager:
                             queued.endpoint,
                             exc_info=queued.error,
                         )
-                        if self.handle_not_delivered:
+                        if self.handle_not_delivered and queued.message:
                             self.handle_not_delivered(queued.profile, queued.message)
                     continue  # remove from buffer
 


### PR DESCRIPTION
Closes #993
Signed-off-by: Shaanjot Gill shaangill025@users.noreply.github.com