### PR TITLE
Correction to out_of_band protocol v1_0 in manager.py

### DIFF
--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -529,7 +529,7 @@ class OutOfBandManager(BaseConnectionManager):
                 if req_attach.data is not None:
                     req_attach_type = req_attach.data.json["@type"]
                     if DIDCommPrefix.unqualify(req_attach_type) == PRESENTATION_REQUEST:
-                        proof_present_mgr = PresentationManager(self._session)
+                        proof_present_mgr = PresentationManager(self._session.profile)
                         indy_proof_request = json.loads(
                             b64_to_bytes(
                                 req_attach.data.json["request_presentations~attach"][0][


### PR DESCRIPTION
In line 532 of aries_cloudagent/protocols/out_of_band/v1_0/manage.py the initialization 
of PresentationManager should take Profile as an argument and not ProfileSession.

The error bellow occurs when the receive_invitation is called:
_AttributeError: 'IndySdkProfileSession' object has no attribute 'session'_

In order to avoid the above error, this line(532) **proof_present_mgr = PresentationManager(self._session)**  
must be replaced with this **proof_present_mgr = PresentationManager(self._session.profile)**.

As a result, with this change the above error disappears.