### PR TITLE
retain unrecognizable decorators as opaque data

### DIFF
--- a/aries_cloudagent/messaging/decorators/base.py
+++ b/aries_cloudagent/messaging/decorators/base.py
@@ -10,7 +10,6 @@ from ...core.error import BaseError
 
 from ..models.base import BaseModel
 
-
 DECORATOR_PREFIX = "~"
 
 
@@ -92,8 +91,6 @@ class BaseDecoratorSet(OrderedDict):
 
     def __setitem__(self, key, value):
         """Add a decorator."""
-        if not isinstance(value, (bool, int, str, float, dict, OrderedDict, BaseModel)):
-            raise ValueError(f"Unsupported decorator value: {value}")
         self.load_decorator(key, value)
 
     def load_decorator(self, key: str, value, serialized=False):

--- a/aries_cloudagent/messaging/decorators/tests/test_base.py
+++ b/aries_cloudagent/messaging/decorators/tests/test_base.py
@@ -11,6 +11,7 @@ from marshmallow import EXCLUDE, fields
 
 from ....messaging.models.base import BaseModel, BaseModelSchema
 
+from .. import base as test_module
 from ..base import BaseDecoratorSet, DECORATOR_PREFIX
 
 
@@ -67,8 +68,10 @@ class TestBaseDecoratorSet(TestCase):
         deco_set.remove_model("c")
         assert "c" not in deco_set.models
 
-        with pytest.raises(ValueError):
-            deco_set["a"] = None
+        deco_set["a"] = None  #
+        deco_set.load_decorator("a", None)
+        assert "a" not in deco_set
+
         deco_set["a"] = {"score": 23}
         deco_set["a"] = SampleDecorator(23)
         deco_set.load_decorator("a", None)

--- a/aries_cloudagent/messaging/models/base.py
+++ b/aries_cloudagent/messaging/models/base.py
@@ -1,7 +1,8 @@
 """Base classes for Models and Schemas."""
 import logging
-from abc import ABC
 import json
+
+from abc import ABC
 from typing import Union
 
 from marshmallow import Schema, post_dump, pre_load, post_load, ValidationError, EXCLUDE


### PR DESCRIPTION
RFC 11 suggests a looser interpretation than our original.
Address https://github.com/hyperledger/aries-cloudagent-python/issues/1147

Signed-off-by: sklump <srklump@hotmail.com>