### PR TITLE
Small AIP-2 updates

### DIFF
--- a/aries_cloudagent/commands/tests/test_provision.py
+++ b/aries_cloudagent/commands/tests/test_provision.py
@@ -10,7 +10,7 @@ from .. import provision as test_module
 
 class TestProvision(AsyncTestCase):
     def test_bad_calls(self):
-        with self.assertRaises(ArgsParseError):
+        with self.assertRaises(SystemExit):
             test_module.execute([])
 
         with self.assertRaises(SystemExit):

--- a/aries_cloudagent/commands/tests/test_start.py
+++ b/aries_cloudagent/commands/tests/test_start.py
@@ -9,7 +9,7 @@ from .. import start as test_module
 
 class TestStart(AsyncTestCase):
     def test_bad_args(self):
-        with self.assertRaises(ArgsParseError):
+        with self.assertRaises(SystemExit):
             test_module.execute([])
 
         with self.assertRaises(SystemExit):

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -78,8 +78,10 @@ def load_argument_groups(parser: ArgumentParser, *groups: Type[ArgumentGroup]):
             for group in group_inst:
                 settings.update(group.get_settings(args))
         except ArgsParseError as e:
-            parser.print_help()
-            raise e
+            # this is defined to exit or raise an exception and is
+            # consistent with an error being raised while the arguments
+            # are being parsed
+            parser.error(str(e))
         return settings
 
     return get_settings

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -652,6 +652,13 @@ class ProtocolGroup(ArgumentGroup):
     def add_arguments(self, parser: ArgumentParser):
         """Add protocol-specific command line arguments to the parser."""
         parser.add_argument(
+            "--aip-version",
+            type=BoundedInt(1, 2),
+            default=1,
+            env_var="ACAPY_AIP_VERSION",
+            help="Set the Aries Interop Profile compatibility version (default 1).",
+        )
+        parser.add_argument(
             "--auto-ping-connection",
             action="store_true",
             env_var="ACAPY_AUTO_PING_CONNECTION",
@@ -726,22 +733,6 @@ class ProtocolGroup(ArgumentGroup):
             help="Keep credential exchange records after exchange has completed.",
         )
         parser.add_argument(
-            "--emit-new-didcomm-prefix",
-            action="store_true",
-            env_var="ACAPY_EMIT_NEW_DIDCOMM_PREFIX",
-            help="Emit protocol messages with new DIDComm prefix; i.e.,\
-            'https://didcomm.org/' instead of (default) prefix\
-            'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/'.",
-        )
-        parser.add_argument(
-            "--emit-new-didcomm-mime-type",
-            action="store_true",
-            env_var="ACAPY_EMIT_NEW_DIDCOMM_MIME_TYPE",
-            help="Send packed agent messages with the DIDComm MIME type\
-            as of RFC 0044; i.e., 'application/didcomm-envelope-enc'\
-            instead of 'application/ssi-agent-wire'.",
-        )
-        parser.add_argument(
             "--exch-use-unencrypted-tags",
             action="store_true",
             env_var="ACAPY_EXCH_USE_UNENCRYPTED_TAGS",
@@ -752,6 +743,7 @@ class ProtocolGroup(ArgumentGroup):
     def get_settings(self, args: Namespace) -> dict:
         """Get protocol settings."""
         settings = {}
+        settings["aip_version"] = args.aip_version
         if args.auto_ping_connection:
             settings["auto_ping_connection"] = True
         if args.invite_base_url:
@@ -796,10 +788,6 @@ class ProtocolGroup(ArgumentGroup):
                 raise ArgsParseError("Error writing trace event " + str(e))
         if args.preserve_exchange_records:
             settings["preserve_exchange_records"] = True
-        if args.emit_new_didcomm_prefix:
-            settings["emit_new_didcomm_prefix"] = True
-        if args.emit_new_didcomm_mime_type:
-            settings["emit_new_didcomm_mime_type"] = True
         if args.exch_use_unencrypted_tags:
             settings["exch_use_unencrypted_tags"] = True
             environ["EXCH_UNENCRYPTED_TAGS"] = "True"

--- a/aries_cloudagent/config/wallet.py
+++ b/aries_cloudagent/config/wallet.py
@@ -2,6 +2,8 @@
 
 import logging
 
+from typing import Tuple
+
 from ..core.error import ProfileNotFoundError
 from ..core.profile import Profile, ProfileManager
 from ..wallet.base import BaseWallet, DIDInfo
@@ -17,7 +19,7 @@ CFG_MAP = {"key", "rekey", "name", "storage_config", "storage_creds", "storage_t
 
 async def wallet_config(
     context: InjectionContext, provision: bool = False
-) -> (Profile, DIDInfo):
+) -> Tuple[Profile, DIDInfo]:
     """Initialize the root profile."""
 
     mgr = context.inject(ProfileManager)

--- a/aries_cloudagent/connections/base_manager.py
+++ b/aries_cloudagent/connections/base_manager.py
@@ -143,10 +143,15 @@ class BaseConnectionManager:
 
         for (endpoint_index, svc_endpoint) in enumerate(svc_endpoints or []):
             endpoint_ident = "indy" if endpoint_index == 0 else f"indy{endpoint_index}"
+            service_type = (
+                "did-communication"
+                if self._session.settings.get("aip_version", 1) >= 2
+                else "IndyAgent"
+            )
             service = Service(
                 did_info.did,
                 endpoint_ident,
-                "IndyAgent",
+                service_type,
                 [pk],
                 routing_keys,
                 svc_endpoint,

--- a/aries_cloudagent/connections/base_manager.py
+++ b/aries_cloudagent/connections/base_manager.py
@@ -59,6 +59,7 @@ class BaseConnectionManager:
         inbound_connection_id: str = None,
         svc_endpoints: Sequence[str] = None,
         mediation_records: List[MediationRecord] = None,
+        svc_type: str = None,
     ) -> DIDDoc:
         """Create our DID doc for a given DID.
 
@@ -68,6 +69,7 @@ class BaseConnectionManager:
             svc_endpoints: Custom endpoints for the DID Document
             mediation_record: The record for mediation that contains routing_keys and
                 service endpoint
+            svc_type: Customize the type used in service entries
 
         Returns:
             The prepared `DIDDoc` instance
@@ -143,15 +145,10 @@ class BaseConnectionManager:
 
         for (endpoint_index, svc_endpoint) in enumerate(svc_endpoints or []):
             endpoint_ident = "indy" if endpoint_index == 0 else f"indy{endpoint_index}"
-            service_type = (
-                "did-communication"
-                if self._session.settings.get("aip_version", 1) >= 2
-                else "IndyAgent"
-            )
             service = Service(
                 did_info.did,
                 endpoint_ident,
-                service_type,
+                svc_type or DIDDoc.SERVICE_TYPE_V1,
                 [pk],
                 routing_keys,
                 svc_endpoint,

--- a/aries_cloudagent/connections/models/diddoc/diddoc.py
+++ b/aries_cloudagent/connections/models/diddoc/diddoc.py
@@ -30,7 +30,7 @@ from .util import canon_ref
 LOGGER = logging.getLogger(__name__)
 
 
-def parseError(msg: str):
+def _parseError(msg: str):
     LOGGER.debug(msg)
     raise ValueError(msg)
 
@@ -253,7 +253,7 @@ class DIDDoc:
         """
 
         if "id" not in did_doc:
-            parseError("no identifier in DID document")
+            _parseError("no identifier in DID document")
 
         rv = DIDDoc(did_doc["id"])
 
@@ -277,7 +277,7 @@ class DIDDoc:
                     True,
                 )
                 if key.id in rv.pubkey:
-                    parseError(f"duplicate key id: {key.id}")
+                    _parseError(f"duplicate key id: {key.id}")
                 rv.pubkey[key.id] = key
 
         pubkeys = did_doc.get("verificationMethod", did_doc.get("publicKey")) or {}
@@ -296,7 +296,7 @@ class DIDDoc:
             if key.id in auth_key_ids:
                 key.authn = True
             if key.id in rv.pubkey:
-                parseError(f"duplicate key id: {key.id}")
+                _parseError(f"duplicate key id: {key.id}")
             rv.pubkey[key.id] = key
 
         for service in did_doc.get("service", {}):

--- a/aries_cloudagent/connections/models/diddoc/diddoc.py
+++ b/aries_cloudagent/connections/models/diddoc/diddoc.py
@@ -46,6 +46,9 @@ class DIDDoc:
     CONTEXT_V0 = "https://w3id.org/did/v1"
     CONTEXT_V1 = "https://www.w3.org/ns/did/v1"
 
+    SERVICE_TYPE_V0 = "IndyAgent"
+    SERVICE_TYPE_V1 = "did-communication"
+
     def __init__(self, did: str = None) -> None:
         """
         Initialize the DIDDoc instance.

--- a/aries_cloudagent/connections/models/diddoc/publickey.py
+++ b/aries_cloudagent/connections/models/diddoc/publickey.py
@@ -21,7 +21,7 @@ limitations under the License.
 from collections import namedtuple
 from enum import Enum
 
-from .util import canon_did, canon_ref
+from .util import canon_ref
 
 
 LinkedDataKeySpec = namedtuple("LinkedDataKeySpec", "ver_type authn_type specifier")
@@ -126,11 +126,11 @@ class PublicKey:
 
         """
 
