### PR TITLE
Py did vs str did

### DIFF
--- a/aries_cloudagent/config/wallet.py
+++ b/aries_cloudagent/config/wallet.py
@@ -4,7 +4,8 @@ import logging
 
 from ..core.error import ProfileNotFoundError
 from ..core.profile import Profile, ProfileManager
-from ..wallet.base import BaseWallet, DIDInfo
+from ..wallet.base import BaseWallet
+from ..wallet.did_info import DIDInfo
 from ..wallet.crypto import seed_to_did
 
 from .base import ConfigError

--- a/aries_cloudagent/connections/base_manager.py
+++ b/aries_cloudagent/connections/base_manager.py
@@ -24,7 +24,8 @@ from ..resolver.did_resolver import DIDResolver
 from ..storage.base import BaseStorage
 from ..storage.error import StorageNotFoundError
 from ..storage.record import StorageRecord
-from ..wallet.base import BaseWallet, DIDInfo
+from ..wallet.base import BaseWallet
+from ..wallet.did_info import DIDInfo
 from ..wallet.util import did_key_to_naked
 from .models.conn_record import ConnRecord
 from .models.connection_target import ConnectionTarget

--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -44,7 +44,7 @@ from ..transport.outbound.queue.loader import get_outbound_queue
 from ..transport.wire_format import BaseWireFormat
 from ..utils.stats import Collector
 from ..utils.task_queue import CompletedTask, TaskQueue
-from ..wallet.base import DIDInfo
+from ..wallet.did_info import DIDInfo
 from .dispatcher import Dispatcher
 
 LOGGER = logging.getLogger(__name__)

--- a/aries_cloudagent/indy/sdk/tests/test_wallet_plugin.py
+++ b/aries_cloudagent/indy/sdk/tests/test_wallet_plugin.py
@@ -1,10 +1,10 @@
 import pytest
 
-from asynctest import TestCase as AsyncTestCase
-from asynctest import mock as async_mock
+from asynctest import mock as async_mock, TestCase as AsyncTestCase
 
 from ....ledger.base import BaseLedger
-from ....wallet.base import BaseWallet, DIDInfo
+from ....wallet.base import BaseWallet
+from ....wallet.did_info import DIDInfo
 
 from .. import wallet_plugin as test_module
 

--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -3,18 +3,14 @@
 import re
 
 from abc import ABC, abstractmethod, ABCMeta
-from collections import namedtuple
 from enum import Enum
 from typing import Sequence, Tuple, Union
 
 from ..indy.issuer import IndyIssuer
 from ..utils import sentinel
+from ..wallet.did_info import DIDInfo
 
 from .endpoint_type import EndpointType
-
-
-# TODO duplicated from ..wallet.base due to recursive import
-DIDInfo = namedtuple("DIDInfo", "did verkey metadata")
 
 
 class BaseLedger(ABC, metaclass=ABCMeta):

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -24,7 +24,7 @@ from ..messaging.schemas.util import SCHEMA_SENT_RECORD_TYPE
 from ..storage.base import StorageRecord
 from ..storage.indy import IndySdkStorage
 from ..utils import sentinel
-from ..wallet.base import DIDInfo
+from ..wallet.did_info import DIDInfo
 from ..wallet.error import WalletNotFoundError
 from ..wallet.indy import IndySdkWallet
 from ..wallet.util import full_verkey

--- a/aries_cloudagent/ledger/tests/test_indy.py
+++ b/aries_cloudagent/ledger/tests/test_indy.py
@@ -11,7 +11,7 @@ from asynctest import mock as async_mock
 from ...cache.in_memory import InMemoryCache
 from ...indy.issuer import IndyIssuer, IndyIssuerError
 from ...storage.record import StorageRecord
-from ...wallet.base import DIDInfo
+from ...wallet.did_info import DIDInfo
 from ...wallet.did_posture import DIDPosture
 from ...wallet.error import WalletNotFoundError
 

--- a/aries_cloudagent/multitenant/tests/test_manager.py
+++ b/aries_cloudagent/multitenant/tests/test_manager.py
@@ -8,7 +8,7 @@ from ...config.base import InjectionError
 from ...messaging.responder import BaseResponder
 from ...wallet.models.wallet_record import WalletRecord
 from ...wallet.in_memory import InMemoryWallet
