### PR TITLE
fix: add missing connection_id to issue v2 schema

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
@@ -268,6 +268,16 @@ class V20CredProposalRequestSchemaBase(V20IssueCredSchemaCore):
     )
 
 
+class V20CredSendRequestSchema(V20IssueCredSchemaCore):
+    """Base class for request schema for sending credential admin message."""
+
+    connection_id = fields.UUID(
+        description="Connection identifier",
+        required=True,
+        example=UUIDFour.EXAMPLE,  # typically but not necessarily a UUID4
+    )
+
+
 class V20CredBoundOfferRequestSchema(OpenAPISchema):
     """Request schema for sending bound credential offer admin message."""
 
@@ -554,7 +564,7 @@ async def credential_exchange_create(request: web.BaseRequest):
     tags=["issue-credential v2.0"],
     summary="Send holder a credential, automating entire flow",
 )
-@request_schema(V20IssueCredSchemaCore())
+@request_schema(V20CredSendRequestSchema())
 @response_schema(V20CredExRecordSchema(), 200, description="")
 async def credential_exchange_send(request: web.BaseRequest):
     """


### PR DESCRIPTION
@sklump, re #1135, I modified the base class which is used for both `credential_exchange_send` and `credential_exchange_create`. My bad. I created a separate schema for `credential_exchange_send` now. 

AFAIK `credential_exchange_send` should take a connection id as input (so does the code also suggest). Otherwise I fail to see the difference between `credential_exchange_create` and `credential_exchange_send`

It is weird because both have the description "Send holder a credential, automating entire flow", while they do different things.