-        self._did = canon_did(did)
+        self._did = did
         self._id = canon_ref(self._did, ident)
         self._value = value
         self._type = pk_type or PublicKeyType.ED25519_SIG_2018
-        self._controller = canon_did(controller) if controller else self._did
+        self._controller = controller or self._did
         self._authn = authn
 
     @property

--- a/aries_cloudagent/connections/models/diddoc/service.py
+++ b/aries_cloudagent/connections/models/diddoc/service.py
@@ -20,7 +20,7 @@ limitations under the License.
 
 from typing import List, Sequence, Union
 
-from .util import canon_did, canon_ref
+from .util import canon_ref
 from .publickey import PublicKey
 
 
@@ -62,7 +62,7 @@ class Service:
 
         """
 
-        self._did = canon_did(did)
+        self._did = did
         self._id = canon_ref(self._did, ident, ";")
         self._type = typ
         self._recip_keys = (

--- a/aries_cloudagent/connections/models/diddoc/tests/test_diddoc.py
+++ b/aries_cloudagent/connections/models/diddoc/tests/test_diddoc.py
@@ -16,12 +16,10 @@ limitations under the License.
 """
 
 
-import json
-
-from asynctest import TestCase as AsyncTestCase, mock as async_mock
+from asynctest import TestCase as AsyncTestCase
 
 from .. import DIDDoc, PublicKey, PublicKeyType, Service
-from ..util import canon_did, canon_ref
+from ..util import canon_ref
 
 
 class TestDIDDoc(AsyncTestCase):
@@ -67,7 +65,7 @@ class TestDIDDoc(AsyncTestCase):
         }
 
         dd = DIDDoc.deserialize(dd_in)
-        assert str(dd) == f"DIDDoc({canon_did(dd_in['id'])})"
+        assert str(dd) == f"DIDDoc({dd_in['id']})"
         assert len(dd.pubkey) == len(dd_in["publicKey"])
         assert len(dd.authnkey) == len(dd_in["authentication"])
 
@@ -97,7 +95,6 @@ class TestDIDDoc(AsyncTestCase):
 
         # Exercise accessors
         dd.did = dd_out["id"]
-        assert dd.did == canon_did(dd_out["id"])
         with self.assertRaises(ValueError):
             dd.set(["neither a service", "nor a public key"])
         assert dd.service[[k for k in dd.service][0]].did == dd.did
@@ -198,50 +195,21 @@ class TestDIDDoc(AsyncTestCase):
         # print('\n\n== 5 == DID Doc on canonical refs: {}'.format(ppjson(dd_out)))
 
     def test_minimal(self):
