### PR TITLE
fix: add missing connection_id to issue v2 schema

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
@@ -187,6 +187,12 @@ class V20CredFilterSchema(OpenAPISchema):
 class V20IssueCredSchemaCore(AdminAPIMessageTracingSchema):
     """Filter, auto-remove, comment, trace."""
 
+    connection_id = fields.UUID(
+        description="Connection identifier",
+        required=True,
+        example=UUIDFour.EXAMPLE,  # typically but not necessarily a UUID4
+    )
+
     filter_ = fields.Nested(
         V20CredFilterSchema,
         required=True,


### PR DESCRIPTION
Noticed while writing documentation that the connection_id was missing. 