-from ...wallet.base import DIDInfo
+from ...wallet.did_info import DIDInfo
 from ...storage.error import StorageNotFoundError
 from ...storage.in_memory import InMemoryStorage
 from ...protocols.routing.v1_0.manager import RoutingManager

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -4,10 +4,6 @@ import logging
 
 from typing import Coroutine, Sequence, Tuple
 
-from aries_cloudagent.protocols.coordinate_mediation.v1_0.manager import (
-    MediationManager,
-)
-
 from ....cache.base import BaseCache
 from ....config.base import InjectionError
 from ....connections.base_manager import BaseConnectionManager
@@ -17,10 +13,12 @@ from ....connections.util import mediation_record_if_id
 from ....core.error import BaseError
 from ....core.profile import ProfileSession
 from ....messaging.responder import BaseResponder
+from ....protocols.coordinate_mediation.v1_0.manager import MediationManager
 from ....protocols.routing.v1_0.manager import RoutingManager
 from ....storage.error import StorageError, StorageNotFoundError
 from ....transport.inbound.receipt import MessageReceipt
-from ....wallet.base import BaseWallet, DIDInfo
+from ....wallet.base import BaseWallet
+from ....wallet.did_info import DIDInfo
 from ....wallet.crypto import create_keypair, seed_to_did
 from ....wallet.error import WalletNotFoundError
 from ....wallet.util import bytes_to_b58

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
@@ -1,9 +1,6 @@
 from unittest.mock import call
-from asynctest import TestCase as AsyncTestCase
-from asynctest import mock as async_mock
+from asynctest import mock as async_mock, TestCase as AsyncTestCase
 
-from aries_cloudagent.resolver.did_resolver import DIDResolver
-from aries_cloudagent.resolver.did_resolver_registry import DIDResolverRegistry
 from .....cache.base import BaseCache
 from .....cache.in_memory import InMemoryCache
 from .....config.base import InjectionError
@@ -17,9 +14,12 @@ from pydid import DIDDocumentBuilder, VerificationSuite, DIDDocument, options
 from .....core.in_memory import InMemoryProfile
 from .....messaging.responder import BaseResponder, MockResponder
 from .....protocols.routing.v1_0.manager import RoutingManager
+from .....resolver.did_resolver import DIDResolver
+from .....resolver.did_resolver_registry import DIDResolverRegistry
 from .....storage.error import StorageNotFoundError
 from .....transport.inbound.receipt import MessageReceipt
-from .....wallet.base import DIDInfo, KeyInfo
+from .....wallet.base import DIDInfo
+from .....wallet.did_info import KeyInfo
 from .....wallet.error import WalletNotFoundError
 from .....wallet.in_memory import InMemoryWallet
 from .....wallet.util import naked_to_did_key

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/manager.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/manager.py
@@ -1,6 +1,7 @@
 """Manager for Mediation coordination."""
 import json
 import logging
+
 from typing import Optional, Sequence, Tuple
 
 from ....core.error import BaseError
@@ -8,11 +9,14 @@ from ....core.profile import Profile, ProfileSession
 from ....storage.base import BaseStorage
 from ....storage.error import StorageNotFoundError
 from ....storage.record import StorageRecord
-from ....wallet.base import BaseWallet, DIDInfo
+from ....wallet.base import BaseWallet
+from ....wallet.did_info import DIDInfo
+
 from ...routing.v1_0.manager import RoutingManager
 from ...routing.v1_0.models.route_record import RouteRecord
 from ...routing.v1_0.models.route_update import RouteUpdate
 from ...routing.v1_0.models.route_updated import RouteUpdated
+
 from .messages.inner.keylist_key import KeylistKey
 from .messages.inner.keylist_query_paginate import KeylistQueryPaginate
 from .messages.inner.keylist_update_rule import KeylistUpdateRule

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -21,7 +21,7 @@ from .....multitenant.manager import MultitenantManager
 from .....storage.error import StorageNotFoundError
 from .....transport.inbound.receipt import MessageReceipt
 from .....multitenant.manager import MultitenantManager