-        # Minimal as per indy-agent test suite without explicit identifiers
-        dd_in = {
-            "@context": "https://w3id.org/did/v1",
-            "publicKey": [
-                {
-                    "id": "LjgpST2rjsoxYegQDRm7EL#keys-1",
-                    "type": "Ed25519VerificationKey2018",
-                    "controller": "LjgpST2rjsoxYegQDRm7EL",
-                    "publicKeyBase58": "~XXXXXXXXXXXXXXXX",
-                }
-            ],
-            "service": [
-                {
-                    "type": "DidMessaging",
-                    "recipientKeys": ["~XXXXXXXXXXXXXXXX"],
-                    "serviceEndpoint": "https://www.von.ca",
-                }
-            ],
-        }
-
-        dd = DIDDoc.deserialize(dd_in)
-        assert len(dd.pubkey) == len(dd_in["publicKey"])
-        assert len(dd.authnkey) == 0
-
-        dd_out = dd.serialize()
-        # print('\n\n== 6 == DID Doc miminal style, implcit DID document identifier: {}'.format(
-        #    ppjson(dd_out)))
-
-    def test_minimal_ids(self):
         # Minimal + ids as per indy-agent test suite with explicit identifiers; novel service recipient key on raw base58
         dd_in = {
             "@context": "https://w3id.org/did/v1",
-            "id": "LjgpST2rjsoxYegQDRm7EL",
+            "id": "did:sov:LjgpST2rjsoxYegQDRm7EL",
             "publicKey": [
                 {
-                    "id": "LjgpST2rjsoxYegQDRm7EL#keys-1",
+                    "id": "did:sov:LjgpST2rjsoxYegQDRm7EL#keys-1",
                     "type": "Ed25519VerificationKey2018",
-                    "controller": "LjgpST2rjsoxYegQDRm7EL",
+                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyBase58": "~XXXXXXXXXXXXXXXX",
                 }
             ],
             "service": [
                 {
-                    "id": "LjgpST2rjsoxYegQDRm7EL;indy",
+                    "id": "did:sov:LjgpST2rjsoxYegQDRm7EL;indy",
                     "type": "DidMessaging",
                     "priority": 1,
                     "recipientKeys": ["~YYYYYYYYYYYYYYYY"],
@@ -262,24 +230,24 @@ class TestDIDDoc(AsyncTestCase):
         # Minimal + ids as per indy-agent test suite with explicit identifiers; novel service recipient key on raw base58
         dd_in = {
             "@context": "https://w3id.org/did/v1",
-            "id": "LjgpST2rjsoxYegQDRm7EL",
+            "id": "did:sov:LjgpST2rjsoxYegQDRm7EL",
             "publicKey": [
                 {
-                    "id": "LjgpST2rjsoxYegQDRm7EL#keys-1",
+                    "id": "did:sov:LjgpST2rjsoxYegQDRm7EL#keys-1",
                     "type": "Ed25519VerificationKey2018",
-                    "controller": "LjgpST2rjsoxYegQDRm7EL",
+                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyBase58": "~XXXXXXXXXXXXXXXX",
                 },
                 {
-                    "id": "LjgpST2rjsoxYegQDRm7EL#keys-2",
+                    "id": "did:sov:LjgpST2rjsoxYegQDRm7EL#keys-2",
                     "type": "Ed25519VerificationKey2018",
-                    "controller": "LjgpST2rjsoxYegQDRm7EL",
+                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyBase58": "~YYYYYYYYYYYYYYYY",
                 },
                 {
-                    "id": "LjgpST2rjsoxYegQDRm7EL#keys-3",
+                    "id": "did:sov:LjgpST2rjsoxYegQDRm7EL#keys-3",
                     "type": "Secp256k1VerificationKey2018",
-                    "controller": "LjgpST2rjsoxYegQDRm7EL",
+                    "controller": "did:sov:LjgpST2rjsoxYegQDRm7EL",
                     "publicKeyHex": "02b97c30de767f084ce3080168ee293053ba33b235d7116a3263d29f1450936b71",
                 },
                 {
@@ -291,7 +259,7 @@ class TestDIDDoc(AsyncTestCase):
             ],
             "service": [
                 {
-                    "id": "LjgpST2rjsoxYegQDRm7EL;indy",
+                    "id": "did:sov:LjgpST2rjsoxYegQDRm7EL;indy",
                     "type": "DidMessaging",
                     "priority": 0,
                     "recipientKeys": ["~ZZZZZZZZZZZZZZZZ"],
@@ -306,7 +274,7 @@ class TestDIDDoc(AsyncTestCase):
                         "did:sov:LjgpST2rjsoxYegQDRm7EL#keys-1",
                     ],
                     "routingKeys": ["did:sov:LjgpST2rjsoxYegQDRm7EL#keys-4"],
-                    "serviceEndpoint": "LjgpST2rjsoxYegQDRm7EL;2",
+                    "serviceEndpoint": "did:sov:LjgpST2rjsoxYegQDRm7EL;2",
                 },
                 {
                     "id": "2",
@@ -342,7 +310,7 @@ class TestDIDDoc(AsyncTestCase):
             )
         )
 
-        dd_out = dd.serialize()
+        _ = dd.serialize()
         # print('\n\n== 8 == DID Doc on mixed service routing and recipient keys: {}'.format(ppjson(dd_out)))
 
         pk = PublicKey(
@@ -447,22 +415,6 @@ class TestDIDDoc(AsyncTestCase):
         with self.assertRaises(ValueError):
             dd = DIDDoc.deserialize(dd_in)
         # print('\n\n== 12 == DID Doc without identifier rejected as expected')
-
-    def test_canon_did(self):
-        # Exercise reference canonicalization, including failure paths
-        valid_did = "LjgpST2rjsoxYegQDRm7EL"
-
-        with self.assertRaises(ValueError):
-            canon_ref("not-a-DID", ref=valid_did, delimiter="#")
-
-        with self.assertRaises(ValueError):
-            canon_ref(valid_did, ref="did:sov:not-a-DID", delimiter="#")
-
-        urlref = (
-            "https://www.clafouti-quasar.ca:8443/supply-management/fruit/index.html"
-        )
-        assert canon_ref(valid_did, ref=urlref) == urlref
-        # print('\n\n== 13 == Reference canonicalization operates as expected')
 
     def test_pubkey_type(self):
         dd_in = {

--- a/aries_cloudagent/connections/models/diddoc/util.py
+++ b/aries_cloudagent/connections/models/diddoc/util.py
@@ -38,30 +38,6 @@ def resource(ref: str, delimiter: str = None) -> str:
     return ref.split(delimiter if delimiter else "#")[0]
 
 
-def canon_did(uri: str) -> str:
-    """
-    Convert a URI into a DID if need be, left-stripping 'did:sov:' if present.
-
-    Args:
-        uri: input URI or DID
-
-    Raises:
-        ValueError: for invalid input.
-
-    """
-
-    if ok_did(uri):
-        return uri
-
-    if uri.startswith("did:sov:"):
-        rv = uri[8:]
-        if ok_did(rv):
-            return rv
-    raise ValueError(
-        "Bad specification {} does not correspond to a sovrin DID".format(uri)
-    )
-
-
 def canon_ref(did: str, ref: str, delimiter: str = None):
     """
     Given a reference in a DID document, return it in its canonical form of a URI.
@@ -74,27 +50,13 @@ def canon_ref(did: str, ref: str, delimiter: str = None):
             introducing identifier (';') against DID resource
     """
 
-    if not ok_did(did):
-        raise ValueError("Bad DID {} cannot act as DID document identifier".format(did))
-
-    if ok_did(ref):  # e.g., LjgpST2rjsoxYegQDRm7EL
-        return "did:sov:{}".format(did)
-
-    if ok_did(resource(ref, delimiter)):  # e.g., LjgpST2rjsoxYegQDRm7EL#keys-1
-        return "did:sov:{}".format(ref)
-
-    if ref.startswith(
-        "did:sov:"
-    ):  # e.g., did:sov:LjgpST2rjsoxYegQDRm7EL, did:sov:LjgpST2rjsoxYegQDRm7EL#3
-        rv = ref[8:]
-        if ok_did(resource(rv, delimiter)):
-            return ref
-        raise ValueError("Bad URI {} does not correspond to a sovrin DID".format(ref))
-
-    if urlparse(ref).scheme:  # e.g., https://example.com/messages/8377464
+    if (
+        ref.startswith("did:")
+        or urlparse(ref).scheme  # e.g., https://example.com/messages/8377464
+    ):
         return ref
 
-    return "did:sov:{}{}{}".format(did, delimiter if delimiter else "#", ref)  # e.g., 3
+    return "{}{}{}".format(did, delimiter if delimiter else "#", ref)
 
 
 def ok_did(token: str) -> bool:

--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -194,7 +194,7 @@ class IndyDID(Regexp):
     """Validate value against indy DID."""
 
     EXAMPLE = "WgWxqztrNooG92RXvxSTWv"
-    PATTERN = rf"^(did:sov:)?[{B58}]{{21,22}}$"
+    PATTERN = rf"^(did:sov:|did:peer:)?[{B58}]{{21,22}}$"
 
     def __init__(self):
         """Initializer."""

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -1,5 +1,6 @@
 """Classes to manage connections."""
 
+from aries_cloudagent.connections.models.diddoc.diddoc import DIDDoc
 import logging
 
 from typing import Coroutine, Sequence, Tuple
@@ -407,6 +408,7 @@ class ConnectionManager(BaseConnectionManager):
             mediation_records=list(
                 filter(None, [base_mediation_record, mediation_record])
             ),
+            svc_type=DIDDoc.SERVICE_TYPE_V0,
         )
 
         if not my_label:
@@ -685,6 +687,7 @@ class ConnectionManager(BaseConnectionManager):
             mediation_records=list(
                 filter(None, [base_mediation_record, mediation_record])
             ),
+            svc_type=DIDDoc.SERVICE_TYPE_V0,
         )
 
         response = ConnectionResponse(
@@ -912,6 +915,7 @@ class ConnectionManager(BaseConnectionManager):
             mediation_records=[base_mediation_record]
             if base_mediation_record
             else None,
+            svc_type=DIDDoc.SERVICE_TYPE_V0,
         )
         await self.store_did_document(did_doc)
 

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
@@ -57,7 +57,7 @@ class TestConnectionManager(AsyncTestCase):
 
     async def setUp(self):
         self.test_seed = "testseed000000000000000000000001"
-        self.test_did = "55GkHamhTU1ZbTbV2ab9DE"
+        self.test_did = "did:peer:55GkHamhTU1ZbTbV2ab9DE"
         self.test_verkey = "3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"
         self.test_endpoint = "http://localhost"
 
@@ -520,7 +520,7 @@ class TestConnectionManager(AsyncTestCase):
                 mediation_id=mediation_record.mediation_id,
                 my_endpoint=self.test_endpoint,
             )
-            create_local_did.assert_called_once_with()
+            create_local_did.assert_called_once_with(method_name="peer")
             create_did_document.assert_called_once_with(
                 self.manager,
                 did_info,
@@ -574,7 +574,7 @@ class TestConnectionManager(AsyncTestCase):
                 record,
                 my_endpoint=self.test_endpoint,
             )
-            create_local_did.assert_called_once_with()
+            create_local_did.assert_called_once_with(method_name="peer")
             create_did_document.assert_called_once_with(
                 self.manager,
                 did_info,

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
@@ -527,6 +527,7 @@ class TestConnectionManager(AsyncTestCase):
                 None,
                 [self.test_endpoint],
                 mediation_records=[mediation_record],
+                svc_type=DIDDoc.SERVICE_TYPE_V0,
             )
             mock_get_default_mediator.assert_not_called()
 
@@ -581,6 +582,7 @@ class TestConnectionManager(AsyncTestCase):
                 None,
                 [self.test_endpoint],
                 mediation_records=[mediation_record],
+                svc_type=DIDDoc.SERVICE_TYPE_V0,
             )
             mock_get_default_mediator.assert_called_once()
 
@@ -1399,9 +1401,14 @@ class TestConnectionManager(AsyncTestCase):
                         None,
                         [self.test_endpoint],
                         mediation_records=[default_mediator],
+                        svc_type=DIDDoc.SERVICE_TYPE_V0,
                     ),
                     call(
-                        their_info, None, [self.test_endpoint], mediation_records=None
+                        their_info,
+                        None,
+                        [self.test_endpoint],
+                        mediation_records=None,
+                        svc_type=DIDDoc.SERVICE_TYPE_V0,
                     ),
                 ]
             )

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/manager.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/manager.py
@@ -99,7 +99,9 @@ class MediationManager:
         """
         wallet = session.inject(BaseWallet)
         storage = session.inject(BaseStorage)
-        info = await wallet.create_local_did(metadata={"type": "routing_did"})
+        info = await wallet.create_local_did(
+            method_name="peer", metadata={"type": "routing_did"}
+        )
         record = StorageRecord(
             type=self.ROUTING_DID_RECORD_TYPE,
             value=json.dumps({"verkey": info.verkey, "metadata": info.metadata}),

--- a/aries_cloudagent/protocols/didcomm_prefix.py
+++ b/aries_cloudagent/protocols/didcomm_prefix.py
@@ -26,7 +26,7 @@ class DIDCommPrefix(Enum):
 
         environ["DIDCOMM_PREFIX"] = (
             DIDCommPrefix.NEW.value
-            if settings.get("emit_new_didcomm_prefix")
+            if settings.get("aip_version", 1) >= 2
             else DIDCommPrefix.OLD.value
         )
 

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -262,7 +262,8 @@ class DIDXManager(BaseConnectionManager):
             ),
         )
         pthid = conn_rec.invitation_msg_id or f"did:sov:{conn_rec.their_public_did}"
-        attach = AttachDecorator.data_base64(did_doc.serialize())
+        LOGGER.error(did_doc.serialize(version=1))
+        attach = AttachDecorator.data_base64(did_doc.serialize(version=1))
         await attach.data.sign(my_info.verkey, wallet)
         if not my_label:
             my_label = self._session.settings.get("default_label")
@@ -570,7 +571,7 @@ class DIDXManager(BaseConnectionManager):
                 filter(None, [base_mediation_record, mediation_record])
             ),
         )
-        attach = AttachDecorator.data_base64(did_doc.serialize())
+        attach = AttachDecorator.data_base64(did_doc.serialize(version=1))
         await attach.data.sign(conn_rec.invitation_key, wallet)
         response = DIDXResponse(did=my_info.did, did_doc_attach=attach)
         # Assign thread information

--- a/aries_cloudagent/protocols/tests/test_didcomm_prefix.py
+++ b/aries_cloudagent/protocols/tests/test_didcomm_prefix.py
@@ -10,13 +10,13 @@ class TestDIDCommPrefix(AsyncTestCase):
         DIDCommPrefix.set({})
         assert environ.get("DIDCOMM_PREFIX") == DIDCommPrefix.OLD.value
 
-        DIDCommPrefix.set({"emit_new_didcomm_prefix": True})
+        DIDCommPrefix.set({"aip_version": 2})
         assert environ.get("DIDCOMM_PREFIX") == DIDCommPrefix.NEW.value
         assert DIDCommPrefix.qualify_current("hello") == (
             f"{DIDCommPrefix.NEW.value}/hello"
         )
 
-        DIDCommPrefix.set({"emit_new_didcomm_prefix": False})
+        DIDCommPrefix.set({"aip_version": 1})
         assert environ.get("DIDCOMM_PREFIX") == DIDCommPrefix.OLD.value
         assert DIDCommPrefix.qualify_current("hello") == (
             f"{DIDCommPrefix.OLD.value}/hello"

--- a/aries_cloudagent/transport/inbound/http.py
+++ b/aries_cloudagent/transport/inbound/http.py
@@ -111,9 +111,7 @@ class HttpTransport(BaseInboundTransport):
                             status=200,
                             headers={
                                 "Content-Type": DIDCOMM_V1_MIME_TYPE
-                                if session.profile.settings.get(
-                                    "emit_new_didcomm_mime_type"
-                                )
+                                if session.profile.settings.get("aip_version", 1) >= 2
                                 else DIDCOMM_V0_MIME_TYPE
                             },
                         )

--- a/aries_cloudagent/transport/outbound/http.py
+++ b/aries_cloudagent/transport/outbound/http.py
@@ -68,7 +68,7 @@ class HttpTransport(BaseOutboundTransport):
         if api_key is not None:
             headers["x-api-key"] = api_key
         if isinstance(payload, bytes):
-            if profile.settings.get("emit_new_didcomm_mime_type"):
+            if profile.settings.get("aip_version", 1) >= 2:
                 headers["Content-Type"] = DIDCOMM_V1_MIME_TYPE
             else:
                 headers["Content-Type"] = DIDCOMM_V0_MIME_TYPE

--- a/aries_cloudagent/transport/outbound/tests/test_http_transport.py
+++ b/aries_cloudagent/transport/outbound/tests/test_http_transport.py
@@ -94,7 +94,7 @@ class TestHttpTransport(AioHTTPTestCase):
 
         transport = HttpTransport()
 
-        self.profile.settings["emit_new_didcomm_mime_type"] = True
+        self.profile.settings["aip_version"] = 2
         await asyncio.wait_for(
             send_message(transport, b"{}", endpoint=server_addr), 5.0
         )

--- a/aries_cloudagent/wallet/base.py
+++ b/aries_cloudagent/wallet/base.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from collections import namedtuple
-from typing import Sequence
+from typing import Sequence, Tuple
 
 from ..ledger.base import BaseLedger
 from ..ledger.endpoint_type import EndpointType
@@ -88,7 +88,11 @@ class BaseWallet(ABC):
 
     @abstractmethod
     async def create_local_did(
-        self, seed: str = None, did: str = None, metadata: dict = None
+        self,
+        seed: str = None,
+        did: str = None,
+        method_name: str = None,
+        metadata: dict = None,
     ) -> DIDInfo:
         """
         Create and store a new local DID.
