### PR TITLE
Align with rfcs for error states in issue cred and present proof

### DIFF
--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -1,6 +1,7 @@
 """Classes for BaseStorage-based record management."""
 
 import json
+import logging
 import sys
 import uuid
 
@@ -12,12 +13,20 @@ from marshmallow import fields
 from ...cache.base import BaseCache
 from ...config.settings import BaseSettings
 from ...core.profile import ProfileSession
-from ...storage.base import BaseStorage, StorageDuplicateError, StorageNotFoundError
+from ...storage.base import (
+    BaseStorage,
+    StorageDuplicateError,
+    StorageError,
+    StorageNotFoundError,
+)
 from ...storage.record import StorageRecord
 
-from .base import BaseModel, BaseModelSchema
 from ..util import datetime_to_str, time_now
 from ..valid import INDY_ISO8601_DATETIME
+
+from .base import BaseModel, BaseModelSchema
+
+LOGGER = logging.getLogger(__name__)
 
 
 def match_post_filter(
@@ -26,7 +35,8 @@ def match_post_filter(
     positive: bool = True,
     alt: bool = False,
 ) -> bool:
-    """Determine if a record value matches the post-filter.
+    """
+    Determine if a record value matches the post-filter.
 
     Args:
         record: record to check
@@ -97,7 +107,8 @@ class BaseRecord(BaseModel):
 
     @classmethod
     def from_storage(cls, record_id: str, record: Mapping[str, Any]):
-        """Initialize a record from its stored representation.
+        """
+        Initialize a record from its stored representation.
 
         Args:
             record_id: The unique record identifier
@@ -113,11 +124,13 @@ class BaseRecord(BaseModel):
     @classmethod
     def get_tag_map(cls) -> Mapping[str, str]:
         """Accessor for the set of defined tags."""
+
         return {tag.lstrip("~"): tag for tag in cls.TAG_NAMES or ()}
 
     @property
     def storage_record(self) -> StorageRecord:
         """Accessor for a `StorageRecord` representing this record."""
+
         return StorageRecord(
             self.RECORD_TYPE, json.dumps(self.value), self.tags, self._id
         )
@@ -125,11 +138,13 @@ class BaseRecord(BaseModel):
     @property
     def record_value(self) -> dict:
         """Accessor to define custom properties for the JSON record value."""
+
         return {}
 
     @property
     def value(self) -> dict:
         """Accessor for the JSON record value generated for this record."""
+
         ret = self.strip_tag_prefix(self.tags)
         ret.update({"created_at": self.created_at, "updated_at": self.updated_at})
         ret.update(self.record_value)
@@ -138,6 +153,7 @@ class BaseRecord(BaseModel):
     @property
     def record_tags(self) -> dict:
         """Accessor to define implementation-specific tags."""
+
         return {
             tag: getattr(self, prop)
             for (prop, tag) in self.get_tag_map().items()
@@ -147,12 +163,14 @@ class BaseRecord(BaseModel):
     @property
     def tags(self) -> dict:
         """Accessor for the record tags generated for this record."""
+
         tags = self.record_tags
         return tags
 
     @classmethod
     async def get_cached_key(cls, session: ProfileSession, cache_key: str):
-        """Shortcut method to fetch a cached key value.
+        """
+        Shortcut method to fetch a cached key value.
 
         Args:
             session: The profile session to use
@@ -168,7 +186,8 @@ class BaseRecord(BaseModel):
     async def set_cached_key(
         cls, session: ProfileSession, cache_key: str, value: Any, ttl=None
     ):
-        """Shortcut method to set a cached key value.
+        """
+        Shortcut method to set a cached key value.
 
         Args:
             session: The profile session to use
@@ -176,6 +195,7 @@ class BaseRecord(BaseModel):
             value: The value to cache
             ttl: The cache ttl
         """
+
         if not cache_key:
             return
         cache = session.inject(BaseCache, required=False)
@@ -184,12 +204,14 @@ class BaseRecord(BaseModel):
 
     @classmethod
     async def clear_cached_key(cls, session: ProfileSession, cache_key: str):
-        """Shortcut method to clear a cached key value, if any.
+        """
+        Shortcut method to clear a cached key value, if any.
 
         Args:
             session: The profile session to use
             cache_key: The unique cache identifier
         """
+
         if not cache_key:
             return
         cache = session.inject(BaseCache, required=False)
@@ -200,12 +222,14 @@ class BaseRecord(BaseModel):
     async def retrieve_by_id(
         cls, session: ProfileSession, record_id: str
     ) -> "BaseRecord":
-        """Retrieve a stored record by ID.
+        """
+        Retrieve a stored record by ID.
 
         Args:
             session: The profile session to use
             record_id: The ID of the record to find
         """
+
         storage = session.inject(BaseStorage)
         result = await storage.get_record(
             cls.RECORD_TYPE, record_id, {"retrieveTags": False}
@@ -217,7 +241,8 @@ class BaseRecord(BaseModel):
     async def retrieve_by_tag_filter(
         cls, session: ProfileSession, tag_filter: dict, post_filter: dict = None
     ) -> "BaseRecord":
-        """Retrieve a record by tag filter.
+        """
+        Retrieve a record by tag filter.
 
         Args:
             session: The profile session to use
@@ -225,6 +250,7 @@ class BaseRecord(BaseModel):
             post_filter: Additional value filters to apply matching positively,
                 with sequence values specifying alternatives to match (hit any)
         """
+
         storage = session.inject(BaseStorage)
         rows = await storage.find_all_records(
             cls.RECORD_TYPE,
@@ -262,7 +288,8 @@ class BaseRecord(BaseModel):
         post_filter_negative: dict = None,
         alt: bool = False,
     ) -> Sequence["BaseRecord"]:
-        """Query stored records.
+        """
+        Query stored records.
 
         Args:
             session: The profile session to use
@@ -272,6 +299,7 @@ class BaseRecord(BaseModel):
             alt: set to match any (positive=True) value or miss all (positive=False)
                 values in post_filter
         """
+
         storage = session.inject(BaseStorage)
         rows = await storage.find_all_records(
             cls.RECORD_TYPE,
@@ -304,14 +332,17 @@ class BaseRecord(BaseModel):
         log_override: bool = False,
         event: bool = None,
     ) -> str:
-        """Persist the record to storage.
+        """
+        Persist the record to storage.
 
         Args:
             session: The profile session to use
             reason: A reason to add to the log
             log_params: Additional parameters to log
+            override: Override configured logging regimen, print to stderr instead
             event: Flag to override whether the event is sent
         """
+
         new_record = None
         log_reason = reason or ("Updated record" if self._id else "Created record")
         try:
@@ -348,7 +379,8 @@ class BaseRecord(BaseModel):
         last_state: Optional[str],
         event: bool = None,
     ):
-        """Perform post-save actions.
+        """
+        Perform post-save actions.
 
         Args:
             session: The profile session to use
@@ -356,24 +388,28 @@ class BaseRecord(BaseModel):
             last_state: The previous state value
             event: Flag to override whether the event is sent
         """
+
         if event is None:
             event = new_record or (last_state != self.state)
         if event:
             await self.emit_event(session, self.serialize())
 
     async def delete_record(self, session: ProfileSession):
-        """Remove the stored record.
+        """
+        Remove the stored record.
 
         Args:
             session: The profile session to use
         """
+
         if self._id:
             storage = session.inject(BaseStorage)
             await storage.delete_record(self.storage_record)
         # FIXME - update state and send webhook?
 
     async def emit_event(self, session: ProfileSession, payload: Any = None):
-        """Emit an event.
+        """
+        Emit an event.
 
         Args:
             session: The profile session to use
@@ -393,6 +429,35 @@ class BaseRecord(BaseModel):
 
         await session.profile.notify(topic, payload)
 
+    async def save_error_state(
+        self,
+        session: ProfileSession,
+        state: str = None,
+        *,
+        reason: str = None,
+        log_params: Mapping[str, Any] = None,
+        log_override: bool = False,
+    ):
+        """
+        Save record state null if need be; log and swallow any storage error.
+
+        Args:
+            session: The profile session to use
+            state: The state to save if need be
+            reason: A reason to add to the log
+            log_params: Additional parameters to log
+            override: Override configured logging regimen, print to stderr instead
+        """
+
+        self.state = state
+        if self._last_state is state:  # already done
+            return
+
+        try:
+            await self.save(session, reason, log_params, log_override)
+        except StorageError as err:
+            LOGGER.exception(err)
+
     @classmethod
     def log_state(
         cls,
@@ -402,6 +467,7 @@ class BaseRecord(BaseModel):
         override: bool = False,
     ):
         """Print a message with increased visibility (for testing)."""
+
         if override or (
             cls.LOG_STATE_FLAG and settings and settings.get(cls.LOG_STATE_FLAG)
         ):
@@ -414,6 +480,7 @@ class BaseRecord(BaseModel):
     @classmethod
     def strip_tag_prefix(cls, tags: dict):
         """Strip tilde from unencrypted tag names."""
+
         return (
             {(k[1:] if "~" in k else k): v for (k, v) in tags.items()} if tags else {}
         )
@@ -421,6 +488,7 @@ class BaseRecord(BaseModel):
     @classmethod
     def prefix_tag_filter(cls, tag_filter: dict):
         """Prefix unencrypted tags used in the tag filter."""
+
         ret = None
         if tag_filter:
             tag_map = cls.get_tag_map()
@@ -436,6 +504,7 @@ class BaseRecord(BaseModel):
 
     def __eq__(self, other: Any) -> bool:
         """Comparison between records."""
+
         if type(other) is type(self):
             return self.value == other.value and self.tags == other.tags
         return False
@@ -453,11 +522,13 @@ class BaseExchangeRecord(BaseRecord):
         **kwargs,
     ):
         """Initialize a new BaseExchangeRecord."""
+
         super().__init__(id, state, **kwargs)
         self.trace = trace
 
     def __eq__(self, other: Any) -> bool:
         """Comparison between records."""
