### PR TITLE
make max client request size configurable

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -364,7 +364,14 @@ class AdminServer(BaseAdminServer):
 
         middlewares.append(setup_context)
 
-        app = web.Application(middlewares=middlewares)
+        app = web.Application(
+            middlewares=middlewares,
+            client_max_size=(
+                self.context.settings.get("admin.admin_client_max_request_size", 1)
+                * 1024
+                * 1024
+            ),
+        )
 
         server_routes = [
             web.get("/", self.redirect_handler, allow_head=False),

--- a/aries_cloudagent/admin/tests/test_admin_server.py
+++ b/aries_cloudagent/admin/tests/test_admin_server.py
@@ -190,10 +190,12 @@ class TestAdminServer(AsyncTestCase):
 
         settings = {
             "admin.admin_insecure_mode": False,
+            "admin.admin_client_max_request_size": 4,
             "admin.admin_api_key": "test-api-key",
         }
         server = self.get_admin_server(settings)
         await server.start()
+        assert server.app._client_max_size == 4 * 1024 * 1024
         with async_mock.patch.object(
             server, "websocket_queues", async_mock.MagicMock()
         ) as mock_wsq:

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -99,54 +99,73 @@ class AdminGroup(ArgumentGroup):
             nargs=2,
             metavar=("<host>", "<port>"),
             env_var="ACAPY_ADMIN",
-            help="Specify the host and port on which to run the administrative server.\
-            If not provided, no admin server is made available.",
+            help=(
+                "Specify the host and port on which to run the administrative server. "
+                "If not provided, no admin server is made available."
+            ),
         )
         parser.add_argument(
             "--admin-api-key",
             type=str,
             metavar="<api-key>",
             env_var="ACAPY_ADMIN_API_KEY",
-            help="Protect all admin endpoints with the provided API key.\
-            API clients (e.g. the controller) must pass the key in the HTTP\
-            header using 'X-API-Key: <api key>'. Either this parameter or the\
-            '--admin-insecure-mode' parameter MUST be specified.",
+            help=(
+                "Protect all admin endpoints with the provided API key. "
+                "API clients (e.g. the controller) must pass the key in the HTTP "
+                "header using 'X-API-Key: <api key>'. Either this parameter or the "
+                "'--admin-insecure-mode' parameter MUST be specified."
+            ),
         )
         parser.add_argument(
             "--admin-insecure-mode",
             action="store_true",
             env_var="ACAPY_ADMIN_INSECURE_MODE",
-            help="Run the admin web server in insecure mode. DO NOT USE FOR\
-            PRODUCTION DEPLOYMENTS. The admin server will be publicly available\
-            to anyone who has access to the interface. Either this parameter or\
-            the '--api-key' parameter MUST be specified.",
+            help=(
+                "Run the admin web server in insecure mode. DO NOT USE FOR "
+                "PRODUCTION DEPLOYMENTS. The admin server will be publicly available "
+                "to anyone who has access to the interface. Either this parameter or "
+                "the '--api-key' parameter MUST be specified."
+            ),
         )
         parser.add_argument(
             "--no-receive-invites",
             action="store_true",
             env_var="ACAPY_NO_RECEIVE_INVITES",
-            help="Prevents an agent from receiving invites by removing the\
-            '/connections/receive-invite' route from the administrative\
-            interface. Default: false.",
+            help=(
+                "Prevents an agent from receiving invites by removing the "
+                "'/connections/receive-invite' route from the administrative "
+                "interface. Default: false."
+            ),
         )
         parser.add_argument(
             "--help-link",
             type=str,
             metavar="<help-url>",
             env_var="ACAPY_HELP_LINK",
-            help="A URL to an administrative interface help web page that a controller\
-            user interface can get from the agent and provide as a link to users.",
+            help=(
+                "A URL to an administrative interface help web page that a controller "
+                "user interface can get from the agent and provide as a link to users."
+            ),
         )
         parser.add_argument(
             "--webhook-url",
             action="append",
             metavar="<url#api_key>",
             env_var="ACAPY_WEBHOOK_URL",
-            help="Send webhooks containing internal state changes to the specified\
-            URL. Optional API key to be passed in the request body can be appended using\
-            a hash separator [#]. This is useful for a controller to monitor agent events\
-            and respond to those events using the admin API. If not specified, \
-            webhooks are not published by the agent.",
+            help=(
+                "Send webhooks containing internal state changes to the specified "
+                "URL. Optional API key to be passed in the request body can be "
+                "appended using a hash separator [#]. This is useful for a controller "
+                "to monitor agent events and respond to those events using the "
+                "admin API. If not specified, webhooks are not published by the agent."
+            ),
+        )
+        parser.add_argument(
+            "--admin-client-max-request-size",
+            default=1,
+            type=BoundedInt(min=1, max=16),
+            env_var="ACAPY_ADMIN_CLIENT_MAX_REQUEST_SIZE",
+            help="Maximum client request size to admin server, in megabytes: default 1",
         )
 
     def get_settings(self, args: Namespace):
@@ -161,7 +180,7 @@ class AdminGroup(ArgumentGroup):
             ):
                 raise ArgsParseError(
                     "Either --admin-api-key or --admin-insecure-mode "
-                    + "must be set but not both."
+                    "must be set but not both."
                 )
 
             settings["admin.admin_api_key"] = admin_api_key