@@ -96,6 +100,7 @@ class BaseWallet(ABC):
         Args:
             seed: Optional seed to use for DID
             did: The DID to use
+            method_name: The DID method to use
             metadata: Metadata to store with DID
 
         Returns:
@@ -104,7 +109,11 @@ class BaseWallet(ABC):
         """
 
     async def create_public_did(
-        self, seed: str = None, did: str = None, metadata: dict = {}
+        self,
+        seed: str = None,
+        did: str = None,
+        method_name: str = None,
+        metadata: dict = {},
     ) -> DIDInfo:
         """
         Create and store a new public DID.
@@ -114,6 +123,7 @@ class BaseWallet(ABC):
         Args:
             seed: Optional seed to use for DID
             did: The DID to use
+            method_name: The DID method to use
             metadata: Metadata to store with DID
 
         Returns:
@@ -127,7 +137,7 @@ class BaseWallet(ABC):
             info_meta = info.metadata
             info_meta["public"] = False
             await self.replace_local_did_metadata(info.did, info_meta)
-        return await self.create_local_did(seed, did, metadata)
+        return await self.create_local_did(seed, did, method_name, metadata)
 
     async def get_public_did(self) -> DIDInfo:
         """
@@ -312,7 +322,7 @@ class BaseWallet(ABC):
         """
 
     @abstractmethod
