### PR TITLE
Feature/didweb

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -271,6 +271,7 @@ class AdminServer(BaseAdminServer):
                     "/api/doc",
                     "/api/docs/swagger.json",
                     "/favicon.ico",
+                    "/.well-known/did.json"
                     "/ws",  # ws handler checks authentication
                 ]
                 or path.startswith("/static/swagger/")

--- a/aries_cloudagent/didweb/__init__.py
+++ b/aries_cloudagent/didweb/__init__.py
@@ -1,0 +1,1 @@
+"""DID Web Identity."""

--- a/aries_cloudagent/didweb/base.py
+++ b/aries_cloudagent/didweb/base.py
@@ -1,19 +1,15 @@
 import logging
 
 from pydid import DID, DIDDocument, DIDDocumentBuilder, VerificationSuite
-from pydid.validation import serialize
 
-# from ..core.profile import Profile
 from ..wallet.base import BaseWallet
-
 from ..core.profile import ProfileSession
-from .util import retrieve_did_document, save_did_document
+from .util import retrieve_did_document, save_did_document, VerificationMethod
 
 LOGGER = logging.getLogger(__name__)
 
-VERIFICATION_METHOD_TYPE = "Ed25519VerificationKey2018"
+
 AGENT_SERVICE_TYPE = "did-communication"
-SUITE = VerificationSuite(VERIFICATION_METHOD_TYPE, "publicKeyBase58")
 
 
 class DIDWeb():