@@ -179,6 +198,10 @@ class AdminGroup(ArgumentGroup):
             if hook_url:
                 hook_urls.append(hook_url)
             settings["admin.webhook_urls"] = hook_urls
+
+            settings["admin.admin_client_max_request_size"] = (
+                args.admin_client_max_request_size or 1
+            )
         return settings
 
 
@@ -194,9 +217,11 @@ class DebugGroup(ArgumentGroup):
             "--debug",
             action="store_true",
             env_var="ACAPY_DEBUG",
-            help="Enables a remote debugging service that can be accessed\
-            using ptvsd for Visual Studio Code. The framework will wait\
-            for the debugger to connect at start-up. Default: false.",
+            help=(
+                "Enables a remote debugging service that can be accessed "
+                "using ptvsd for Visual Studio Code. The framework will wait "
+                "for the debugger to connect at start-up. Default: false."
+            ),
         )
         parser.add_argument(
             "--debug-seed",
@@ -216,29 +241,37 @@ class DebugGroup(ArgumentGroup):
             "--debug-credentials",
             action="store_true",
             env_var="ACAPY_DEBUG_CREDENTIALS",
-            help="Enable additional logging around credential exchanges.\
-            Default: false.",
+            help=(
+                "Enable additional logging around credential exchanges. "
+                "Default: false."
+            ),
         )
         parser.add_argument(
             "--debug-presentations",
             action="store_true",
             env_var="ACAPY_DEBUG_PRESENTATIONS",
-            help="Enable additional logging around presentation exchanges.\
-            Default: false.",
+            help=(
+                "Enable additional logging around presentation exchanges. "
+                "Default: false."
+            ),
         )
         parser.add_argument(
             "--invite",
             action="store_true",
             env_var="ACAPY_INVITE",
-            help="After startup, generate and print a new out-of-band connection invitation\
-            URL. Default: false.",
+            help=(
+                "After startup, generate and print a new out-of-band connection "
+                "invitation URL. Default: false."
+            ),
         )
         parser.add_argument(
             "--connections-invite",
             action="store_true",
             env_var="ACAPY_CONNECTIONS_INVITE",
-            help="After startup, generate and print a new connections protocol \
-            style invitation URL. Default: false.",
+            help=(
+                "After startup, generate and print a new connections protocol "
+                "style invitation URL. Default: false."
+            ),
         )
         parser.add_argument(
             "--invite-label",
@@ -279,36 +312,46 @@ class DebugGroup(ArgumentGroup):
             "--auto-accept-invites",
             action="store_true",
             env_var="ACAPY_AUTO_ACCEPT_INVITES",
-            help="Automatically accept invites without firing a webhook event or\
-            waiting for an admin request. Default: false.",
+            help=(
+                "Automatically accept invites without firing a webhook event or "
+                "waiting for an admin request. Default: false."
+            ),
         )
         parser.add_argument(
             "--auto-accept-requests",
             action="store_true",
             env_var="ACAPY_AUTO_ACCEPT_REQUESTS",
-            help="Automatically accept connection requests without firing\
-            a webhook event or waiting for an admin request. Default: false.",
+            help=(
+                "Automatically accept connection requests without firing "
+                "a webhook event or waiting for an admin request. Default: false."
+            ),
         )
         parser.add_argument(
             "--auto-respond-messages",
             action="store_true",
             env_var="ACAPY_AUTO_RESPOND_MESSAGES",
-            help="Automatically respond to basic messages indicating the message was\
-            received. Default: false.",
+            help=(
+                "Automatically respond to basic messages indicating the message was "
+                "received. Default: false."
+            ),
         )
         parser.add_argument(
             "--auto-respond-credential-proposal",
             action="store_true",
             env_var="ACAPY_AUTO_RESPOND_CREDENTIAL_PROPOSAL",
-            help="Auto-respond to credential proposals with corresponding "
-            + "credential offers",
+            help=(
+                "Auto-respond to credential proposals with corresponding "
+                "credential offers"
+            ),
         )
         parser.add_argument(
             "--auto-respond-credential-offer",
             action="store_true",
             env_var="ACAPY_AUTO_RESPOND_CREDENTIAL_OFFER",
-            help="Automatically respond to Indy credential offers with a credential\
-            request. Default: false",
+            help=(
+                "Automatically respond to Indy credential offers with a credential "
+                "request. Default: false"
+            ),
         )
         parser.add_argument(
             "--auto-respond-credential-request",
@@ -320,30 +363,39 @@ class DebugGroup(ArgumentGroup):
             "--auto-respond-presentation-proposal",
             action="store_true",
             env_var="ACAPY_AUTO_RESPOND_PRESENTATION_PROPOSAL",
-            help="Auto-respond to presentation proposals with corresponding "
-            + "presentation requests",
+            help=(
+                "Auto-respond to presentation proposals with corresponding "
+                "presentation requests"
+            ),
         )
         parser.add_argument(
             "--auto-respond-presentation-request",
             action="store_true",
             env_var="ACAPY_AUTO_RESPOND_PRESENTATION_REQUEST",
-            help="Automatically respond to Indy presentation requests with a\
-            constructed presentation if a corresponding credential can be retrieved\
-            for every referent in the presentation request. Default: false.",
+            help=(
+                "Automatically respond to Indy presentation requests with a "
+                "constructed presentation if a corresponding credential can be "
+                "retrieved for every referent in the presentation request. "
+                "Default: false."
+            ),
         )
         parser.add_argument(
             "--auto-store-credential",
             action="store_true",
             env_var="ACAPY_AUTO_STORE_CREDENTIAL",
-            help="Automatically store an issued credential upon receipt.\
-            Default: false.",
+            help=(
+                "Automatically store an issued credential upon receipt. "
+                "Default: false."
+            ),
         )
         parser.add_argument(
             "--auto-verify-presentation",
             action="store_true",
             env_var="ACAPY_AUTO_VERIFY_PRESENTATION",
-            help="Automatically verify a presentation when it is received.\
-            Default: false.",
+            help=(
+                "Automatically verify a presentation when it is received. "
+                "Default: false."
+            ),
         )
 
     def get_settings(self, args: Namespace) -> dict:
