### PR TITLE
feat: permissive plugin loading

### DIFF
--- a/aries_cloudagent/core/plugin_registry.py
+++ b/aries_cloudagent/core/plugin_registry.py
@@ -130,6 +130,11 @@ class PluginRegistry:
                 LOGGER.error(f"Module doesn't exist: {module_name}")
                 return None
 
+            # Any plugin with a setup method is considered valid.
+            if hasattr(mod, "setup"):
+                self._plugins[module_name] = mod
+                return mod
+
             # Make an exception for non-protocol modules
             # that contain admin routes and for old-style protocol
             # modules without version support

--- a/aries_cloudagent/core/tests/test_plugin_registry.py
+++ b/aries_cloudagent/core/tests/test_plugin_registry.py
@@ -449,6 +449,13 @@ class TestPluginRegistry(AsyncTestCase):
             ]
             assert self.registry.register_plugin("dummy") is None
 
+    async def test_register_plugin_has_setup(self):
+        with async_mock.patch.object(
+            ClassLoader, "load_module", async_mock.MagicMock(return_value = {"setup":"valid"})
+        ) as load_module:
+            self.registry.register_plugin("dummy")
+            assert self.registry._plugins["dummy"] == {"setup":"valid"}
+    
     async def test_register_definitions_malformed(self):
         with async_mock.patch.object(
             ClassLoader, "load_module", async_mock.MagicMock()

--- a/aries_cloudagent/core/tests/test_plugin_registry.py
+++ b/aries_cloudagent/core/tests/test_plugin_registry.py
@@ -430,7 +430,7 @@ class TestPluginRegistry(AsyncTestCase):
             ClassLoader, "load_module", async_mock.MagicMock()
         ) as load_module:
             load_module.side_effect = [
-                async_mock.MagicMock(),  # module
+                {},  # module
                 None,  # routes
                 None,  # message types
                 None,  # definition
@@ -442,7 +442,7 @@ class TestPluginRegistry(AsyncTestCase):
             ClassLoader, "load_module", async_mock.MagicMock()
         ) as load_module:
             load_module.side_effect = [
-                async_mock.MagicMock(),  # module
+                {},  # module
                 None,  # routes
                 None,  # message types
                 "str-has-no-versions-attr",  # definition without versions attr
@@ -450,18 +450,27 @@ class TestPluginRegistry(AsyncTestCase):
             assert self.registry.register_plugin("dummy") is None
 
     async def test_register_plugin_has_setup(self):
+        class MODULE:
+            setup = "present"
+
+        obj = MODULE()
         with async_mock.patch.object(
-            ClassLoader, "load_module", async_mock.MagicMock(return_value = {"setup":"valid"})
+            ClassLoader, "load_module", async_mock.MagicMock()
         ) as load_module:
-            self.registry.register_plugin("dummy")
-            assert self.registry._plugins["dummy"] == {"setup":"valid"}
-    
+            load_module.side_effect = [
+                obj,  # module
+                None,  # routes
+                None,  # message types
+                None,  # definition without versions attr
+            ]
+            assert self.registry.register_plugin("dummy") == obj
+
     async def test_register_definitions_malformed(self):
         with async_mock.patch.object(
             ClassLoader, "load_module", async_mock.MagicMock()
         ) as load_module:
             load_module.side_effect = [
-                async_mock.MagicMock(),  # module
+                {},  # module
                 None,  # routes
                 None,  # message types
                 async_mock.MagicMock(versions="not-a-list"),


### PR DESCRIPTION
This PR lets any plugin module defining a `setup` method to be loaded as a plugin. This supports the DID Resolver interfaces recently merged as resolvers are pluggable components but do not necessarily define `routes` or `definitions`.