-    async def unpack_message(self, enc_message: bytes) -> (str, str, str):
+    async def unpack_message(self, enc_message: bytes) -> Tuple[str, str, str]:
         """
         Unpack a message.
 

--- a/aries_cloudagent/wallet/in_memory.py
+++ b/aries_cloudagent/wallet/in_memory.py
@@ -1,7 +1,7 @@
 """In-memory implementation of BaseWallet interface."""
 
 import asyncio
-from typing import Sequence
+from typing import Sequence, Tuple
 
 from ..core.in_memory import InMemoryProfile
 
@@ -152,7 +152,11 @@ class InMemoryWallet(BaseWallet):
         return DIDInfo(did, verkey_enc, self.profile.local_dids[did]["metadata"].copy())
 
     async def create_local_did(
-        self, seed: str = None, did: str = None, metadata: dict = None
+        self,
+        seed: str = None,
+        did: str = None,
+        method_name: str = None,
+        metadata: dict = None,
     ) -> DIDInfo:
         """
         Create and store a new local DID.
@@ -160,6 +164,7 @@ class InMemoryWallet(BaseWallet):
         Args:
             seed: Optional seed to use for DID
             did: The DID to use
+            method_name: The DID method to use
             metadata: Metadata to store with DID
 
         Returns:
@@ -174,6 +179,8 @@ class InMemoryWallet(BaseWallet):
         verkey_enc = bytes_to_b58(verkey)
         if not did:
             did = bytes_to_b58(verkey[:16])
