### PR TITLE
Arg client max req size

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -364,7 +364,14 @@ class AdminServer(BaseAdminServer):
 
         middlewares.append(setup_context)
 
-        app = web.Application(middlewares=middlewares)
+        app = web.Application(
+            middlewares=middlewares,
+            client_max_size=(
+                self.context.settings.get(
+                    "admin.admin_client_max_request_size", 1
+                ) * 1024 * 1024
+            )
+        )
 
         server_routes = [
             web.get("/", self.redirect_handler, allow_head=False),

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -367,10 +367,10 @@ class AdminServer(BaseAdminServer):
         app = web.Application(
             middlewares=middlewares,
             client_max_size=(
-                self.context.settings.get(
-                    "admin.admin_client_max_request_size", 1
-                ) * 1024 * 1024
-            )
+                self.context.settings.get("admin.admin_client_max_request_size", 1)
+                * 1024
+                * 1024
+            ),
         )
 
         server_routes = [

--- a/aries_cloudagent/admin/tests/test_admin_server.py
+++ b/aries_cloudagent/admin/tests/test_admin_server.py
@@ -194,6 +194,8 @@ class TestAdminServer(AsyncTestCase):
         }
         server = self.get_admin_server(settings)
         await server.start()
+        assert server.app._client_max_size == 1 * 1024 * 1024
+
         with async_mock.patch.object(
             server, "websocket_queues", async_mock.MagicMock()
         ) as mock_wsq:
@@ -315,9 +317,14 @@ class TestAdminServer(AsyncTestCase):
             await builder.load_plugins(context)
 
     async def test_visit_insecure_mode(self):
-        settings = {"admin.admin_insecure_mode": True, "task_queue": True}
+        settings = {
+            "admin.admin_insecure_mode": True,
+            "admin.admin_client_max_request_size": 4,
+            "task_queue": True,
+        }
         server = self.get_admin_server(settings)
         await server.start()
+        assert server.app._client_max_size == 4 * 1024 * 1024
 
         async with self.client_session.post(
             f"http://127.0.0.1:{self.port}/status/reset", headers={}

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -165,7 +165,7 @@ class AdminGroup(ArgumentGroup):
             default=1,
             type=BoundedInt(min=1, max=16),
             env_var="ACAPY_ADMIN_CLIENT_MAX_REQUEST_SIZE",
-            help="Maximum client request size to admin server, in megabytes: default 1"
+            help="Maximum client request size to admin server, in megabytes: default 1",
         )
 
     def get_settings(self, args: Namespace):
@@ -200,7 +200,7 @@ class AdminGroup(ArgumentGroup):
             settings["admin.webhook_urls"] = hook_urls
 
             settings["admin.admin_client_max_request_size"] = (
-                args.admin_client_max_request_size
+                args.admin_client_max_request_size or 1
             )
         return settings
 

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -148,6 +148,13 @@ class AdminGroup(ArgumentGroup):
             and respond to those events using the admin API. If not specified, \
             webhooks are not published by the agent.",
         )
+        parser.add_argument(
+            "--admin-client-max-request-size",
+            default=1,
+            type=BoundedInt(min=1, max=16),
+            env_var="ACAPY_ADMIN_CLIENT_MAX_REQUEST_SIZE",
+            help="Maximum client request size to admin server, in megabytes: default 1"
+        )
 
     def get_settings(self, args: Namespace):
         """Extract admin settings."""
@@ -179,6 +186,10 @@ class AdminGroup(ArgumentGroup):
             if hook_url:
                 hook_urls.append(hook_url)
             settings["admin.webhook_urls"] = hook_urls
+
+            settings["admin.admin_client_max_request_size"] = (
+                args.admin_client_max_request_size
+            )
         return settings
 
 


### PR DESCRIPTION
Formalize DucaDellaForcoleta's approach of
https://chat.hyperledger.org/channel/aries-cloudagent-python/thread/XKFaiAQj364yW4amW?msg=aZwH7qZmLax8yDFhq
to allow larger client requests than default if need be. Range is from 1 (default) through 16MB.