### PR TITLE
Tone down the endorser validation when setting up connection metadata

### DIFF
--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/routes.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/routes.py
@@ -671,23 +671,12 @@ async def set_endorser_info(request: web.BaseRequest):
                 " in connection metadata for this connection record"
             )
         )
-    if "transaction_their_job" not in jobs.keys():
-        raise web.HTTPForbidden(
-            reason=(
-                'Ask the other agent to set up "transaction_my_job" in '
-                '"transaction_jobs" in connection metadata for their connection record'
-            )
-        )
     if jobs["transaction_my_job"] != TransactionJob.TRANSACTION_AUTHOR.name:
         raise web.HTTPForbidden(
             reason=(
                 "Only a TRANSACTION_AUTHOR can add endorser_info "
                 "to metadata of its connection record"
             )
-        )
-    if jobs["transaction_their_job"] != TransactionJob.TRANSACTION_ENDORSER.name:
-        raise web.HTTPForbidden(
-            reason="The Other agent should have job TRANSACTION_ENDORSER"
         )
     value = await record.metadata_get(session, "endorser_info")
     if value:

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/tests/test_routes.py
@@ -1427,25 +1427,6 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPForbidden):
                 await test_module.set_endorser_info(self.request)
 
-    async def test_set_endorser_info_no_transaction_their_job_x(self):
-        self.request.match_info = {"conn_id": "dummy"}
-        self.request.query = {"endorser_did": "did", "endorser_name": "name"}
-
-        with async_mock.patch.object(
-            ConnRecord, "retrieve_by_id", async_mock.CoroutineMock()
-        ) as mock_conn_rec_retrieve:
-            mock_conn_rec_retrieve.return_value = async_mock.MagicMock(
-                metadata_get=async_mock.CoroutineMock(
-                    return_value={
-                        "transaction_my_job": (
-                            test_module.TransactionJob.TRANSACTION_AUTHOR.name
-                        ),
-                    }
-                )
-            )
-            with self.assertRaises(test_module.web.HTTPForbidden):
-                await test_module.set_endorser_info(self.request)
-
     async def test_set_endorser_info_my_wrong_job_x(self):
         self.request.match_info = {"conn_id": "dummy"}
         self.request.query = {"endorser_did": "did", "endorser_name": "name"}
@@ -1459,26 +1440,6 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                             test_module.TransactionJob.TRANSACTION_ENDORSER.name
                         ),
                         "transaction_my_job": "a suffusion of yellow",
-                    }
-                )
-            )
-
-            with self.assertRaises(test_module.web.HTTPForbidden):
-                await test_module.set_endorser_info(self.request)
-
-    async def test_set_endorser_info_their_wrong_job_x(self):
-        self.request.match_info = {"conn_id": "dummy"}
-        self.request.query = {"endorser_did": "did", "endorser_name": "name"}
-        with async_mock.patch.object(
-            ConnRecord, "retrieve_by_id", async_mock.CoroutineMock()
-        ) as mock_conn_rec_retrieve:
-            mock_conn_rec_retrieve.return_value = async_mock.MagicMock(
-                metadata_get=async_mock.CoroutineMock(
-                    return_value={
-                        "transaction_my_job": (
-                            test_module.TransactionJob.TRANSACTION_AUTHOR.name
-                        ),
-                        "transaction_their_job": "a suffusion of yellow",
                     }
                 )
             )


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

@esune 

Removes some of the validation when setting up connection meta-data to remove timing dependencies between the author and endorser setup tasks