@@ -408,8 +460,10 @@ class GeneralGroup(ArgumentGroup):
         parser.add_argument(
             "--arg-file",
             is_config_file=True,
-            help="Load aca-py arguments from the specified file.  Note that\
-            this file *must* be in YAML format.",
+            help=(
+                "Load aca-py arguments from the specified file.  Note that "
+                "this file *must* be in YAML format."
+            ),
         )
         parser.add_argument(
             "--plugin",
@@ -419,19 +473,23 @@ class GeneralGroup(ArgumentGroup):
             required=False,
             metavar="<module>",
             env_var="ACAPY_PLUGIN",
-            help="Load <module> as external plugin module. Multiple\
-            instances of this parameter can be specified.",
+            help=(
+                "Load <module> as external plugin module. Multiple "
+                "instances of this parameter can be specified."
+            ),
         )
         parser.add_argument(
             "--storage-type",
             type=str,
             metavar="<storage-type>",
             env_var="ACAPY_STORAGE_TYPE",
-            help="Specifies the type of storage provider to use for the internal\
-            storage engine. This storage interface is used to store internal state.\
-            Supported internal storage types are 'basic' (memory)\
-            and 'indy'.  The default (if not specified) is 'indy' if the wallet type\
-            is set to 'indy', otherwise 'basic'.",
+            help=(
+                "Specifies the type of storage provider to use for the internal "
+                "storage engine. This storage interface is used to store internal "
+                "state  Supported internal storage types are 'basic' (memory) "
+                "and 'indy'.  The default (if not specified) is 'indy' if the "
+                "wallet type is set to 'indy', otherwise 'basic'."
+            ),
         )
         parser.add_argument(
             "-e",
@@ -440,15 +498,17 @@ class GeneralGroup(ArgumentGroup):
             nargs="+",
             metavar="<endpoint>",
             env_var="ACAPY_ENDPOINT",
-            help="Specifies the endpoints to put into DIDDocs\
-            to inform other agents of where they should send messages destined\
-            for this agent. Each endpoint could be one of the specified inbound\
-            transports for this agent, or the endpoint could be that of\
-            another agent (e.g. 'https://example.com/agent-endpoint') if the\
-            routing of messages to this agent by a mediator is configured.\
-            The first endpoint specified will be used in invitations.\
-            The endpoints are used in the formation of a connection\
-            with another agent.",
+            help=(
+                "Specifies the endpoints to put into DIDDocs "
+                "to inform other agents of where they should send messages destined "
+                "for this agent. Each endpoint could be one of the specified inbound "
+                "transports for this agent, or the endpoint could be that of "
+                "another agent (e.g. 'https://example.com/agent-endpoint') if the "
+                "routing of messages to this agent by a mediator is configured. "
+                "The first endpoint specified will be used in invitations. "
+                "The endpoints are used in the formation of a connection "
+                "with another agent."
+            ),
         )
         parser.add_argument(
             "--profile-endpoint",
@@ -461,8 +521,7 @@ class GeneralGroup(ArgumentGroup):
             "--read-only-ledger",
             action="store_true",
             env_var="ACAPY_READ_ONLY_LEDGER",
-            help="Sets ledger to read-only to prevent updates.\
-            Default: false.",
+            help="Sets ledger to read-only to prevent updates. Default: false.",
         )
         parser.add_argument(
             "--tails-server-base-url",
@@ -476,8 +535,10 @@ class GeneralGroup(ArgumentGroup):
             type=str,
             metavar="<tails-server-upload-url>",
             env_var="ACAPY_TAILS_SERVER_UPLOAD_URL",
-            help="Sets the base url of the tails server for upload, defaulting to the\
-            tails server base url.",
+            help=(
+                "Sets the base url of the tails server for upload, defaulting to the "
+                "tails server base url."
+            ),
         )
 
     def get_settings(self, args: Namespace) -> dict:
@@ -519,8 +580,10 @@ class LedgerGroup(ArgumentGroup):
             type=str,
             metavar="<ledger-pool-name>",
             env_var="ACAPY_LEDGER_POOL_NAME",
