### PR TITLE
Holder reject proof req on bad attr value restriction

### DIFF
--- a/aries_cloudagent/indy/sdk/holder.py
+++ b/aries_cloudagent/indy/sdk/holder.py
@@ -421,9 +421,7 @@ class IndySdkHolder(IndyHolder):
                         continue
 
                     named_attrs = (
-                        [spec["name"]]
-                        if "name" in spec
-                        else spec.get("names", [])
+                        [spec["name"]] if "name" in spec else spec.get("names", [])
                     )
                     restricted_attr = m.group(1)
                     if m and m.group(1) not in named_attrs:  # wrong attr: hopeless

--- a/aries_cloudagent/indy/sdk/holder.py
+++ b/aries_cloudagent/indy/sdk/holder.py
@@ -424,15 +424,15 @@ class IndySdkHolder(IndyHolder):
                         [spec["name"]] if "name" in spec else spec.get("names", [])
                     )
                     restricted_attr = m.group(1)
-                    if m and m.group(1) not in named_attrs:  # wrong attr: hopeless
+                    if m and restricted_attr not in named_attrs:  # wrong attr: hopeless
                         LOGGER.error(
                             f"Presentation request {presentation_request['nonce']} "
                             f"requested attribute {reft} names {named_attrs} "
-                            f"but restricts {m.group(1)} value"
+                            f"but restricts {restricted_attr} value"
                         )
                         raise IndyHolderError(
                             f"Requested attribute {reft} names {named_attrs} "
-                            f"but restricts {m.group(1)} value"
+                            f"but restricts {restricted_attr} value"
                         )
 
         with IndyErrorHandler("Error when constructing proof", IndyHolderError):

--- a/aries_cloudagent/indy/sdk/holder.py
+++ b/aries_cloudagent/indy/sdk/holder.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 
 from collections import OrderedDict
 from typing import Sequence, Tuple, Union