+        if method_name:
+            did = f"did:{method_name}{did}"
         if (
             did in self.profile.local_dids
             and self.profile.local_dids[did]["verkey"] != verkey_enc
@@ -371,7 +378,7 @@ class InMemoryWallet(BaseWallet):
         )
         return result
 
-    async def unpack_message(self, enc_message: bytes) -> (str, str, str):
+    async def unpack_message(self, enc_message: bytes) -> Tuple[str, str, str]:
         """
         Unpack a message.
 

--- a/aries_cloudagent/wallet/indy.py
+++ b/aries_cloudagent/wallet/indy.py
@@ -2,7 +2,7 @@
 
 import json
 
-from typing import Sequence
+from typing import Sequence, Tuple
 
 import indy.anoncreds
 import indy.did
@@ -163,7 +163,11 @@ class IndySdkWallet(BaseWallet):
             ) from x_indy
 
     async def create_local_did(
-        self, seed: str = None, did: str = None, metadata: dict = None
+        self,
+        seed: str = None,
+        did: str = None,
+        method_name: str = None,
+        metadata: dict = None,
     ) -> DIDInfo:
         """
         Create and store a new local DID.
@@ -171,6 +175,7 @@ class IndySdkWallet(BaseWallet):
         Args:
             seed: Optional seed to use for DID
             did: The DID to use
