### PR TITLE
feat: feedback from responder methods about message delivery

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -1,5 +1,6 @@
 """Admin server classes."""
 
+from aries_cloudagent.transport.outbound.status import OutboundSendStatus
 import asyncio
 from hmac import compare_digest
 import logging
@@ -116,14 +117,14 @@ class AdminResponder(BaseResponder):
         self._profile = profile
         self._send = send
 
-    async def send_outbound(self, message: OutboundMessage):
+    async def send_outbound(self, message: OutboundMessage) -> OutboundSendStatus:
         """
         Send outbound message.
 
         Args:
             message: The `OutboundMessage` to be sent
         """
-        await self._send(self._profile, message)
+        return await self._send(self._profile, message)
 
     async def send_webhook(self, topic: str, payload: dict):
         """

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -1,6 +1,5 @@
 """Admin server classes."""
 
-from aries_cloudagent.transport.outbound.status import OutboundSendStatus
 import asyncio
 from hmac import compare_digest
 import logging
@@ -30,6 +29,7 @@ from ..messaging.responder import BaseResponder
 from ..multitenant.manager import MultitenantManager, MultitenantManagerError
 from ..storage.error import StorageNotFoundError
 from ..transport.outbound.message import OutboundMessage
+from ..transport.outbound.status import OutboundSendStatus
 from ..transport.queue.basic import BasicMessageQueue
 from ..utils.stats import Collector
 from ..utils.task_queue import TaskQueue

--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -5,6 +5,7 @@ The dispatcher is responsible for coordinating data flow between handlers, provi
 lifecycle hook callbacks storing state for message threads, etc.
 """
 
+from aries_cloudagent.transport.outbound.status import OutboundSendStatus
 import asyncio
 import logging
 import os
@@ -282,14 +283,14 @@ class DispatcherResponder(BaseResponder):
                 }
         return await super().create_outbound(message, **kwargs)
 
-    async def send_outbound(self, message: OutboundMessage):
+    async def send_outbound(self, message: OutboundMessage) -> OutboundSendStatus:
         """
         Send outbound message.
 
         Args:
             message: The `OutboundMessage` to be sent
         """
-        await self._send(self._context.profile, message, self._inbound_message)
+        return await self._send(self._context.profile, message, self._inbound_message)
 
     async def send_webhook(self, topic: str, payload: dict):
         """

--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -5,7 +5,6 @@ The dispatcher is responsible for coordinating data flow between handlers, provi
 lifecycle hook callbacks storing state for message threads, etc.
 """
 
-from aries_cloudagent.transport.outbound.status import OutboundSendStatus
 import asyncio
 import logging
 import os
@@ -25,10 +24,10 @@ from ..protocols.connections.v1_0.manager import ConnectionManager
 from ..protocols.problem_report.v1_0.message import ProblemReport
 from ..transport.inbound.message import InboundMessage
 from ..transport.outbound.message import OutboundMessage
+from ..transport.outbound.status import OutboundSendStatus
 from ..utils.stats import Collector
 from ..utils.task_queue import CompletedTask, PendingTask, TaskQueue
-from ..utils.tracing import trace_event, get_timer
-
+from ..utils.tracing import get_timer, trace_event
 from .error import ProtocolMinorVersionNotSupported
 from .protocol_registry import ProtocolRegistry
 

--- a/aries_cloudagent/messaging/responder.py
+++ b/aries_cloudagent/messaging/responder.py
@@ -6,13 +6,12 @@ in response to the message being handled.
 """
 
 from abc import ABC, abstractmethod
-from aries_cloudagent.transport.outbound.status import OutboundSendStatus
 from typing import Sequence, Union
 
-from ..core.error import BaseError
 from ..connections.models.connection_target import ConnectionTarget
+from ..core.error import BaseError
 from ..transport.outbound.message import OutboundMessage
-
+from ..transport.outbound.status import OutboundSendStatus
 from .agent_message import AgentMessage
 
 

--- a/aries_cloudagent/messaging/responder.py
+++ b/aries_cloudagent/messaging/responder.py
@@ -6,6 +6,7 @@ in response to the message being handled.
 """
 
 from abc import ABC, abstractmethod
+from aries_cloudagent.transport.outbound.status import OutboundSendStatus
 from typing import Sequence, Union
 
 from ..core.error import BaseError
@@ -69,10 +70,12 @@ class BaseResponder(ABC):
             to_session_only=to_session_only,
         )
 
-    async def send(self, message: Union[AgentMessage, str, bytes], **kwargs):
+    async def send(
+        self, message: Union[AgentMessage, str, bytes], **kwargs
+    ) -> OutboundSendStatus:
         """Convert a message to an OutboundMessage and send it."""
         outbound = await self.create_outbound(message, **kwargs)
-        await self.send_outbound(outbound)
+        return await self.send_outbound(outbound)
 
     async def send_reply(
         self,
@@ -81,7 +84,7 @@ class BaseResponder(ABC):
         connection_id: str = None,
         target: ConnectionTarget = None,
         target_list: Sequence[ConnectionTarget] = None,
-    ):
+    ) -> OutboundSendStatus:
         """
         Send a reply to an incoming message.
 
@@ -102,10 +105,10 @@ class BaseResponder(ABC):
             target=target,
             target_list=target_list,
         )
-        await self.send_outbound(outbound)
+        return await self.send_outbound(outbound)
 
     @abstractmethod
-    async def send_outbound(self, message: OutboundMessage):
+    async def send_outbound(self, message: OutboundMessage) -> OutboundSendStatus:
         """
         Send an outbound message.
 

--- a/aries_cloudagent/transport/outbound/status.py
+++ b/aries_cloudagent/transport/outbound/status.py
@@ -1,0 +1,10 @@
+"""Enum representing captured send status of outbound messages."""
+
+from enum import Enum, auto
+
+
+class OutboundSendStatus(Enum):
+    """Send status of outbound messages."""
+
+    SENT_TO_SESSION = auto()
+    QUEUED_FOR_DELIVERY = auto()


### PR DESCRIPTION
As a result of some discussion in #950, I did a quick investigation of what it would look like to provide some feedback to the responder send methods about message delivery so that from the `forward` message handler, for example, we could determine whether the message was sent directly or not. This doesn't provide a ton of information but I think it provides just enough to know whether a push notification should be sent to a mobile device or not from the forward message handler, as @TimoGlastra described in the comments of that issue.

I think there are a lot of ways to end up at similar functionality though this one ended up being simpler than I anticipated. Interested to hear thoughts.

Signed-off-by: Daniel Bluhm <dbluhm@pm.me>