@@ -411,6 +412,30 @@ class IndySdkHolder(IndyHolder):
             rev_states: Indy format revocation states JSON
 
         """
+
+        for reft, spec in presentation_request.get("requested_attributes", {}).items():
+            for r in spec.get("restrictions", []):
+                for k in r:
+                    m = re.match("^attr::(.*)::value$", k)
+                    if not m:
+                        continue
+
+                    named_attrs = (
+                        [spec["name"]]
+                        if "name" in spec
+                        else spec.get("names", [])
+                    )
+                    restricted_attr = m.group(1)
+                    if m and m.group(1) not in named_attrs:  # wrong attr: hopeless
+                        LOGGER.error(
+                            f"Presentation request {presentation_request['nonce']} "
+                            f"requested attribute {reft} names {named_attrs} "
+                            f"but restricts {m.group(1)} value"
+                        )
+                        raise IndyHolderError(
+                            f"Requested attribute {reft} names {named_attrs} "
+                            f"but restricts {m.group(1)} value"
+                        )
 
         with IndyErrorHandler("Error when constructing proof", IndyHolderError):
             presentation_json = await indy.anoncreds.prover_create_proof(

--- a/aries_cloudagent/indy/sdk/tests/test_holder.py
+++ b/aries_cloudagent/indy/sdk/tests/test_holder.py
@@ -7,7 +7,7 @@ import indy.anoncreds
 
 from indy.error import IndyError, ErrorCode
 
-from ...holder import IndyHolder
+from ...holder import IndyHolder, IndyHolderError
 
 from .. import holder as test_module
 
@@ -462,9 +462,36 @@ class TestIndySdkHolder(AsyncTestCase):
     @async_mock.patch("indy.anoncreds.prover_create_proof")
     async def test_create_presentation(self, mock_create_proof):
         mock_create_proof.return_value = "{}"
+        PROOF_REQ = {
+            "nonce": "1554990836",
+            "name": "proof_req",
+            "version": "0.0",
+            "requested_attributes": {
+                "20_legalname_uuid": {
+                    "name": "legalName",
+                    "restrictions": [
+                        {
+                            "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag"
+                        }
+                    ]
+                }
+            },
+            "requested_predicates": {
+                "21_jurisdictionid_GE_uuid": {
+                    "name": "jurisdictionId",
+                    "p_type": ">=",
+                    "p_value": 1,
+                    "restrictions": [
+                        {
+                            "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:21:tag"
+                        }
+                    ]
+                }
+            }
+        }
 
         presentation_json = await self.holder.create_presentation(
-            "presentation_request",
+            PROOF_REQ,
             "requested_credentials",
             "schemas",
             "credential_definitions",
@@ -472,7 +499,7 @@ class TestIndySdkHolder(AsyncTestCase):
 
         mock_create_proof.assert_called_once_with(
             self.wallet.handle,
-            json.dumps("presentation_request"),
+            json.dumps(PROOF_REQ),
             json.dumps("requested_credentials"),
             self.wallet.master_secret_id,
             json.dumps("schemas"),
@@ -481,6 +508,75 @@ class TestIndySdkHolder(AsyncTestCase):
         )
 
         assert json.loads(presentation_json) == {}
+
+    async def test_create_presentation_restr_attr_mismatch_x(self):
+        PROOF_REQS = [
+            {
+                "nonce": "1554990836",
+                "name": "proof_req",
+                "version": "0.0",
+                "requested_attributes": {
+                    "20_legalname_uuid": {
+                        "name": "legalName",
+                        "restrictions": [
+                            {
+                                "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+                                "attr::wrong::value": "Waffle Asteroid"
+                            }
+                        ]
+                    }
+                },
+                "requested_predicates": {
+                    "21_jurisdictionid_GE_uuid": {
+                        "name": "jurisdictionId",
+                        "p_type": ">=",
+                        "p_value": 1,
+                        "restrictions": [
+                            {
+                                "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:21:tag"
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "nonce": "1554990836",
+                "name": "proof_req",
+                "version": "0.0",
+                "requested_attributes": {
+                    "20_legalname_uuid": {
+                        "names": ["legalName", "businessLang"],
+                        "restrictions": [
+                            {
+                                "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+                                "attr::wrong::value": "Waffle Asteroid"
+                            }
+                        ]
+                    }
+                },
+                "requested_predicates": {
+                    "21_jurisdictionid_GE_uuid": {
+                        "name": "jurisdictionId",
+                        "p_type": ">=",
+                        "p_value": 1,
+                        "restrictions": [
+                            {
+                                "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:21:tag"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+
+        for proof_req in PROOF_REQS:
+            with self.assertRaises(IndyHolderError):
+                await self.holder.create_presentation(
+                    proof_req,
+                    "requested_credentials",
+                    "schemas",
+                    "credential_definitions",
+                )
 
     async def test_create_revocation_state(self):
         rr_state = {

--- a/aries_cloudagent/indy/sdk/tests/test_holder.py
+++ b/aries_cloudagent/indy/sdk/tests/test_holder.py
@@ -470,10 +470,8 @@ class TestIndySdkHolder(AsyncTestCase):
                 "20_legalname_uuid": {
                     "name": "legalName",
                     "restrictions": [
-                        {
-                            "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag"
-                        }
-                    ]
+                        {"cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag"}
+                    ],
                 }
             },
             "requested_predicates": {
@@ -482,12 +480,10 @@ class TestIndySdkHolder(AsyncTestCase):
                     "p_type": ">=",
                     "p_value": 1,
                     "restrictions": [
-                        {
-                            "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:21:tag"
-                        }
-                    ]
+                        {"cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:21:tag"}
+                    ],
                 }
-            }
+            },
         }
 
         presentation_json = await self.holder.create_presentation(
@@ -521,9 +517,9 @@ class TestIndySdkHolder(AsyncTestCase):
                         "restrictions": [
                             {
                                 "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
-                                "attr::wrong::value": "Waffle Asteroid"
+                                "attr::wrong::value": "Waffle Asteroid",
                             }
-                        ]
+                        ],
                     }
                 },
                 "requested_predicates": {
@@ -532,12 +528,10 @@ class TestIndySdkHolder(AsyncTestCase):
                         "p_type": ">=",
                         "p_value": 1,
                         "restrictions": [
-                            {
-                                "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:21:tag"
-                            }
-                        ]
+                            {"cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:21:tag"}
+                        ],
                     }
-                }
+                },
             },
             {
                 "nonce": "1554990836",
@@ -549,9 +543,9 @@ class TestIndySdkHolder(AsyncTestCase):
                         "restrictions": [
                             {
                                 "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
-                                "attr::wrong::value": "Waffle Asteroid"
+                                "attr::wrong::value": "Waffle Asteroid",
                             }
-                        ]
+                        ],
                     }
                 },
                 "requested_predicates": {
@@ -560,13 +554,11 @@ class TestIndySdkHolder(AsyncTestCase):
                         "p_type": ">=",
                         "p_value": 1,
                         "restrictions": [
-                            {
-                                "cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:21:tag"
-                            }
-                        ]
+                            {"cred_def_id": "WgWxqztrNooG92RXvxSTWv:3:CL:21:tag"}
+                        ],
                     }
-                }
-            }
+                },
+            },
         ]
 
         for proof_req in PROOF_REQS:

--- a/aries_cloudagent/protocols/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/manager.py
@@ -277,6 +277,7 @@ class PresentationManager:
         non_revoc_intervals = indy_proof_req2non_revoc_intervals(presentation_request)
         attr_creds = requested_credentials.get("requested_attributes", {})
         req_attrs = presentation_request.get("requested_attributes", {})
+
         for reft in attr_creds:
             requested_referents[reft] = {"cred_id": attr_creds[reft]["cred_id"]}
             if reft in req_attrs and reft in non_revoc_intervals:


### PR DESCRIPTION
Address https://github.com/hyperledger/aries-cloudagent-python/issues/1163 partially: have holder refuse to send hopeless proof request to indy-sdk.

Ultimately the handlers should send problem reports - that's a bigger job and needs its own PR