### PR TITLE
Fix: stateless record webhooks

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -40,7 +40,7 @@ from .request_context import AdminRequestContext
 LOGGER = logging.getLogger(__name__)
 
 EVENT_PATTERN_WEBHOOK = re.compile("^acapy::webhook::(.*)$")
-EVENT_PATTERN_RECORD = re.compile("^acapy::record::(.*)$")
+EVENT_PATTERN_RECORD = re.compile("^acapy::record::([^:]*)(?:::.*)?$")
 
 EVENT_WEBHOOK_MAPPING = {
     "acapy::basicmessage::received": "basicmessages",
@@ -450,8 +450,8 @@ class AdminServer(BaseAdminServer):
 
         event_bus = self.context.inject(EventBus, required=False)
         if event_bus:
-            event_bus.subscribe(EVENT_PATTERN_WEBHOOK, self.__on_webhook_event)
-            event_bus.subscribe(EVENT_PATTERN_RECORD, self.__on_record_event)
+            event_bus.subscribe(EVENT_PATTERN_WEBHOOK, self._on_webhook_event)
+            event_bus.subscribe(EVENT_PATTERN_RECORD, self._on_record_event)
 
             for event_topic, webhook_topic in EVENT_WEBHOOK_MAPPING.items():
                 event_bus.subscribe(
@@ -788,13 +788,13 @@ class AdminServer(BaseAdminServer):
 
         return ws
 
-    async def __on_webhook_event(self, profile: Profile, event: Event):
+    async def _on_webhook_event(self, profile: Profile, event: Event):
         match = EVENT_PATTERN_WEBHOOK.search(event.topic)
         webhook_topic = match.group(1) if match else None
         if webhook_topic:
             await self.send_webhook(profile, webhook_topic, event.payload)
 
-    async def __on_record_event(self, profile: Profile, event: Event):
+    async def _on_record_event(self, profile: Profile, event: Event):
         match = EVENT_PATTERN_RECORD.search(event.topic)
         webhook_topic = match.group(1) if match else None
         if webhook_topic:

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -40,7 +40,7 @@ from .request_context import AdminRequestContext
 LOGGER = logging.getLogger(__name__)
 
 EVENT_PATTERN_WEBHOOK = re.compile("^acapy::webhook::(.*)$")
-EVENT_PATTERN_RECORD = re.compile("^acapy::record::(.*)::(.*)$")
+EVENT_PATTERN_RECORD = re.compile("^acapy::record::(.*)$")
 
 EVENT_WEBHOOK_MAPPING = {
     "acapy::basicmessage::received": "basicmessages",
@@ -800,7 +800,7 @@ class AdminServer(BaseAdminServer):
         if webhook_topic:
             await self.send_webhook(profile, webhook_topic, event.payload)
 
-    async def send_webhook(self, profile: Profile, topic: str, payload: dict):
+    async def send_webhook(self, profile: Profile, topic: str, payload: dict = None):
         """Add a webhook to the queue, to send to all registered targets."""
         wallet_id = profile.settings.get("wallet.id")
         webhook_urls = profile.settings.get("admin.webhook_urls")

--- a/aries_cloudagent/admin/tests/test_admin_server.py
+++ b/aries_cloudagent/admin/tests/test_admin_server.py
@@ -1,13 +1,14 @@
-from aries_cloudagent.core.event_bus import Event
 import json
 
 from aiohttp import ClientSession, DummyCookieJar, TCPConnector, web
 from aiohttp.test_utils import unused_port
 import pytest
 
+from ...core.event_bus import Event
 from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
 
+from .. import server as test_module
 from ...config.default_context import DefaultContextBuilder
 from ...config.injection_context import InjectionContext
 from ...core.in_memory import InMemoryProfile
@@ -15,8 +16,6 @@ from ...core.protocol_registry import ProtocolRegistry
 from ...transport.outbound.message import OutboundMessage
 from ...utils.stats import Collector
 from ...utils.task_queue import TaskQueue
-
-from .. import server as test_module
 from ..server import AdminServer, AdminSetupError
 
 

--- a/aries_cloudagent/admin/tests/test_admin_server.py
+++ b/aries_cloudagent/admin/tests/test_admin_server.py
@@ -4,13 +4,13 @@ from aiohttp import ClientSession, DummyCookieJar, TCPConnector, web
 from aiohttp.test_utils import unused_port
 import pytest
 
-from ...core.event_bus import Event
 from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
 
 from .. import server as test_module
 from ...config.default_context import DefaultContextBuilder
 from ...config.injection_context import InjectionContext
+from ...core.event_bus import Event
 from ...core.in_memory import InMemoryProfile
 from ...core.protocol_registry import ProtocolRegistry
 from ...transport.outbound.message import OutboundMessage

--- a/aries_cloudagent/admin/tests/test_admin_server.py
+++ b/aries_cloudagent/admin/tests/test_admin_server.py
@@ -1,7 +1,9 @@
+from aries_cloudagent.core.event_bus import Event
 import json
 
 from aiohttp import ClientSession, DummyCookieJar, TCPConnector, web
 from aiohttp.test_utils import unused_port
+import pytest
 
 from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
@@ -434,3 +436,25 @@ class TestAdminServer(AsyncTestCase):
         ) as response:
             assert response.status == 503
         await server.stop()
+
+
+@pytest.fixture
+async def server():
+    test_class = TestAdminServer()
+    await test_class.setUp()
+    yield test_class.get_admin_server()
+    await test_class.tearDown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "event_topic, webhook_topic",
+    [("acapy::record::topic", "topic"), ("acapy::record::topic::state", "topic")],
+)
+async def test_on_record_event(server, event_topic, webhook_topic):
+    profile = InMemoryProfile.test_profile()
+    with async_mock.patch.object(
+        server, "send_webhook", async_mock.CoroutineMock()
+    ) as mock_send_webhook:
+        await server._on_record_event(profile, Event(event_topic, None))
+        mock_send_webhook.assert_called_once_with(profile, webhook_topic, None)

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -371,7 +371,7 @@ class BaseRecord(BaseModel):
             await storage.delete_record(self.storage_record)
         # FIXME - update state and send webhook?
 
-    async def emit_event(self, session: ProfileSession, payload: Any):
+    async def emit_event(self, session: ProfileSession, payload: Any = None):
         """Emit an event.
 
         Args:
@@ -379,12 +379,18 @@ class BaseRecord(BaseModel):
             payload: The event payload
         """
 
-        if not self.RECORD_TOPIC or not self.state or not payload:
+        if not self.RECORD_TOPIC:
             return
 
-        await session.profile.notify(
-            f"acapy::record::{self.RECORD_TOPIC}::{self.state}", payload
-        )
+        if self.state:
+            topic = f"acapy::record::{self.RECORD_TOPIC}::{self.state}"
+        else:
+            topic = f"acapy::record::{self.RECORD_TOPIC}"
+
+        if not payload:
+            payload = self.serialize()
+
+        await session.profile.notify(topic, payload)
 
     @classmethod
     def log_state(

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -70,6 +70,7 @@ class BaseRecord(BaseModel):
     RECORD_ID_NAME = "id"
     RECORD_TYPE = None
     RECORD_TOPIC: Optional[str] = None
+    EVENT_NAMESPACE: str = "acapy::record"
     LOG_STATE_FLAG = None
     TAG_NAMES = {"state"}
 
@@ -383,9 +384,9 @@ class BaseRecord(BaseModel):
             return
 
         if self.state:
-            topic = f"acapy::record::{self.RECORD_TOPIC}::{self.state}"
+            topic = f"{self.EVENT_NAMESPACE}::{self.RECORD_TOPIC}::{self.state}"
         else:
-            topic = f"acapy::record::{self.RECORD_TOPIC}"
+            topic = f"{self.EVENT_NAMESPACE}::{self.RECORD_TOPIC}"
 
         if not payload:
             payload = self.serialize()


### PR DESCRIPTION
This should hopefully address #1123.

### Changes
**fix: stateless records emit events**

Error on the side of caution for BaseRecord.emit_event, using topic
without state when none is given, and inserting the serialized record as
the payload if no payload is given.

Events are only not emitted by records when no record topic is set.

**fix: relax admin server record event pattern**

Should now accept stateless record event topics

**fix: add event namespace to base records to allow plugins to override**

**test: record topic parsing for webhook**