### PR TITLE
Make BaseResolver.supports async and prefer regex matching

### DIFF
--- a/aries_cloudagent/resolver/base.py
+++ b/aries_cloudagent/resolver/base.py
@@ -105,11 +105,13 @@ class BaseDIDResolver(ABC):
 
     async def resolve(self, profile: Profile, did: Union[str, DID]) -> DIDDocument:
         """Resolve a DID using this resolver."""
-        py_did = DID(did) if isinstance(did, str) else did
-        did = str(py_did)
+        if isinstance(did, DID):
+            did = str(did)
+        else:
+            DID.validate(did)
         if not await self.supports(profile, did):
             raise DIDMethodNotSupported(
-                f"{self.__class__.__name__} does not support DID method {py_did.method}"
+                f"{self.__class__.__name__} does not support DID method for: {did}"
             )
 
         did_document = await self._resolve(profile, did)

--- a/aries_cloudagent/resolver/base.py
+++ b/aries_cloudagent/resolver/base.py
@@ -107,9 +107,9 @@ class BaseDIDResolver(ABC):
         """Resolve a DID using this resolver."""
         py_did = DID(did) if isinstance(did, str) else did
 
-        if not await self.supports(profile, py_did.method):
+        if not await self.supports(profile, str(py_did)):
             raise DIDMethodNotSupported(
-                f"{self.__class__.__name__} does not support DID method {py_did.method}"
+                f"{self.__class__.__name__} does not support DID method {str(py_did)}"
             )
 
         did_document = await self._resolve(profile, str(py_did))

--- a/aries_cloudagent/resolver/base.py
+++ b/aries_cloudagent/resolver/base.py
@@ -106,13 +106,13 @@ class BaseDIDResolver(ABC):
     async def resolve(self, profile: Profile, did: Union[str, DID]) -> DIDDocument:
         """Resolve a DID using this resolver."""
         py_did = DID(did) if isinstance(did, str) else did
-
-        if not await self.supports(profile, str(py_did)):
+        did = str(py_did)
+        if not await self.supports(profile, did):
             raise DIDMethodNotSupported(
                 f"{self.__class__.__name__} does not support DID method {py_did.method}"
             )
 
