### PR TITLE
feat: send webhooks for forward messages 

### DIFF
--- a/AdminAPI.md
+++ b/AdminAPI.md
@@ -54,6 +54,19 @@ When a webhook is dispatched, the record `topic` is appended as a path component
  * `content`: the contents of the agent message
  * `state`: `received`
 
+#### Forward Message Received  (`/forward`)
+
+Enable using `--monitor-forward`.
+
+ * `connection_id`: the identifier of the connection associated with the recipient key
+ * `recipient_key`: the recipient key of the forward message (`to` field of the forward message)
+ * `status`: The delivery status of the received forward message. Possible values:
+   * `sent_to_session`: Message is sent directly to the connection over an active transport session
+   * `sent_to_external_queue`: Message is sent to external queue. No information is known on the delivery of the message
+   * `queued_for_delivery`: Message is queued for delivery using outbound transport (recipient connection has an endpoint)
+   * `waiting_for_pickup`: The connection has no reachable endpoint. Need to wait for the recipient to connect with return routing for delivery
+   * `undeliverable`: The connection has no reachable endpoint, and the internal queue for messages is not enabled (`--enable-undelivered-queue`). 
+
 #### Credential Exchange Record Updated (`/issue_credential`)
 
 * `credential_exchange_id`: the unique identifier of the credential exchange

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -454,6 +454,10 @@ class AdminServer(BaseAdminServer):
             event_bus.subscribe(EVENT_PATTERN_WEBHOOK, self._on_webhook_event)
             event_bus.subscribe(EVENT_PATTERN_RECORD, self._on_record_event)
 
+            # Only include forward webhook events if the option is enabled
+            if self.context.settings.get_bool("monitor_forward", False):
+                EVENT_WEBHOOK_MAPPING["acapy::forward::received"] = "forward"
+
             for event_topic, webhook_topic in EVENT_WEBHOOK_MAPPING.items():
                 event_bus.subscribe(
                     re.compile(re.escape(event_topic)),

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -756,6 +756,12 @@ class ProtocolGroup(ArgumentGroup):
             help="Send a webhook when a ping is sent or received.",
         )
         parser.add_argument(
+            "--monitor-forward",
+            action="store_true",
+            env_var="ACAPY_MONITOR_FORWARD",
+            help="Send a webhook when a forward is received.",
+        )
+        parser.add_argument(
             "--public-invites",
             action="store_true",
             env_var="ACAPY_PUBLIC_INVITES",
@@ -851,6 +857,8 @@ class ProtocolGroup(ArgumentGroup):
             settings["invite_base_url"] = args.invite_base_url
         if args.monitor_ping:
             settings["debug.monitor_ping"] = args.monitor_ping
+        if args.monitor_forward:
+            settings["monitor_forward"] = args.monitor_forward
         if args.public_invites:
             settings["public_invites"] = True
         if args.timing:

--- a/aries_cloudagent/messaging/responder.py
+++ b/aries_cloudagent/messaging/responder.py
@@ -138,17 +138,24 @@ class MockResponder(BaseResponder):
         """Initialize the mock responder."""
         self.messages = []
 
-    async def send(self, message: Union[BaseMessage, str, bytes], **kwargs):
+    async def send(
+        self, message: Union[BaseMessage, str, bytes], **kwargs
+    ) -> OutboundSendStatus:
         """Convert a message to an OutboundMessage and send it."""
         self.messages.append((message, kwargs))
+        return OutboundSendStatus.QUEUED_FOR_DELIVERY
 
-    async def send_reply(self, message: Union[BaseMessage, str, bytes], **kwargs):
+    async def send_reply(
+        self, message: Union[BaseMessage, str, bytes], **kwargs
+    ) -> OutboundSendStatus:
         """Send a reply to an incoming message."""
         self.messages.append((message, kwargs))
+        return OutboundSendStatus.QUEUED_FOR_DELIVERY
 
-    async def send_outbound(self, message: OutboundMessage):
+    async def send_outbound(self, message: OutboundMessage) -> OutboundSendStatus:
         """Send an outbound message."""
         self.messages.append((message, None))
+        return OutboundSendStatus.QUEUED_FOR_DELIVERY
 
     async def send_webhook(self, topic: str, payload: dict):
         """Send an outbound message."""

--- a/aries_cloudagent/protocols/routing/v1_0/handlers/forward_handler.py
+++ b/aries_cloudagent/protocols/routing/v1_0/handlers/forward_handler.py
@@ -51,9 +51,20 @@ class ForwardHandler(BaseHandler):
         self._logger.info(
             f"Forwarding message to connection: {recipient.connection_id}"
         )
-        await responder.send(
+
+        send_status = await responder.send(
             packed,
             connection_id=recipient.connection_id,
             target_list=connection_targets,
             reply_to_verkey=connection_verkey,
+        )
+
+        # emit event that a forward message is received (may trigger webhook event)
+        await context.profile.notify(
+            "acapy::forward::received",
+            {
+                "connection_id": recipient.connection_id,
+                "status": send_status.value,
+                "recipient_key": context.message.to,
+            },
         )

--- a/aries_cloudagent/transport/outbound/status.py
+++ b/aries_cloudagent/transport/outbound/status.py
@@ -1,10 +1,23 @@
 """Enum representing captured send status of outbound messages."""
 
-from enum import Enum, auto
+from enum import Enum
 
 
 class OutboundSendStatus(Enum):
     """Send status of outbound messages."""
 
-    SENT_TO_SESSION = auto()
-    QUEUED_FOR_DELIVERY = auto()
+    # Could directly send the message to the connection over active session
+    SENT_TO_SESSION = "sent_to_session"
+
+    # Message is sent to external queue. We don't know how it will process the queue
+    SENT_TO_EXTERNAL_QUEUE = "sent_to_external_queue"
+
+    # Message is queued for delivery using outbound transport (recipient has endpoint)
+    QUEUED_FOR_DELIVERY = "queued_for_delivery"
+
+    # No endpoint available.
+    # Need to wait for the recipient to connect with return routing for delivery
+    WAITING_FOR_PICKUP = "waiting_for_pickup"
+
+    # No endpoint available, and no internal queue for messages.
+    UNDELIVERABLE = "undeliverable"


### PR DESCRIPTION
This adds an option to ACA-Py to send webhook events on received forward messages (`--monitor-forward`, taken from `monitor-ping`).

I extended the `OutboundSendStatus` work from Daniel and added a few more status options. These are then included in the webhook event, so the controller can react to the event. 

If `--monitor-forward` is not enabled, the event is still dispatched in the event bus (just not as webhook), so other parts of the codebase/plugins can hook into this if they want to manage it in ACA-Py instead of the controller