### PR TITLE
Add "minimum viable message" base class for use in plugins

### DIFF
--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -15,6 +15,7 @@ from aiohttp.web import HTTPException
 
 from ..core.profile import Profile
 from ..messaging.agent_message import AgentMessage
+from ..messaging.base_message import BaseMessage
 from ..messaging.error import MessageParseError
 from ..messaging.models.base import BaseModelError
 from ..messaging.request_context import RequestContext
@@ -189,7 +190,7 @@ class Dispatcher:
             perf_counter=r_time,
         )
 
-    async def make_message(self, parsed_msg: dict) -> AgentMessage:
+    async def make_message(self, parsed_msg: dict) -> BaseMessage:
         """
         Deserialize a message dict into the appropriate message instance.
 
@@ -260,7 +261,7 @@ class DispatcherResponder(BaseResponder):
         self._send = send_outbound
 
     async def create_outbound(
-        self, message: Union[AgentMessage, str, bytes], **kwargs
+        self, message: Union[AgentMessage, BaseMessage, str, bytes], **kwargs
     ) -> OutboundMessage:
         """
         Create an OutboundMessage from a message body.

--- a/aries_cloudagent/messaging/agent_message.py
+++ b/aries_cloudagent/messaging/agent_message.py
@@ -35,13 +35,14 @@ from .models.base import (
     resolve_meta_property,
 )
 from .valid import UUIDFour
+from .base_message import BaseMessage, DIDCommVersion
 
 
 class AgentMessageError(BaseModelError):
     """Base exception for agent message issues."""
 
 
-class AgentMessage(BaseModel):
+class AgentMessage(BaseModel, BaseMessage):
     """Agent message base class."""
 
     class Meta:
@@ -382,6 +383,41 @@ class AgentMessage(BaseModel):
         if not self._trace:
             self.add_trace_decorator(target=TRACE_MESSAGE_TARGET, full_thread=True)
         self._trace.append_trace_report(val)
+
+    # BaseMessage implementations {{{
+    @property
+    def type(self) -> str:
+        """Return message type."""
+        return self._type
+
+    @property
+    def id(self) -> str:
+        """Return message id."""
+        return self._message_id
+
+    @property
+    def thread_id(self) -> str:
+        """Return message thread id."""
+        return self._thread_id
+
+    def serialize(self, msg_format: DIDCommVersion = DIDCommVersion.v1, **kwargs):
+        """Return serialized message in format specified."""
+        if msg_format is DIDCommVersion.v2:
+            raise NotImplementedError("DIDComm v2 is not yet supported")
+
+        return super().serialize(**kwargs)
+
+    @classmethod
+    def deserialize(
+        cls, value: dict, msg_format: DIDCommVersion = DIDCommVersion.v1, **kwargs
+    ):
+        """Return message object deserialized from value in format specified."""
+        if msg_format is DIDCommVersion.v2:
+            raise NotImplementedError("DIDComm v2 is not yet supported")
+
+        return super().deserialize(value, **kwargs)
+
+    # }}}
 
 
 class AgentMessageSchema(BaseModelSchema):

--- a/aries_cloudagent/messaging/agent_message.py
+++ b/aries_cloudagent/messaging/agent_message.py
@@ -384,22 +384,6 @@ class AgentMessage(BaseModel, BaseMessage):
             self.add_trace_decorator(target=TRACE_MESSAGE_TARGET, full_thread=True)
         self._trace.append_trace_report(val)
 
-    # BaseMessage implementations {{{
-    @property
-    def type(self) -> str:
-        """Return message type."""
-        return self._type
-
-    @property
-    def id(self) -> str:
-        """Return message id."""
-        return self._message_id
-
-    @property
-    def thread_id(self) -> str:
-        """Return message thread id."""
-        return self._thread_id
-
     def serialize(self, msg_format: DIDCommVersion = DIDCommVersion.v1, **kwargs):
         """Return serialized message in format specified."""
         if msg_format is DIDCommVersion.v2:
@@ -416,8 +400,6 @@ class AgentMessage(BaseModel, BaseMessage):
             raise NotImplementedError("DIDComm v2 is not yet supported")
 
         return super().deserialize(value, **kwargs)
-
-    # }}}
 
 
 class AgentMessageSchema(BaseModelSchema):

--- a/aries_cloudagent/messaging/base_message.py
+++ b/aries_cloudagent/messaging/base_message.py
@@ -1,0 +1,48 @@
+"""Base message."""
+
+from abc import ABC, abstractclassmethod, abstractmethod, abstractproperty
+from enum import Enum, auto
+from typing import Type, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .base_handler import BaseHandler
+
+
+class DIDCommVersion(Enum):
+    """Serialized message formats."""
+
+    v1 = auto()
+    v2 = auto()
+
+
+class BaseMessage(ABC):
+    """Abstract base class for messages.
+
+    This formally defines a "minimum viable message" and provides an
+    unopinionated class for plugins to extend in whatever way makes sense in
+    the context of the plugin.
+    """
+
+    @abstractproperty
+    def type(self) -> str:
+        """Return message type."""
+
+    @abstractproperty
+    def id(self) -> str:  # pylint: disable=invalid-name
+        """Return message id."""
+
+    @abstractproperty
+    def thread_id(self) -> str:  # pylint: disable=invalid-name
+        """Return message thread id."""
+
+    @abstractmethod
+    def serialize(self, msg_format: DIDCommVersion = DIDCommVersion.v1) -> dict:
+        """Return serialized message in format specified."""
+
+    @abstractclassmethod
+    def deserialize(cls, value: dict, msg_format: DIDCommVersion = DIDCommVersion.v1):
+        """Return message object deserialized from value in format specified."""
+
+    @abstractproperty
+    def Handler(self) -> Type["BaseHandler"]:  # pylint: disable=invalid-name
+        """Return reference to handler class."""