-            help="Specifies the name of the indy pool to be opened.\
-            This is useful if you have multiple pool configurations.",
+            help=(
+                "Specifies the name of the indy pool to be opened. "
+                "This is useful if you have multiple pool configurations."
+            ),
         )
         parser.add_argument(
             "--genesis-transactions",
@@ -528,9 +591,11 @@ class LedgerGroup(ArgumentGroup):
             dest="genesis_transactions",
             metavar="<genesis-transactions>",
             env_var="ACAPY_GENESIS_TRANSACTIONS",
-            help='Specifies the genesis transactions to use to connect to\
-            an Hyperledger Indy ledger. The transactions are provided as string\
-            of JSON e.g. \'{"reqSignature":{},"txn":{"data":{"d... <snip>\'',
+            help=(
+                "Specifies the genesis transactions to use to connect to "
+                "a Hyperledger Indy ledger. The transactions are provided as string "
+                'of JSON e.g. \'{"reqSignature":{},"txn":{"data":{"d... <snip>}}}\''
+            ),
         )
         parser.add_argument(
             "--genesis-file",
@@ -546,18 +611,23 @@ class LedgerGroup(ArgumentGroup):
             dest="genesis_url",
             metavar="<genesis-url>",
             env_var="ACAPY_GENESIS_URL",
-            help="Specifies the url from which to download the genesis\
-            transactions. For example, if you are using 'von-network',\
-            the URL might be 'http://localhost:9000/genesis'.\
-            Genesis transactions URLs are available for the Sovrin test/main networks.",
+            help=(
+                "Specifies the url from which to download the genesis "
+                "transactions. For example, if you are using 'von-network', "
+                "the URL might be 'http://localhost:9000/genesis'. "
+                "Genesis transactions URLs are available for the "
+                "Sovrin test/main networks."
+            ),
         )
         parser.add_argument(
             "--no-ledger",
             action="store_true",
             env_var="ACAPY_NO_LEDGER",
-            help="Specifies that aca-py will run with no ledger configured.\
-            This must be set if running in no-ledger mode.  Overrides any\
-            specified ledger or genesis configurations.  Default: false.",
+            help=(
+                "Specifies that aca-py will run with no ledger configured. "
+                "This must be set if running in no-ledger mode.  Overrides any "
+                "specified ledger or genesis configurations.  Default: false."
+            ),
         )
         parser.add_argument(
             "--ledger-keepalive",
@@ -582,8 +652,8 @@ class LedgerGroup(ArgumentGroup):
             else:
                 raise ArgsParseError(
                     "One of --genesis-url --genesis-file or --genesis-transactions "
-                    + "must be specified (unless --no-ledger is specified to "
-                    + "explicitly configure aca-py to run with no ledger)."
+                    "must be specified (unless --no-ledger is specified to "
+                    "explicitly configure aca-py to run with no ledger)."
                 )
             if args.ledger_pool_name:
                 settings["ledger.pool_name"] = args.ledger_pool_name
@@ -617,8 +687,10 @@ class LoggingGroup(ArgumentGroup):
             metavar="<log-file>",
             default=None,
             env_var="ACAPY_LOG_FILE",
-            help="Overrides the output destination for the root logger (as defined\
-            by the log config file) to the named <log-file>.",
+            help=(
+                "Overrides the output destination for the root logger (as defined "
+                "by the log config file) to the named <log-file>."
+            ),
         )
         parser.add_argument(
             "--log-level",
@@ -627,8 +699,10 @@ class LoggingGroup(ArgumentGroup):
             metavar="<log-level>",
             default=None,
             env_var="ACAPY_LOG_LEVEL",
-            help="Specifies a custom logging level as one of:\
-            ('debug', 'info', 'warning', 'error', 'critical')",
+            help=(
+                "Specifies a custom logging level as one of: "
+                "('debug', 'info', 'warning', 'error', 'critical')"
+            ),
         )
 
     def get_settings(self, args: Namespace) -> dict:
@@ -655,16 +729,20 @@ class ProtocolGroup(ArgumentGroup):
             "--auto-ping-connection",
             action="store_true",
             env_var="ACAPY_AUTO_PING_CONNECTION",