+
         if type(other) is type(self):
             return (
                 self.value == other.value

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -439,11 +439,11 @@ class BaseRecord(BaseModel):
         log_override: bool = False,
     ):
         """
-        Save record state null if need be; log and swallow any storage error.
+        Save record error state if need be; log and swallow any storage error.
 
         Args:
             session: The profile session to use
-            state: The state to save if need be
+            state: The state to save if need be (typically None but by protocol)
             reason: A reason to add to the log
             log_params: Additional parameters to log
             override: Override configured logging regimen, print to stderr instead

--- a/aries_cloudagent/messaging/models/tests/test_base_record.py
+++ b/aries_cloudagent/messaging/models/tests/test_base_record.py
@@ -6,11 +6,16 @@ from marshmallow import EXCLUDE, fields
 from ....cache.base import BaseCache
 from ....core.event_bus import EventBus, MockEventBus, Event
 from ....core.in_memory import InMemoryProfile
-from ....storage.base import BaseStorage, StorageDuplicateError, StorageRecord
+from ....storage.base import (
+    BaseStorage,
+    StorageDuplicateError,
+    StorageError,
+    StorageRecord,
+)
 
 from ...util import time_now
 
-from ..base_record import BaseRecord, BaseRecordSchema
+from ..base_record import BaseRecord, BaseRecordSchema, LOGGER
 
 
 class BaseRecordImpl(BaseRecord):
@@ -288,6 +293,24 @@ class TestBaseRecord(AsyncTestCase):
         assert mock_event_bus.events == [
             (session.profile, Event("acapy::record::topic::test_state", payload))
         ]
+
+    async def test_save_error_state(self):
+        session = InMemoryProfile.test_session()
+        record = ARecordImpl(a="1", b="0", code="one")
+        assert record._last_state is None
+        await record.save_error_state(session)
+
+        record.state = "a-record-state"
+        await record.save(session)
+
+        with async_mock.patch.object(
+            record, "save", async_mock.CoroutineMock()
+        ) as mock_save, async_mock.patch.object(
+            LOGGER, "exception", async_mock.MagicMock()
+        ) as mock_log_exc:
+            mock_save.side_effect = StorageError()
+            await record.save_error_state(session)
+            mock_log_exc.assert_called_once()
 
     async def test_tag_prefix(self):
         tags = {"~x": "a", "y": "b"}

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_ack_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_ack_handler.py
@@ -3,11 +3,10 @@
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
+from .....utils.tracing import trace_event, get_timer
 
 from ..manager import CredentialManager
 from ..messages.credential_ack import CredentialAck
-
-from .....utils.tracing import trace_event, get_timer
 
 
 class CredentialAckHandler(BaseHandler):

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_issue_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_issue_handler.py
@@ -56,10 +56,9 @@ class CredentialIssueHandler(BaseHandler):
                 # protocol finished OK: do not set cred ex record state null
                 self._logger.exception(err)
 
-            credential_ack_message = await credential_manager.create_credential_ack(
+            credential_ack_message = await credential_manager.send_credential_ack(
                 cred_ex_record
             )
-            await responder.send_reply(credential_ack_message)
 
             trace_event(
                 context.settings,

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_issue_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_issue_handler.py
@@ -1,13 +1,14 @@
 """Credential issue message handler."""
 
+from .....indy.holder import IndyHolderError
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
-
-from ..manager import CredentialManager
-from ..messages.credential_issue import CredentialIssue
-
+from .....storage.error import StorageError
 from .....utils.tracing import trace_event, get_timer
+
+from ..manager import CredentialManager, CredentialManagerError
+from ..messages.credential_issue import CredentialIssue
 
 
 class CredentialIssueHandler(BaseHandler):
@@ -36,7 +37,7 @@ class CredentialIssueHandler(BaseHandler):
         credential_manager = CredentialManager(context.profile)
         cred_ex_record = await credential_manager.receive_credential(
             context.message, context.connection_record.connection_id
-        )
+        )  # mgr only finds, saves record: on exception, saving state null is hopeless
 
         r_time = trace_event(
             context.settings,
@@ -47,12 +48,17 @@ class CredentialIssueHandler(BaseHandler):
 
         # Automatically move to next state if flag is set
         if context.settings.get("debug.auto_store_credential"):
-            (
-                cred_ex_record,
-                credential_ack_message,
-            ) = await credential_manager.store_credential(cred_ex_record)
+            try:
+                cred_ex_record = await credential_manager.store_credential(
+                    cred_ex_record
+                )
+            except (CredentialManagerError, IndyHolderError, StorageError) as err:
+                # protocol finished OK: do not set cred ex record state null
+                self._logger.exception(err)
 
-            # Ack issuer that holder stored credential
+            credential_ack_message = await credential_manager.create_credential_ack(
+                cred_ex_record
+            )
             await responder.send_reply(credential_ack_message)
 
             trace_event(

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_offer_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_offer_handler.py
@@ -1,13 +1,15 @@
 """Credential offer message handler."""
 
+from .....indy.holder import IndyHolderError
+from .....ledger.error import LedgerError
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
-
-from ..manager import CredentialManager
-from ..messages.credential_offer import CredentialOffer
-
+from .....storage.error import StorageError
 from .....utils.tracing import trace_event, get_timer
+
+from ..manager import CredentialManager, CredentialManagerError
+from ..messages.credential_offer import CredentialOffer
 
 
 class CredentialOfferHandler(BaseHandler):
@@ -37,7 +39,7 @@ class CredentialOfferHandler(BaseHandler):
         credential_manager = CredentialManager(context.profile)
         cred_ex_record = await credential_manager.receive_offer(
             context.message, context.connection_record.connection_id
-        )
+        )  # mgr only finds, saves record: on exception, saving state null is hopeless
 
         r_time = trace_event(
             context.settings,
@@ -48,11 +50,29 @@ class CredentialOfferHandler(BaseHandler):
 
         # If auto respond is turned on, automatically reply with credential request
         if context.settings.get("debug.auto_respond_credential_offer"):
-            (_, credential_request_message) = await credential_manager.create_request(
-                cred_ex_record=cred_ex_record,
-                holder_did=context.connection_record.my_did,
-            )
-            await responder.send_reply(credential_request_message)
+            credential_request_message = None
+            try:
+                (
+                    _,
+                    credential_request_message,
+                ) = await credential_manager.create_request(
+                    cred_ex_record=cred_ex_record,
+                    holder_did=context.connection_record.my_did,
+                )
+                await responder.send_reply(credential_request_message)
+            except (
+                CredentialManagerError,
+                IndyHolderError,
+                LedgerError,
+            ) as err:
+                self._logger.exception(err)
+                if cred_ex_record:
+                    await cred_ex_record.save_error_state(
+                        context.session(),
+                        reason=err.message,
+                    )
+            except StorageError as err:
+                self._logger.exception(err)  # may be logging to wire, not dead disk
 
             trace_event(
                 context.settings,

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_offer_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_offer_handler.py
@@ -60,11 +60,7 @@ class CredentialOfferHandler(BaseHandler):
                     holder_did=context.connection_record.my_did,
                 )
                 await responder.send_reply(credential_request_message)
-            except (
-                CredentialManagerError,
-                IndyHolderError,
-                LedgerError,
-            ) as err:
+            except (CredentialManagerError, IndyHolderError, LedgerError) as err:
                 self._logger.exception(err)
                 if cred_ex_record:
                     await cred_ex_record.save_error_state(

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_proposal_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_proposal_handler.py
@@ -1,13 +1,15 @@
 """Credential proposal message handler."""
 
+from .....indy.issuer import IndyIssuerError
+from .....ledger.error import LedgerError
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
-
-from ..manager import CredentialManager
-from ..messages.credential_proposal import CredentialProposal
-
+from .....storage.error import StorageError
 from .....utils.tracing import trace_event, get_timer
+
+from ..manager import CredentialManager, CredentialManagerError
+from ..messages.credential_proposal import CredentialProposal
 
 
 class CredentialProposalHandler(BaseHandler):
@@ -37,7 +39,7 @@ class CredentialProposalHandler(BaseHandler):
         credential_manager = CredentialManager(context.profile)
         cred_ex_record = await credential_manager.receive_proposal(
             context.message, context.connection_record.connection_id
-        )
+        )  # mgr only finds, saves record: on exception, saving state null is hopeless
 
         r_time = trace_event(
             context.settings,
@@ -48,16 +50,30 @@ class CredentialProposalHandler(BaseHandler):
 
         # If auto_offer is enabled, respond immediately with offer
         if cred_ex_record.auto_offer:
-            (
-                cred_ex_record,
-                credential_offer_message,
-            ) = await credential_manager.create_offer(
-                cred_ex_record,
-                counter_proposal=None,
-                comment=context.message.comment,
-            )
-
-            await responder.send_reply(credential_offer_message)
+            credential_offer_message = None
+            try:
+                (
+                    cred_ex_record,
+                    credential_offer_message,
+                ) = await credential_manager.create_offer(
+                    cred_ex_record,
+                    counter_proposal=None,
+                    comment=context.message.comment,
+                )
+                await responder.send_reply(credential_offer_message)
+            except (
+                CredentialManagerError,
+                IndyIssuerError,
+                LedgerError,
+            ) as err:
+                self._logger.exception(err)
+                if cred_ex_record:
+                    await cred_ex_record.save_error_state(
+                        context.session(),
+                        reason=err.message,
+                    )
+            except StorageError as err:
+                self._logger.exception(err)  # may be logging to wire, not dead disk
 
             trace_event(
                 context.settings,

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_proposal_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_proposal_handler.py
@@ -61,11 +61,7 @@ class CredentialProposalHandler(BaseHandler):
                     comment=context.message.comment,
                 )
                 await responder.send_reply(credential_offer_message)
-            except (
-                CredentialManagerError,
-                IndyIssuerError,
-                LedgerError,
-            ) as err:
+            except (CredentialManagerError, IndyIssuerError, LedgerError) as err:
                 self._logger.exception(err)
                 if cred_ex_record:
                     await cred_ex_record.save_error_state(

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_request_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_request_handler.py
@@ -1,13 +1,15 @@
 """Credential request message handler."""
 
+from .....indy.issuer import IndyIssuerError
+from .....ledger.error import LedgerError
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
-
-from ..manager import CredentialManager
-from ..messages.credential_request import CredentialRequest
-
+from .....storage.error import StorageError
 from .....utils.tracing import trace_event, get_timer
+
+from ..manager import CredentialManager, CredentialManagerError
+from ..messages.credential_request import CredentialRequest
 
 
 class CredentialRequestHandler(BaseHandler):
@@ -37,7 +39,7 @@ class CredentialRequestHandler(BaseHandler):
         credential_manager = CredentialManager(context.profile)
         cred_ex_record = await credential_manager.receive_request(
             context.message, context.connection_record.connection_id
-        )
+        )  # mgr only finds, saves record: on exception, saving state null is hopeless
 
         r_time = trace_event(
             context.settings,
@@ -52,14 +54,29 @@ class CredentialRequestHandler(BaseHandler):
                 cred_ex_record.credential_proposal_dict
                 and "credential_proposal" in cred_ex_record.credential_proposal_dict
             ):
-                (
-                    cred_ex_record,
-                    credential_issue_message,
-                ) = await credential_manager.issue_credential(
-                    cred_ex_record=cred_ex_record, comment=context.message.comment
-                )
-
-                await responder.send_reply(credential_issue_message)
+                credential_issue_message = None
+                try:
+                    (
+                        cred_ex_record,
+                        credential_issue_message,
+                    ) = await credential_manager.issue_credential(
+                        cred_ex_record=cred_ex_record,
+                        comment=context.message.comment,
+                    )
+                    await responder.send_reply(credential_issue_message)
+                except (
+                    CredentialManagerError,
+                    IndyIssuerError,
+                    LedgerError,
+                ) as err:
+                    self._logger.exception(err)
+                    if cred_ex_record:
+                        await cred_ex_record.save_error_state(
+                            context.session(),
+                            reason=err.message,
+                        )
+                except StorageError as err:
+                    self._logger.exception(err)  # may be logging to wire, not dead disk
 
                 trace_event(
                     context.settings,

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_request_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_request_handler.py
@@ -64,11 +64,7 @@ class CredentialRequestHandler(BaseHandler):
                         comment=context.message.comment,
                     )
                     await responder.send_reply(credential_issue_message)
-                except (
-                    CredentialManagerError,
-                    IndyIssuerError,
-                    LedgerError,
-                ) as err:
+                except (CredentialManagerError, IndyIssuerError, LedgerError) as err:
                     self._logger.exception(err)
                     if cred_ex_record:
                         await cred_ex_record.save_error_state(

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_issue_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_issue_handler.py
@@ -41,9 +41,12 @@ class TestCredentialIssueHandler(AsyncTestCase):
         with async_mock.patch.object(
             test_module, "CredentialManager", autospec=True
         ) as mock_cred_mgr:
-            mock_cred_mgr.return_value.receive_credential = async_mock.CoroutineMock()
-            mock_cred_mgr.return_value.store_credential = async_mock.CoroutineMock(
-                return_value=(None, "credential_ack_message")
+            mock_cred_mgr.return_value = async_mock.MagicMock(
+                receive_credential=async_mock.CoroutineMock(),
+                store_credential=async_mock.CoroutineMock(),
+                create_credential_ack=async_mock.CoroutineMock(
+                    return_value="credential_ack_message"
+                ),
             )
             request_context.message = CredentialIssue()
             request_context.connection_ready = True
@@ -60,6 +63,42 @@ class TestCredentialIssueHandler(AsyncTestCase):
         (result, target) = messages[0]
         assert result == "credential_ack_message"
         assert target == {}
+
+    async def test_called_auto_store_x(self):
+        request_context = RequestContext.test_context()
+        request_context.message_receipt = MessageReceipt()
+        request_context.settings["debug.auto_store_credential"] = True
+        request_context.connection_record = async_mock.MagicMock()
+
+        with async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_cred_mgr:
+            mock_cred_mgr.return_value = async_mock.MagicMock(
+                receive_credential=async_mock.CoroutineMock(
+                    return_value=async_mock.MagicMock(
+                        save_error_state=async_mock.CoroutineMock()
+                    )
+                ),
+                store_credential=async_mock.CoroutineMock(
+                    side_effect=[
+                        test_module.IndyHolderError(),
+                        test_module.StorageError(),
+                    ]
+                ),
+                create_credential_ack=async_mock.CoroutineMock(),
+            )
+
+            request_context.message = CredentialIssue()
+            request_context.connection_ready = True
+            handler = test_module.CredentialIssueHandler()
+            responder = MockResponder()
+
+            with async_mock.patch.object(
+                responder, "send_reply", async_mock.CoroutineMock()
+            ) as mock_send_reply:
+                await handler.handle(request_context, responder)  # holder error
+                await handler.handle(request_context, responder)  # storage error
+                assert mock_send_reply.call_count == 2
 
     async def test_called_not_ready(self):
         request_context = RequestContext.test_context()

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_offer_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_offer_handler.py
@@ -62,6 +62,40 @@ class TestCredentialOfferHandler(AsyncTestCase):
         assert result == "credential_request_message"
         assert target == {}
 
+    async def test_called_auto_request_x(self):
+        request_context = RequestContext.test_context()
+        request_context.message_receipt = MessageReceipt()
+        request_context.settings["debug.auto_respond_credential_offer"] = True
+        request_context.connection_record = async_mock.MagicMock()
+        request_context.connection_record.my_did = "dummy"
+
+        with async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_cred_mgr:
+            mock_cred_mgr.return_value.receive_offer = async_mock.CoroutineMock(
+                return_value=async_mock.MagicMock(
+                    save_error_state=async_mock.CoroutineMock()
+                )
+            )
+            mock_cred_mgr.return_value.create_request = async_mock.CoroutineMock(
+                side_effect=[
+                    test_module.IndyHolderError(),
+                    test_module.StorageError(),
+                ]
+            )
+
+            request_context.message = CredentialOffer()
+            request_context.connection_ready = True
+            handler = test_module.CredentialOfferHandler()
+            responder = MockResponder()
+
+            with async_mock.patch.object(
+                responder, "send_reply", async_mock.CoroutineMock()
+            ) as mock_send_reply:
+                await handler.handle(request_context, responder)  # holder error
+                await handler.handle(request_context, responder)  # storage error
+                mock_send_reply.assert_not_called()
+
     async def test_called_not_ready(self):
         request_context = RequestContext.test_context()
         request_context.message_receipt = MessageReceipt()

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_proposal_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_proposal_handler.py
@@ -65,6 +65,39 @@ class TestCredentialProposalHandler(AsyncTestCase):
         assert result == "credential_offer_message"
         assert target == {}
 
+    async def test_called_auto_offer_x(self):
+        request_context = RequestContext.test_context()
+        request_context.message_receipt = MessageReceipt()
+        request_context.connection_record = async_mock.MagicMock()
+
+        with async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_cred_mgr:
+            mock_cred_mgr.return_value.receive_proposal = async_mock.CoroutineMock(
+                return_value=async_mock.MagicMock(
+                    save_error_state=async_mock.CoroutineMock()
+                )
+            )
+            mock_cred_mgr.return_value.receive_proposal.return_value.auto_offer = True
+            mock_cred_mgr.return_value.create_offer = async_mock.CoroutineMock(
+                side_effect=[
+                    test_module.IndyIssuerError(),
+                    test_module.StorageError(),
+                ]
+            )
+
+            request_context.message = CredentialProposal()
+            request_context.connection_ready = True
+            handler = test_module.CredentialProposalHandler()
+            responder = MockResponder()
+
+            with async_mock.patch.object(
+                responder, "send_reply", async_mock.CoroutineMock()
+            ) as mock_send_reply:
+                await handler.handle(request_context, responder)  # holder error
+                await handler.handle(request_context, responder)  # storage error
+                mock_send_reply.assert_not_called()
+
     async def test_called_not_ready(self):
         request_context = RequestContext.test_context()
         request_context.message_receipt = MessageReceipt()

--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_request_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/tests/test_credential_request_handler.py
@@ -82,6 +82,49 @@ class TestCredentialRequestHandler(AsyncTestCase):
         assert result == "credential_issue_message"
         assert target == {}
 
+    async def test_called_auto_issue_x(self):
+        request_context = RequestContext.test_context()
+        request_context.message_receipt = MessageReceipt()
+        request_context.connection_record = async_mock.MagicMock()
+
+        ATTR_DICT = {"test": "123", "hello": "world"}
+        cred_ex_rec = V10CredentialExchange(
+            credential_proposal_dict={
+                "credential_proposal": CredentialPreview(
+                    attributes=(CredAttrSpec.list_plain(ATTR_DICT))
+                ).serialize(),
+                "cred_def_id": CD_ID,
+            },
+        )
+
+        with async_mock.patch.object(
+            test_module, "CredentialManager", autospec=True
+        ) as mock_cred_mgr, async_mock.patch.object(
+            cred_ex_rec, "save_error_state", async_mock.CoroutineMock()
+        ):
+            mock_cred_mgr.return_value.receive_request = async_mock.CoroutineMock(
+                return_value=cred_ex_rec
+            )
+            mock_cred_mgr.return_value.receive_request.return_value.auto_issue = True
+            mock_cred_mgr.return_value.issue_credential = async_mock.CoroutineMock(
+                side_effect=[
+                    test_module.IndyIssuerError(),
+                    test_module.StorageError(),
+                ]
+            )
+
+            request_context.message = CredentialRequest()
+            request_context.connection_ready = True
+            handler = test_module.CredentialRequestHandler()
+            responder = MockResponder()
+
+            with async_mock.patch.object(
+                responder, "send_reply", async_mock.CoroutineMock()
+            ) as mock_send_reply:
+                await handler.handle(request_context, responder)  # holder error
+                await handler.handle(request_context, responder)  # storage error
+                mock_send_reply.assert_not_called()
+
     async def test_called_auto_issue_no_preview(self):
         request_context = RequestContext.test_context()
         request_context.message_receipt = MessageReceipt()

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -802,9 +802,9 @@ class CredentialManager:
                 # FIXME - re-fetch record to check state, apply transactional update
                 await cred_ex_record.save(session, reason="ack credential")
 
-            if cred_ex_record.auto_remove:
-                async with self._profile.session() as session:
+                if cred_ex_record.auto_remove:
                     await cred_ex_record.delete_record(session)  # all done: delete
+
         except StorageError as err:
             LOGGER.exception(err)  # holder still owes an ack: carry on
 

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -20,7 +20,7 @@ from ....revocation.indy import IndyRevocation
 from ....revocation.models.revocation_registry import RevocationRegistry
 from ....revocation.models.issuer_rev_reg_record import IssuerRevRegRecord
 from ....storage.base import BaseStorage
-from ....storage.error import StorageNotFoundError
+from ....storage.error import StorageError, StorageNotFoundError
 
 from .messages.credential_ack import CredentialAck
 from .messages.credential_issue import CredentialIssue
@@ -712,7 +712,7 @@ class CredentialManager:
             credential_id: optional credential identifier to override default on storage
 
         Returns:
-            Tuple: (Updated credential exchange record, credential ack message)
+            Updated credential exchange record
 
         """
         if cred_ex_record.state != (V10CredentialExchange.STATE_CREDENTIAL_RECEIVED):