--- a/aries_cloudagent/messaging/base_message.py
+++ b/aries_cloudagent/messaging/base_message.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractclassmethod, abstractmethod, abstractproperty
 from enum import Enum, auto
-from typing import Type, TYPE_CHECKING
+from typing import Optional, Type, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .base_handler import BaseHandler
@@ -24,15 +24,15 @@ class BaseMessage(ABC):
     """
 
     @abstractproperty
-    def type(self) -> str:
+    def _type(self) -> str:
         """Return message type."""
 
     @abstractproperty
-    def id(self) -> str:  # pylint: disable=invalid-name
+    def _id(self) -> str:
         """Return message id."""
 
     @abstractproperty
-    def thread_id(self) -> str:  # pylint: disable=invalid-name
+    def _thread_id(self) -> Optional[str]:
         """Return message thread id."""
 
     @abstractmethod
@@ -44,5 +44,5 @@ class BaseMessage(ABC):
         """Return message object deserialized from value in format specified."""
 
     @abstractproperty
-    def Handler(self) -> Type["BaseHandler"]:  # pylint: disable=invalid-name
+    def Handler(self) -> Type["BaseHandler"]:
         """Return reference to handler class."""

--- a/aries_cloudagent/messaging/responder.py
+++ b/aries_cloudagent/messaging/responder.py
@@ -6,13 +6,14 @@ in response to the message being handled.
 """
 
 from abc import ABC, abstractmethod
+import json
 from typing import Sequence, Union
 
 from ..core.error import BaseError
 from ..connections.models.connection_target import ConnectionTarget
 from ..transport.outbound.message import OutboundMessage
 
-from .agent_message import AgentMessage
+from .base_message import BaseMessage
 
 
 class ResponderError(BaseError):
@@ -36,7 +37,7 @@ class BaseResponder(ABC):
 
     async def create_outbound(
         self,
-        message: Union[AgentMessage, str, bytes],
+        message: Union[BaseMessage, str, bytes],
         *,
         connection_id: str = None,
         reply_session_id: str = None,
@@ -48,11 +49,14 @@ class BaseResponder(ABC):
         to_session_only: bool = False,
     ) -> OutboundMessage:
         """Create an OutboundMessage from a message payload."""
-        if isinstance(message, AgentMessage):
-            payload = message.to_json()
+        if isinstance(message, BaseMessage):
+            # TODO DIDComm version selection
+            serialized = message.serialize()
+            # TODO serialized format selection?
+            payload = json.dumps(serialized)
             enc_payload = None
             if not reply_thread_id:
-                reply_thread_id = message._thread_id
+                reply_thread_id = message.thread_id
         else:
             payload = None
             enc_payload = message
@@ -69,14 +73,14 @@ class BaseResponder(ABC):
             to_session_only=to_session_only,
         )
 
-    async def send(self, message: Union[AgentMessage, str, bytes], **kwargs):
+    async def send(self, message: Union[BaseMessage, str, bytes], **kwargs):
         """Convert a message to an OutboundMessage and send it."""
         outbound = await self.create_outbound(message, **kwargs)
         await self.send_outbound(outbound)
 
     async def send_reply(
         self,
-        message: Union[AgentMessage, str, bytes],
+        message: Union[BaseMessage, str, bytes],
         *,
         connection_id: str = None,
         target: ConnectionTarget = None,
@@ -86,7 +90,7 @@ class BaseResponder(ABC):
         Send a reply to an incoming message.
 
         Args:
-            message: the `AgentMessage`, or pre-packed str or bytes to reply with
+            message: the `BaseMessage`, or pre-packed str or bytes to reply with
             connection_id: optionally override the target connection ID
             target: optionally specify a `ConnectionTarget` to send to
 
@@ -131,11 +135,11 @@ class MockResponder(BaseResponder):
         """Initialize the mock responder."""
         self.messages = []
 
-    async def send(self, message: Union[AgentMessage, str, bytes], **kwargs):
+    async def send(self, message: Union[BaseMessage, str, bytes], **kwargs):
         """Convert a message to an OutboundMessage and send it."""
         self.messages.append((message, kwargs))
 
-    async def send_reply(self, message: Union[AgentMessage, str, bytes], **kwargs):
+    async def send_reply(self, message: Union[BaseMessage, str, bytes], **kwargs):
         """Send a reply to an incoming message."""
         self.messages.append((message, kwargs))
 

--- a/aries_cloudagent/messaging/responder.py
+++ b/aries_cloudagent/messaging/responder.py
@@ -56,7 +56,7 @@ class BaseResponder(ABC):
             payload = json.dumps(serialized)
             enc_payload = None
             if not reply_thread_id:
-                reply_thread_id = message.thread_id
+                reply_thread_id = message._thread_id
         else:
             payload = None
             enc_payload = message


### PR DESCRIPTION
As discussed in #1096, when writing plugins, having the flexibility to implement messages differently than the pattern followed within ACA-Py can be really significant. This PR defines a minimized base message class that is unopinionated and trivial to extend.

This PR also addresses concerns around message serialization in anticipation of changes coming with DIDComm v2 by defining `serialize` and `deserialize` methods that specify the output/input format. At present, the `AgentMessage` class only implements DIDComm v1 message structure.