-            help="Automatically send a trust ping immediately after a\
-            connection response is accepted. Some agents require this before\
-            marking a connection as 'active'. Default: false.",
+            help=(
+                "Automatically send a trust ping immediately after a "
+                "connection response is accepted. Some agents require this before "
+                "marking a connection as 'active'. Default: false."
+            ),
         )
         parser.add_argument(
             "--invite-base-url",
             type=str,
             metavar="<base-url>",
             env_var="ACAPY_INVITE_BASE_URL",
-            help="Base URL to use when formatting connection invitations in URL format.",
+            help=(
+                "Base URL to use when formatting connection invitations in URL format."
+            ),
         )
         parser.add_argument(
             "--monitor-ping",
@@ -676,8 +754,10 @@ class ProtocolGroup(ArgumentGroup):
             "--public-invites",
             action="store_true",
             env_var="ACAPY_PUBLIC_INVITES",
-            help="Send invitations out, and receive connection requests,\
-            using the public DID for the agent. Default: false.",
+            help=(
+                "Send invitations out, and receive connection requests, "
+                "using the public DID for the agent. Default: false."
+            ),
         )
         parser.add_argument(
             "--timing",
@@ -729,24 +809,30 @@ class ProtocolGroup(ArgumentGroup):
             "--emit-new-didcomm-prefix",
             action="store_true",
             env_var="ACAPY_EMIT_NEW_DIDCOMM_PREFIX",
-            help="Emit protocol messages with new DIDComm prefix; i.e.,\
-            'https://didcomm.org/' instead of (default) prefix\
-            'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/'.",
+            help=(
+                "Emit protocol messages with new DIDComm prefix; i.e., "
+                "'https://didcomm.org/' instead of (default) prefix "
+                "'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/'."
+            ),
         )
         parser.add_argument(
             "--emit-new-didcomm-mime-type",
             action="store_true",
             env_var="ACAPY_EMIT_NEW_DIDCOMM_MIME_TYPE",
-            help="Send packed agent messages with the DIDComm MIME type\
-            as of RFC 0044; i.e., 'application/didcomm-envelope-enc'\
-            instead of 'application/ssi-agent-wire'.",
+            help=(
+                "Send packed agent messages with the DIDComm MIME type "
+                "as of RFC 0044; i.e., 'application/didcomm-envelope-enc' "
+                "instead of 'application/ssi-agent-wire'."
+            ),
         )
         parser.add_argument(
             "--exch-use-unencrypted-tags",
             action="store_true",
             env_var="ACAPY_EXCH_USE_UNENCRYPTED_TAGS",
-            help="Store tags for exchange protocols (credential and presentation)\
-            using unencrypted rather than encrypted tags",
+            help=(
+                "Store tags for exchange protocols (credential and presentation) "
+                "using unencrypted rather than encrypted tags"
+            ),
         )
 
     def get_settings(self, args: Namespace) -> dict:
@@ -818,8 +904,10 @@ class StartupGroup(ArgumentGroup):
             "--auto-provision",
             action="store_true",
             env_var="ACAPY_AUTO_PROVISION",
-            help="If the requested profile does not exist, initialize it with\
-            the given parameters.",
+            help=(
+                "If the requested profile does not exist, initialize it with "
+                "the given parameters."
+            ),
         )
 
     def get_settings(self, args: Namespace):
@@ -847,12 +935,14 @@ class TransportGroup(ArgumentGroup):
             nargs=3,
             metavar=("<module>", "<host>", "<port>"),
             env_var="ACAPY_INBOUND_TRANSPORT",
-            help="REQUIRED. Defines the inbound transport(s) on which the agent\
-            listens for receiving messages from other agents. This parameter can\
-            be specified multiple times to create multiple interfaces.\
-            Built-in inbound transport types include 'http' and 'ws'.\
-            However, other transports can be loaded by specifying an absolute\
-            module path.",
+            help=(
+                "REQUIRED. Defines the inbound transport(s) on which the agent "
+                "listens for receiving messages from other agents. This parameter can "
+                "be specified multiple times to create multiple interfaces. "
+                "Built-in inbound transport types include 'http' and 'ws'. "
+                "However, other transports can be loaded by specifying an absolute "
+                "module path."
+            ),
         )
         parser.add_argument(
             "-ot",
@@ -862,10 +952,12 @@ class TransportGroup(ArgumentGroup):
             action="append",
             metavar="<module>",
             env_var="ACAPY_OUTBOUND_TRANSPORT",
-            help="REQUIRED. Defines the outbound transport(s) on which the agent\
-            will send outgoing messages to other agents. This parameter can be passed\
-            multiple times to supoort multiple transport types. Supported outbound\
-            transport types are 'http' and 'ws'.",
+            help=(
+                "REQUIRED. Defines the outbound transport(s) on which the agent "
+                "will send outgoing messages to other agents. This parameter can be "
+                "passed multiple times to supoort multiple transport types. "
+                "Supported outbound transport types are 'http' and 'ws'."
+            ),
         )
         parser.add_argument(
             "-oq",
@@ -873,9 +965,10 @@ class TransportGroup(ArgumentGroup):
             dest="outbound_queue",
             type=str,
             env_var="ACAPY_OUTBOUND_TRANSPORT_QUEUE",
-            help="""Defines connection details for outbound queue in a single
-                    connection string. For example, 'redis://127.0.0.1:6379'.
-                 """,
+            help=(
+                "Defines connection details for outbound queue in a single "
+                "connection string; e.g., 'redis://127.0.0.1:6379'."
+            ),
         )
         parser.add_argument(
             "-oqp",
@@ -883,10 +976,11 @@ class TransportGroup(ArgumentGroup):
             dest="outbound_queue_prefix",
             type=str,
             env_var="ACAPY_OUTBOUND_TRANSPORT_QUEUE_PREFIX",
-            help="""Defines the prefix used to generate the queue key. The
-                    default is 'acapy', which generates a queue key as follows:
-                    'acapy.outbound_transport'.
-                 """,
+            help=(
+                "Defines the prefix used to generate the queue key. The "
+                "default is 'acapy', which generates a queue key as follows: "
+                "'acapy.outbound_transport'."
+            ),
         )
         parser.add_argument(
             "-oqc",
@@ -894,13 +988,15 @@ class TransportGroup(ArgumentGroup):
             dest="outbound_queue_class",
             type=str,
             env_var="ACAPY_OUTBOUND_TRANSPORT_QUEUE_CLASS",
-            help="""Defines the location of the Outbound Queue Engine. This must be
-                    a 'dotpath' to a Python module on the PYTHONPATH, followed by a
-                    colon, followed by the name of a Python class that implements
-                    BaseOutboundQueue. This commandline option is the official entry
-                    point of ACA-py's pluggable queue interface. The default value is:
-                    'aries_cloudagent.transport.outbound.queue.redis:RedisOutboundQueue'
-                 """,
+            help=(
+                "Defines the location of the Outbound Queue Engine. This must be "
+                "a 'dotpath' to a Python module on the PYTHONPATH, followed by a "
+                "colon, followed by the name of a Python class that implements "
+                "BaseOutboundQueue. This commandline option is the official entry "
+                "point of ACA-py's pluggable queue interface. The default value is: "
+                "'aries_cloudagent.transport.outbound.queue.redis:RedisOutboundQueue'."
+                ""
+            ),
         )
         parser.add_argument(
             "-l",
@@ -908,15 +1004,19 @@ class TransportGroup(ArgumentGroup):
             type=str,
             metavar="<label>",
             env_var="ACAPY_LABEL",
-            help="Specifies the label for this agent. This label is publicized\
-            (self-attested) to other agents as part of forming a connection.",
+            help=(
+                "Specifies the label for this agent. This label is publicized "
+                "(self-attested) to other agents as part of forming a connection."
+            ),
         )
         parser.add_argument(
             "--image-url",
             type=str,
             env_var="ACAPY_IMAGE_URL",
-            help="Specifies the image url for this agent. This image url is publicized\
-            (self-attested) to other agents as part of forming a connection.",
+            help=(
+                "Specifies the image url for this agent. This image url is publicized "
+                "(self-attested) to other agents as part of forming a connection."
+            ),
         )
         parser.add_argument(
             "--max-message-size",
@@ -930,18 +1030,22 @@ class TransportGroup(ArgumentGroup):
             "--enable-undelivered-queue",
             action="store_true",
             env_var="ACAPY_ENABLE_UNDELIVERED_QUEUE",
-            help="Enable the outbound undelivered queue that enables this agent\
-            to hold messages for delivery to agents without an endpoint. This\
-            option will require additional memory to store messages in the queue.",
+            help=(
+                "Enable the outbound undelivered queue that enables this agent "
+                "to hold messages for delivery to agents without an endpoint. This "
+                "option will require additional memory to store messages in the queue."
+            ),
         )
         parser.add_argument(
             "--max-outbound-retry",
             default=4,
             type=BoundedInt(min=1),
             env_var="ACAPY_MAX_OUTBOUND_RETRY",
-            help="Set the maximum retry number for undelivered outbound\
-            messages. Increasing this number might cause to increase the\
-            accumulated messages in message queue. Default value is 4.",
+            help=(
+                "Set the maximum retry number for undelivered outbound "
+                "messages. Increasing this number might cause to increase the "
+                "accumulated messages in message queue. Default value is 4."
+            ),
         )
 
     def get_settings(self, args: Namespace):