@@ -767,7 +767,6 @@ class CredentialManager:
         credential_json = await holder.get_credential(credential_id)
         credential = json.loads(credential_json)
 
-        cred_ex_record.state = V10CredentialExchange.STATE_ACKED
         cred_ex_record.credential_id = credential_id
         cred_ex_record.credential = credential
         cred_ex_record.revoc_reg_id = credential.get("rev_reg_id", None)
@@ -777,6 +776,18 @@ class CredentialManager:
             # FIXME - re-fetch record to check state, apply transactional update
             await cred_ex_record.save(session, reason="store credential")
 
+        return cred_ex_record
+
+    async def create_credential_ack(
+        self,
+        cred_ex_record: V10CredentialExchange,
+    ):
+        """
+        Create and return ack message for input credential exchange record.
+
+        Delete credential exchange record if set to auto-remove.
+        """
+
         credential_ack_message = CredentialAck()
         credential_ack_message.assign_thread_id(
             cred_ex_record.thread_id, cred_ex_record.parent_thread_id
@@ -785,11 +796,19 @@ class CredentialManager:
             self._profile.settings, cred_ex_record.trace
         )
 
-        if cred_ex_record.auto_remove:
+        cred_ex_record.state = V10CredentialExchange.STATE_ACKED
+        try:
             async with self._profile.session() as session:
-                await cred_ex_record.delete_record(session)  # all done: delete
+                # FIXME - re-fetch record to check state, apply transactional update
+                await cred_ex_record.save(session, reason="ack credential")
 
-        return (cred_ex_record, credential_ack_message)
+            if cred_ex_record.auto_remove:
+                async with self._profile.session() as session:
+                    await cred_ex_record.delete_record(session)  # all done: delete
+        except StorageError as err:
+            LOGGER.exception(err)  # holder still owes an ack: carry on
+
+        return credential_ack_message
 
     async def receive_credential_ack(
         self, message: CredentialAck, connection_id: str

--- a/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
@@ -988,9 +988,7 @@ async def credential_exchange_send_request(request: web.BaseRequest):
                 connection_id,
             )
             if not connection_record.is_ready:
-                raise web.HTTPForbidden(
-                    reason=f"Connection {connection_id} not ready"
-                )
+                raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
 
         credential_manager = CredentialManager(context.profile)
         (
@@ -1179,10 +1177,9 @@ async def credential_exchange_store(request: web.BaseRequest):
             outbound_handler,
         )
 
-    credential_ack_message = await credential_manager.create_credential_ack(
+    credential_ack_message = await credential_manager.send_credential_ack(
         cred_ex_record
     )
-    await outbound_handler(credential_ack_message, connection_id=connection_id)
 
     trace_event(
         context.settings,

--- a/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
@@ -891,7 +891,6 @@ async def credential_exchange_send_bound_offer(request: web.BaseRequest):
             except StorageNotFoundError as err:
                 raise web.HTTPNotFound(reason=err.roll_up) from err
 
-            connection_id = cred_ex_record.connection_id
             if cred_ex_record.state != (
                 V10CredentialExchange.STATE_PROPOSAL_RECEIVED
             ):  # check state here: manager call creates free offers too
@@ -901,6 +900,7 @@ async def credential_exchange_send_bound_offer(request: web.BaseRequest):
                     f"(must be {V10CredentialExchange.STATE_PROPOSAL_RECEIVED})"
                 )
 
+            connection_id = cred_ex_record.connection_id
             connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
             if not connection_record.is_ready:
                 raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
@@ -979,13 +979,18 @@ async def credential_exchange_send_request(request: web.BaseRequest):
                 cred_ex_record = await V10CredentialExchange.retrieve_by_id(
                     session, credential_exchange_id
                 )
+                connection_id = cred_ex_record.connection_id
             except StorageNotFoundError as err:
                 raise web.HTTPNotFound(reason=err.roll_up) from err
-            connection_id = cred_ex_record.connection_id
 
-            connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
+            connection_record = await ConnRecord.retrieve_by_id(
+                session,
+                connection_id,
+            )
             if not connection_record.is_ready:
-                raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
+                raise web.HTTPForbidden(
+                    reason=f"Connection {connection_id} not ready"
+                )
 
         credential_manager = CredentialManager(context.profile)
         (

--- a/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_routes.py
@@ -1087,10 +1087,10 @@ class TestCredentialRoutes(AsyncTestCase):
             test_module, "CredentialManager", autospec=True
         ) as mock_credential_manager, async_mock.patch.object(
             test_module, "V10CredentialExchange", autospec=True
-        ) as mock_cred_ex:
+        ) as mock_cred_ex_cls:
 
-            mock_cred_ex_rec.state = mock_cred_ex.STATE_REQUEST_RECEIVED
-            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock(
+            mock_cred_ex_rec.state = mock_cred_ex_cls.STATE_REQUEST_RECEIVED
+            mock_cred_ex_cls.retrieve_by_id = async_mock.CoroutineMock(
                 return_value=mock_cred_ex_rec
             )
 
@@ -1157,9 +1157,9 @@ class TestCredentialRoutes(AsyncTestCase):
             test_module, "CredentialManager", autospec=True
         ) as mock_credential_manager, async_mock.patch.object(
             test_module, "V10CredentialExchange", autospec=True
-        ) as mock_cred_ex:
-            mock_cred_ex_rec.state = mock_cred_ex.STATE_REQUEST_RECEIVED
-            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock(
+        ) as mock_cred_ex_cls:
+            mock_cred_ex_cls.state = mock_cred_ex_cls.STATE_REQUEST_RECEIVED
+            mock_cred_ex_cls.retrieve_by_id = async_mock.CoroutineMock(
                 return_value=mock_cred_ex_rec
             )
 
