### PR TITLE
fix: run_tests script

### DIFF
--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM python:3.6.13
 
 RUN apt-get update -y && \
 	apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Signed-off-by: Daniel Bluhm <dbluhm@pm.me>

Not sure what happened (perhaps related to Ubuntu 18.04 EOL?) but `run_tests` stopped working all of a sudden. This switches image base to `python:3.6.13`.