@@ -997,25 +1101,33 @@ class MediationGroup(ArgumentGroup):
         parser.add_argument(
             "--open-mediation",
             action="store_true",
-            help="Enables didcomm mediation. After establishing a connection, if enabled, \
-                an agent may request message mediation, which will allow the mediator to \
-                forward messages on behalf of the recipient. See aries-rfc:0211.",
+            env_var="ACAPY_MEDIATION_OPEN",
+            help=(
+                "Enables didcomm mediation. After establishing a connection, "
+                "if enabled, an agent may request message mediation, which will "
+                "allow the mediator to forward messages on behalf of the recipient. "
+                "See aries-rfc:0211."
+            ),
         )
         parser.add_argument(
             "--mediator-invitation",
             type=str,
             metavar="<invite URL to mediator>",
             env_var="ACAPY_MEDIATION_INVITATION",
-            help="Connect to mediator through provided invitation\
-            and send mediation request and set as default mediator.",
+            help=(
+                "Connect to mediator through provided invitation "
+                "and send mediation request and set as default mediator."
+            ),
         )
         parser.add_argument(
             "--mediator-connections-invite",
             action="store_true",
             env_var="ACAPY_MEDIATION_CONNECTIONS_INVITE",
-            help="Connect to mediator through a connection invitation. \
-                If not specified, connect using an OOB invitation. \
-                Default: false.",
+            help=(
+                "Connect to mediator through a connection invitation. "
+                "If not specified, connect using an OOB invitation. "
+                "Default: false."
+            ),
         )
         parser.add_argument(
             "--default-mediator-id",
@@ -1066,18 +1178,22 @@ class WalletGroup(ArgumentGroup):
             type=str,
             metavar="<wallet-seed>",
             env_var="ACAPY_WALLET_SEED",
-            help="Specifies the seed to use for the creation of a public\
-            DID for the agent to use with a Hyperledger Indy ledger, or a local\
-            ('--wallet-local-did') DID. If public, the DID must already exist\
-            on the ledger.",
+            help=(
+                "Specifies the seed to use for the creation of a public "
+                "DID for the agent to use with a Hyperledger Indy ledger, or a local "
+                "('--wallet-local-did') DID. If public, the DID must already exist "
+                "on the ledger."
+            ),
         )
         parser.add_argument(
             "--wallet-local-did",
             action="store_true",
             env_var="ACAPY_WALLET_LOCAL_DID",
-            help="If this parameter is set, provisions the wallet with a\
-            local DID from the '--seed' parameter, instead of a public DID\
-            to use with a Hyperledger Indy ledger.",
+            help=(
+                "If this parameter is set, provisions the wallet with a "
+                "local DID from the '--seed' parameter, instead of a public DID "
+                "to use with a Hyperledger Indy ledger."
+            ),
         )
         parser.add_argument(
             "--wallet-key",
@@ -1091,16 +1207,20 @@ class WalletGroup(ArgumentGroup):
             type=str,
             metavar="<wallet-rekey>",
             env_var="ACAPY_WALLET_REKEY",
-            help="Specifies a new master key value to which to rotate and to\
-            open the wallet next time.",
+            help=(
+                "Specifies a new master key value to which to rotate and to "
+                "open the wallet next time."
+            ),
         )
         parser.add_argument(
             "--wallet-name",
             type=str,
             metavar="<wallet-name>",
             env_var="ACAPY_WALLET_NAME",
-            help="Specifies the wallet name to be used by the agent.\
-            This is useful if your deployment has multiple wallets.",
+            help=(
+                "Specifies the wallet name to be used by the agent. "
+                "This is useful if your deployment has multiple wallets."
+            ),
         )
         parser.add_argument(
             "--wallet-type",
@@ -1108,9 +1228,11 @@ class WalletGroup(ArgumentGroup):
             metavar="<wallet-type>",
             default="basic",
             env_var="ACAPY_WALLET_TYPE",
-            help="Specifies the type of Indy wallet provider to use.\
-            Supported internal storage types are 'basic' (memory) and 'indy'.\
-            The default (if not specified) is 'basic'.",
+            help=(
+                "Specifies the type of Indy wallet provider to use. "
+                "Supported internal storage types are 'basic' (memory) and 'indy'. "
+                "The default (if not specified) is 'basic'."
+            ),
         )
         parser.add_argument(
             "--wallet-storage-type",
@@ -1118,51 +1240,61 @@ class WalletGroup(ArgumentGroup):
             metavar="<storage-type>",
             default="default",
             env_var="ACAPY_WALLET_STORAGE_TYPE",
-            help="Specifies the type of Indy wallet backend to use.\
-            Supported internal storage types are 'basic' (memory),\
-            'default' (sqlite), and 'postgres_storage'.  The default,\
-            if not specified, is 'default'.",
+            help=(
+                "Specifies the type of Indy wallet backend to use. "
+                "Supported internal storage types are 'basic' (memory), "
+                "'default' (sqlite), and 'postgres_storage'.  The default, "
+                "if not specified, is 'default'."
+            ),
         )
         parser.add_argument(
             "--wallet-storage-config",
             type=str,
             metavar="<storage-config>",
             env_var="ACAPY_WALLET_STORAGE_CONFIG",
-            help='Specifies the storage configuration to use for the wallet.\
-            This is required if you are for using \'postgres_storage\' wallet\
-            storage type. For example, \'{"url":"localhost:5432",\
-            "wallet_scheme":"MultiWalletSingleTable"}\'. This\
-            configuration maps to the indy sdk postgres plugin\
-            (PostgresConfig).',
+            help=(
+                "Specifies the storage configuration to use for the wallet. "
+                "This is required if you are for using 'postgres_storage' wallet "
+                'storage type. For example, \'{"url":"localhost:5432", '
+                '"wallet_scheme":"MultiWalletSingleTable"}\'. This '
+                "configuration maps to the indy sdk postgres plugin "
+                "(PostgresConfig)."
+            ),
         )
         parser.add_argument(
             "--wallet-storage-creds",
             type=str,
             metavar="<storage-creds>",
             env_var="ACAPY_WALLET_STORAGE_CREDS",
-            help='Specifies the storage credentials to use for the wallet.\
-            This is required if you are for using \'postgres_storage\' wallet\
-            For example, \'{"account":"postgres","password":\
-            "mysecretpassword","admin_account":"postgres",\
-            "admin_password":"mysecretpassword"}\'. This configuration maps\
-            to the indy sdk postgres plugin (PostgresCredentials). NOTE:\
-            admin_user must have the CREATEDB role or else initialization\
-            will fail.',
+            help=(
+                "Specifies the storage credentials to use for the wallet. "
+                "This is required if you are for using 'postgres_storage' wallet "
+                'For example, \'{"account":"postgres","password": '
+                '"mysecretpassword","admin_account":"postgres", '
+                '"admin_password":"mysecretpassword"}\'. This configuration maps '
+                "to the indy sdk postgres plugin (PostgresCredentials). NOTE: "
+                "admin_user must have the CREATEDB role or else initialization "
+                "will fail."
+            ),
         )
         parser.add_argument(
             "--replace-public-did",
             action="store_true",
             env_var="ACAPY_REPLACE_PUBLIC_DID",
-            help="If this parameter is set and an agent already has a public DID,\
-            and the '--seed' parameter specifies a new DID, the agent will use\
-            the new DID in place of the existing DID. Default: false.",
+            help=(
+                "If this parameter is set and an agent already has a public DID, "
+                "and the '--seed' parameter specifies a new DID, the agent will use "
+                "the new DID in place of the existing DID. Default: false."
+            ),
         )
         parser.add_argument(
             "--recreate-wallet",
             action="store_true",
             env_var="ACAPY_RECREATE_WALLET",
-            help="If an existing wallet exists with the same name, remove and\
-            recreate it during provisioning.",
+            help=(
+                "If an existing wallet exists with the same name, remove and "
+                "recreate it during provisioning."
+            ),
         )
 
     def get_settings(self, args: Namespace) -> dict:
@@ -1195,8 +1327,8 @@ class WalletGroup(ArgumentGroup):
             # requires name, key
             if not args.wallet_name or not args.wallet_key:
                 raise ArgsParseError(
-                    "Parameters --wallet-name and --wallet-key must be provided"
-                    + " for indy wallets"
+                    "Parameters --wallet-name and --wallet-key must be provided "
+                    "for indy wallets"
                 )
             # postgres storage requires additional configuration
             if (
@@ -1205,8 +1337,8 @@ class WalletGroup(ArgumentGroup):
             ):
                 if not args.wallet_storage_config or not args.wallet_storage_creds:
                     raise ArgsParseError(
-                        "Parameters --wallet-storage-config and --wallet-storage-creds"
-                        + " must be provided for indy postgres wallets"
+                        "Parameters --wallet-storage-config and --wallet-storage-creds "
+                        "must be provided for indy postgres wallets"
                     )
         return settings
 
@@ -1230,9 +1362,11 @@ class MultitenantGroup(ArgumentGroup):
             type=str,
             metavar="<jwt-secret>",
             env_var="ACAPY_MULTITENANT_JWT_SECRET",
-            help="Specify the secret to be used for Json Web Token (JWT) \
-            creation and verification. The JWTs are used to authenticate and authorize \
-            multitenant wallets.",
+            help=(
+                "Specify the secret to be used for Json Web Token (JWT) creation and "
+                "verification. The JWTs are used to authenticate and authorize "
+                "multitenant wallets."
+            ),
         )
         parser.add_argument(
             "--multitenant-admin",

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_routes.py
@@ -1,13 +1,11 @@
 import json
 
-import asynctest
-from asynctest import TestCase as AsyncTestCase
-from asynctest import mock as async_mock
-
-from aries_cloudagent.config.injection_context import InjectionContext
-from aries_cloudagent.messaging.request_context import RequestContext
+from asynctest import mock as async_mock, TestCase as AsyncTestCase
 
 from .....admin.request_context import AdminRequestContext
+from .....config.injection_context import InjectionContext
+from .....messaging.request_context import RequestContext
+
 from .. import routes as test_module
 from ..manager import MediationManager
 from ..models.mediation_record import MediationRecord

--- a/aries_cloudagent/protocols/problem_report/v1_0/tests/test_handler.py
+++ b/aries_cloudagent/protocols/problem_report/v1_0/tests/test_handler.py
@@ -1,9 +1,9 @@
 import pytest
 
-from aries_cloudagent.messaging.base_handler import HandlerException
-from aries_cloudagent.messaging.request_context import RequestContext
-from aries_cloudagent.messaging.responder import MockResponder
-from aries_cloudagent.transport.inbound.receipt import MessageReceipt
+from .....messaging.base_handler import HandlerException
+from .....messaging.request_context import RequestContext
+from .....messaging.responder import MockResponder
+from .....transport.inbound.receipt import MessageReceipt
 
 from ..handler import ProblemReportHandler
 from ..message import ProblemReport

--- a/aries_cloudagent/protocols/trustping/v1_0/handlers/tests/test_ping_handler.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/handlers/tests/test_ping_handler.py
@@ -1,9 +1,9 @@
 import pytest
 
-from aries_cloudagent.messaging.base_handler import HandlerException
-from aries_cloudagent.messaging.request_context import RequestContext
-from aries_cloudagent.messaging.responder import MockResponder
-from aries_cloudagent.transport.inbound.receipt import MessageReceipt
+from ......messaging.base_handler import HandlerException
+from ......messaging.request_context import RequestContext
+from ......messaging.responder import MockResponder
+from ......transport.inbound.receipt import MessageReceipt
 
 from ...handlers.ping_handler import PingHandler
 from ...messages.ping import Ping

--- a/aries_cloudagent/protocols/trustping/v1_0/handlers/tests/test_ping_response_handler.py
+++ b/aries_cloudagent/protocols/trustping/v1_0/handlers/tests/test_ping_response_handler.py
@@ -1,9 +1,9 @@
 import pytest
 
-from aries_cloudagent.messaging.base_handler import HandlerException
-from aries_cloudagent.messaging.request_context import RequestContext
-from aries_cloudagent.messaging.responder import MockResponder
-from aries_cloudagent.transport.inbound.receipt import MessageReceipt
+from ......messaging.base_handler import HandlerException
+from ......messaging.request_context import RequestContext
+from ......messaging.responder import MockResponder
+from ......transport.inbound.receipt import MessageReceipt
 
 from ...handlers.ping_response_handler import PingResponseHandler
 from ...messages.ping_response import PingResponse


### PR DESCRIPTION
Formalize DucaDellaForcoleta's approach of
https://chat.hyperledger.org/channel/aries-cloudagent-python/thread/XKFaiAQj364yW4amW?msg=aZwH7qZmLax8yDFhq
to allow larger client requests than default if need be. Range is from 1 (default) through 16MB.

Signed-off-by: sklump <srklump@hotmail.com>