### PR TITLE
DIDX create-request [return ConnRecord]

### DIFF
--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -163,7 +163,7 @@ class DIDXManager(BaseConnectionManager):
         my_endpoint: str = None,
         mediation_id: str = None,
         send_request: bool = False,
-    ) -> DIDXRequest:
+    ) -> ConnRecord:
         """
         Create a request against a public DID only (no explicit invitation).
 
@@ -203,7 +203,7 @@ class DIDXManager(BaseConnectionManager):
             if responder:
                 await responder.send(request, connection_id=conn_rec.connection_id)
 
-        return request
+        return conn_rec
 
     async def create_request(
         self,

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -162,10 +162,9 @@ class DIDXManager(BaseConnectionManager):
         my_label: str = None,
         my_endpoint: str = None,
         mediation_id: str = None,
-        send_request: bool = False,
     ) -> ConnRecord:
         """
-        Create a request against a public DID only (no explicit invitation).
+        Create and send a request against a public DID only (no explicit invitation).
 
         Args:
             their_public_did: public DID to which to request a connection
@@ -174,7 +173,7 @@ class DIDXManager(BaseConnectionManager):
             mediation_id: record id for mediation with routing_keys, service endpoint
 
         Returns:
-            DID exchange request
+            The new `ConnRecord` instance
 
         """
 
@@ -198,10 +197,9 @@ class DIDXManager(BaseConnectionManager):
         conn_rec.request_id = request._id
         conn_rec.state = ConnRecord.State.REQUEST.rfc23
         await conn_rec.save(self._session, reason="Created connection request")
-        if send_request:
-            responder = self._session.inject(BaseResponder, required=False)
-            if responder:
-                await responder.send(request, connection_id=conn_rec.connection_id)
+        responder = self._session.inject(BaseResponder, required=False)
+        if responder:
+            await responder.send(request, connection_id=conn_rec.connection_id)
 
         return conn_rec
 

--- a/aries_cloudagent/protocols/didexchange/v1_0/routes.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/routes.py
@@ -53,9 +53,6 @@ class DIDXCreateRequestImplicitQueryStringSchema(OpenAPISchema):
         description="Identifier for active mediation record to be used",
         **UUID4,
     )
-    send_request = fields.Bool(
-        description="Whether to send request for implicit invitations", default=False
-    )
 
 
 class DIDXReceiveRequestImplicitQueryStringSchema(OpenAPISchema):
@@ -160,13 +157,13 @@ async def didx_accept_invitation(request: web.BaseRequest):
 
 @docs(
     tags=["did-exchange"],
-    summary="Create request against public DID's implicit invitation",
+    summary="Create and send a request against public DID's implicit invitation",
 )
 @querystring_schema(DIDXCreateRequestImplicitQueryStringSchema())
 @response_schema(ConnRecordSchema(), 200, description="")
 async def didx_create_request_implicit(request: web.BaseRequest):
     """
-    Request handler for creating a request to an implicit invitation.
+    Request handler for creating and sending a request to an implicit invitation.
 
     Args:
         request: aiohttp request object
@@ -182,7 +179,6 @@ async def didx_create_request_implicit(request: web.BaseRequest):
     my_label = request.query.get("my_label") or None
     my_endpoint = request.query.get("my_endpoint") or None
     mediation_id = request.query.get("mediation_id") or None
-    send_request = request.query.get("send_request")
 
     didx_mgr = DIDXManager(session)
     try:
@@ -191,7 +187,6 @@ async def didx_create_request_implicit(request: web.BaseRequest):
             my_label=my_label,
             my_endpoint=my_endpoint,
             mediation_id=mediation_id,
-            send_request=send_request,
         )
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err

--- a/aries_cloudagent/protocols/didexchange/v1_0/routes.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/routes.py
@@ -163,7 +163,7 @@ async def didx_accept_invitation(request: web.BaseRequest):
     summary="Create request against public DID's implicit invitation",
 )
 @querystring_schema(DIDXCreateRequestImplicitQueryStringSchema())
-@response_schema(DIDXRequestSchema(), 200, description="")
+@response_schema(ConnRecordSchema(), 200, description="")
 async def didx_create_request_implicit(request: web.BaseRequest):
     """
     Request handler for creating a request to an implicit invitation.

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -235,35 +235,6 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
 
             assert conn_rec
 
-    async def test_create_send_request_implicit(self):
-        mediation_record = MediationRecord(
-            role=MediationRecord.ROLE_CLIENT,
-            state=MediationRecord.STATE_GRANTED,
-            connection_id=self.test_mediator_conn_id,
-            routing_keys=self.test_mediator_routing_keys,
-            endpoint=self.test_mediator_endpoint,
-        )
-        await mediation_record.save(self.session)
-
-        with async_mock.patch.object(
-            self.manager, "create_did_document", async_mock.CoroutineMock()
-        ) as mock_create_did_doc, async_mock.patch.object(
-            self.multitenant_mgr, "get_default_mediator"
-        ) as mock_get_default_mediator:
-            mock_get_default_mediator.return_value = mediation_record
-            mock_create_did_doc.return_value = async_mock.MagicMock(
-                serialize=async_mock.MagicMock(return_value={})
-            )
-            conn_rec = await self.manager.create_request_implicit(
-                their_public_did=TestConfig.test_target_did,
-                my_label=None,
-                my_endpoint=None,
-                mediation_id=mediation_record._id,
-                send_request=True,
-            )
-
-            assert conn_rec
-
     async def test_create_request(self):
         mock_conn_rec = async_mock.MagicMock(
             connection_id="dummy",

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -226,14 +226,14 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             mock_create_did_doc.return_value = async_mock.MagicMock(
                 serialize=async_mock.MagicMock(return_value={})
             )
-            didx_req = await self.manager.create_request_implicit(
+            conn_rec = await self.manager.create_request_implicit(
                 their_public_did=TestConfig.test_target_did,
                 my_label=None,
                 my_endpoint=None,
                 mediation_id=mediation_record._id,
             )
 
-            assert didx_req._id
+            assert conn_rec
 
     async def test_create_send_request_implicit(self):
         mediation_record = MediationRecord(
@@ -254,7 +254,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             mock_create_did_doc.return_value = async_mock.MagicMock(
                 serialize=async_mock.MagicMock(return_value={})
             )
-            didx_req = await self.manager.create_request_implicit(
+            conn_rec = await self.manager.create_request_implicit(
                 their_public_did=TestConfig.test_target_did,
                 my_label=None,
                 my_endpoint=None,
@@ -262,7 +262,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
                 send_request=True,
             )
 
-            assert didx_req._id
+            assert conn_rec
 
     async def test_create_request(self):
         mock_conn_rec = async_mock.MagicMock(


### PR DESCRIPTION
Work left from #1174 and #1137.

- /didexchange/create-request now return ConnRecord
- Based upon feedback from @domwoe and  @andrewwhitehead, this will make it more consistent