### PR TITLE
Feature/secure comparison

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -300,7 +300,7 @@ class AdminServer(BaseAdminServer):
             async def check_token(request: web.Request, handler):
                 header_admin_api_key = request.headers.get("x-api-key")
                 valid_key = header_admin_api_key and compare_digest(
-                    self.admin_api_key, header_admin_api_key
+                    self.admin_api_key.encode(), header_admin_api_key.encode()
                 )
 
                 if valid_key or is_unprotected_path(request.path):
@@ -711,7 +711,7 @@ class AdminServer(BaseAdminServer):
             header_admin_api_key = request.headers.get("x-api-key")
             # authenticated via http header?
             queue.authenticated = header_admin_api_key and compare_digest(
-                header_admin_api_key, self.admin_api_key
+                header_admin_api_key.encode(), self.admin_api_key.encode()
             )
 
         try:
@@ -758,7 +758,7 @@ class AdminServer(BaseAdminServer):
                             if (
                                 self.admin_api_key
                                 and msg_api_key
-                                and compare_digest(self.admin_api_key, msg_api_key)
+                                and compare_digest(self.admin_api_key.encode(), msg_api_key.encode())
                             ):
                                 # authenticated via websocket message
                                 queue.authenticated = True

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -219,12 +219,12 @@ async def debug_middleware(request: web.BaseRequest, handler: Coroutine):
 
     return await handler(request)
 
+
 def const_compare(string1, string2):
     """Compares two strings in constant time, prevents timing attacks"""
     if string1 is None or string2 is None:
         return False
     return compare_digest(string1.encode(), string2.encode())
-
 
 
 class AdminServer(BaseAdminServer):
@@ -306,9 +306,7 @@ class AdminServer(BaseAdminServer):
             @web.middleware
             async def check_token(request: web.Request, handler):
                 header_admin_api_key = request.headers.get("x-api-key")
-                valid_key = const_compare(
-                    self.admin_api_key, header_admin_api_key
-                )
+                valid_key = const_compare(self.admin_api_key, header_admin_api_key)
 
                 if valid_key or is_unprotected_path(request.path):
                     return await handler(request)
@@ -762,9 +760,8 @@ class AdminServer(BaseAdminServer):
                                 LOGGER.exception(
                                     "Exception in websocket receiving task:"
                                 )
-                            if (
-                                self.admin_api_key
-                                and const_compare(self.admin_api_key, msg_api_key)
+                            if self.admin_api_key and const_compare(
+                                self.admin_api_key, msg_api_key
                             ):
                                 # authenticated via websocket message
                                 queue.authenticated = True

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -221,7 +221,7 @@ async def debug_middleware(request: web.BaseRequest, handler: Coroutine):
 
 
 def const_compare(string1, string2):
-    """Compares two strings in constant time, prevents timing attacks"""
+    """Compare two strings in constant time. This prevents timing attacks."""
     if string1 is None or string2 is None:
         return False
     return compare_digest(string1.encode(), string2.encode())

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -221,7 +221,7 @@ async def debug_middleware(request: web.BaseRequest, handler: Coroutine):
 
 
 def const_compare(string1, string2):
-    """Compare two strings in constant time. This prevents timing attacks."""
+    """Compare two strings in constant time."""
     if string1 is None or string2 is None:
         return False
     return compare_digest(string1.encode(), string2.encode())

--- a/aries_cloudagent/transport/outbound/tests/test_http_transport.py
+++ b/aries_cloudagent/transport/outbound/tests/test_http_transport.py
@@ -1,7 +1,6 @@
 import asyncio
 import pytest
 
-from hmac import compare_digest
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 from aiohttp import web
 from asynctest import mock as async_mock
@@ -67,7 +66,7 @@ class TestHttpTransport(AioHTTPTestCase):
             send_message(transport, "{}", endpoint=server_addr, api_key=api_key), 5.0
         )
         assert self.message_results == [{}]
-        assert api_key and compare_digest(self.headers.get("x-api-key"), api_key)
+        assert self.headers.get("x-api-key") == api_key
 
     @unittest_run_loop
     async def test_handle_message_packed_compat_mime_type(self):


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

compare_digest only supports ascii strings or bytes like objects. I added .encode() method to the compare_digest to allow utf string to be compared.