### PR TITLE
Loosen type checks in responder

### DIFF
--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -17,7 +17,7 @@ from ..messaging.agent_message import AgentMessage
 from ..messaging.error import MessageParseError
 from ..messaging.models.base import BaseModelError
 from ..messaging.request_context import RequestContext
-from ..messaging.responder import BaseResponder
+from ..messaging.responder import BaseResponder, Message
 from ..messaging.util import datetime_now
 from ..protocols.connections.v1_0.manager import ConnectionManager
 from ..protocols.problem_report.v1_0.message import ProblemReport
@@ -267,7 +267,7 @@ class DispatcherResponder(BaseResponder):
         self._webhook = send_webhook
 
     async def create_outbound(
-        self, message: Union[AgentMessage, str, bytes], **kwargs
+        self, message: Union[Message, AgentMessage, str, bytes], **kwargs
     ) -> OutboundMessage:
         """
         Create an OutboundMessage from a message body.

--- a/aries_cloudagent/messaging/responder.py
+++ b/aries_cloudagent/messaging/responder.py
@@ -6,7 +6,7 @@ in response to the message being handled.
 """
 
 from abc import ABC, abstractmethod
-from typing import Sequence, Union
+from typing import Optional, Sequence, Union
 from typing_extensions import Protocol, runtime_checkable
 
 from ..core.error import BaseError
@@ -26,7 +26,7 @@ class Message(Protocol):
         """Serialize the message to json."""
 
     @property
-    def _thread_id(self) -> str:
+    def _thread_id(self) -> Optional[str]:
         """Get the message's thread id."""
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pyyaml~=5.3.1
 ConfigArgParse~=1.2.3
 pyjwt~=1.7.1
 pydid==0.2.3
+typing-extensions~=3.7.4


### PR DESCRIPTION
This one might be a bit of a stretch but here's my reasoning. I think I'm one of the most active ACA-Py plugin developers at the moment and one of the things I've found is that it can be somewhat burdensome to follow the same pattern ACA-Py does for defining messages and handlers in all cases. I've experimented with using a simplified base class other than the `AgentMessage` in ACA-Py and have had favorable results. There _is_ a loss of functionality but, with these tweaks, the core functions work. From what I've gathered so far, the lost functionality is limited primarily to timing and tracing features, which might be a reasonable trade-off in a plugin context if a different root message class integrates better with the rest of your code.

This PR uses `typing.Protocol` to define the expected methods on messages to send, loosening the original explicit type check for `AgentMessage` to a "shape" check. This uses the `typing-extensions` package to backport `typing.Protocol` for python 3.6.

Rather than defining just what the responder needs to send a message, it might make sense to define something somewhere else that outlines the minimum functional agent message attributes. To get a message from decrypted object to being handled, a minimum of `Handler`, and `deserialize` is required. To get a message from creation (in a handler, for instance) to being sent as an encrypted message, a minimum of `to_json` and `_thread_id` is required.

Interested to hear thoughts :slightly_smiling_face: 