-from .....wallet.base import DIDInfo
+from .....wallet.did_info import DIDInfo
 from .....wallet.in_memory import InMemoryWallet
 from .....wallet.util import naked_to_did_key
 from .....connections.base_manager import (

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/tests/test_routes.py
@@ -6,7 +6,8 @@ from .....admin.request_context import AdminRequestContext
 from .....connections.models.conn_record import ConnRecord
 from .....core.in_memory import InMemoryProfile
 from .....ledger.base import BaseLedger
-from .....wallet.base import BaseWallet, DIDInfo
+from .....wallet.base import BaseWallet
+from .....wallet.did_info import DIDInfo
 
 from .. import routes as test_module
 from ..models.transaction_record import TransactionRecord

--- a/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
@@ -1,8 +1,8 @@
-from asynctest import TestCase as AsyncTestCase
-from asynctest import mock as async_mock
+from asynctest import mock as async_mock, TestCase as AsyncTestCase
 
 from .....admin.request_context import AdminRequestContext
-from .....wallet.base import BaseWallet, DIDInfo
+from .....wallet.base import BaseWallet
+from .....wallet.did_info import DIDInfo
 
 from .. import routes as test_module
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
@@ -2,7 +2,8 @@ from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
 
 from .....admin.request_context import AdminRequestContext
-from .....wallet.base import BaseWallet, DIDInfo
+from .....wallet.base import BaseWallet
+from .....wallet.did_info import DIDInfo
 
 from .. import routes as test_module
 

--- a/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
@@ -59,7 +59,8 @@ from .....protocols.present_proof.v2_0.messages.pres_request import V20PresReque
 from .....storage.error import StorageError, StorageNotFoundError
 from .....multitenant.manager import MultitenantManager
 from .....transport.inbound.receipt import MessageReceipt
-from .....wallet.base import DIDInfo, KeyInfo
+from .....wallet.base import BaseWallet
+from .....wallet.did_info import DIDInfo, KeyInfo
 from .....wallet.in_memory import InMemoryWallet
 from .....wallet.util import did_key_to_naked, naked_to_did_key
 

--- a/aries_cloudagent/resolver/base.py
+++ b/aries_cloudagent/resolver/base.py
@@ -61,19 +61,17 @@ class BaseDIDResolver(ABC):
 
     async def resolve(self, profile: Profile, did: Union[str, DID]) -> DIDDocument:
         """Resolve a DID using this resolver."""
-        if isinstance(did, str):
-            did = DID(did)
+        py_did = DID(did) if isinstance(did, str) else did
 
-        if not self.supports(did.method):
+        if not self.supports(py_did.method):
             raise DIDMethodNotSupported(
-                f"{self.__class__.__name__} does not support DID method {did.method}"
+                f"{self.__class__.__name__} does not support DID method {py_did.method}"
             )
 
-        did = str(did)
-        did_document = await self._resolve(profile, did)
+        did_document = await self._resolve(profile, str(py_did))
         result = DIDDocument.deserialize(did_document)
         return result
 
     @abstractmethod
-    async def _resolve(self, profile: Profile, did: DID) -> dict:
+    async def _resolve(self, profile: Profile, py_did: DID) -> dict:
         """Resolve a DID using this resolver."""

--- a/aries_cloudagent/resolver/base.py
+++ b/aries_cloudagent/resolver/base.py
@@ -73,5 +73,5 @@ class BaseDIDResolver(ABC):
         return result
 
     @abstractmethod
-    async def _resolve(self, profile: Profile, py_did: DID) -> dict:
+    async def _resolve(self, profile: Profile, did: str) -> dict:
         """Resolve a DID using this resolver."""

--- a/aries_cloudagent/resolver/default/indy.py
+++ b/aries_cloudagent/resolver/default/indy.py
@@ -37,7 +37,7 @@ class IndyDIDResolver(BaseDIDResolver):
         """Return supported methods of Indy DID Resolver."""
         return ["sov"]
 
-    async def _resolve(self, profile: Profile, py_did: DID) -> dict:
+    async def _resolve(self, profile: Profile, did: str) -> dict:
         """Resolve an indy DID."""
         ledger = profile.inject(BaseLedger, required=False)
         if not ledger or not isinstance(ledger, IndySdkLedger):
@@ -45,12 +45,12 @@ class IndyDIDResolver(BaseDIDResolver):
 
         try:
             async with ledger:
-                recipient_key = await ledger.get_key_for_did(str(py_did))
-                endpoint = await ledger.get_endpoint_for_did(str(py_did))
+                recipient_key = await ledger.get_key_for_did(did)
+                endpoint = await ledger.get_endpoint_for_did(did)
         except LedgerError as err:
-            raise DIDNotFound(f"DID {py_did} could not be resolved") from err
+            raise DIDNotFound(f"DID {did} could not be resolved") from err
 
-        builder = DIDDocumentBuilder(py_did)
+        builder = DIDDocumentBuilder(DID(did))
 
         vmethod = builder.verification_methods.add(
             ident="key-1", suite=self.SUITE, material=recipient_key

--- a/aries_cloudagent/resolver/default/indy.py
+++ b/aries_cloudagent/resolver/default/indy.py
@@ -37,21 +37,20 @@ class IndyDIDResolver(BaseDIDResolver):
         """Return supported methods of Indy DID Resolver."""
         return ["sov"]
 
-    async def _resolve(self, profile: Profile, did: str) -> dict:
+    async def _resolve(self, profile: Profile, py_did: DID) -> dict:
         """Resolve an indy DID."""
-        did = DID(did)
         ledger = profile.inject(BaseLedger, required=False)
         if not ledger or not isinstance(ledger, IndySdkLedger):
             raise NoIndyLedger("No Indy ledger instance is configured.")
 
         try:
             async with ledger:
-                recipient_key = await ledger.get_key_for_did(did)
-                endpoint = await ledger.get_endpoint_for_did(did)
+                recipient_key = await ledger.get_key_for_did(str(py_did))
+                endpoint = await ledger.get_endpoint_for_did(str(py_did))
         except LedgerError as err:
-            raise DIDNotFound(f"DID {did} could not be resolved") from err
+            raise DIDNotFound(f"DID {py_did} could not be resolved") from err
 
-        builder = DIDDocumentBuilder(did)
+        builder = DIDDocumentBuilder(py_did)
 
         vmethod = builder.verification_methods.add(
             ident="key-1", suite=self.SUITE, material=recipient_key

--- a/aries_cloudagent/resolver/did_resolver.py
+++ b/aries_cloudagent/resolver/did_resolver.py
@@ -28,18 +28,17 @@ class DIDResolver:
     async def resolve(self, profile: Profile, did: Union[str, DID]) -> DIDDocument:
         """Retrieve did doc from public registry."""
         # TODO Cache results
-        if isinstance(did, str):
-            did = DID(did)
-        for resolver in self._match_did_to_resolver(did):
+        py_did = DID(did) if isinstance(did, str) else did
+        for resolver in self._match_did_to_resolver(py_did):
             try:
                 LOGGER.debug("Resolving DID %s with %s", did, resolver)
-                return await resolver.resolve(profile, did)
+                return await resolver.resolve(profile, py_did)
             except DIDNotFound:
                 LOGGER.debug("DID %s not found by resolver %s", did, resolver)
 
         raise DIDNotFound(f"DID {did} could not be resolved")
 
-    def _match_did_to_resolver(self, did: DID) -> BaseDIDResolver:
+    def _match_did_to_resolver(self, py_did: DID) -> BaseDIDResolver:
         """Generate supported DID Resolvers.
 
         Native resolvers are yielded first, in registered order followed by
@@ -47,7 +46,7 @@ class DIDResolver:
         """
         valid_resolvers = list(
             filter(
-                lambda resolver: resolver.supports(did.method),
+                lambda resolver: resolver.supports(py_did.method),
                 self.did_resolver_registry.resolvers,
             )
         )
@@ -57,7 +56,7 @@ class DIDResolver:
         )
         resolvers = list(chain(native_resolvers, non_native_resolvers))
         if not resolvers:
-            raise DIDMethodNotSupported(f"DID method '{did.method}' not supported")
+            raise DIDMethodNotSupported(f"DID method '{py_did.method}' not supported")
         return resolvers
 
     async def dereference(

--- a/aries_cloudagent/resolver/tests/test_base.py
+++ b/aries_cloudagent/resolver/tests/test_base.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from pydid import DID, DIDDocument
+from pydid import DIDDocument
 
 from ..base import BaseDIDResolver, DIDMethodNotSupported, ResolverType
 
@@ -20,7 +20,7 @@ class ExampleDIDResolver(BaseDIDResolver):
     def supported_methods(self):
         return ["test"]
 
-    async def _resolve(self, profile, py_did) -> DIDDocument:
+    async def _resolve(self, profile, did) -> DIDDocument:
         return DIDDocument("did:example:123")
 
 
@@ -52,5 +52,5 @@ def test_supports(native_resolver):
 @pytest.mark.asyncio
 async def test_resolve_x(native_resolver):
     with pytest.raises(DIDMethodNotSupported) as x_did:
-        await native_resolver.resolve(None, DID("did:nosuchmethod:xxx"))
+        await native_resolver.resolve(None, "did:nosuchmethod:xxx")
     assert "does not support DID method" in str(x_did.value)

--- a/aries_cloudagent/resolver/tests/test_base.py
+++ b/aries_cloudagent/resolver/tests/test_base.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from pydid import DIDDocument
+from pydid import DID, DIDDocument
 
 from ..base import BaseDIDResolver, DIDMethodNotSupported, ResolverType
 
@@ -20,7 +20,7 @@ class ExampleDIDResolver(BaseDIDResolver):
     def supported_methods(self):
         return ["test"]
 
-    async def _resolve(self, profile, did) -> DIDDocument:
+    async def _resolve(self, profile, py_did) -> DIDDocument:
         return DIDDocument("did:example:123")
 
 
@@ -52,5 +52,5 @@ def test_supports(native_resolver):
 @pytest.mark.asyncio
 async def test_resolve_x(native_resolver):
     with pytest.raises(DIDMethodNotSupported) as x_did:
-        await native_resolver.resolve(None, "did:nosuchmethod:xxx")
+        await native_resolver.resolve(None, DID("did:nosuchmethod:xxx"))
     assert "does not support DID method" in str(x_did.value)

--- a/aries_cloudagent/resolver/tests/test_did_resolver.py
+++ b/aries_cloudagent/resolver/tests/test_did_resolver.py
@@ -1,8 +1,8 @@
 """Test did resolver registry."""
 
 import unittest
-
 import pytest
+
 from asynctest import mock as async_mock
 
 from ...resolver.base import (
@@ -73,7 +73,7 @@ class MockResolver(BaseDIDResolver):
     def supported_methods(self):
         return self._supported_methods
 
-    async def _resolve(self, profile, did):
+    async def _resolve(self, profile, py_did):
         if isinstance(self.resolved, Exception):
             raise self.resolved
         return self.resolved.serialize()
@@ -99,15 +99,14 @@ def test_create_resolver(resolver):
 
 @pytest.mark.parametrize("did, method", zip(TEST_DIDS, TEST_DID_METHODS))
 def test_match_did_to_resolver(resolver, did, method):
-    did = DID(did)
-    base_resolver, *_ = resolver._match_did_to_resolver(did)
+    base_resolver, *_ = resolver._match_did_to_resolver(DID(did))
     assert base_resolver.supports(method)
 
 
 def test_match_did_to_resolver_x_not_supported(resolver):
-    did = DID("did:cowsay:EiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A")
+    py_did = DID("did:cowsay:EiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A")
     with pytest.raises(DIDMethodNotSupported):
-        resolver._match_did_to_resolver(did)
+        resolver._match_did_to_resolver(py_did)
 
 
 def test_match_did_to_resolver_native_priority():
@@ -154,24 +153,23 @@ async def test_resolve(resolver, profile, did):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("did", TEST_DIDS)
 async def test_resolve_did(resolver, profile, did):
-    did = DID(did)
-    did_doc = await resolver.resolve(profile, did)
+    did_doc = await resolver.resolve(profile, DID(did))
     assert isinstance(did_doc, DIDDocument)
 
 
 @pytest.mark.asyncio
 async def test_resolve_did_x_not_supported(resolver, profile):
-    did = DID("did:cowsay:EiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A")
+    py_did = DID("did:cowsay:EiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A")
     with pytest.raises(DIDMethodNotSupported):
-        await resolver.resolve(profile, did)
+        await resolver.resolve(profile, py_did)
 
 
 @pytest.mark.asyncio
 async def test_resolve_did_x_not_found(profile):
-    did = DID("did:cowsay:EiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A")
+    py_did = DID("did:cowsay:EiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A")
     cowsay_resolver_not_found = MockResolver("cowsay", resolved=DIDNotFound())
     registry = DIDResolverRegistry()
     registry.register(cowsay_resolver_not_found)
     resolver = DIDResolver(registry)
     with pytest.raises(DIDNotFound):
-        await resolver.resolve(profile, did)
+        await resolver.resolve(profile, py_did)

--- a/aries_cloudagent/resolver/tests/test_did_resolver.py
+++ b/aries_cloudagent/resolver/tests/test_did_resolver.py
@@ -73,7 +73,7 @@ class MockResolver(BaseDIDResolver):
     def supported_methods(self):
         return self._supported_methods
 
-    async def _resolve(self, profile, py_did):
+    async def _resolve(self, profile, did):
         if isinstance(self.resolved, Exception):
             raise self.resolved
         return self.resolved.serialize()

--- a/aries_cloudagent/revocation/models/tests/test_issuer_rev_reg_record.py
+++ b/aries_cloudagent/revocation/models/tests/test_issuer_rev_reg_record.py
@@ -9,7 +9,7 @@ from ....indy.issuer import IndyIssuer, IndyIssuerError
 from ....indy.util import indy_client_dir
 from ....ledger.base import BaseLedger
 from ....tails.base import BaseTailsServer
-from ....wallet.base import DIDInfo
+from ....wallet.did_info import DIDInfo
 
 from ...error import RevocationError
 

--- a/aries_cloudagent/utils/outofband.py
+++ b/aries_cloudagent/utils/outofband.py
@@ -5,7 +5,7 @@ import json
 from urllib.parse import quote, urljoin
 
 from ..messaging.agent_message import AgentMessage
-from ..wallet.base import DIDInfo
+from ..wallet.did_info import DIDInfo
 from ..wallet.util import str_to_b64
 
 

--- a/aries_cloudagent/utils/tests/test_outofband.py
+++ b/aries_cloudagent/utils/tests/test_outofband.py
@@ -2,7 +2,7 @@ from asynctest import mock, TestCase
 
 from ...messaging.agent_message import AgentMessage
 from ...protocols.out_of_band.v1_0.messages.invitation import InvitationMessage
-from ...wallet.base import DIDInfo
+from ...wallet.did_info import DIDInfo
 
 from .. import outofband as test_module
 

--- a/aries_cloudagent/wallet/base.py
+++ b/aries_cloudagent/wallet/base.py
@@ -1,16 +1,13 @@
 """Wallet base class."""
 
 from abc import ABC, abstractmethod
-from collections import namedtuple
 from typing import Sequence
 
 from ..ledger.base import BaseLedger
 from ..ledger.endpoint_type import EndpointType
 
 from .did_posture import DIDPosture
-
-KeyInfo = namedtuple("KeyInfo", "verkey metadata")
-DIDInfo = namedtuple("DIDInfo", "did verkey metadata")
+from .did_info import DIDInfo, KeyInfo
 
 
 class BaseWallet(ABC):

--- a/aries_cloudagent/wallet/did_info.py
+++ b/aries_cloudagent/wallet/did_info.py
@@ -1,0 +1,6 @@
+"""KeyInfo, DIDInfo."""
+
+from collections import namedtuple
+
+KeyInfo = namedtuple("KeyInfo", "verkey metadata")
+DIDInfo = namedtuple("DIDInfo", "did verkey metadata")

--- a/aries_cloudagent/wallet/in_memory.py
+++ b/aries_cloudagent/wallet/in_memory.py
@@ -5,7 +5,8 @@ from typing import Sequence
 
 from ..core.in_memory import InMemoryProfile
 
-from .base import BaseWallet, KeyInfo, DIDInfo
+from .base import BaseWallet
+from .did_info import KeyInfo, DIDInfo
 from .crypto import (
     create_keypair,
     random_seed,

--- a/aries_cloudagent/wallet/indy.py
+++ b/aries_cloudagent/wallet/indy.py
@@ -17,7 +17,8 @@ from ..ledger.base import BaseLedger
 from ..ledger.endpoint_type import EndpointType
 from ..ledger.error import LedgerConfigError
 
-from .base import BaseWallet, KeyInfo, DIDInfo
+from .base import BaseWallet
+from .did_info import DIDInfo, KeyInfo
 from .crypto import validate_seed
 from .error import WalletError, WalletDuplicateError, WalletNotFoundError
 from .util import bytes_to_b64

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -26,7 +26,8 @@ from ..messaging.valid import (
 )
 from ..multitenant.manager import MultitenantManager
 
-from .base import DIDInfo, BaseWallet
+from .base import BaseWallet
+from .did_info import DIDInfo
 from .did_posture import DIDPosture
 from .error import WalletError, WalletNotFoundError
 

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -3,10 +3,11 @@ from aiohttp.web import HTTPForbidden
 
 from ...admin.request_context import AdminRequestContext
 from ...ledger.base import BaseLedger
-from ...wallet.base import BaseWallet, DIDInfo
 from ...multitenant.manager import MultitenantManager
 
 from .. import routes as test_module
+from ..base import BaseWallet
+from ..did_info import DIDInfo
 from ..did_posture import DIDPosture
 
 


### PR DESCRIPTION
Note that throughout aca-py, `did` is typically a string. This gave rise to some ambiguity in passing public (PyDID) DID objects into what expected a string.

Also refactored the DIDInfo duplication away.