-        did_document = await self._resolve(profile, str(py_did))
+        did_document = await self._resolve(profile, did)
         result = DIDDocument.deserialize(
             did_document,
             options={

--- a/aries_cloudagent/resolver/base.py
+++ b/aries_cloudagent/resolver/base.py
@@ -109,7 +109,7 @@ class BaseDIDResolver(ABC):
 
         if not await self.supports(profile, str(py_did)):
             raise DIDMethodNotSupported(
-                f"{self.__class__.__name__} does not support DID method {str(py_did)}"
+                f"{self.__class__.__name__} does not support DID method {py_did.method}"
             )
 
         did_document = await self._resolve(profile, str(py_did))

--- a/aries_cloudagent/resolver/base.py
+++ b/aries_cloudagent/resolver/base.py
@@ -1,8 +1,10 @@
 """Base Class for DID Resolvers."""
 
+import re
+import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Sequence, Union
+from typing import Pattern, Sequence, Union
 
 from pydid import DID, DIDDocument
 from pydid.options import (
@@ -58,19 +60,54 @@ class BaseDIDResolver(ABC):
         return self.type == ResolverType.NATIVE
 
     @property
-    @abstractmethod
     def supported_methods(self) -> Sequence[str]:
-        """Return list of DID methods supported by this resolver."""
+        """Return supported methods.
 
-    def supports(self, method: str) -> bool:
-        """Return if this resolver supports the given method."""
-        return method in self.supported_methods
+        DEPRECATED: Use supported_did_regex instead.
+        """
+        return []
+
+    @property
+    def supported_did_regex(self) -> Pattern:
+        """Supported DID regex for matching this resolver to DIDs it can resolve.
+
+        Override this property with a class var or similar to use regex
+        matching on DIDs to determine if this resolver supports a given DID.
+        """
+        raise NotImplementedError(
+            "supported_did_regex must be overriden by subclasses of BaseResolver "
+            "to use default supports method"
+        )
+
+    async def supports(self, profile: Profile, did: str) -> bool:
+        """Return if this resolver supports the given DID.
+
+        Override this method to determine if this resolver supports a DID based
+        on information other than just a regular expression; i.e. check a value
+        in storage, query a resolver connection record, etc.
+        """
+        try:
+            supported_did_regex = self.supported_did_regex
+        except NotImplementedError as error:
+            if not self.supported_methods:
+                raise error
+            warnings.warn(
+                "BaseResolver.supported_methods is deprecated; "
+                "use supported_did_regex instead",
+                DeprecationWarning,
+            )
+
+            supported_did_regex = re.compile(
+                "^did:(?:{}):.*$".format("|".join(self.supported_methods))
+            )
+
+        return bool(supported_did_regex.match(did))
 
     async def resolve(self, profile: Profile, did: Union[str, DID]) -> DIDDocument:
         """Resolve a DID using this resolver."""
         py_did = DID(did) if isinstance(did, str) else did
 
-        if not self.supports(py_did.method):
+        if not await self.supports(profile, py_did.method):
             raise DIDMethodNotSupported(
                 f"{self.__class__.__name__} does not support DID method {py_did.method}"
             )

--- a/aries_cloudagent/resolver/default/tests/test_indy.py
+++ b/aries_cloudagent/resolver/default/tests/test_indy.py
@@ -44,7 +44,9 @@ def profile(ledger):
 async def test_supported_methods(profile, resolver: IndyDIDResolver):
     """Test the supported_methods."""
     assert resolver.supported_methods == ["sov"]
-    assert await resolver.supports(profile, "did:sov:U292ZXJlaWdudHksIGxveWFsdHksIGFuZCBzb2xpdHVkZS4=")
+    assert await resolver.supports(
+        profile, "did:sov:U292ZXJlaWdudHksIGxveWFsdHksIGFuZCBzb2xpdHVkZS4="
+    )
 
 
 @pytest.mark.asyncio

--- a/aries_cloudagent/resolver/default/tests/test_indy.py
+++ b/aries_cloudagent/resolver/default/tests/test_indy.py
@@ -44,17 +44,17 @@ def profile(ledger):
 async def test_supported_methods(profile, resolver: IndyDIDResolver):
     """Test the supported_methods."""
     assert resolver.supported_methods == ["sov"]
-    assert await resolver.supports(profile, "sov")
+    assert await resolver.supports(profile, "did:sov:U292ZXJlaWdudHksIGxveWFsdHksIGFuZCBzb2xpdHVkZS4=")
 
 
 @pytest.mark.asyncio
-async def test_resolve(resolver: IndyDIDResolver, profile: Profile):
+async def test_resolve(profile: Profile, resolver: IndyDIDResolver):
     """Test resolve method."""
     assert await resolver.resolve(profile, TEST_DID0)
 
 
 @pytest.mark.asyncio
-async def test_resolve_x_no_ledger(resolver: IndyDIDResolver, profile: Profile):
+async def test_resolve_x_no_ledger(profile: Profile, resolver: IndyDIDResolver):
     """Test resolve method with no ledger."""
     profile.context.injector.clear_binding(BaseLedger)
     with pytest.raises(ResolverError):

--- a/aries_cloudagent/resolver/default/tests/test_indy.py
+++ b/aries_cloudagent/resolver/default/tests/test_indy.py
@@ -40,10 +40,11 @@ def profile(ledger):
     yield profile
 
 
-def test_supported_methods(resolver: IndyDIDResolver):
+@pytest.mark.asyncio
+async def test_supported_methods(profile, resolver: IndyDIDResolver):
     """Test the supported_methods."""
     assert resolver.supported_methods == ["sov"]
-    assert resolver.supports("sov")
+    assert await resolver.supports(profile, "sov")
 
 
 @pytest.mark.asyncio

--- a/aries_cloudagent/resolver/default/tests/test_indy.py
+++ b/aries_cloudagent/resolver/default/tests/test_indy.py
@@ -45,7 +45,7 @@ async def test_supported_methods(profile, resolver: IndyDIDResolver):
     """Test the supported_methods."""
     assert resolver.supported_methods == ["sov"]
     assert await resolver.supports(
-        profile, "did:sov:U292ZXJlaWdudHksIGxveWFsdHksIGFuZCBzb2xpdHVkZS4="
+        profile, "did:sov:9KrtwYfHJpNRzErBeA7U6n1CAGxghgs4Xf5kYxbtGQ7541eM"
     )
 
 

--- a/aries_cloudagent/resolver/default/tests/test_key.py
+++ b/aries_cloudagent/resolver/default/tests/test_key.py
@@ -25,10 +25,11 @@ def profile():
     yield profile
 
 
-def test_supported_methods(resolver: KeyDIDResolver):
+@pytest.mark.asyncio
+async def test_supported_methods(profile, resolver: KeyDIDResolver):
     """Test the supported_methods."""
     assert resolver.supported_methods == ["key"]
-    assert resolver.supports("key")
+    assert await resolver.supports(profile, "key")
 
 
 @pytest.mark.asyncio

--- a/aries_cloudagent/resolver/default/tests/test_key.py
+++ b/aries_cloudagent/resolver/default/tests/test_key.py
@@ -29,7 +29,7 @@ def profile():
 async def test_supported_methods(profile, resolver: KeyDIDResolver):
     """Test the supported_methods."""
     assert resolver.supported_methods == ["key"]
-    assert await resolver.supports(profile, "key")
+    assert await resolver.supports(profile, "did:key:UG9saXRlbmVzcyBpcyB0aGUgZmlyc3QgdGhpbmcgcGVvcGxlIGxvc2Ugb25jZSB0aGV5IGdldCB0aGUgcG93ZXIu")
 
 
 @pytest.mark.asyncio

--- a/aries_cloudagent/resolver/default/tests/test_key.py
+++ b/aries_cloudagent/resolver/default/tests/test_key.py
@@ -29,7 +29,10 @@ def profile():
 async def test_supported_methods(profile, resolver: KeyDIDResolver):
     """Test the supported_methods."""
     assert resolver.supported_methods == ["key"]
-    assert await resolver.supports(profile, "did:key:UG9saXRlbmVzcyBpcyB0aGUgZmlyc3QgdGhpbmcgcGVvcGxlIGxvc2Ugb25jZSB0aGV5IGdldCB0aGUgcG93ZXIu")
+    assert await resolver.supports(
+        profile,
+        "did:key:UG9saXRlbmVzcyBpcyB0aGUgZmlyc3QgdGhpbmcgcGVvcGxlIGxvc2Ugb25jZSB0aGV5IGdldCB0aGUgcG93ZXIu",
+    )
 
 
 @pytest.mark.asyncio

--- a/aries_cloudagent/resolver/did_resolver.py
+++ b/aries_cloudagent/resolver/did_resolver.py
@@ -57,7 +57,7 @@ class DIDResolver:
         )
         resolvers = list(chain(native_resolvers, non_native_resolvers))
         if not resolvers:
-            raise DIDMethodNotSupported(f"DID method '{py_did.method}' not supported")
+            raise DIDMethodNotSupported(f"DID method '{str(py_did)}' not supported")
         return resolvers
 
     async def dereference(

--- a/aries_cloudagent/resolver/did_resolver.py
+++ b/aries_cloudagent/resolver/did_resolver.py
@@ -32,7 +32,7 @@ class DIDResolver:
         for resolver in await self._match_did_to_resolver(profile, py_did):
             try:
                 LOGGER.debug("Resolving DID %s with %s", did, resolver)
-                return await resolver.resolve(profile, py_did)
+                return await resolver.resolve(profile, str(py_did))
             except DIDNotFound:
                 LOGGER.debug("DID %s not found by resolver %s", did, resolver)
 
@@ -57,7 +57,7 @@ class DIDResolver:
         )
         resolvers = list(chain(native_resolvers, non_native_resolvers))
         if not resolvers:
-            raise DIDMethodNotSupported(f"DID method '{str(py_did)}' not supported")
+            raise DIDMethodNotSupported(f"DID method '{py_did.method}' not supported")
         return resolvers
 
     async def dereference(

--- a/aries_cloudagent/resolver/did_resolver.py
+++ b/aries_cloudagent/resolver/did_resolver.py
@@ -59,10 +59,8 @@ class DIDResolver:
             lambda resolver: not resolver.native, valid_resolvers
         )
         resolvers = list(chain(native_resolvers, non_native_resolvers))
-        if not await self.supports(profile, did):
-            raise DIDMethodNotSupported(
-                f"{self.__class__.__name__} does not support DID method for: {did}"
-            )
+        if not resolvers:
+            raise DIDMethodNotSupported(f'No resolver supprting DID "{did}" loaded')
         return resolvers
 
     async def dereference(
@@ -71,9 +69,9 @@ class DIDResolver:
         """Dereference a DID URL to its corresponding DID Doc object."""
         # TODO Use cached DID Docs when possible
         try:
-            did_url = DIDUrl.parse(did_url)
-            doc = await self.resolve(profile, did_url.did)
-            return doc.dereference(did_url)
+            parsed = DIDUrl.parse(did_url)
+            doc = await self.resolve(profile, parsed.did)
+            return doc.dereference(parsed)
         except DIDError as err:
             raise ResolverError(
                 "Failed to parse DID URL from {}".format(did_url)

--- a/aries_cloudagent/resolver/did_resolver.py
+++ b/aries_cloudagent/resolver/did_resolver.py
@@ -29,10 +29,11 @@ class DIDResolver:
         """Retrieve did doc from public registry."""
         # TODO Cache results
         py_did = DID(did) if isinstance(did, str) else did
+        did = str(py_did)
         for resolver in await self._match_did_to_resolver(profile, py_did):
             try:
                 LOGGER.debug("Resolving DID %s with %s", did, resolver)
-                return await resolver.resolve(profile, str(py_did))
+                return await resolver.resolve(profile, did)
             except DIDNotFound:
                 LOGGER.debug("DID %s not found by resolver %s", did, resolver)
 
@@ -46,10 +47,11 @@ class DIDResolver:
         Native resolvers are yielded first, in registered order followed by
         non-native resolvers in registered order.
         """
+        did = str(py_did)
         valid_resolvers = [
             resolver
             for resolver in self.did_resolver_registry.resolvers
-            if await resolver.supports(profile, str(py_did))
+            if await resolver.supports(profile, did)
         ]
         native_resolvers = filter(lambda resolver: resolver.native, valid_resolvers)
         non_native_resolvers = filter(

--- a/aries_cloudagent/resolver/did_resolver.py
+++ b/aries_cloudagent/resolver/did_resolver.py
@@ -49,7 +49,7 @@ class DIDResolver:
         valid_resolvers = [
             resolver
             for resolver in self.did_resolver_registry.resolvers
-            if await resolver.supports(profile, py_did.method)
+            if await resolver.supports(profile, str(py_did))
         ]
         native_resolvers = filter(lambda resolver: resolver.native, valid_resolvers)
         non_native_resolvers = filter(

--- a/aries_cloudagent/resolver/did_resolver_registry.py
+++ b/aries_cloudagent/resolver/did_resolver_registry.py
@@ -3,6 +3,8 @@
 import logging
 from typing import Sequence
 
+from .base import BaseDIDResolver
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -16,7 +18,7 @@ class DIDResolverRegistry:
     @property
     def resolvers(
         self,
-    ) -> Sequence[str]:
+    ) -> Sequence[BaseDIDResolver]:
         """Accessor for a list of all did resolvers."""
         return self._resolvers
 

--- a/aries_cloudagent/resolver/tests/test_base.py
+++ b/aries_cloudagent/resolver/tests/test_base.py
@@ -44,9 +44,10 @@ def test_native_on_non_native(non_native_resolver):
     assert non_native_resolver.native is False
 
 
-def test_supports(native_resolver):
-    assert native_resolver.supports("test") is True
-    assert native_resolver.supports("not supported") is False
+@pytest.mark.asyncio
+async def test_supports(profile, native_resolver):
+    assert await native_resolver.supports(profile, "test") is True
+    assert await native_resolver.supports(profile, "not supported") is False
 
 
 @pytest.mark.asyncio

--- a/aries_cloudagent/resolver/tests/test_base.py
+++ b/aries_cloudagent/resolver/tests/test_base.py
@@ -1,7 +1,7 @@
 """Test Base DID Resolver methods."""
 
 import pytest
-
+from asynctest import mock as async_mock
 from pydid import DIDDocument
 
 from ..base import BaseDIDResolver, DIDMethodNotSupported, ResolverType
@@ -36,6 +36,11 @@ def non_native_resolver():
     yield ExampleDIDResolver()
 
 
+@pytest.fixture
+def profile():
+    yield async_mock.MagicMock()
+
+
 def test_native_on_native(native_resolver):
     assert native_resolver.native is True
 
@@ -46,7 +51,7 @@ def test_native_on_non_native(non_native_resolver):
 
 @pytest.mark.asyncio
 async def test_supports(profile, native_resolver):
-    assert await native_resolver.supports(profile, "test") is True
+    assert await native_resolver.supports(profile, "did:test:basdfasdfas") is True
     assert await native_resolver.supports(profile, "not supported") is False
 
 

--- a/aries_cloudagent/resolver/tests/test_did_resolver.py
+++ b/aries_cloudagent/resolver/tests/test_did_resolver.py
@@ -98,10 +98,11 @@ def test_create_resolver(resolver):
     assert len(resolver.did_resolver_registry.resolvers) == len(TEST_DID_METHODS)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("did, method", zip(TEST_DIDS, TEST_DID_METHODS))
-def test_match_did_to_resolver(resolver, did, method):
+async def test_match_did_to_resolver(profile, resolver, did, method):
     base_resolver, *_ = resolver._match_did_to_resolver(DID(did))
-    assert base_resolver.supports(method)
+    assert await base_resolver.supports(profile, method)
 
 
 def test_match_did_to_resolver_x_not_supported(resolver):

--- a/aries_cloudagent/resolver/tests/test_did_resolver.py
+++ b/aries_cloudagent/resolver/tests/test_did_resolver.py
@@ -102,7 +102,7 @@ def test_create_resolver(resolver):
 @pytest.mark.parametrize("did, method", zip(TEST_DIDS, TEST_DID_METHODS))
 async def test_match_did_to_resolver(profile, resolver, did, method):
     base_resolver, *_ = await resolver._match_did_to_resolver(profile, DID(did))
-    assert await base_resolver.supports(profile, method)
+    assert await base_resolver.supports(profile, did)
 
 
 @pytest.mark.asyncio
@@ -184,7 +184,7 @@ async def test_resolve_did_x_not_supported(resolver, profile):
 @pytest.mark.asyncio
 async def test_resolve_did_x_not_found(profile):
     py_did = DID("did:cowsay:EiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A")
-    cowsay_resolver_not_found = MockResolver("cowsay", resolved=DIDNotFound())
+    cowsay_resolver_not_found = MockResolver(["cowsay"], resolved=DIDNotFound())
     registry = DIDResolverRegistry()
     registry.register(cowsay_resolver_not_found)
     resolver = DIDResolver(registry)

--- a/aries_cloudagent/resolver/tests/test_did_resolver.py
+++ b/aries_cloudagent/resolver/tests/test_did_resolver.py
@@ -101,27 +101,32 @@ def test_create_resolver(resolver):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("did, method", zip(TEST_DIDS, TEST_DID_METHODS))
 async def test_match_did_to_resolver(profile, resolver, did, method):
-    base_resolver, *_ = resolver._match_did_to_resolver(DID(did))
+    base_resolver, *_ = await resolver._match_did_to_resolver(profile, DID(did))
     assert await base_resolver.supports(profile, method)
 
 
-def test_match_did_to_resolver_x_not_supported(resolver):
+@pytest.mark.asyncio
+async def test_match_did_to_resolver_x_not_supported(resolver):
     py_did = DID("did:cowsay:EiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A")
     with pytest.raises(DIDMethodNotSupported):
-        resolver._match_did_to_resolver(py_did)
+        await resolver._match_did_to_resolver(profile, py_did)
 
 
-def test_match_did_to_resolver_native_priority():
+@pytest.mark.asyncio
+async def test_match_did_to_resolver_native_priority(profile):
     registry = DIDResolverRegistry()
     native = MockResolver(["sov"], native=True)
     non_native = MockResolver(["sov"], native=False)
     registry.register(non_native)
     registry.register(native)
     resolver = DIDResolver(registry)
-    assert [native, non_native] == resolver._match_did_to_resolver(DID(TEST_DID0))
+    assert [native, non_native] == await resolver._match_did_to_resolver(
+        profile, DID(TEST_DID0)
+    )
 
 
-def test_match_did_to_resolver_registration_order():
+@pytest.mark.asyncio
+async def test_match_did_to_resolver_registration_order(profile):
     registry = DIDResolverRegistry()
     native1 = MockResolver(["sov"], native=True)
     registry.register(native1)
@@ -132,9 +137,12 @@ def test_match_did_to_resolver_registration_order():
     native4 = MockResolver(["sov"], native=True)
     registry.register(native4)
     resolver = DIDResolver(registry)
-    assert [native1, native2, native4, non_native3] == resolver._match_did_to_resolver(
-        DID(TEST_DID0)
-    )
+    assert [
+        native1,
+        native2,
+        native4,
+        non_native3,
+    ] == await resolver._match_did_to_resolver(profile, DID(TEST_DID0))
 
 
 @pytest.mark.asyncio

--- a/aries_cloudagent/resolver/tests/test_did_resolver.py
+++ b/aries_cloudagent/resolver/tests/test_did_resolver.py
@@ -101,15 +101,16 @@ def test_create_resolver(resolver):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("did, method", zip(TEST_DIDS, TEST_DID_METHODS))
 async def test_match_did_to_resolver(profile, resolver, did, method):
-    base_resolver, *_ = await resolver._match_did_to_resolver(profile, DID(did))
+    base_resolver, *_ = await resolver._match_did_to_resolver(profile, did)
     assert await base_resolver.supports(profile, did)
 
 
 @pytest.mark.asyncio
 async def test_match_did_to_resolver_x_not_supported(resolver):
-    py_did = DID("did:cowsay:EiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A")
     with pytest.raises(DIDMethodNotSupported):
-        await resolver._match_did_to_resolver(profile, py_did)
+        await resolver._match_did_to_resolver(
+            profile, "did:cowsay:EiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A"
+        )
 
 
 @pytest.mark.asyncio
@@ -121,7 +122,7 @@ async def test_match_did_to_resolver_native_priority(profile):
     registry.register(native)
     resolver = DIDResolver(registry)
     assert [native, non_native] == await resolver._match_did_to_resolver(
-        profile, DID(TEST_DID0)
+        profile, TEST_DID0
     )
 
 
@@ -142,7 +143,7 @@ async def test_match_did_to_resolver_registration_order(profile):
         native2,
         native4,
         non_native3,
-    ] == await resolver._match_did_to_resolver(profile, DID(TEST_DID0))
+    ] == await resolver._match_did_to_resolver(profile, TEST_DID0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR extends the `BaseResolver.supports` method to be asynchronous and to take a `Profile` to support such use cases as retrieving resolver connections from storage and checking DIDs supported by those resolver connections. Additionally, this PR adds `supported_did_regex` as a value intended to be implemented by subclasses of `BaseResolver` and used in the default `supports` implementation. This changes the previous behavior of matching on the DID method alone to regex matching, granting more flexibility in how resolvers are selected to handle DID resolution.

`supported_methods` remains functional to prevent breaking resolver plugins already in the wild but is marked as deprecated.