+            method_name: The DID method to use
             metadata: Metadata to store with DID
 
         Returns:
@@ -186,6 +191,9 @@ class IndySdkWallet(BaseWallet):
             cfg["seed"] = bytes_to_b64(validate_seed(seed))
         if did:
             cfg["did"] = did
+        if method_name:
+            # FIXME - use an application default method if not specified?
+            cfg["method_name"] = method_name
         did_json = json.dumps(cfg)
         # crypto_type, cid - optional parameters skipped
         try:
@@ -434,7 +442,7 @@ class IndySdkWallet(BaseWallet):
 
         return result
 
-    async def unpack_message(self, enc_message: bytes) -> (str, str, str):
+    async def unpack_message(self, enc_message: bytes) -> Tuple[str, str, str]:
         """
         Unpack a message.
 

--- a/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
@@ -142,7 +142,7 @@ class TestInMemoryWallet:
     @pytest.mark.asyncio
     async def test_local_metadata(self, wallet):
         info = await wallet.create_local_did(
-            self.test_seed, self.test_did, self.test_metadata
+            self.test_seed, self.test_did, None, self.test_metadata
         )
         assert info.did == self.test_did
         assert info.verkey == self.test_verkey
@@ -167,7 +167,7 @@ class TestInMemoryWallet:
     @pytest.mark.asyncio
     async def test_create_public_did(self, wallet):
         info = await wallet.create_local_did(
-            self.test_seed, self.test_did, self.test_metadata
+            self.test_seed, self.test_did, None, self.test_metadata
         )
         assert not info.metadata.get("public")
         assert not info.metadata.get("posted")
@@ -193,7 +193,7 @@ class TestInMemoryWallet:
     @pytest.mark.asyncio
     async def test_set_public_did(self, wallet):
         info = await wallet.create_local_did(
-            self.test_seed, self.test_did, self.test_metadata
+            self.test_seed, self.test_did, None, self.test_metadata
         )
         assert not info.metadata.get("public")
 

--- a/aries_cloudagent/wallet/tests/test_indy_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_indy_wallet.py
@@ -165,7 +165,7 @@ class TestIndySdkWallet(test_in_memory_wallet.TestInMemoryWallet):
     @pytest.mark.asyncio
     async def test_replace_local_did_metadata_x(self, wallet):
         info = await wallet.create_local_did(
-            self.test_seed, self.test_did, self.test_metadata
+            self.test_seed, self.test_did, None, self.test_metadata
         )
         assert info.did == self.test_did
         assert info.verkey == self.test_verkey


### PR DESCRIPTION
- Remove `--emit-new-didcomm-prefix` and `--emit-new-didcomm-mime-type` in favour of `--aip-version` (1 or 2). I believe the .NET framework will currently only accept the old MIME type.
- Change the DID document service type to `did-communication` when using the `did-exchange` protocol.
- Remove DID shortening from DIDDoc and related classes.
- Do not accept DID documents without an `id` property.
- Qualify connection DIDs with `did:peer:` (does NOT yet qualify other DIDs with `did:sov:`).
- Updates the `INDY_DID` pattern to accept `did:sov:` or `did:peer:`, which isn't technically correct. We should be using a generic DID pattern in most places.
- Should permissively accept DID documents in the current v1.0 format, or in the older format (which I'm calling v0). When using the `did-exchange` protocol, the new format (with `verificationMethod`) is used for serialization regardless of the AIP version setting. When using the `connections` protocol, the old format (with `publicKey`) is used.

These changes might be better addressed though the generic resolver PR depending on the timeline, but this is for testing compatibility with other agents.