@@ -38,18 +34,9 @@ class DIDWeb():
 
         """
         return self._session
-    
-    # @property
-    # def did_document(self) -> DIDDocument:
-    #     return self._did_document
-    
-    # @property
-    # def did_document_as_json(self) -> str:
-    #     LOGGER.info(self._did_document.to_json())
-    #     return self._did_document.to_json()
 
     async def create_from_wallet(
-        self, did: DID
+        self, did: DID, extras=None
     ) -> str:
         """Add content from wallet to DID document."""
         wallet = self.session.inject(BaseWallet, required=False)
@@ -58,9 +45,9 @@ class DIDWeb():
         endpoint = public_did_obj.metadata["endpoint"]
         did_document = DIDDocument
         builder = DIDDocumentBuilder(did)
-
+        suite = VerificationSuite(VerificationMethod.ED25519.value, "publicKeyBase58")
         vmethod = builder.verification_methods.add(
-            ident="key-1", suite=SUITE, material=recipient_key
+            ident="key-1", suite=suite, material=recipient_key
         )
         builder.authentication.reference(vmethod.id)
         builder.assertion_method.reference(vmethod.id)
@@ -72,16 +59,42 @@ class DIDWeb():
                 recipient_keys=[vmethod],
                 routing_keys=[],
             )
+
+        if extras is not None:
+            if "verification_methods" in extras:
+                verification_methods = extras["verification_methods"]
+                for idx, verification_method in enumerate(verification_methods):
+                    did = verification_method["did"]
+                    did_info = await wallet.get_local_did(did)
+                    key_type = did_info.key_type
+                    suite = VerificationSuite(
+                        VerificationMethod[key_type.name].value,
+                        "publicKeyBase58"
+                    )
+                    vmethod = builder.verification_methods.add(
+                        # +2 since there's already the key related to the public DID
+                        ident=f"key-{idx+2}", suite=suite, material=did_info.verkey
+                    )
+                    if "verification_relationships" in verification_method:
+                        vrelations = verification_method["verification_relationships"]
+                        for vrelation in vrelations:
+                            getattr(builder, vrelation).reference(vmethod.id)
+
+            if "services" in extras:
+                # TODO: Implement adding custom services
+                None
+
         did_document = builder.build()
+
         await save_did_document(did_document, self._session)
         self._did_document = did_document
         return did_document.serialize()
 
     async def create(self, did_document) -> str:
-        await save_did_document(did_document, self._session)
+        await save_did_document(None, self._session)
         self._did_document = did_document
         return did_document
-       
+
     async def delete(self):
         await save_did_document(None, self._session)
         return None
@@ -92,4 +105,3 @@ class DIDWeb():
             return did_document.serialize()
         else:
             return None
-

--- a/aries_cloudagent/didweb/base.py
+++ b/aries_cloudagent/didweb/base.py
@@ -1,0 +1,95 @@
+import logging
+
+from pydid import DID, DIDDocument, DIDDocumentBuilder, VerificationSuite
+from pydid.validation import serialize
+
+# from ..core.profile import Profile
+from ..wallet.base import BaseWallet
+
+from ..core.profile import ProfileSession
+from .util import retrieve_did_document, save_did_document
+
+LOGGER = logging.getLogger(__name__)
+
+VERIFICATION_METHOD_TYPE = "Ed25519VerificationKey2018"
+AGENT_SERVICE_TYPE = "did-communication"
+SUITE = VerificationSuite(VERIFICATION_METHOD_TYPE, "publicKeyBase58")
+
+
+class DIDWeb():
+    """Class for managing a did:web DID document."""
+
+    def __init__(self, session: ProfileSession):
+        """
+        Initialize DIDWeb.
+
+        Args:
+            session: The current profile session
+        """
+        self._session = session
+
+    @property
+    def session(self) -> ProfileSession:
+        """
+        Accessor for the current profile session.
+
+        Returns:
+            The current profile session
+
+        """
+        return self._session
+    
+    # @property
+    # def did_document(self) -> DIDDocument:
+    #     return self._did_document
+    
+    # @property
+    # def did_document_as_json(self) -> str:
+    #     LOGGER.info(self._did_document.to_json())
+    #     return self._did_document.to_json()
+
+    async def create_from_wallet(
+        self, did: DID
+    ) -> str:
+        """Add content from wallet to DID document."""
+        wallet = self.session.inject(BaseWallet, required=False)
+        public_did_obj = await wallet.get_public_did()
+        recipient_key = public_did_obj.verkey
+        endpoint = public_did_obj.metadata["endpoint"]
+        did_document = DIDDocument
+        builder = DIDDocumentBuilder(did)
+
+        vmethod = builder.verification_methods.add(
+            ident="key-1", suite=SUITE, material=recipient_key
+        )
+        builder.authentication.reference(vmethod.id)
+        builder.assertion_method.reference(vmethod.id)
+        if endpoint:
+            builder.services.add_didcomm(
+                ident=AGENT_SERVICE_TYPE,
+                type_=AGENT_SERVICE_TYPE,
+                endpoint=endpoint,
+                recipient_keys=[vmethod],
+                routing_keys=[],
+            )
+        did_document = builder.build()
+        await save_did_document(did_document, self._session)
+        self._did_document = did_document
+        return did_document.serialize()
+
+    async def create(self, did_document) -> str:
+        await save_did_document(did_document, self._session)
+        self._did_document = did_document
+        return did_document
+       
+    async def delete(self):
+        await save_did_document(None, self._session)
+        return None
+
+    async def retrieve(self) -> str:
+        did_document = await retrieve_did_document(self._session)
+        if did_document:
+            return did_document.serialize()
+        else:
+            return None
+

--- a/aries_cloudagent/didweb/routes.py
+++ b/aries_cloudagent/didweb/routes.py
@@ -1,0 +1,176 @@
+"""
+DID web admin routes and public endpoint.
+
+"""
+
+import json
+from aiohttp import web
+from aiohttp_apispec import (
+    docs,
+    match_info_schema,
+    # querystring_schema,
+    request_schema,
+    response_schema,
+)
+
+from marshmallow import fields, validate
+
+from ..admin.request_context import AdminRequestContext
+from ..messaging.models.openapi import OpenAPISchema
+from pydid.common import DID_PATTERN
+from .base import DIDWeb
+
+
+class W3cDIDDoc(validate.Regexp):
+    """Validate value against w3c DID document."""
+
+    EXAMPLE = "*"
+    PATTERN = DID_PATTERN
+
+    def __init__(self):
+        """Initializer."""
+
+        super().__init__(
+            W3cDIDDoc.PATTERN,
+            error="Value {input} is not a w3c decentralized identifier (DID) doc.",
+        )
+
+
+_W3cDIDDoc = {"validate": W3cDIDDoc(), "example": W3cDIDDoc.EXAMPLE}
+
+
+class DIDDocSchema(OpenAPISchema):
+    """Result schema for did document query."""
+
+    did_doc = fields.Str(
+        description="decentralize identifier(DID) document", required=True
+    )
+
+
+class W3cDID(validate.Regexp):
+    """Validate value against w3c DID."""
+
+    EXAMPLE = "did:ted:WgWxqztrNooG92RXvxSTWv"
+    PATTERN = DID_PATTERN
+
+    def __init__(self):
+        """Initializer."""
+
+        super().__init__(
+            W3cDID.PATTERN,
+            error="Value {input} is not a w3c decentralized identifier (DID)",
+        )
+
+
+_W3cDID = {"validate": W3cDID(), "example": W3cDID.EXAMPLE}
+
+
+class DIDMatchInfoSchema(OpenAPISchema):
+    """Path parameters and validators for request taking DID."""
+
+    did = fields.Str(
+        description="decentralize identifier(DID)", required=True, **_W3cDID
+    )
+
+
+async def did_document(request: web.BaseRequest):
+    """Retrieve a did document."""
+    context: AdminRequestContext = request["context"]
+    session = await context.session()
+    did_web = DIDWeb(session)
+    # did_web = session.inject(DIDWeb)
+    did_document = await did_web.retrieve()
+    # except DIDNotFound as err:
+    #     raise web.HTTPNotFound(reason=err.roll_up) from err
+    # except DIDMethodNotSupported as err:
+    #     raise web.HTTPNotImplemented(reason=err.roll_up) from err
+    # except ResolverError as err:
+    #     raise web.HTTPInternalServerError(reason=err.roll_up) from err
+    return web.json_response(did_document)
+
+
+@docs(tags=["didweb"], summary="Retrieve DID document")
+@response_schema(DIDDocSchema(), 200)
+async def read_did_document(request: web.BaseRequest):
+    """Retrieve a did document."""
+    # context: AdminRequestContext = request["context"]
+    # session = await context.session()
+    context: AdminRequestContext = request["context"]
+    session = await context.session()
+    did_web = DIDWeb(session)
+    # did_web = session.inject(DIDWeb)
+    did_document = await did_web.retrieve()
+    # except DIDNotFound as err:
+    #     raise web.HTTPNotFound(reason=err.roll_up) from err
+    # except DIDMethodNotSupported as err:
+    #     raise web.HTTPNotImplemented(reason=err.roll_up) from err
+    # except ResolverError as err:
+    #     raise web.HTTPInternalServerError(reason=err.roll_up) from err
+    if not did_document:
+        return web.HTTPNotFound()
+    else:
+        return web.json_response(did_document)
+
+
+@docs(tags=["didweb"], summary="Create DID document")
+@request_schema(DIDDocSchema())
+@response_schema(DIDDocSchema(), 200, description="")
+async def create_did_document(request: web.BaseRequest):
+    """Create a did document."""
+    # context: AdminRequestContext = request["context"]
+    # session = await context.session()
+    # did_web = session.inject(DIDWeb)
+    context: AdminRequestContext = request["context"]
+    session = await context.session()
+    did_web = DIDWeb(session)
+    # did_web = session.inject(DIDWeb)
+    did_document = await did_web.create()
+    # except DIDNotFound as err:
+    #     raise web.HTTPNotFound(reason=err.roll_up) from err
+    # except DIDMethodNotSupported as err:
+    #     raise web.HTTPNotImplemented(reason=err.roll_up) from err
+    # except ResolverError as err:
+    #     raise web.HTTPInternalServerError(reason=err.roll_up) from err
+    return web.json_response(did_document)
+
+
+@docs(tags=["didweb"], summary="Create DID document")
+@match_info_schema(DIDMatchInfoSchema())
+@request_schema(DIDDocSchema())
+@response_schema(DIDDocSchema(), 200, description="")
+async def create_did_document_from_wallet(request: web.BaseRequest):
+    """Create a did document."""
+    did = request.match_info["did"]
+    context: AdminRequestContext = request["context"]
+    session = await context.session()
+    did_web = DIDWeb(session)
+    did_document = await did_web.create_from_wallet(did)
+    return web.json_response(did_document)
+
+
+async def register(app: web.Application):
+    """Register routes."""
+
+    app.add_routes(
+        [
+            web.get("/.well-known/did.json", did_document, allow_head=False),
+            web.get("/didweb/read", read_did_document, allow_head=False),
+            web.post("/didweb/create-raw", create_did_document),
+            web.post("/didweb/create-from-wallet/{did}", create_did_document_from_wallet)
+        ]
+    )
+
+
+def post_process_routes(app: web.Application):
+    """Amend swagger API."""
+
+    # Add top-level tags description
+    if "tags" not in app._state["swagger_dict"]:
+        app._state["swagger_dict"]["tags"] = []
+    app._state["swagger_dict"]["tags"].append(
+        {
+            "name": "didweb",
+            "description": "did resolver interface.",
+            "externalDocs": {"description": "Specification"},  # , "url": SPEC_URI},
+        }
+    )

--- a/aries_cloudagent/didweb/tests/__init__.py
+++ b/aries_cloudagent/didweb/tests/__init__.py
@@ -1,0 +1,43 @@
+DOC = {
+    "@context": "https://w3id.org/did/v1",
+    "id": "did:example:1234abcd",
+    "verificationMethod": [
+        {
+            "id": "did:example:1234abcd#4",
+            "type": "RsaVerificationKey2018",
+            "controller": "did:example:1234abcd",
+            "publicKeyPem": "-----BEGIN PUBLIC X…",
+        },
+        {
+            "id": "did:example:1234abcd#5",
+            "type": "RsaVerificationKey2018",
+            "controller": "did:example:1234abcd",
+            "publicKeyPem": "-----BEGIN PUBLIC 9…",
+        },
+        {
+            "id": "did:example:1234abcd#6",
+            "type": "RsaVerificationKey2018",
+            "controller": "did:example:1234abcd",
+            "publicKeyPem": "-----BEGIN PUBLIC A…",
+        },
+    ],
+    "authentication": [
+        {
+            "id": "did:example:123456789abcdefghi#ted",
+            "controller": "did:example:1234abcd",
+            "type": "RsaSignatureAuthentication2018",
+            "publicKey": "did:example:1234abcd#4",
+        },
+        "did:example:123456789abcdefghi#5",
+    ],
+    "service": [
+        {
+            "id": "did:example:123456789abcdefghi#did-communication",
+            "type": "did-communication",
+            "priority": 0,
+            "recipientKeys": ["did:example:1234abcd#4"],
+            "routingKeys": ["did:example:1234abcd#6"],
+            "serviceEndpoint": "did:example:xd45fr567794lrzti67;did-communication",
+        }
+    ],
+}

--- a/aries_cloudagent/didweb/tests/test_didweb.py
+++ b/aries_cloudagent/didweb/tests/test_didweb.py
@@ -1,0 +1,8 @@
+"""Test DID web."""
+
+import unittest
+
+import pytest
+from asynctest import mock as async_mock
+
+from pydid import DID, DIDDocument, VerificationMethod

--- a/aries_cloudagent/didweb/tests/test_routes.py
+++ b/aries_cloudagent/didweb/tests/test_routes.py
@@ -1,0 +1,9 @@
+"""Test DID web routes."""
+
+# pylint: disable=redefined-outer-name
+
+import pytest
+from asynctest import mock as async_mock
+from pydid import DIDDocument
+
+from ...admin.request_context import AdminRequestContext

--- a/aries_cloudagent/didweb/util.py
+++ b/aries_cloudagent/didweb/util.py
@@ -1,0 +1,50 @@
+from pydid import DIDDocument
+from ..core.profile import ProfileSession
+from ..storage.base import (
+    BaseStorage,
+    StorageRecord,
+    StorageNotFoundError,
+)
+
+DID_WEB_RECORD_TYPE = "did_web_did_document"
+
+
+async def retrieve_did_document(
+    session: ProfileSession
+) -> DIDDocument:
+    """Retrieve DID document."""
+    storage = session.inject(BaseStorage)
+    try:
+        record = await storage.find_record(
+            DID_WEB_RECORD_TYPE
+        )
+    except StorageNotFoundError:
+        record = None
+    return DIDDocument.from_json(record.value) if record else None
+
+
+async def save_did_document(
+    did_document: DIDDocument, session: ProfileSession
+):
+    """Save a DID document"""
+    storage = session.inject(BaseStorage)
+    try:
+        record = await storage.find_record(
+            DID_WEB_RECORD_TYPE,
+            {"did_doc": "x"}
+        )
+    except StorageNotFoundError:
+        if did_document:
+            record = StorageRecord(
+                type=DID_WEB_RECORD_TYPE,
+                value=did_document.to_json(),
+                tags={"did_doc": "x"}
+            )
+            await storage.add_record(record)
+    else:
+        if did_document:
+            await storage.update_record(
+                record, did_document.to_json(), {"did_doc": "x"}
+            )
+        else:
+            await storage.delete_record(record)

--- a/aries_cloudagent/didweb/util.py
+++ b/aries_cloudagent/didweb/util.py
@@ -13,7 +13,7 @@ RECORD_TYPE_DID_DOC = "did_doc"
 class VerificationMethod(Enum):
 
     BLS12381G2 = "Bls12381G2Key2020"
-    ED25519 = "Ed25519Signature2018"
+    ED25519 = "Ed25519VerificationKey2018"
 
 
 async def retrieve_did_document(

--- a/aries_cloudagent/didweb/util.py
+++ b/aries_cloudagent/didweb/util.py
@@ -1,4 +1,5 @@
 from pydid import DIDDocument
+from enum import Enum
 from ..core.profile import ProfileSession
 from ..storage.base import (
     BaseStorage,
@@ -6,7 +7,13 @@ from ..storage.base import (
     StorageNotFoundError,
 )
 
-DID_WEB_RECORD_TYPE = "did_web_did_document"
+RECORD_TYPE_DID_DOC = "did_doc"
+
+
+class VerificationMethod(Enum):
+
+    BLS12381G2 = "Bls12381G2Key2020"
+    ED25519 = "Ed25519Signature2018"
 
 
 async def retrieve_did_document(
@@ -16,7 +23,8 @@ async def retrieve_did_document(
     storage = session.inject(BaseStorage)
     try:
         record = await storage.find_record(
-            DID_WEB_RECORD_TYPE
+            RECORD_TYPE_DID_DOC,
+            {"did": "did:web"}
         )
     except StorageNotFoundError:
         record = None
@@ -30,21 +38,21 @@ async def save_did_document(
     storage = session.inject(BaseStorage)
     try:
         record = await storage.find_record(
-            DID_WEB_RECORD_TYPE,
-            {"did_doc": "x"}
+            RECORD_TYPE_DID_DOC,
+            {"did": "did:web"}
         )
     except StorageNotFoundError:
         if did_document:
             record = StorageRecord(
-                type=DID_WEB_RECORD_TYPE,
+                type=RECORD_TYPE_DID_DOC,
                 value=did_document.to_json(),
-                tags={"did_doc": "x"}
+                tags={"did": "did:web"}
             )
             await storage.add_record(record)
     else:
         if did_document:
             await storage.update_record(
-                record, did_document.to_json(), {"did_doc": "x"}
+                record, did_document.to_json(), {"did": "did:web"}
             )
         else:
             await storage.delete_record(record)

--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -210,6 +210,20 @@ class JSONWebToken(Regexp):
         )
 
 
+class GenericDID(Regexp):
+    """Validate value against DID specification."""
+
+    EXAMPLE = "did:indy:idu:WgWxqztrNooG92RXvxSTWv"
+    PATTERN = r"^did:([a-z0-9]+):((?:[a-zA-Z0-9._-]*:)*[a-zA-Z0-9._-]+)"
+
+    def __init__(self):
+        """Initializer."""
+
+        super().__init__(
+            GenericDID.PATTERN, error="Value {input} is not in W3C did format"
+        )
+
+
 class DIDKey(Regexp):
     """Validate value against DID key specification."""
 
@@ -687,6 +701,22 @@ class IndyOrKeyDID(Regexp):
         )
 
 
+class IndyOrGenericDID(Regexp):
+    """Indy or Generic DID class."""
+
+    PATTERN = re.compile("|".join([GenericDID.PATTERN, IndyDID.PATTERN]))
+    EXAMPLE = IndyDID.EXAMPLE
+
+    def __init__(
+        self,
+    ):
+        """Initializer."""
+        super().__init__(
+            IndyOrGenericDID.PATTERN,
+            error="Value {input} is not in generic did or indy did format",
+        )
+
+
 # Instances for marshmallow schema specification
 INT_EPOCH = {"validate": IntEpoch(), "example": IntEpoch.EXAMPLE}
 WHOLE_NUM = {"validate": WholeNumber(), "example": WholeNumber.EXAMPLE}
@@ -699,6 +729,7 @@ NUM_STR_NATURAL = {
 INDY_REV_REG_SIZE = {"validate": IndyRevRegSize(), "example": IndyRevRegSize.EXAMPLE}
 JWS_HEADER_KID = {"validate": JWSHeaderKid(), "example": JWSHeaderKid.EXAMPLE}
 JWT = {"validate": JSONWebToken(), "example": JSONWebToken.EXAMPLE}
+GENERIC_DID = {"validate": GenericDID(), "example": GenericDID.EXAMPLE}
 DID_KEY = {"validate": DIDKey(), "example": DIDKey.EXAMPLE}
 DID_POSTURE = {"validate": DIDPosture(), "example": DIDPosture.EXAMPLE}
 INDY_DID = {"validate": IndyDID(), "example": IndyDID.EXAMPLE}
@@ -743,4 +774,8 @@ CREDENTIAL_SUBJECT = {
 INDY_OR_KEY_DID = {
     "validate": IndyOrKeyDID(),
     "example": IndyOrKeyDID.EXAMPLE,
+}
+INDY_OR_GENERIC_DID = {
+    "validate": IndyOrGenericDID(),
+    "example": IndyOrGenericDID.EXAMPLE,
 }

--- a/aries_cloudagent/protocols/connections/v1_0/messages/connection_invitation.py
+++ b/aries_cloudagent/protocols/connections/v1_0/messages/connection_invitation.py
@@ -6,7 +6,7 @@ from urllib.parse import parse_qs, urljoin, urlparse
 from marshmallow import EXCLUDE, fields, validates_schema, ValidationError
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
-from .....messaging.valid import INDY_DID, INDY_RAW_PUBLIC_KEY
+from .....messaging.valid import GENERIC_DID, INDY_RAW_PUBLIC_KEY
 from .....wallet.util import b64_to_bytes, bytes_to_b64
 
 from ..message_types import CONNECTION_INVITATION, PROTOCOL_PACKAGE
@@ -106,7 +106,7 @@ class ConnectionInvitationSchema(AgentMessageSchema):
         example="Bob",
     )
     did = fields.Str(
-        required=False, description="DID for connection invitation", **INDY_DID
+        required=False, description="DID for connection invitation", **GENERIC_DID
     )
     recipient_keys = fields.List(
         fields.Str(description="Recipient public key", **INDY_RAW_PUBLIC_KEY),

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -19,7 +19,7 @@ from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
 from ....messaging.valid import (
     ENDPOINT,
-    INDY_DID,
+    GENERIC_DID,
     INDY_RAW_PUBLIC_KEY,
     UUIDFour,
 )
@@ -136,11 +136,11 @@ class ConnectionStaticRequestSchema(OpenAPISchema):
     """Request schema for a new static connection."""
 
     my_seed = fields.Str(description="Seed to use for the local DID", required=False)
-    my_did = fields.Str(description="Local DID", required=False, **INDY_DID)
+    my_did = fields.Str(description="Local DID", required=False, **GENERIC_DID)
     their_seed = fields.Str(
         description="Seed to use for the remote DID", required=False
     )
-    their_did = fields.Str(description="Remote DID", required=False, **INDY_DID)
+    their_did = fields.Str(description="Remote DID", required=False, **GENERIC_DID)
     their_verkey = fields.Str(description="Remote verification key", required=False)
     their_endpoint = fields.Str(
         description="URL endpoint for other party", required=False, **ENDPOINT
@@ -154,12 +154,12 @@ class ConnectionStaticRequestSchema(OpenAPISchema):
 class ConnectionStaticResultSchema(OpenAPISchema):
     """Result schema for new static connection."""
 
-    my_did = fields.Str(description="Local DID", required=True, **INDY_DID)
+    my_did = fields.Str(description="Local DID", required=True, **GENERIC_DID)
     mv_verkey = fields.Str(
         description="My verification key", required=True, **INDY_RAW_PUBLIC_KEY
     )
     my_endpoint = fields.Str(description="My URL endpoint", required=True, **ENDPOINT)
-    their_did = fields.Str(description="Remote DID", required=True, **INDY_DID)
+    their_did = fields.Str(description="Remote DID", required=True, **GENERIC_DID)
     their_verkey = fields.Str(
         description="Remote verification key", required=True, **INDY_RAW_PUBLIC_KEY
     )
@@ -177,7 +177,7 @@ class ConnectionsListQueryStringSchema(OpenAPISchema):
     invitation_key = fields.Str(
         description="invitation key", required=False, **INDY_RAW_PUBLIC_KEY
     )
-    my_did = fields.Str(description="My DID", required=False, **INDY_DID)
+    my_did = fields.Str(description="My DID", required=False, **GENERIC_DID)
     state = fields.Str(
         description="Connection state",
         required=False,
@@ -185,7 +185,7 @@ class ConnectionsListQueryStringSchema(OpenAPISchema):
             {label for state in ConnRecord.State for label in state.value}
         ),
     )
-    their_did = fields.Str(description="Their DID", required=False, **INDY_DID)
+    their_did = fields.Str(description="Their DID", required=False, **GENERIC_DID)
     their_role = fields.Str(
         description="Their role in the connection protocol",
         required=False,

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -267,7 +267,10 @@ class DIDXManager(BaseConnectionManager):
                 filter(None, [base_mediation_record, mediation_record])
             ),
         )
-        if conn_rec.their_public_did is not None and conn_rec.their_public_did.startswith("did:"):
+        if (
+            conn_rec.their_public_did is not None and
+            conn_rec.their_public_did.startswith("did:")
+        ):
             qualified_did = conn_rec.their_public_did
         else:
             qualified_did = f"did:sov:{conn_rec.their_public_did}"

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -267,7 +267,11 @@ class DIDXManager(BaseConnectionManager):
                 filter(None, [base_mediation_record, mediation_record])
             ),
         )
-        pthid = conn_rec.invitation_msg_id or f"did:sov:{conn_rec.their_public_did}"
+        if conn_rec.their_public_did is not None and conn_rec.their_public_did.startswith("did:"):
+            qualified_did = conn_rec.their_public_did
+        else:
+            qualified_did = f"did:sov:{conn_rec.their_public_did}"
+        pthid = conn_rec.invitation_msg_id or qualified_did
         attach = AttachDecorator.data_base64(did_doc.serialize())
         await attach.data.sign(my_info.verkey, wallet)
         if not my_label:
@@ -290,6 +294,12 @@ class DIDXManager(BaseConnectionManager):
             await responder.send(
                 keylist_updates, connection_id=mediation_record.connection_id
             )
+
+        # # Send request
+        # responder = self._session.inject(BaseResponder, required=False)
+        # if responder:
+        #     await responder.send(request, connection_id=conn_rec.connection_id)
+
         return request
 
     async def receive_request(

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -405,7 +405,8 @@ class OutOfBandManager(BaseConnectionManager):
             endpoint, recipient_keys, routing_keys = await self.resolve_invitation(
                 service_did
             )
-            public_did = service_did.split(":")[-1]
+            # public_did = service_did.split(":")[-1]
+            public_did = service_did
             service = ServiceMessage.deserialize(
                 {
                     "id": "#inline",

--- a/aries_cloudagent/protocols/out_of_band/v1_0/messages/invitation.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/messages/invitation.py
@@ -20,7 +20,7 @@ from .....messaging.decorators.attach_decorator import (
     AttachDecorator,
     AttachDecoratorSchema,
 )
-from .....messaging.valid import INDY_DID
+from .....messaging.valid import INDY_OR_GENERIC_DID
 from .....wallet.util import bytes_to_b64, b64_to_bytes
 
 from ....didcomm_prefix import DIDCommPrefix
@@ -208,7 +208,10 @@ class InvitationMessageSchema(AgentMessageSchema):
     )
 
     service_blocks = fields.Nested(ServiceSchema, many=True)
-    service_dids = fields.List(fields.Str(description="Service DID", **INDY_DID))
+    service_dids = fields.List(fields.Str(
+        description="Service DID",
+        **INDY_OR_GENERIC_DID
+    ))
 
     @validates_schema
     def validate_fields(self, data, **kwargs):

--- a/aries_cloudagent/resolver/__init__.py
+++ b/aries_cloudagent/resolver/__init__.py
@@ -22,6 +22,12 @@ async def setup(context: InjectionContext):
     await key_resolver.setup(context)
     registry.register(key_resolver)
 
+    web_resolver = ClassProvider(
+        "aries_cloudagent.resolver.default.web.WebDIDResolver"
+    ).provide(context.settings, context.injector)
+    await web_resolver.setup(context)
+    registry.register(web_resolver)
+
     if not context.settings.get("ledger.disabled"):
         indy_resolver = ClassProvider(
             "aries_cloudagent.resolver.default.indy.IndyDIDResolver"

--- a/aries_cloudagent/resolver/default/tests/test_web.py
+++ b/aries_cloudagent/resolver/default/tests/test_web.py
@@ -1,0 +1,26 @@
+"""Test did:web Resolver."""
+
+import pytest
+from ..web import WebDIDResolver
+
+
+@pytest.fixture
+def resolver():
+    yield WebDIDResolver()
+
+
+@pytest.fixture
+def profile():
+    yield None
+
+
+def test_transformation_domain_only(resolver):
+    did = "did:web:example.com"
+    url = resolver._WebDIDResolver__transform_to_url(did)
+    assert url == "https://example.com/.well-known/did.json"
+
+
+def test_transformation_domain_with_path(resolver):
+    did = "did:web:example.com:department:example"
+    url = resolver._WebDIDResolver__transform_to_url(did)
+    assert url == "https://example.com/department/example/did.json"

--- a/aries_cloudagent/resolver/default/web.py
+++ b/aries_cloudagent/resolver/default/web.py
@@ -1,0 +1,66 @@
+"""Web DID Resolver."""
+
+import json
+from typing import Sequence
+
+import aiohttp
+from ...config.injection_context import InjectionContext
+from ...core.profile import Profile
+from ..base import (
+    BaseDIDResolver,
+    DIDNotFound,
+    ResolverError,
+    ResolverType,
+)
+from pydid import DID
+
+
+class WebDIDResolver(BaseDIDResolver):
+    """Web DID Resolver."""
+
+    def __init__(self):
+        super().__init__(ResolverType.NATIVE)
+
+    async def setup(self, context: InjectionContext):
+        """Setup the did:web resolver."""
+
+    @property
+    def supported_methods(self) -> Sequence[str]:
+        """Return list of supported methods."""
+        return ["web"]
+
+    def __transform_to_url(self, did):
+        """
+        Transform did to url according to
+        https://w3c-ccg.github.io/did-method-web/#read-resolve
+        """
+
+        as_did = DID(did)
+        method_specific_id = as_did.method_specific_id
+        if ":" in method_specific_id:
+            # contains path
+            url = method_specific_id.replace(":", "/")
+        else:
+            # bare domain needs /.well-known path
+            url = method_specific_id + "/.well-known"
+
+        return "https://" + url + "/did.json"
+
+    async def _resolve(self, profile: Profile, did: str) -> dict:
+        """Resolve did:web DIDs."""
+
+        url = self.__transform_to_url(did)
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                if response.status == 200:
+                    try:
+                        return json.loads(await response.text())
+                    except Exception as err:
+                        raise ResolverError(
+                            "Response was incorrectly formatted"
+                        ) from err
+                if response.status == 404:
+                    raise DIDNotFound(f"No document found for {did}")
+                raise ResolverError(
+                    "Could not find doc for {}: {}".format(did, await response.text())
+                )


### PR DESCRIPTION
Work in progress PR to add the did web capabilities to ACA-PY

* Native did:web resolver
* Serve did document under `/.well-known/did.json`
* Create a did document from wallet content (uses public DID and endpoint) + additional keys (e.g.) BBS+ keys can be referenced
* Connection/DID Exchange based on implicit invitation with public did:web

Multitenancy is currently not supported.
Needs cleaning and tests.
I'm not an experienced Python programmer so there might be stupid things I've done. Would be cool if someone could take a look.

Example usage:
Assumption: ACA-Py has configured a public DID, admin interface with HTTPS (e.g. via ngrok) and a BBS+ did:key 
```
POST:  /didweb​/create-from-wallet​/{did}

{
  "verification_methods": [{
"did":"did:key:zUC71v7BaQAEpNCN9wVetcqMWtWPygSuQ2t4MJ1H9654Aio3DypS8wCd253CZ29C1CiLSMmC8MrepFYvKrvdMHBatyEoQa5pffr8HMqvRR98Vb7NtEBkpN9Ld73jyeyAqYxg8Fy", "
verification_relationships": ["assertion_method"]
}]}
```

will produce:
```
{
  "@context": "https://www.w3.org/ns/did/v1",
  "id": "did:web:478eb39f6464.ngrok.io",
  "verificationMethod": [
  {
    "id": "did:web:478eb39f6464.ngrok.io#key-1",
    "type": "Ed25519VerificationKey2018",
    "controller": "did:web:478eb39f6464.ngrok.io",
    "publicKeyBase58": "DAwrZwgMwkTVHUQ8ZYAmuvzwprDmX8vFNXzFioxrWpCA"
  },
  {
     "id": "did:web:478eb39f6464.ngrok.io#key-2",
     "type": "Bls12381G2Key2020",
     "controller": "did:web:478eb39f6464.ngrok.io",
     "publicKeyBase58": 
"n5ZJWiW1TkL9jzpoig99Db9UjQ8hN4L8UuRTfEcFRqSEpNroSGoUDd5XQ2nwUuAhJ9MK5wzqSMzxNzCWC1qs51i5cEBii2ie1i9XXCWG1dyWXKr9jRyETJdmWUEHFzoodef"
}
],
"authentication": [
"did:web:478eb39f6464.ngrok.io#key-1"
],
"assertionMethod": [
"did:web:478eb39f6464.ngrok.io#key-1",
"did:web:478eb39f6464.ngrok.io#key-2"
],
"service": [
{
"id": "did:web:478eb39f6464.ngrok.io#did-communication",
"type": "did-communication",
"serviceEndpoint": "http://host.docker.internal:8000",
"recipientKeys": [
"did:web:478eb39f6464.ngrok.io#key-1"
],
"routingKeys": [],
"priority": 0
}
]
}
```

served under `https:478eb39f6464.ngrok.io/.well-known/did.json`