### PR TITLE
secured api_key against timing attacks

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -756,8 +756,8 @@ class AdminServer(BaseAdminServer):
                                     "Exception in websocket receiving task:"
                                 )
                             if (
-                                self.admin_api_key 
-                                and msg_api_key 
+                                self.admin_api_key
+                                and msg_api_key
                                 and compare_digest(self.admin_api_key, msg_api_key)
                             ):
                                 # authenticated via websocket message

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -10,6 +10,7 @@ from typing import Callable, Coroutine, Sequence, Set
 import aiohttp_cors
 import jwt
 
+from hmac import compare_digest
 from aiohttp import web
 from aiohttp_apispec import (
     docs,
@@ -298,7 +299,7 @@ class AdminServer(BaseAdminServer):
             @web.middleware
             async def check_token(request: web.Request, handler):
                 header_admin_api_key = request.headers.get("x-api-key")
-                valid_key = self.admin_api_key == header_admin_api_key
+                valid_key = header_admin_api_key and compare_digest(self.admin_api_key, header_admin_api_key)
 
                 if valid_key or is_unprotected_path(request.path):
                     return await handler(request)
@@ -707,7 +708,7 @@ class AdminServer(BaseAdminServer):
         else:
             header_admin_api_key = request.headers.get("x-api-key")
             # authenticated via http header?
-            queue.authenticated = header_admin_api_key == self.admin_api_key
+            queue.authenticated = header_admin_api_key and compare_digest(header_admin_api_key, self.admin_api_key)
 
         try:
             self.websocket_queues[socket_id] = queue
@@ -750,7 +751,7 @@ class AdminServer(BaseAdminServer):
                                 LOGGER.exception(
                                     "Exception in websocket receiving task:"
                                 )
-                            if self.admin_api_key and self.admin_api_key == msg_api_key:
+                            if self.admin_api_key and msg_api_key and compare_digest(self.admin_api_key, msg_api_key):
                                 # authenticated via websocket message
                                 queue.authenticated = True
 

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -299,7 +299,9 @@ class AdminServer(BaseAdminServer):
             @web.middleware
             async def check_token(request: web.Request, handler):
                 header_admin_api_key = request.headers.get("x-api-key")
-                valid_key = header_admin_api_key and compare_digest(self.admin_api_key, header_admin_api_key)
+                valid_key = header_admin_api_key and compare_digest(
+                    self.admin_api_key, header_admin_api_key
+                )
 
                 if valid_key or is_unprotected_path(request.path):
                     return await handler(request)
@@ -708,7 +710,9 @@ class AdminServer(BaseAdminServer):
         else:
             header_admin_api_key = request.headers.get("x-api-key")
             # authenticated via http header?
-            queue.authenticated = header_admin_api_key and compare_digest(header_admin_api_key, self.admin_api_key)
+            queue.authenticated = header_admin_api_key and compare_digest(
+                header_admin_api_key, self.admin_api_key
+            )
 
         try:
             self.websocket_queues[socket_id] = queue
@@ -751,7 +755,11 @@ class AdminServer(BaseAdminServer):
                                 LOGGER.exception(
                                     "Exception in websocket receiving task:"
                                 )
-                            if self.admin_api_key and msg_api_key and compare_digest(self.admin_api_key, msg_api_key):
+                            if (
+                                self.admin_api_key 
+                                and msg_api_key 
+                                and compare_digest(self.admin_api_key, msg_api_key)
+                            ):
                                 # authenticated via websocket message
                                 queue.authenticated = True
 

--- a/aries_cloudagent/transport/outbound/tests/test_http_transport.py
+++ b/aries_cloudagent/transport/outbound/tests/test_http_transport.py
@@ -1,6 +1,7 @@
 import asyncio
 import pytest
 
+from hmac import compare_digest
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 from aiohttp import web
 from asynctest import mock as async_mock
@@ -66,7 +67,7 @@ class TestHttpTransport(AioHTTPTestCase):
             send_message(transport, "{}", endpoint=server_addr, api_key=api_key), 5.0
         )
         assert self.message_results == [{}]
-        assert self.headers.get("x-api-key") == api_key
+        assert api_key and compare_digest(self.headers.get("x-api-key"), api_key)
 
     @unittest_run_loop
     async def test_handle_message_packed_compat_mime_type(self):

--- a/aries_cloudagent/transport/outbound/tests/test_http_transport.py
+++ b/aries_cloudagent/transport/outbound/tests/test_http_transport.py
@@ -1,7 +1,6 @@
 import asyncio
 import pytest
 
-from hmac import compare_digest
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 from aiohttp import web
 from asynctest import mock as async_mock
@@ -67,7 +66,7 @@ class TestHttpTransport(AioHTTPTestCase):
             send_message(transport, "{}", endpoint=server_addr, api_key=api_key), 5.0
         )
         assert self.message_results == [{}]
-        assert api_key and compare_digest(self.headers.get("x-api-key"), api_key)
+        assert self.headers.get("x-api-key") == api_key
 
     @unittest_run_loop
     async def test_handle_message_packed_compat_mime_type(self):


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>
@andrewwhitehead 
comparing user input to secrets and then responding makes this application vulnerable to timing attacks. See resource here: https://blog.sqreen.com/developer-security-best-practices-protecting-against-timing-attacks/  
  
While an attacker isn’t likely to be able to exploit this from somewhere over the internet due to network jitter, they might be able to pull it off if the agent ever supports TOR, HTTP/2 (timeless timing attack), or if they get access to a pod inside the same openshift cluster that can send requests to the agent (ie: the api pod)