@@ -1189,8 +1189,8 @@ class TestCredentialRoutes(AsyncTestCase):
             test_module, "CredentialManager", autospec=True
         ) as mock_credential_manager, async_mock.patch.object(
             test_module, "V10CredentialExchange", autospec=True
-        ) as mock_cred_ex:
-            mock_cred_ex.retrieve_by_id = async_mock.CoroutineMock(
+        ) as mock_cred_ex_cls:
+            mock_cred_ex_cls.retrieve_by_id = async_mock.CoroutineMock(
                 return_value=mock_cred_ex_rec
             )
             mock_credential_manager.return_value = async_mock.MagicMock(

--- a/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_ack_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_ack_handler.py
@@ -3,11 +3,10 @@
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
+from .....utils.tracing import trace_event, get_timer
 
 from ..manager import V20CredManager
 from ..messages.cred_ack import V20CredAck
-
-from .....utils.tracing import trace_event, get_timer
 
 
 class V20CredAckHandler(BaseHandler):

--- a/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_issue_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_issue_handler.py
@@ -55,8 +55,7 @@ class V20CredIssueHandler(BaseHandler):
                 # protocol finished OK: do not set cred ex record state null
                 self._logger.exception(err)
 
-            cred_ack_message = await cred_manager.create_cred_ack(cred_ex_record)
-            await responder.send_reply(cred_ack_message)
+            cred_ack_message = await cred_manager.send_cred_ack(cred_ex_record)
 
             trace_event(
                 context.settings,

--- a/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_issue_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_issue_handler.py
@@ -1,11 +1,13 @@
 """Credential issue message handler."""
 
+from .....indy.holder import IndyHolderError
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
+from .....storage.error import StorageError
 from .....utils.tracing import trace_event, get_timer
 
-from ..manager import V20CredManager
+from ..manager import V20CredManager, V20CredManagerError
 from ..messages.cred_issue import V20CredIssue
 
 
@@ -36,7 +38,7 @@ class V20CredIssueHandler(BaseHandler):
         cred_manager = V20CredManager(context.profile)
         cred_ex_record = await cred_manager.receive_credential(
             context.message, context.connection_record.connection_id
-        )
+        )  # mgr only finds, saves record: on exception, saving null state is hopeless
 
         r_time = trace_event(
             context.settings,
@@ -47,15 +49,13 @@ class V20CredIssueHandler(BaseHandler):
 
         # Automatically move to next state if flag is set
         if context.settings.get("debug.auto_store_credential"):
-            (
-                cred_ex_record,
-                cred_ack_message,
-            ) = await cred_manager.store_credential(cred_ex_record)
+            try:
+                cred_ex_record = await cred_manager.store_credential(cred_ex_record)
+            except (V20CredManagerError, IndyHolderError, StorageError) as err:
+                # protocol finished OK: do not set cred ex record state null
+                self._logger.exception(err)
 
-            if cred_ex_record.auto_remove:
-                await cred_manager.delete_cred_ex_record(cred_ex_record.cred_ex_id)
-
-            # Ack issuer that holder stored credential
+            cred_ack_message = await cred_manager.create_cred_ack(cred_ex_record)
             await responder.send_reply(cred_ack_message)
 
             trace_event(

--- a/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_issue_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_issue_handler.py
@@ -3,11 +3,10 @@
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
+from .....utils.tracing import trace_event, get_timer
 
 from ..manager import V20CredManager
 from ..messages.cred_issue import V20CredIssue
-
-from .....utils.tracing import trace_event, get_timer
 
 
 class V20CredIssueHandler(BaseHandler):

--- a/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_offer_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_offer_handler.py
@@ -1,11 +1,14 @@
 """Credential offer message handler."""
 
+from .....indy.holder import IndyHolderError
+from .....ledger.error import LedgerError
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
+from .....storage.error import StorageError
 from .....utils.tracing import trace_event, get_timer
 
-from ..manager import V20CredManager
+from ..manager import V20CredManager, V20CredManagerError
 from ..messages.cred_offer import V20CredOffer
 
 
@@ -36,7 +39,7 @@ class V20CredOfferHandler(BaseHandler):
         cred_manager = V20CredManager(context.profile)
         cred_ex_record = await cred_manager.receive_offer(
             context.message, context.connection_record.connection_id
-        )
+        )  # mgr only finds, saves record: on exception, saving state null is hopeless
 
         r_time = trace_event(
             context.settings,
@@ -47,11 +50,22 @@ class V20CredOfferHandler(BaseHandler):
 
         # If auto respond is turned on, automatically reply with credential request
         if context.settings.get("debug.auto_respond_credential_offer"):
-            (_, cred_request_message) = await cred_manager.create_request(
-                cred_ex_record=cred_ex_record,
-                holder_did=context.connection_record.my_did,
-            )
-            await responder.send_reply(cred_request_message)
+            cred_request_message = None
+            try:
+                (_, cred_request_message) = await cred_manager.create_request(
+                    cred_ex_record=cred_ex_record,
+                    holder_did=context.connection_record.my_did,
+                )
+                await responder.send_reply(cred_request_message)
+            except (V20CredManagerError, IndyHolderError, LedgerError) as err:
+                self._logger.exception(err)
+                if cred_ex_record:
+                    await cred_ex_record.save_error_state(
+                        context.session,
+                        reason=err.message,
+                    )
+            except StorageError as err:
+                self._logger.exception(err)  # may be logging to wire, not dead disk
 
             trace_event(
                 context.settings,

--- a/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_offer_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_offer_handler.py
@@ -3,11 +3,10 @@
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
+from .....utils.tracing import trace_event, get_timer
 
 from ..manager import V20CredManager
 from ..messages.cred_offer import V20CredOffer
-
-from .....utils.tracing import trace_event, get_timer
 
 
 class V20CredOfferHandler(BaseHandler):

--- a/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_proposal_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_proposal_handler.py
@@ -3,11 +3,10 @@
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
+from .....utils.tracing import trace_event, get_timer
 
 from ..manager import V20CredManager
 from ..messages.cred_proposal import V20CredProposal
-
-from .....utils.tracing import trace_event, get_timer
 
 
 class V20CredProposalHandler(BaseHandler):

--- a/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_proposal_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_proposal_handler.py
@@ -1,11 +1,14 @@
 """Credential proposal message handler."""
 
+from .....indy.issuer import IndyIssuerError
+from .....ledger.error import LedgerError
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
+from .....storage.error import StorageError
 from .....utils.tracing import trace_event, get_timer
 
-from ..manager import V20CredManager
+from ..manager import V20CredManager, V20CredManagerError
 from ..messages.cred_proposal import V20CredProposal
 
 
@@ -36,7 +39,7 @@ class V20CredProposalHandler(BaseHandler):
         cred_manager = V20CredManager(context.profile)
         cred_ex_record = await cred_manager.receive_proposal(
             context.message, context.connection_record.connection_id
-        )
+        )  # mgr only finds, saves record: on exception, saving state null is hopeless
 
         r_time = trace_event(
             context.settings,
@@ -47,13 +50,23 @@ class V20CredProposalHandler(BaseHandler):
 
         # If auto_offer is enabled, respond immediately with offer
         if cred_ex_record.auto_offer:
-            (cred_ex_record, cred_offer_message) = await cred_manager.create_offer(
-                cred_ex_record,
-                counter_proposal=None,
-                comment=context.message.comment,
-            )
-
-            await responder.send_reply(cred_offer_message)
+            cred_offer_message = None
+            try:
+                (cred_ex_record, cred_offer_message) = await cred_manager.create_offer(
+                    cred_ex_record,
+                    counter_proposal=None,
+                    comment=context.message.comment,
+                )
+                await responder.send_reply(cred_offer_message)
+            except (V20CredManagerError, IndyIssuerError, LedgerError) as err:
+                self._logger.exception(err)
+                if cred_ex_record:
+                    await cred_ex_record.save_error_state(
+                        context.session(),
+                        reason=err.message,
+                    )
+            except StorageError as err:
+                self._logger.exception(err)  # may be logging to wire, not dead disk
 
             trace_event(
                 context.settings,

--- a/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_request_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_request_handler.py
@@ -3,11 +3,10 @@
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
+from .....utils.tracing import trace_event, get_timer
 
 from ..manager import V20CredManager
 from ..messages.cred_request import V20CredRequest
-
-from .....utils.tracing import trace_event, get_timer
 
 
 class V20CredRequestHandler(BaseHandler):

--- a/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_request_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/handlers/cred_request_handler.py
@@ -1,11 +1,14 @@
 """Credential request message handler."""
 
+from .....indy.issuer import IndyIssuerError
+from .....ledger.error import LedgerError
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
+from .....storage.error import StorageError
 from .....utils.tracing import trace_event, get_timer
 
-from ..manager import V20CredManager
+from ..manager import V20CredManager, V20CredManagerError
 from ..messages.cred_request import V20CredRequest
 
 
@@ -36,7 +39,7 @@ class V20CredRequestHandler(BaseHandler):
         cred_manager = V20CredManager(context.profile)
         cred_ex_record = await cred_manager.receive_request(
             context.message, context.connection_record.connection_id
-        )
+        )  # mgr only finds, saves record: on exception, saving state null is hopeless
 
         r_time = trace_event(
             context.settings,
@@ -47,11 +50,20 @@ class V20CredRequestHandler(BaseHandler):
 
         # If auto_issue is enabled, respond immediately
         if cred_ex_record.auto_issue:
-            (cred_ex_record, cred_issue_message,) = await cred_manager.issue_credential(
-                cred_ex_record=cred_ex_record, comment=context.message.comment
-            )
-
-            await responder.send_reply(cred_issue_message)
+            cred_issue_message = None
+            try:
+                (
+                    cred_ex_record,
+                    cred_issue_message,
+                ) = await cred_manager.issue_credential(
+                    cred_ex_record=cred_ex_record,
+                    comment=context.message.comment,
+                )
+                await responder.send_reply(cred_issue_message)
+            except (V20CredManagerError, IndyIssuerError, LedgerError) as err:
+                self._logger.exception(err)
+            except StorageError as err:
+                self._logger.exception(err)  # may be logging to wire, not dead disk
 
             trace_event(
                 context.settings,

--- a/aries_cloudagent/protocols/issue_credential/v2_0/handlers/tests/test_cred_ack_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/handlers/tests/test_cred_ack_handler.py
@@ -1,13 +1,11 @@
-from asynctest import (
-    mock as async_mock,
-    TestCase as AsyncTestCase,
-)
+from asynctest import mock as async_mock, TestCase as AsyncTestCase
 
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
 from ......transport.inbound.receipt import MessageReceipt
 
 from ...messages.cred_ack import V20CredAck
+
 from .. import cred_ack_handler as test_module
 
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/handlers/tests/test_cred_issue_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/handlers/tests/test_cred_issue_handler.py
@@ -1,7 +1,4 @@
-from asynctest import (
-    mock as async_mock,
-    TestCase as AsyncTestCase,
-)
+from asynctest import mock as async_mock, TestCase as AsyncTestCase
 
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
@@ -41,18 +38,15 @@ class TestCredentialIssueHandler(AsyncTestCase):
         request_context.settings["debug.auto_store_credential"] = True
         request_context.connection_record = async_mock.MagicMock()
 
-        cred_ex_id = "cred-ex-id"
-        cred_ex_record = async_mock.MagicMock(auto_remove=True, cred_ex_id=cred_ex_id)
-
         with async_mock.patch.object(
             test_module, "V20CredManager", autospec=True
         ) as mock_cred_mgr:
-            mock_cred_mgr.return_value.receive_credential = async_mock.CoroutineMock()
-            mock_cred_mgr.return_value.store_credential = async_mock.CoroutineMock(
-                return_value=(cred_ex_record, "cred_ack_message")
-            )
-            mock_cred_mgr.return_value.delete_cred_ex_record = (
-                async_mock.CoroutineMock()
+            mock_cred_mgr.return_value = async_mock.MagicMock(
+                receive_credential=async_mock.CoroutineMock(),
+                store_credential=async_mock.CoroutineMock(),
+                create_cred_ack=async_mock.CoroutineMock(
+                    return_value="cred_ack_message"
+                ),
             )
             request_context.message = V20CredIssue()
             request_context.connection_ready = True
@@ -64,14 +58,47 @@ class TestCredentialIssueHandler(AsyncTestCase):
         mock_cred_mgr.return_value.receive_credential.assert_called_once_with(
             request_context.message, request_context.connection_record.connection_id
         )
-        mock_cred_mgr.return_value.delete_cred_ex_record.assert_called_once_with(
-            cred_ex_id
-        )
         messages = responder.messages
         assert len(messages) == 1
         (result, target) = messages[0]
         assert result == "cred_ack_message"
         assert target == {}
+
+    async def test_called_auto_store_x(self):
+        request_context = RequestContext.test_context()
+        request_context.message_receipt = MessageReceipt()
+        request_context.settings["debug.auto_store_credential"] = True
+        request_context.connection_record = async_mock.MagicMock()
+
+        with async_mock.patch.object(
+            test_module, "V20CredManager", autospec=True
+        ) as mock_cred_mgr:
+            mock_cred_mgr.return_value = async_mock.MagicMock(
+                receive_credential=async_mock.CoroutineMock(
+                    return_value=async_mock.MagicMock(
+                        save_error_state=async_mock.CoroutineMock()
+                    )
+                ),
+                store_credential=async_mock.CoroutineMock(
+                    side_effect=[
+                        test_module.IndyHolderError,
+                        test_module.StorageError(),
+                    ]
+                ),
+                create_cred_ack=async_mock.CoroutineMock(),
+            )
+
+            request_context.message = V20CredIssue()
+            request_context.connection_ready = True
+            handler_inst = test_module.V20CredIssueHandler()
+            responder = MockResponder()
+
+            with async_mock.patch.object(
+                responder, "send_reply", async_mock.CoroutineMock()
+            ) as mock_send_reply:
+                await handler_inst.handle(request_context, responder)  # holder error
+                await handler_inst.handle(request_context, responder)  # storage error
+                assert mock_send_reply.call_count == 2
 
     async def test_called_not_ready(self):
         request_context = RequestContext.test_context()

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_format.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_format.py
@@ -1,8 +1,8 @@
 """Issue-credential protocol message attachment format."""
 
 from collections import namedtuple
-from typing import Mapping, Sequence, Type, Union
 from enum import Enum
+from typing import Mapping, Sequence, Type, TYPE_CHECKING, Union
 from uuid import uuid4
 
 from marshmallow import EXCLUDE, fields
@@ -11,9 +11,9 @@ from .....utils.classloader import DeferLoad
 from .....messaging.decorators.attach_decorator import AttachDecorator
 from .....messaging.models.base import BaseModel, BaseModelSchema
 from .....messaging.valid import UUIDFour
+
 from ..models.detail.indy import V20CredExRecordIndy
 from ..models.detail.ld_proof import V20CredExRecordLDProof
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..formats.handler import V20CredFormatHandler

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
@@ -1,4 +1,4 @@
-"""Aries#0036 v1.0 credential exchange information with non-secrets storage."""
+"""Aries#0453 v2.0 credential exchange information with non-secrets storage."""
 
 from typing import Any, Mapping, Union
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
@@ -16,6 +16,7 @@ from marshmallow import fields, validate, validates_schema, ValidationError
 from ....admin.request_context import AdminRequestContext
 from ....connections.models.conn_record import ConnRecord
 from ....core.profile import Profile
+from ....indy.holder import IndyHolderError
 from ....indy.issuer import IndyIssuerError
 from ....ledger.error import LedgerError
 from ....messaging.decorators.attach_decorator import AttachDecorator
@@ -939,11 +940,12 @@ async def credential_exchange_send_free_offer(request: web.BaseRequest):
         result = cred_ex_record.serialize()
 
     except (
-        StorageNotFoundError,
         BaseModelError,
-        V20CredManagerError,
+        IndyIssuerError,
         LedgerError,
+        StorageNotFoundError,
         V20CredFormatError,
+        V20CredManagerError,
     ) as err:
         await internal_error(
             err,
@@ -1037,16 +1039,19 @@ async def credential_exchange_send_bound_offer(request: web.BaseRequest):
         result = cred_ex_record.serialize()
 
     except (
-        StorageError,
         BaseModelError,
-        V20CredManagerError,
+        IndyIssuerError,
         LedgerError,
+        StorageError,
+        V20CredManagerError,
         V20CredFormatError,
     ) as err:
+        async with context.session() as session:
+            await cred_ex_record.save_error_state(session, reason=err.message)
         await internal_error(
             err,
             web.HTTPBadRequest,
-            cred_ex_record or conn_record,
+            cred_ex_record,
             outbound_handler,
         )
 
@@ -1101,9 +1106,14 @@ async def credential_exchange_send_free_request(request: web.BaseRequest):
     cred_ex_record = None
     try:
         async with context.session() as session:
-            conn_record = await ConnRecord.retrieve_by_id(session, connection_id)
-            if not conn_record.is_ready:
-                raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
+            try:
+                conn_record = await ConnRecord.retrieve_by_id(session, connection_id)
+                if not conn_record.is_ready:
+                    raise web.HTTPForbidden(
+                        reason=f"Connection {connection_id} not ready"
+                    )
+            except StorageNotFoundError as err:
+                raise web.HTTPBadRequest(reason=err.roll_up) from err
 
         cred_manager = V20CredManager(context.profile)
 
@@ -1129,11 +1139,19 @@ async def credential_exchange_send_free_request(request: web.BaseRequest):
 
         result = cred_ex_record.serialize()
 
-    except (BaseModelError, StorageError) as err:
+    except (
+        BaseModelError,
+        IndyHolderError,
+        LedgerError,
+        StorageError,
+        V20CredManagerError,
+    ) as err:
+        async with context.session() as session:
+            await cred_ex_record.save_error_state(session, reason=err.message)
         await internal_error(
             err,
             web.HTTPBadRequest,
-            cred_ex_record or conn_record,
+            cred_ex_record,
             outbound_handler,
         )
 
@@ -1184,8 +1202,8 @@ async def credential_exchange_send_bound_request(request: web.BaseRequest):
                 )
             except StorageNotFoundError as err:
                 raise web.HTTPNotFound(reason=err.roll_up) from err
-            connection_id = cred_ex_record.connection_id
 
+            connection_id = cred_ex_record.connection_id
             conn_record = await ConnRecord.retrieve_by_id(session, connection_id)
             if not conn_record.is_ready:
                 raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
@@ -1199,15 +1217,17 @@ async def credential_exchange_send_bound_request(request: web.BaseRequest):
         result = cred_ex_record.serialize()
 
     except (
-        StorageError,
-        V20CredManagerError,
         BaseModelError,
+        IndyHolderError,
+        LedgerError,
+        StorageError,
         V20CredFormatError,
+        V20CredManagerError,
     ) as err:
         await internal_error(
             err,
             web.HTTPBadRequest,
-            cred_ex_record or conn_record,
+            cred_ex_record,
             outbound_handler,
         )
 
@@ -1278,15 +1298,18 @@ async def credential_exchange_issue(request: web.BaseRequest):
 
     except (
         BaseModelError,
-        V20CredManagerError,
         IndyIssuerError,
+        LedgerError,
         StorageError,
         V20CredFormatError,
+        V20CredManagerError,
     ) as err:
+        async with context.session() as session:
+            await cred_ex_record.save_error_state(session, reason=err.message)
         await internal_error(
             err,
             web.HTTPBadRequest,
-            cred_ex_record or conn_record,
+            cred_ex_record,
             outbound_handler,
         )
 
@@ -1350,36 +1373,33 @@ async def credential_exchange_store(request: web.BaseRequest):
                 raise web.HTTPForbidden(reason=f"Connection {connection_id} not ready")
 
         cred_manager = V20CredManager(context.profile)
-        (cred_ex_record, cred_stored_message) = await cred_manager.store_credential(
-            cred_ex_record,
-            cred_id,
-        )
+        cred_ex_record = await cred_manager.store_credential(cred_ex_record, cred_id)
 
         # We first need to retrieve the the cred_ex_record with detail record
         # as the record may be auto removed
         result = await _get_result_with_details(context.profile, cred_ex_record)
 
-        if cred_ex_record.auto_remove:
-            await cred_manager.delete_cred_ex_record(cred_ex_record.cred_ex_id)
-
     except (
-        StorageError,
-        V20CredManagerError,
         BaseModelError,
+        IndyHolderError,
+        StorageError,
         V20CredFormatError,
+        V20CredManagerError,
     ) as err:
+        # protocol finished OK: do not set cred ex record state null
         await internal_error(
             err,
             web.HTTPBadRequest,
-            cred_ex_record or conn_record,
+            cred_ex_record,
             outbound_handler,
         )
 
-    await outbound_handler(cred_stored_message, connection_id=connection_id)
+    cred_ack_message = await cred_manager.create_cred_ack(cred_ex_record)
+    await outbound_handler(cred_ack_message, connection_id=connection_id)
 
     trace_event(
         context.settings,
-        cred_stored_message,
+        cred_ack_message,
         outcome="credential_exchange_store.END",
         perf_counter=r_time,
     )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
@@ -1394,8 +1394,7 @@ async def credential_exchange_store(request: web.BaseRequest):
             outbound_handler,
         )
 
-    cred_ack_message = await cred_manager.create_cred_ack(cred_ex_record)
-    await outbound_handler(cred_ack_message, connection_id=connection_id)
+    cred_ack_message = await cred_manager.send_cred_ack(cred_ex_record)
 
     trace_event(
         context.settings,

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_manager.py
@@ -1300,7 +1300,7 @@ class TestV20CredManager(AsyncTestCase):
 
             mock_handler.return_value.store_credential = async_mock.CoroutineMock()
 
-            ret_cx_rec, ret_cred_ack = await self.manager.store_credential(
+            ret_cx_rec = await self.manager.store_credential(
                 stored_cx_rec, cred_id=cred_id
             )
 
@@ -1312,8 +1312,7 @@ class TestV20CredManager(AsyncTestCase):
                 V20CredIssue.deserialize(ret_cx_rec.cred_issue).attachment()
                 == INDY_CRED
             )
-            assert ret_cx_rec.state == V20CredExRecord.STATE_DONE
-            assert ret_cred_ack._thread_id == thread_id
+            assert ret_cx_rec.state == V20CredExRecord.STATE_CREDENTIAL_RECEIVED
 
     async def test_store_credential_bad_state(self):
         thread_id = "thread-id"
@@ -1329,7 +1328,32 @@ class TestV20CredManager(AsyncTestCase):
             await self.manager.store_credential(stored_cx_rec, cred_id=cred_id)
         assert " state " in str(context.exception)
 
-    async def test_credential_ack(self):
+    async def test_create_credential_ack(self):
+        connection_id = "connection-id"
+        stored_exchange = V20CredExRecord(
+            cred_ex_id="dummy-cxid",
+            connection_id=connection_id,
+            initiator=V20CredExRecord.INITIATOR_SELF,
+            thread_id="thid",
+            parent_thread_id="pthid",
+            role=V20CredExRecord.ROLE_ISSUER,
+            trace=False,
+            auto_remove=True,
+        )
+
+        with async_mock.patch.object(
+            V20CredExRecord, "save", autospec=True
+        ) as mock_save_ex, async_mock.patch.object(
+            V20CredExRecord, "delete_record", autospec=True
+        ) as mock_delete_ex, async_mock.patch.object(
+            test_module.LOGGER, "exception", async_mock.MagicMock()
+        ) as mock_log_exception:
+            mock_delete_ex.side_effect = test_module.StorageError()
+            ack = await self.manager.create_cred_ack(stored_exchange)
+            assert ack._thread
+            mock_log_exception.assert_called_once()  # cover exception log-and-continue
+
+    async def test_receive_credential_ack(self):
         connection_id = "conn-id"
         stored_cx_rec = V20CredExRecord(
             cred_ex_id="dummy-cxid",

--- a/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_handler.py
@@ -1,8 +1,10 @@
 """Presentation message handler."""
 
+from .....ledger.error import LedgerError
 from .....messaging.base_handler import BaseHandler
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
+from .....storage.error import StorageError
 from .....utils.tracing import trace_event, get_timer
 
 from ..manager import PresentationManager
@@ -34,7 +36,7 @@ class PresentationHandler(BaseHandler):
 
         presentation_exchange_record = await presentation_manager.receive_presentation(
             context.message, context.connection_record
-        )
+        )  # mgr saves record state null if need be and possible
 
         r_time = trace_event(
             context.settings,
@@ -44,7 +46,19 @@ class PresentationHandler(BaseHandler):
         )
 
         if context.settings.get("debug.auto_verify_presentation"):
-            await presentation_manager.verify_presentation(presentation_exchange_record)
+            try:
+                await presentation_manager.verify_presentation(
+                    presentation_exchange_record
+                )
+            except LedgerError as err:
+                self._logger.exception(err)
+                if presentation_exchange_record:
+                    await presentation_exchange_record.save_error_state(
+                        context.session(),
+                        reason=err.message,
+                    )
+            except StorageError as err:
+                self._logger.exception(err)  # may be logging to wire, not dead disk
 
             trace_event(
                 context.settings,

--- a/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_proposal_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_proposal_handler.py
@@ -1,8 +1,10 @@
 """Presentation proposal message handler."""
 
+from .....ledger.error import LedgerError
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
+from .....storage.error import StorageError
 from .....utils.tracing import trace_event, get_timer
 
 from ..manager import PresentationManager
@@ -40,7 +42,7 @@ class PresentationProposalHandler(BaseHandler):
         presentation_manager = PresentationManager(context.profile)
         presentation_exchange_record = await presentation_manager.receive_proposal(
             context.message, context.connection_record
-        )
+        )  # mgr only creates, saves record: on exception, saving state null is hopeless
 
         r_time = trace_event(
             context.settings,
@@ -51,15 +53,25 @@ class PresentationProposalHandler(BaseHandler):
 
         # If auto_respond_presentation_proposal is set, reply with proof req
         if context.settings.get("debug.auto_respond_presentation_proposal"):
-            (
-                presentation_exchange_record,
-                presentation_request_message,
-            ) = await presentation_manager.create_bound_request(
-                presentation_exchange_record=presentation_exchange_record,
-                comment=context.message.comment,
-            )
-
-            await responder.send_reply(presentation_request_message)
+            presentation_request_message = None
+            try:
+                (
+                    presentation_exchange_record,
+                    presentation_request_message,
+                ) = await presentation_manager.create_bound_request(
+                    presentation_exchange_record=presentation_exchange_record,
+                    comment=context.message.comment,
+                )
+                await responder.send_reply(presentation_request_message)
+            except LedgerError as err:
+                self._logger.exception(err)
+                if presentation_exchange_record:
+                    await presentation_exchange_record.save_error_state(
+                        context.session(),
+                        reason=err.message,
+                    )
+            except StorageError as err:
+                self._logger.exception(err)  # may be logging to wire, not dead disk
 
             trace_event(
                 context.settings,

--- a/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_request_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_request_handler.py
@@ -1,14 +1,15 @@
 """Presentation request message handler."""
 
-from .....indy.holder import IndyHolder
+from .....indy.holder import IndyHolder, IndyHolderError
 from .....indy.sdk.models.xform import indy_proof_req_preview2indy_requested_creds
+from .....ledger.error import LedgerError
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
-from .....storage.error import StorageNotFoundError
+from .....storage.error import StorageError, StorageNotFoundError
 from .....utils.tracing import trace_event, get_timer
 
-from ..manager import PresentationManager
+from ..manager import PresentationManager, PresentationManagerError
 from ..messages.presentation_proposal import PresentationProposal
 from ..messages.presentation_request import PresentationRequest
 from ..models.presentation_exchange import V10PresentationExchange
@@ -70,7 +71,7 @@ class PresentationRequestHandler(BaseHandler):
         presentation_exchange_record.presentation_request = indy_proof_request
         presentation_exchange_record = await presentation_manager.receive_request(
             presentation_exchange_record
-        )
+        )  # mgr only saves record: on exception, saving state null is hopeless
 
         r_time = trace_event(
             context.settings,
@@ -98,18 +99,28 @@ class PresentationRequestHandler(BaseHandler):
                 self._logger.warning(f"{err}")
                 return
 
-            (
-                presentation_exchange_record,
-                presentation_message,
-            ) = await presentation_manager.create_presentation(
-                presentation_exchange_record=presentation_exchange_record,
-                requested_credentials=req_creds,
-                comment="auto-presented for proof request nonce={}".format(
-                    indy_proof_request["nonce"]
-                ),
-            )
-
-            await responder.send_reply(presentation_message)
+            presentation_message = None
+            try:
+                (
+                    presentation_exchange_record,
+                    presentation_message,
+                ) = await presentation_manager.create_presentation(
+                    presentation_exchange_record=presentation_exchange_record,
+                    requested_credentials=req_creds,
+                    comment="auto-presented for proof request nonce={}".format(
+                        indy_proof_request["nonce"]
+                    ),
+                )
+                await responder.send_reply(presentation_message)
+            except (IndyHolderError, PresentationManagerError, LedgerError) as err:
+                self._logger.exception(err)
+                if presentation_exchange_record:
+                    await presentation_exchange_record.save_error_state(
+                        context.session(),
+                        reason=err.message,
+                    )
+            except StorageError as err:
+                self._logger.exception(err)  # may be logging to wire, not dead disk
 
             trace_event(
                 context.settings,

--- a/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_request_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_request_handler.py
@@ -8,6 +8,7 @@ from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
 from .....storage.error import StorageError, StorageNotFoundError
 from .....utils.tracing import trace_event, get_timer
+from .....wallet.error import WalletNotFoundError
 
 from ..manager import PresentationManager, PresentationManagerError
 from ..messages.presentation_proposal import PresentationProposal
@@ -112,7 +113,12 @@ class PresentationRequestHandler(BaseHandler):
                     ),
                 )
                 await responder.send_reply(presentation_message)
-            except (IndyHolderError, PresentationManagerError, LedgerError) as err:
+            except (
+                IndyHolderError,
+                LedgerError,
+                PresentationManagerError,
+                WalletNotFoundError,
+            ) as err:
                 self._logger.exception(err)
                 if presentation_exchange_record:
                     await presentation_exchange_record.save_error_state(

--- a/aries_cloudagent/protocols/present_proof/v1_0/handlers/tests/test_presentation_ack_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/handlers/tests/test_presentation_ack_handler.py
@@ -6,7 +6,7 @@ from ......transport.inbound.receipt import MessageReceipt
 
 from ...messages.presentation_ack import PresentationAck
 
-from .. import presentation_ack_handler as handler
+from .. import presentation_ack_handler as test_module
 
 
 class TestPresentationAckHandler(AsyncTestCase):
@@ -16,7 +16,7 @@ class TestPresentationAckHandler(AsyncTestCase):
         session = request_context.session()
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr:
             mock_pres_mgr.return_value.receive_presentation_ack = (
                 async_mock.CoroutineMock()
@@ -24,9 +24,9 @@ class TestPresentationAckHandler(AsyncTestCase):
             request_context.message = PresentationAck()
             request_context.connection_ready = True
             request_context.connection_record = async_mock.MagicMock()
-            handler_inst = handler.PresentationAckHandler()
+            handler = test_module.PresentationAckHandler()
             responder = MockResponder()
-            await handler_inst.handle(request_context, responder)
+            await handler.handle(request_context, responder)
 
         mock_pres_mgr.assert_called_once_with(request_context.profile)
         mock_pres_mgr.return_value.receive_presentation_ack.assert_called_once_with(
@@ -39,16 +39,16 @@ class TestPresentationAckHandler(AsyncTestCase):
         request_context.message_receipt = MessageReceipt()
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr:
             mock_pres_mgr.return_value.receive_presentation_ack = (
                 async_mock.CoroutineMock()
             )
             request_context.message = PresentationAck()
             request_context.connection_ready = False
-            handler_inst = handler.PresentationAckHandler()
+            handler = test_module.PresentationAckHandler()
             responder = MockResponder()
-            with self.assertRaises(handler.HandlerException):
-                await handler_inst.handle(request_context, responder)
+            with self.assertRaises(test_module.HandlerException):
+                await handler.handle(request_context, responder)
 
         assert not responder.messages

--- a/aries_cloudagent/protocols/present_proof/v1_0/handlers/tests/test_presentation_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/handlers/tests/test_presentation_handler.py
@@ -8,7 +8,7 @@ from ......transport.inbound.receipt import MessageReceipt
 
 from ...messages.presentation import Presentation
 
-from .. import presentation_handler as handler
+from .. import presentation_handler as test_module
 
 
 class TestPresentationHandler(AsyncTestCase):
@@ -18,15 +18,15 @@ class TestPresentationHandler(AsyncTestCase):
         request_context.settings["debug.auto_verify_presentation"] = False
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr:
             mock_pres_mgr.return_value.receive_presentation = async_mock.CoroutineMock()
             request_context.message = Presentation()
             request_context.connection_ready = True
             request_context.connection_record = async_mock.MagicMock()
-            handler_inst = handler.PresentationHandler()
+            handler = test_module.PresentationHandler()
             responder = MockResponder()
-            await handler_inst.handle(request_context, responder)
+            await handler.handle(request_context, responder)
 
         mock_pres_mgr.assert_called_once_with(request_context.profile)
         mock_pres_mgr.return_value.receive_presentation.assert_called_once_with(
@@ -40,19 +40,47 @@ class TestPresentationHandler(AsyncTestCase):
         request_context.settings["debug.auto_verify_presentation"] = True
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr:
             mock_pres_mgr.return_value.receive_presentation = async_mock.CoroutineMock()
             mock_pres_mgr.return_value.verify_presentation = async_mock.CoroutineMock()
             request_context.message = Presentation()
             request_context.connection_ready = True
             request_context.connection_record = async_mock.MagicMock()
-            handler_inst = handler.PresentationHandler()
+            handler = test_module.PresentationHandler()
             responder = MockResponder()
-            await handler_inst.handle(request_context, responder)
+            await handler.handle(request_context, responder)
 
         mock_pres_mgr.assert_called_once_with(request_context.profile)
         mock_pres_mgr.return_value.receive_presentation.assert_called_once_with(
             request_context.message, request_context.connection_record
         )
         assert not responder.messages
+
+    async def test_called_auto_verify_x(self):
+        request_context = RequestContext.test_context()
+        request_context.message_receipt = MessageReceipt()
+        request_context.settings["debug.auto_verify_presentation"] = True
+
+        with async_mock.patch.object(
+            test_module, "PresentationManager", autospec=True
+        ) as mock_pres_mgr:
+            mock_pres_mgr.return_value.receive_presentation = async_mock.CoroutineMock(
+                return_value=async_mock.MagicMock(
+                    save_error_state=async_mock.CoroutineMock()
+                )
+            )
+            mock_pres_mgr.return_value.verify_presentation = async_mock.CoroutineMock(
+                side_effect=[
+                    test_module.LedgerError(),
+                    test_module.StorageError(),
+                ]
+            )
+            request_context.message = Presentation()
+            request_context.connection_ready = True
+            request_context.connection_record = async_mock.MagicMock()
+            handler = test_module.PresentationHandler()
+            responder = MockResponder()
+
+            await handler.handle(request_context, responder)  # ledger error
+            await handler.handle(request_context, responder)  # storage error

--- a/aries_cloudagent/protocols/present_proof/v1_0/handlers/tests/test_presentation_proposal_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/handlers/tests/test_presentation_proposal_handler.py
@@ -1,4 +1,5 @@
 import pytest
+
 from asynctest import mock as async_mock, TestCase as AsyncTestCase
 
 from ......messaging.request_context import RequestContext
@@ -7,7 +8,7 @@ from ......transport.inbound.receipt import MessageReceipt
 
 from ...messages.presentation_proposal import PresentationProposal
 
-from .. import presentation_proposal_handler as handler
+from .. import presentation_proposal_handler as test_module
 
 
 class TestPresentationProposalHandler(AsyncTestCase):
@@ -17,7 +18,7 @@ class TestPresentationProposalHandler(AsyncTestCase):
         request_context.settings["debug.auto_respond_presentation_proposal"] = False
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr:
             mock_pres_mgr.return_value.receive_proposal = async_mock.CoroutineMock(
                 return_value=async_mock.MagicMock()
@@ -25,9 +26,9 @@ class TestPresentationProposalHandler(AsyncTestCase):
             request_context.message = PresentationProposal()
             request_context.connection_ready = True
             request_context.connection_record = async_mock.MagicMock()
-            handler_inst = handler.PresentationProposalHandler()
+            handler = test_module.PresentationProposalHandler()
             responder = MockResponder()
-            await handler_inst.handle(request_context, responder)
+            await handler.handle(request_context, responder)
 
         mock_pres_mgr.assert_called_once_with(request_context.profile)
         mock_pres_mgr.return_value.receive_proposal.assert_called_once_with(
@@ -43,7 +44,7 @@ class TestPresentationProposalHandler(AsyncTestCase):
         request_context.settings["debug.auto_respond_presentation_proposal"] = True
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr:
             mock_pres_mgr.return_value.receive_proposal = async_mock.CoroutineMock(
                 return_value="presentation_exchange_record"
@@ -56,9 +57,9 @@ class TestPresentationProposalHandler(AsyncTestCase):
             )
             request_context.message = PresentationProposal()
             request_context.connection_ready = True
-            handler_inst = handler.PresentationProposalHandler()
+            handler = test_module.PresentationProposalHandler()
             responder = MockResponder()
-            await handler_inst.handle(request_context, responder)
+            await handler.handle(request_context, responder)
 
         mock_pres_mgr.assert_called_once_with(request_context.profile)
         mock_pres_mgr.return_value.create_bound_request.assert_called_once_with(
@@ -73,19 +74,53 @@ class TestPresentationProposalHandler(AsyncTestCase):
         assert result == "presentation_request_message"
         assert target == {}
 
+    async def test_called_auto_request_x(self):
+        request_context = RequestContext.test_context()
+        request_context.message = async_mock.MagicMock()
+        request_context.message.comment = "hello world"
+        request_context.message_receipt = MessageReceipt()
+        request_context.settings["debug.auto_respond_presentation_proposal"] = True
+
+        with async_mock.patch.object(
+            test_module, "PresentationManager", autospec=True
+        ) as mock_pres_mgr:
+            mock_pres_mgr.return_value.receive_proposal = async_mock.CoroutineMock(
+                return_value=async_mock.MagicMock(
+                    save_error_state=async_mock.CoroutineMock()
+                )
+            )
+            mock_pres_mgr.return_value.create_bound_request = async_mock.CoroutineMock(
+                side_effect=[
+                    test_module.LedgerError(),
+                    test_module.StorageError(),
+                ]
+            )
+
+            request_context.message = PresentationProposal()
+            request_context.connection_ready = True
+            handler = test_module.PresentationProposalHandler()
+            responder = MockResponder()
+
+            with async_mock.patch.object(
+                responder, "send_reply", async_mock.CoroutineMock()
+            ) as mock_send_reply:
+                await handler.handle(request_context, responder)  # ledger error
+                await handler.handle(request_context, responder)  # storage error
+                mock_send_reply.assert_not_called()
+
     async def test_called_not_ready(self):
         request_context = RequestContext.test_context()
         request_context.message_receipt = MessageReceipt()
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr:
             mock_pres_mgr.return_value.receive_proposal = async_mock.CoroutineMock()
             request_context.message = PresentationProposal()
             request_context.connection_ready = False
-            handler_inst = handler.PresentationProposalHandler()
+            handler = test_module.PresentationProposalHandler()
             responder = MockResponder()
-            with self.assertRaises(handler.HandlerException):
-                await handler_inst.handle(request_context, responder)
+            with self.assertRaises(test_module.HandlerException):
+                await handler.handle(request_context, responder)
 
         assert not responder.messages

--- a/aries_cloudagent/protocols/present_proof/v1_0/handlers/tests/test_presentation_request_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/handlers/tests/test_presentation_request_handler.py
@@ -280,13 +280,11 @@ class TestPresentationRequestHandler(AsyncTestCase):
                 return_value=mock_px_rec
             )
 
-            mock_pres_mgr.return_value.create_presentation = (
-                async_mock.CoroutineMock(
-                    side_effect=[
-                        test_module.IndyHolderError(),
-                        test_module.StorageError(),
-                    ]
-                )
+            mock_pres_mgr.return_value.create_presentation = async_mock.CoroutineMock(
+                side_effect=[
+                    test_module.IndyHolderError(),
+                    test_module.StorageError(),
+                ]
             )
 
             request_context.connection_ready = True

--- a/aries_cloudagent/protocols/present_proof/v1_0/handlers/tests/test_presentation_request_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/handlers/tests/test_presentation_request_handler.py
@@ -9,7 +9,7 @@ from .....didcomm_prefix import DIDCommPrefix
 
 from ...messages.presentation_request import PresentationRequest
 
-from .. import presentation_request_handler as handler
+from .. import presentation_request_handler as test_module
 
 S_ID = "NcYxiDXkpYi6ov5FcYDi1e:2:vidya:1.0"
 CD_ID = f"NcYxiDXkpYi6ov5FcYDi1e:3:CL:{S_ID}:tag1"
@@ -26,14 +26,30 @@ class TestPresentationRequestHandler(AsyncTestCase):
             return_value=async_mock.MagicMock()
         )
 
-        with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
-        ) as mock_pres_mgr, async_mock.patch.object(
-            handler, "V10PresentationExchange", autospec=True
-        ) as mock_pres_ex_rec:
+        px_rec_instance = test_module.V10PresentationExchange(
+            presentation_proposal_dict={
+                "presentation_proposal": {
+                    "@type": DIDCommPrefix.qualify_current(
+                        "present-proof/1.0/presentation-preview"
+                    ),
+                    "attributes": [
+                        {"name": "favourite", "cred_def_id": CD_ID, "value": "potato"},
+                        {"name": "icon", "cred_def_id": CD_ID, "value": "cG90YXRv"},
+                    ],
+                    "predicates": [],
+                }
+            },
+            auto_present=True,
+        )
 
-            mock_pres_ex_rec.retrieve_by_tag_filter = async_mock.CoroutineMock(
-                return_value=mock_pres_ex_rec
+        with async_mock.patch.object(
+            test_module, "PresentationManager", autospec=True
+        ) as mock_pres_mgr, async_mock.patch.object(
+            test_module, "V10PresentationExchange", autospec=True
+        ) as mock_pres_ex_cls:
+
+            mock_pres_ex_cls.retrieve_by_tag_filter = async_mock.CoroutineMock(
+                return_value=px_rec_instance
             )
 
             mock_pres_mgr.return_value.receive_request = async_mock.CoroutineMock(
@@ -42,12 +58,12 @@ class TestPresentationRequestHandler(AsyncTestCase):
             mock_pres_mgr.return_value.receive_request.return_value.auto_present = False
 
             request_context.connection_ready = True
-            handler_inst = handler.PresentationRequestHandler()
+            handler = test_module.PresentationRequestHandler()
             responder = MockResponder()
-            await handler_inst.handle(request_context, responder)
+            await handler.handle(request_context, responder)
 
         mock_pres_mgr.return_value.receive_request.assert_called_once_with(
-            mock_pres_ex_rec
+            px_rec_instance
         )
         assert not responder.messages
 
@@ -61,16 +77,32 @@ class TestPresentationRequestHandler(AsyncTestCase):
             return_value=async_mock.MagicMock()
         )
 
-        with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
-        ) as mock_pres_mgr, async_mock.patch.object(
-            handler, "V10PresentationExchange", autospec=True
-        ) as mock_pres_ex_rec:
+        px_rec_instance = test_module.V10PresentationExchange(
+            presentation_proposal_dict={
+                "presentation_proposal": {
+                    "@type": DIDCommPrefix.qualify_current(
+                        "present-proof/1.0/presentation-preview"
+                    ),
+                    "attributes": [
+                        {"name": "favourite", "cred_def_id": CD_ID, "value": "potato"},
+                        {"name": "icon", "cred_def_id": CD_ID, "value": "cG90YXRv"},
+                    ],
+                    "predicates": [],
+                }
+            },
+            auto_present=True,
+        )
 
-            mock_pres_ex_rec.retrieve_by_tag_filter = async_mock.CoroutineMock(
+        with async_mock.patch.object(
+            test_module, "PresentationManager", autospec=True
+        ) as mock_pres_mgr, async_mock.patch.object(
+            test_module, "V10PresentationExchange", autospec=True
+        ) as mock_pres_ex_cls:
+
+            mock_pres_ex_cls.retrieve_by_tag_filter = async_mock.CoroutineMock(
                 side_effect=StorageNotFoundError
             )
-            mock_pres_ex_rec.return_value = mock_pres_ex_rec
+            mock_pres_ex_cls.return_value = px_rec_instance
 
             mock_pres_mgr.return_value.receive_request = async_mock.CoroutineMock(
                 return_value=async_mock.MagicMock()
@@ -78,12 +110,12 @@ class TestPresentationRequestHandler(AsyncTestCase):
             mock_pres_mgr.return_value.receive_request.return_value.auto_present = False
 
             request_context.connection_ready = True
-            handler_inst = handler.PresentationRequestHandler()
+            handler = test_module.PresentationRequestHandler()
             responder = MockResponder()
-            await handler_inst.handle(request_context, responder)
+            await handler.handle(request_context, responder)
 
         mock_pres_mgr.return_value.receive_request.assert_called_once_with(
-            mock_pres_ex_rec
+            px_rec_instance
         )
         assert not responder.messages
 
@@ -119,7 +151,7 @@ class TestPresentationRequestHandler(AsyncTestCase):
             }
         )
         request_context.message_receipt = MessageReceipt()
-        px_rec_instance = handler.V10PresentationExchange(
+        px_rec_instance = test_module.V10PresentationExchange(
             presentation_proposal_dict={
                 "presentation_proposal": {
                     "@type": DIDCommPrefix.qualify_current(
@@ -136,11 +168,11 @@ class TestPresentationRequestHandler(AsyncTestCase):
         )
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr, async_mock.patch.object(
-            handler, "V10PresentationExchange", autospec=True
-        ) as mock_pres_ex_rec, async_mock.patch.object(
-            handler, "IndyHolder", autospec=True
+            test_module, "V10PresentationExchange", autospec=True
+        ) as mock_pres_ex_cls, async_mock.patch.object(
+            test_module, "IndyHolder", autospec=True
         ) as mock_holder:
 
             mock_holder.get_credentials_for_presentation_request_by_referent = (
@@ -150,8 +182,8 @@ class TestPresentationRequestHandler(AsyncTestCase):
             )
             request_context.inject = async_mock.MagicMock(return_value=mock_holder)
 
-            mock_pres_ex_rec.return_value = px_rec_instance
-            mock_pres_ex_rec.retrieve_by_tag_filter = async_mock.CoroutineMock(
+            mock_pres_ex_cls.return_value = px_rec_instance
+            mock_pres_ex_cls.retrieve_by_tag_filter = async_mock.CoroutineMock(
                 return_value=px_rec_instance
             )
             mock_pres_mgr.return_value.receive_request = async_mock.CoroutineMock(
@@ -162,9 +194,9 @@ class TestPresentationRequestHandler(AsyncTestCase):
                 return_value=(px_rec_instance, "presentation_message")
             )
             request_context.connection_ready = True
-            handler_inst = handler.PresentationRequestHandler()
+            handler = test_module.PresentationRequestHandler()
             responder = MockResponder()
-            await handler_inst.handle(request_context, responder)
+            await handler.handle(request_context, responder)
             mock_pres_mgr.return_value.create_presentation.assert_called_once()
 
         mock_pres_mgr.return_value.receive_request.assert_called_once_with(
@@ -175,6 +207,95 @@ class TestPresentationRequestHandler(AsyncTestCase):
         (result, target) = messages[0]
         assert result == "presentation_message"
         assert target == {}
+
+    async def test_called_auto_present_x(self):
+        request_context = RequestContext.test_context()
+        request_context.connection_record = async_mock.MagicMock()
+        request_context.connection_record.connection_id = "dummy"
+        request_context.message = PresentationRequest()
+        request_context.message.indy_proof_request = async_mock.MagicMock(
+            return_value={
+                "name": "proof-request",
+                "version": "1.0",
+                "nonce": "1234567890",
+                "requested_attributes": {
+                    "0_favourite_uuid": {
+                        "name": "favourite",
+                        "restrictions": [
+                            {
+                                "cred_def_id": CD_ID,
+                            }
+                        ],
+                    },
+                    "1_icon_uuid": {
+                        "name": "icon",
+                        "restrictions": [
+                            {
+                                "cred_def_id": CD_ID,
+                            }
+                        ],
+                    },
+                },
+                "requested_predicates": {},
+            }
+        )
+        request_context.message_receipt = MessageReceipt()
+        mock_px_rec = async_mock.MagicMock(
+            presentation_proposal_dict={
+                "presentation_proposal": {
+                    "@type": DIDCommPrefix.qualify_current(
+                        "present-proof/1.0/presentation-preview"
+                    ),
+                    "attributes": [
+                        {"name": "favourite", "cred_def_id": CD_ID, "value": "potato"},
+                        {"name": "icon", "cred_def_id": CD_ID, "value": "cG90YXRv"},
+                    ],
+                    "predicates": [],
+                }
+            },
+            auto_present=True,
+            save_error_state=async_mock.CoroutineMock(),
+        )
+
+        with async_mock.patch.object(
+            test_module, "PresentationManager", autospec=True
+        ) as mock_pres_mgr, async_mock.patch.object(
+            test_module, "V10PresentationExchange", autospec=True
+        ) as mock_pres_ex_cls, async_mock.patch.object(
+            test_module, "IndyHolder", autospec=True
+        ) as mock_holder:
+
+            mock_holder.get_credentials_for_presentation_request_by_referent = (
+                async_mock.CoroutineMock(
+                    return_value=[{"cred_info": {"referent": "dummy"}}]
+                )
+            )
+            request_context.inject = async_mock.MagicMock(return_value=mock_holder)
+
+            mock_pres_ex_cls.return_value = mock_px_rec
+            mock_pres_ex_cls.retrieve_by_tag_filter = async_mock.CoroutineMock(
+                return_value=mock_px_rec
+            )
+            mock_pres_mgr.return_value.receive_request = async_mock.CoroutineMock(
+                return_value=mock_px_rec
+            )
+
+            mock_pres_mgr.return_value.create_presentation = (
+                async_mock.CoroutineMock(
+                    side_effect=[
+                        test_module.IndyHolderError(),
+                        test_module.StorageError(),
+                    ]
+                )
+            )
+
+            request_context.connection_ready = True
+            handler = test_module.PresentationRequestHandler()
+            responder = MockResponder()
+
+            await handler.handle(request_context, responder)
+            await handler.handle(request_context, responder)
+            mock_px_rec.save_error_state.assert_called_once()
 
     async def test_called_auto_present_no_preview(self):
         request_context = RequestContext.test_context()
@@ -208,14 +329,14 @@ class TestPresentationRequestHandler(AsyncTestCase):
             }
         )
         request_context.message_receipt = MessageReceipt()
-        px_rec_instance = handler.V10PresentationExchange(auto_present=True)
+        px_rec_instance = test_module.V10PresentationExchange(auto_present=True)
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr, async_mock.patch.object(
-            handler, "V10PresentationExchange", autospec=True
-        ) as mock_pres_ex_rec, async_mock.patch.object(
-            handler, "IndyHolder", autospec=True
+            test_module, "V10PresentationExchange", autospec=True
+        ) as mock_pres_ex_cls, async_mock.patch.object(
+            test_module, "IndyHolder", autospec=True
         ) as mock_holder:
 
             mock_holder.get_credentials_for_presentation_request_by_referent = (
@@ -228,8 +349,8 @@ class TestPresentationRequestHandler(AsyncTestCase):
             )
             request_context.inject = async_mock.MagicMock(return_value=mock_holder)
 
-            mock_pres_ex_rec.return_value = px_rec_instance
-            mock_pres_ex_rec.retrieve_by_tag_filter = async_mock.CoroutineMock(
+            mock_pres_ex_cls.return_value = px_rec_instance
+            mock_pres_ex_cls.retrieve_by_tag_filter = async_mock.CoroutineMock(
                 return_value=px_rec_instance
             )
             mock_pres_mgr.return_value.receive_request = async_mock.CoroutineMock(
@@ -240,9 +361,9 @@ class TestPresentationRequestHandler(AsyncTestCase):
                 return_value=(px_rec_instance, "presentation_message")
             )
             request_context.connection_ready = True
-            handler_inst = handler.PresentationRequestHandler()
+            handler = test_module.PresentationRequestHandler()
             responder = MockResponder()
-            await handler_inst.handle(request_context, responder)
+            await handler.handle(request_context, responder)
             mock_pres_mgr.return_value.create_presentation.assert_called_once()
 
         mock_pres_mgr.return_value.receive_request.assert_called_once_with(
@@ -280,14 +401,14 @@ class TestPresentationRequestHandler(AsyncTestCase):
             }
         )
         request_context.message_receipt = MessageReceipt()
-        px_rec_instance = handler.V10PresentationExchange(auto_present=True)
+        px_rec_instance = test_module.V10PresentationExchange(auto_present=True)
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr, async_mock.patch.object(
-            handler, "V10PresentationExchange", autospec=True
-        ) as mock_pres_ex_rec, async_mock.patch.object(
-            handler, "IndyHolder", autospec=True
+            test_module, "V10PresentationExchange", autospec=True
+        ) as mock_pres_ex_cls, async_mock.patch.object(
+            test_module, "IndyHolder", autospec=True
         ) as mock_holder:
 
             mock_holder.get_credentials_for_presentation_request_by_referent = (
@@ -295,8 +416,8 @@ class TestPresentationRequestHandler(AsyncTestCase):
             )
             request_context.inject = async_mock.MagicMock(return_value=mock_holder)
 
-            mock_pres_ex_rec.return_value = px_rec_instance
-            mock_pres_ex_rec.retrieve_by_tag_filter = async_mock.CoroutineMock(
+            mock_pres_ex_cls.return_value = px_rec_instance
+            mock_pres_ex_cls.retrieve_by_tag_filter = async_mock.CoroutineMock(
                 return_value=px_rec_instance
             )
             mock_pres_mgr.return_value.receive_request = async_mock.CoroutineMock(
@@ -307,9 +428,9 @@ class TestPresentationRequestHandler(AsyncTestCase):
                 return_value=(px_rec_instance, "presentation_message")
             )
             request_context.connection_ready = True
-            handler_inst = handler.PresentationRequestHandler()
+            handler = test_module.PresentationRequestHandler()
             responder = MockResponder()
-            await handler_inst.handle(request_context, responder)
+            await handler.handle(request_context, responder)
             mock_pres_mgr.return_value.create_presentation.assert_not_called()
 
         mock_pres_mgr.return_value.receive_request.assert_called_once_with(
@@ -343,14 +464,14 @@ class TestPresentationRequestHandler(AsyncTestCase):
             }
         )
         request_context.message_receipt = MessageReceipt()
-        px_rec_instance = handler.V10PresentationExchange(auto_present=True)
+        px_rec_instance = test_module.V10PresentationExchange(auto_present=True)
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr, async_mock.patch.object(
-            handler, "V10PresentationExchange", autospec=True
-        ) as mock_pres_ex_rec, async_mock.patch.object(
-            handler, "IndyHolder", autospec=True
+            test_module, "V10PresentationExchange", autospec=True
+        ) as mock_pres_ex_cls, async_mock.patch.object(
+            test_module, "IndyHolder", autospec=True
         ) as mock_holder:
 
             mock_holder.get_credentials_for_presentation_request_by_referent = (
@@ -360,8 +481,8 @@ class TestPresentationRequestHandler(AsyncTestCase):
             )
             request_context.inject = async_mock.MagicMock(return_value=mock_holder)
 
-            mock_pres_ex_rec.return_value = px_rec_instance
-            mock_pres_ex_rec.retrieve_by_tag_filter = async_mock.CoroutineMock(
+            mock_pres_ex_cls.return_value = px_rec_instance
+            mock_pres_ex_cls.retrieve_by_tag_filter = async_mock.CoroutineMock(
                 return_value=px_rec_instance
             )
             mock_pres_mgr.return_value.receive_request = async_mock.CoroutineMock(
@@ -372,9 +493,9 @@ class TestPresentationRequestHandler(AsyncTestCase):
                 return_value=(px_rec_instance, "presentation_message")
             )
             request_context.connection_ready = True
-            handler_inst = handler.PresentationRequestHandler()
+            handler = test_module.PresentationRequestHandler()
             responder = MockResponder()
-            await handler_inst.handle(request_context, responder)
+            await handler.handle(request_context, responder)
             mock_pres_mgr.return_value.create_presentation.assert_called_once()
 
         mock_pres_mgr.return_value.receive_request.assert_called_once_with(
@@ -412,14 +533,14 @@ class TestPresentationRequestHandler(AsyncTestCase):
             }
         )
         request_context.message_receipt = MessageReceipt()
-        px_rec_instance = handler.V10PresentationExchange(auto_present=True)
+        px_rec_instance = test_module.V10PresentationExchange(auto_present=True)
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr, async_mock.patch.object(
-            handler, "V10PresentationExchange", autospec=True
-        ) as mock_pres_ex_rec, async_mock.patch.object(
-            handler, "IndyHolder", autospec=True
+            test_module, "V10PresentationExchange", autospec=True
+        ) as mock_pres_ex_cls, async_mock.patch.object(
+            test_module, "IndyHolder", autospec=True
         ) as mock_holder:
 
             mock_holder.get_credentials_for_presentation_request_by_referent = (
@@ -432,8 +553,8 @@ class TestPresentationRequestHandler(AsyncTestCase):
             )
             request_context.inject = async_mock.MagicMock(return_value=mock_holder)
 
-            mock_pres_ex_rec.return_value = px_rec_instance
-            mock_pres_ex_rec.retrieve_by_tag_filter = async_mock.CoroutineMock(
+            mock_pres_ex_cls.return_value = px_rec_instance
+            mock_pres_ex_cls.retrieve_by_tag_filter = async_mock.CoroutineMock(
                 return_value=px_rec_instance
             )
             mock_pres_mgr.return_value.receive_request = async_mock.CoroutineMock(
@@ -444,9 +565,9 @@ class TestPresentationRequestHandler(AsyncTestCase):
                 return_value=(px_rec_instance, "presentation_message")
             )
             request_context.connection_ready = True
-            handler_inst = handler.PresentationRequestHandler()
+            handler = test_module.PresentationRequestHandler()
             responder = MockResponder()
-            await handler_inst.handle(request_context, responder)
+            await handler.handle(request_context, responder)
             mock_pres_mgr.return_value.create_presentation.assert_called_once()
 
         mock_pres_mgr.return_value.receive_request.assert_called_once_with(
@@ -490,7 +611,7 @@ class TestPresentationRequestHandler(AsyncTestCase):
             }
         )
         request_context.message_receipt = MessageReceipt()
-        px_rec_instance = handler.V10PresentationExchange(
+        px_rec_instance = test_module.V10PresentationExchange(
             presentation_proposal_dict={
                 "presentation_proposal": {
                     "@type": DIDCommPrefix.qualify_current(
@@ -507,11 +628,11 @@ class TestPresentationRequestHandler(AsyncTestCase):
         )
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr, async_mock.patch.object(
-            handler, "V10PresentationExchange", autospec=True
-        ) as mock_pres_ex_rec, async_mock.patch.object(
-            handler, "IndyHolder", autospec=True
+            test_module, "V10PresentationExchange", autospec=True
+        ) as mock_pres_ex_cls, async_mock.patch.object(
+            test_module, "IndyHolder", autospec=True
         ) as mock_holder:
 
             mock_holder.get_credentials_for_presentation_request_by_referent = (
@@ -555,8 +676,8 @@ class TestPresentationRequestHandler(AsyncTestCase):
             )
             request_context.inject = async_mock.MagicMock(return_value=mock_holder)
 
-            mock_pres_ex_rec.return_value = px_rec_instance
-            mock_pres_ex_rec.retrieve_by_tag_filter = async_mock.CoroutineMock(
+            mock_pres_ex_cls.return_value = px_rec_instance
+            mock_pres_ex_cls.retrieve_by_tag_filter = async_mock.CoroutineMock(
                 return_value=px_rec_instance
             )
             mock_pres_mgr.return_value.receive_request = async_mock.CoroutineMock(
@@ -567,9 +688,9 @@ class TestPresentationRequestHandler(AsyncTestCase):
                 return_value=(px_rec_instance, "presentation_message")
             )
             request_context.connection_ready = True
-            handler_inst = handler.PresentationRequestHandler()
+            handler = test_module.PresentationRequestHandler()
             responder = MockResponder()
-            await handler_inst.handle(request_context, responder)
+            await handler.handle(request_context, responder)
             mock_pres_mgr.return_value.create_presentation.assert_called_once()
 
         mock_pres_mgr.return_value.receive_request.assert_called_once_with(
@@ -605,7 +726,7 @@ class TestPresentationRequestHandler(AsyncTestCase):
             }
         )
         request_context.message_receipt = MessageReceipt()
-        px_rec_instance = handler.V10PresentationExchange(
+        px_rec_instance = test_module.V10PresentationExchange(
             presentation_proposal_dict={
                 "presentation_proposal": {
                     "@type": DIDCommPrefix.qualify_current(
@@ -621,11 +742,11 @@ class TestPresentationRequestHandler(AsyncTestCase):
         )
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr, async_mock.patch.object(
-            handler, "V10PresentationExchange", autospec=True
-        ) as mock_pres_ex_rec, async_mock.patch.object(
-            handler, "IndyHolder", autospec=True
+            test_module, "V10PresentationExchange", autospec=True
+        ) as mock_pres_ex_cls, async_mock.patch.object(
+            test_module, "IndyHolder", autospec=True
         ) as mock_holder:
 
             by_reft = async_mock.CoroutineMock(
@@ -659,8 +780,8 @@ class TestPresentationRequestHandler(AsyncTestCase):
             mock_holder.get_credentials_for_presentation_request_by_referent = by_reft
             request_context.inject = async_mock.MagicMock(return_value=mock_holder)
 
-            mock_pres_ex_rec.return_value = px_rec_instance
-            mock_pres_ex_rec.retrieve_by_tag_filter = async_mock.CoroutineMock(
+            mock_pres_ex_cls.return_value = px_rec_instance
+            mock_pres_ex_cls.retrieve_by_tag_filter = async_mock.CoroutineMock(
                 return_value=px_rec_instance
             )
             mock_pres_mgr.return_value.receive_request = async_mock.CoroutineMock(
@@ -671,10 +792,10 @@ class TestPresentationRequestHandler(AsyncTestCase):
                 return_value=(px_rec_instance, "presentation_message")
             )
             request_context.connection_ready = True
-            handler_inst = handler.PresentationRequestHandler()
+            handler = test_module.PresentationRequestHandler()
             responder = MockResponder()
 
-            await handler_inst.handle(request_context, responder)
+            await handler.handle(request_context, responder)
             mock_pres_mgr.return_value.create_presentation.assert_not_called()
 
         mock_pres_mgr.return_value.receive_request.assert_called_once_with(
@@ -687,14 +808,14 @@ class TestPresentationRequestHandler(AsyncTestCase):
         request_context.message_receipt = MessageReceipt()
 
         with async_mock.patch.object(
-            handler, "PresentationManager", autospec=True
+            test_module, "PresentationManager", autospec=True
         ) as mock_pres_mgr:
             mock_pres_mgr.return_value.receive_request = async_mock.CoroutineMock()
             request_context.message = PresentationRequest()
             request_context.connection_ready = False
-            handler_inst = handler.PresentationRequestHandler()
+            handler = test_module.PresentationRequestHandler()
             responder = MockResponder()
-            with self.assertRaises(handler.HandlerException):
-                await handler_inst.handle(request_context, responder)
+            with self.assertRaises(test_module.HandlerException):
+                await handler.handle(request_context, responder)
 
         assert not responder.messages

--- a/aries_cloudagent/protocols/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/manager.py
@@ -503,6 +503,14 @@ class PresentationManager:
                     name=name,
                     value=value,
                 ):
+                    presentation_exchange_record.state = None
+                    async with self._profile.session() as session:
+                        await presentation_exchange_record.save(
+                            session,
+                            reason=(
+                                f"Presentation {name}={value} mismatches proposal value"
+                            ),
+                        )
                     raise PresentationManagerError(
                         f"Presentation {name}={value} mismatches proposal value"
                     )

--- a/aries_cloudagent/protocols/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/routes.py
@@ -633,11 +633,20 @@ async def presentation_exchange_send_bound_request(request: web.BaseRequest):
             presentation_request_message,
         ) = await presentation_manager.create_bound_request(pres_ex_record)
         result = pres_ex_record.serialize()
-    except (BaseModelError, StorageError) as err:
+    except (BaseModelError, LedgerError) as err:
+        async with context.session() as session:
+            await pres_ex_record.save_error_state(session, reason=err.message)
         return await internal_error(
             err,
             web.HTTPBadRequest,
-            pres_ex_record or connection_record,
+            pres_ex_record,
+            outbound_handler,
+        )
+    except StorageError as err:
+        return await internal_error(
+            err,
+            web.HTTPBadRequest,
+            pres_ex_record,
             outbound_handler,
         )
 
@@ -731,10 +740,12 @@ async def presentation_exchange_send_presentation(request: web.BaseRequest):
         StorageError,
         WalletNotFoundError,
     ) as err:
+        async with context.session() as session:
+            await pres_ex_record.save_error_state(session, reason=err.message)
         return await internal_error(
             err,
             web.HTTPBadRequest,
-            pres_ex_record or connection_record,
+            pres_ex_record,
             outbound_handler,
         )
 
@@ -812,7 +823,13 @@ async def presentation_exchange_verify_presentation(request: web.BaseRequest):
     try:
         pres_ex_record = await presentation_manager.verify_presentation(pres_ex_record)
         result = pres_ex_record.serialize()
-    except (LedgerError, BaseModelError) as err:
+    except (BaseModelError, LedgerError) as err:
+        async with context.session() as session:
+            await pres_ex_record.save_error_state(session, reason=err.message)
+        return await internal_error(
+            err, web.HTTPBadRequest, pres_ex_record, outbound_handler
+        )
+    except StorageError as err:
         return await internal_error(
             err, web.HTTPBadRequest, pres_ex_record, outbound_handler
         )

--- a/aries_cloudagent/protocols/present_proof/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/tests/test_routes.py
@@ -1184,9 +1184,6 @@ class TestProofRoutes(AsyncTestCase):
             # Since we are mocking import
             importlib.reload(test_module)
 
-            mock_presentation_exchange.state = (
-                test_module.V10PresentationExchange.STATE_REQUEST_RECEIVED
-            )
             mock_presentation_exchange.retrieve_by_id = async_mock.CoroutineMock(
                 return_value=async_mock.MagicMock(
                     state=mock_presentation_exchange.STATE_REQUEST_RECEIVED,
@@ -1194,7 +1191,8 @@ class TestProofRoutes(AsyncTestCase):
                     serialize=async_mock.MagicMock(
                         return_value={"thread_id": "sample-thread-id"}
                     ),
-                )
+                    save_error_state=async_mock.CoroutineMock(),
+                ),
             )
             mock_connection_record.is_ready = True
             mock_connection_record.retrieve_by_id = async_mock.CoroutineMock(
@@ -1438,6 +1436,7 @@ class TestProofRoutes(AsyncTestCase):
                     serialize=async_mock.MagicMock(
                         return_value={"thread_id": "sample-thread-id"}
                     ),
+                    save_error_state=async_mock.CoroutineMock(),
                 )
             )
 

--- a/aries_cloudagent/protocols/present_proof/v2_0/handlers/pres_proposal_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/handlers/pres_proposal_handler.py
@@ -1,11 +1,14 @@
 """Presentation proposal message handler."""
 
+from .....ledger.error import LedgerError
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
+from .....storage.error import StorageError
 from .....utils.tracing import trace_event, get_timer
 
 from ..manager import V20PresManager
+from ..models.pres_exchange import V20PresExRecord
 from ..messages.pres_proposal import V20PresProposal
 
 
@@ -38,7 +41,7 @@ class V20PresProposalHandler(BaseHandler):
         pres_manager = V20PresManager(context.profile)
         pres_ex_record = await pres_manager.receive_pres_proposal(
             context.message, context.connection_record
-        )
+        )  # mgr only creates, saves record: on exception, saving state err is hopeless
 
         r_time = trace_event(
             context.settings,
@@ -49,15 +52,26 @@ class V20PresProposalHandler(BaseHandler):
 
         # If auto_respond_presentation_proposal is set, reply with proof req
         if context.settings.get("debug.auto_respond_presentation_proposal"):
-            (
-                pres_ex_record,
-                pres_request_message,
-            ) = await pres_manager.create_bound_request(
-                pres_ex_record=pres_ex_record,
-                comment=context.message.comment,
-            )
-
-            await responder.send_reply(pres_request_message)
+            pres_request_message = None
+            try:
+                (
+                    pres_ex_record,
+                    pres_request_message,
+                ) = await pres_manager.create_bound_request(
+                    pres_ex_record=pres_ex_record,
+                    comment=context.message.comment,
+                )
+                await responder.send_reply(pres_request_message)
+            except LedgerError as err:
+                self._logger.exception(err)
+                if pres_ex_record:
+                    await pres_ex_record.save_error_state(
+                        context.session(),
+                        state=V20PresExRecord.STATE_ABANDONED,
+                        reason=err.message,
+                    )
+            except StorageError as err:
+                self._logger.exception(err)  # may be logging to wire, not dead disk
 
             trace_event(
                 context.settings,

--- a/aries_cloudagent/protocols/present_proof/v2_0/handlers/pres_request_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/handlers/pres_request_handler.py
@@ -1,14 +1,16 @@
 """Presentation request message handler."""
 
-from .....indy.holder import IndyHolder
+from .....indy.holder import IndyHolder, IndyHolderError
 from .....indy.sdk.models.xform import indy_proof_req_preview2indy_requested_creds
+from .....ledger.error import LedgerError
 from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
-from .....storage.error import StorageNotFoundError
+from .....storage.error import StorageError, StorageNotFoundError
 from .....utils.tracing import trace_event, get_timer
+from .....wallet.error import WalletNotFoundError
 
-from ..manager import V20PresManager
+from ..manager import V20PresManager, V20PresManagerError
 from ..messages.pres_format import V20PresFormat
 from ..messages.pres_request import V20PresRequest
 from ..models.pres_exchange import V20PresExRecord
@@ -63,7 +65,9 @@ class V20PresRequestHandler(BaseHandler):
                 trace=(context.message._trace is not None),
             )
 
-        pres_ex_record = await pres_manager.receive_pres_request(pres_ex_record)
+        pres_ex_record = await pres_manager.receive_pres_request(
+            pres_ex_record
+        )  # mgr only saves record: on exception, saving state err is hopeless
 
         r_time = trace_event(
             context.settings,
@@ -86,16 +90,32 @@ class V20PresRequestHandler(BaseHandler):
                 self._logger.warning(f"{err}")
                 return
 
-            (pres_ex_record, pres_message) = await pres_manager.create_pres(
-                pres_ex_record=pres_ex_record,
-                requested_credentials=req_creds,
-                comment=(
-                    "auto-presented for proof request nonce "
-                    f"{indy_proof_request['nonce']}"
-                ),
-            )
-
-            await responder.send_reply(pres_message)
+            pres_message = None
+            try:
+                (pres_ex_record, pres_message) = await pres_manager.create_pres(
+                    pres_ex_record=pres_ex_record,
+                    requested_credentials=req_creds,
+                    comment=(
+                        "auto-presented for proof request nonce "
+                        f"{indy_proof_request['nonce']}"
+                    ),
+                )
+                await responder.send_reply(pres_message)
+            except (
+                IndyHolderError,
+                LedgerError,
+                V20PresManagerError,
+                WalletNotFoundError,
+            ) as err:
+                self._logger.exception(err)
+                if pres_ex_record:
+                    await pres_ex_record.save_error_state(
+                        context.session(),
+                        state=V20PresExRecord.STATE_ABANDONED,
+                        reason=err.message,
+                    )
+            except StorageError as err:
+                self._logger.exception(err)  # may be logging to wire, not dead disk
 
             trace_event(
                 context.settings,

--- a/aries_cloudagent/protocols/present_proof/v2_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/tests/test_routes.py
@@ -825,6 +825,7 @@ class TestPresentProofRoutes(AsyncTestCase):
                 serialize=async_mock.MagicMock(
                     return_value={"thread_id": "sample-thread-id"}
                 ),
+                save_error_state=async_mock.CoroutineMock(),
             )
             mock_px_rec_cls.retrieve_by_id = async_mock.CoroutineMock(
                 return_value=mock_px_rec_inst
@@ -1088,6 +1089,7 @@ class TestPresentProofRoutes(AsyncTestCase):
                 serialize=async_mock.MagicMock(
                     return_value={"thread_id": "sample-thread-id"}
                 ),
+                save_error_state=async_mock.CoroutineMock(),
             )
             mock_px_rec_cls.retrieve_by_id = async_mock.CoroutineMock(
                 return_value=mock_px_rec_inst
@@ -1248,6 +1250,7 @@ class TestPresentProofRoutes(AsyncTestCase):
                 serialize=async_mock.MagicMock(
                     return_value={"thread_id": "sample-thread-id"}
                 ),
+                save_error_state=async_mock.CoroutineMock(),
             )
             mock_px_rec_cls.retrieve_by_id = async_mock.CoroutineMock(
                 return_value=mock_px_rec_inst


### PR DESCRIPTION
RFCs 36, 37, 453 state that exchange states go to null on both sides on error; 454 uses "abandoned".

This work sets states accordingly where possible (unless there is no such record or the problem is storage itself), but does not (yet) send problem reports - that's another PR for the near-ish future.

In issue-credential, separate store-credential from send-ack: whether storage succeeds or fails, the protocol owes an ack because acknowledgement is to credential receipt, not storage.