### PR TITLE
Tags on connection metadata

### DIFF
--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -180,6 +180,7 @@ class ConnRecord(BaseRecord):
         accept: str = None,
         invitation_mode: str = None,
         alias: str = None,
+        metadata: dict = None,
         their_public_did: str = None,
         rfc23_state: str = None,  # from state: formalism for base_record.from_storage()
         initiator: str = None,  # for backward compatibility with old ConnectionRecord
@@ -210,6 +211,7 @@ class ConnRecord(BaseRecord):
         self.accept = accept or self.ACCEPT_MANUAL
         self.invitation_mode = invitation_mode or self.INVITATION_MODE_ONCE
         self.alias = alias
+        self.metadata = metadata
         self.their_public_did = their_public_did
 
     @property
@@ -235,6 +237,7 @@ class ConnRecord(BaseRecord):
                 "invitation_mode",
                 "invitation_msg_id",
                 "alias",
+                "metadata",
                 "error_msg",
                 "their_label",
                 "state",
@@ -598,6 +601,13 @@ class ConnRecordSchema(BaseRecordSchema):
         description="Optional alias to apply to connection for later use",
         example="Bob, providing quotes",
     )
+
+    metadata = fields.Dict(
+        description="Optional metadata to tag connections",
+        required=False,
+        example={"tags": ["tag1", "tag2"]},
+    )
+
     their_public_did = fields.Str(
         required=False,
         description="Other agent's public DID for connection",

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -46,16 +46,21 @@ def match_post_filter(
             values in post_filter
     """
 
-    def filter_keys(record, k, filter_tags):
-        if k == "tags":
-            metadata = record.get("metadata")
-            if not metadata:
-                return False
-            tags = metadata.get(k, [])
-            intersect = list(set(filter_tags) & set(tags))
-            return tags and len(intersect) == len(filter_tags)
+    def filter_tags(record, k, filter_tags):
 
-        return record.get(k) and record.get(k) in filter_tags
+        metadata = record.get("metadata")
+        if not metadata:
+            return False
+        tags = metadata.get(k, [])
+        intersect = list(set(filter_tags) & set(tags))
+        return tags and len(intersect) == len(filter_tags)
+
+    def filter_keys(record, k, alts):
+        if k == "tags":
+
+            return filter_tags(record, k, alts)
+
+        return record.get(k) and record.get(k) in alts
 
     if not post_filter:
         return True
@@ -73,10 +78,7 @@ def match_post_filter(
         if record.get(k) == v:
             continue
         elif k == "tags":
-            record_tags = record.get("metadata").get(k)
-            filter_tags = v
-            intersect = list(set(filter_tags) & set(record_tags))
-            if len(intersect) != len(filter_tags):
+            if not filter_tags(record, k, v):
                 return not positive
 
         else:

--- a/aries_cloudagent/messaging/models/tests/test_base_record.py
+++ b/aries_cloudagent/messaging/models/tests/test_base_record.py
@@ -15,7 +15,7 @@ from ....storage.base import (
 
 from ...util import time_now
 
-from ..base_record import BaseRecord, BaseRecordSchema, LOGGER
+from ..base_record import BaseRecord, BaseRecordSchema, LOGGER, match_post_filter
 
 
 class BaseRecordImpl(BaseRecord):
@@ -328,3 +328,11 @@ class TestBaseRecord(AsyncTestCase):
         assert UnencTestImpl.prefix_tag_filter(tags) == {
             "$or": [{"~a": "x"}, {"c": "z"}]
         }
+
+    async def test_match_post_filter_tags_purposes(self):
+        assert match_post_filter(
+            record={"metadata": {"tags": [1, 2]}}, post_filter={"tags": [1, 2]}
+        )
+        assert not match_post_filter(
+            record={"alias": "test"}, post_filter={"tags": [1, 2]}
+        )

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -214,6 +214,7 @@ class ConnectionManager(BaseConnectionManager):
             accept=accept,
             invitation_mode=invitation_mode,
             alias=alias,
+            metadata=metadata,
         )
 
         await connection.save(self._session, reason="Created new invitation")
@@ -273,6 +274,7 @@ class ConnectionManager(BaseConnectionManager):
         their_public_did: str = None,
         auto_accept: bool = None,
         alias: str = None,
+        metadata: dict = None,
         mediation_id: str = None,
         mediation_record: MediationRecord = None,
     ) -> ConnRecord:
@@ -318,6 +320,7 @@ class ConnectionManager(BaseConnectionManager):
             state=ConnRecord.State.INVITATION.rfc160,
             accept=accept,
             alias=alias,
+            metadata=metadata,
             their_public_did=their_public_did,
         )
 
@@ -855,6 +858,7 @@ class ConnectionManager(BaseConnectionManager):
         their_endpoint: str = None,
         their_label: str = None,
         alias: str = None,
+        metadata: str = None,
     ) -> Tuple[DIDInfo, DIDInfo, ConnRecord]:
         """
         Register a new static connection (for use by the test suite).
@@ -906,6 +910,7 @@ class ConnectionManager(BaseConnectionManager):
             their_label=their_label,
             state=ConnRecord.State.COMPLETED.rfc160,
             alias=alias,
+            metadata=metadata,
         )
         await connection.save(self._session, reason="Created new static connection")
 

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -176,7 +176,7 @@ class ConnectionsListQueryStringSchema(OpenAPISchema):
     )
 
     tags = fields.Str(
-        description="Tags",
+        description="Tags separated by commas",
         required=False,
         example="tag1,tag2",
     )
@@ -213,7 +213,7 @@ class CreateInvitationQueryStringSchema(OpenAPISchema):
     )
 
     tags = fields.Str(
-        description="Tags",
+        description="Tags separated by commas",
         required=False,
         example="tag1,tag2",
     )
@@ -239,7 +239,7 @@ class ReceiveInvitationQueryStringSchema(OpenAPISchema):
         example="Barry",
     )
     tags = fields.Str(
-        description="Tags",
+        description="Tags separated by commas",
         required=False,
         example="tag1,tag2",
     )

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -238,6 +238,11 @@ class ReceiveInvitationQueryStringSchema(OpenAPISchema):
         required=False,
         example="Barry",
     )
+    tags = fields.Str(
+        description="Tags",
+        required=False,
+        example="tag1,tag2",
+    )
 
     auto_accept = fields.Boolean(
         description="Auto-accept connection (defaults to configuration)",
@@ -584,8 +589,17 @@ async def connections_receive_invitation(request: web.BaseRequest):
         auto_accept = json.loads(request.query.get("auto_accept", "null"))
         alias = request.query.get("alias")
         mediation_id = request.query.get("mediation_id")
+        tags = request.query.get("tags")
+        metadata = None
+        if tags:
+            metadata = {"tags": tags.split(",")}
+
         connection = await connection_mgr.receive_invitation(
-            invitation, auto_accept=auto_accept, alias=alias, mediation_id=mediation_id
+            invitation,
+            auto_accept=auto_accept,
+            alias=alias,
+            mediation_id=mediation_id,
+            metadata=metadata,
         )
         result = connection.serialize()
     except (ConnectionManagerError, StorageError, BaseModelError) as err:

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
@@ -29,6 +29,7 @@ class TestConnectionRoutes(AsyncTestCase):
         self.request.query = {
             "invitation_id": "dummy",  # exercise tag filter assignment
             "their_role": ConnRecord.Role.REQUESTER.rfc160,
+            "tags":  "tag1"
         }
 
         STATE_COMPLETED = ConnRecord.State.COMPLETED
@@ -58,6 +59,7 @@ class TestConnectionRoutes(AsyncTestCase):
                         return_value={
                             "state": ConnRecord.State.COMPLETED.rfc23,
                             "created_at": "1234567890",
+                            "metadata": {"tags": ["tag1"]},
                         }
                     )
                 ),
@@ -66,6 +68,7 @@ class TestConnectionRoutes(AsyncTestCase):
                         return_value={
                             "state": ConnRecord.State.INVITATION.rfc23,
                             "created_at": "1234567890",
+                            "metadata": {"tags": ["tag1"]},
                         }
                     )
                 ),
@@ -74,6 +77,8 @@ class TestConnectionRoutes(AsyncTestCase):
                         return_value={
                             "state": ConnRecord.State.ABANDONED.rfc23,
                             "created_at": "1234567890",
+                            "metadata": {"tags": ["tag1"]},
+
                         }
                     )
                 ),
@@ -89,7 +94,7 @@ class TestConnectionRoutes(AsyncTestCase):
                         "results": [
                             {
                                 k: c.serialize.return_value[k]
-                                for k in ["state", "created_at"]
+                                for k in ["state", "created_at", "metadata"]
                             }
                             for c in conns
                         ]


### PR DESCRIPTION
With this PR, It is possible to add tags to connections. The tags are saved as a metadata key-value on the connections record.
Once the connections have been tagged, it is possible to group them on tags.

The tags are added on `/connections/create-invitation` & `/connections/receive-invitation` via a query parameter called `tags` in the request.  The input is a string, it is possible to add multiple tags if they are separated by commas. 

The tags could be filtered on `/connections` via a query parameter called `tags` in the request. The input is a string, it is possible to filter by multiple tags if they are separated by commas.

**Examples**:

- Create invitation

> Request
`curl -X POST "http://localhost:8021/connections/create-invitation?tags=tag1%2Ctag3" -H "accept: application/json" -H "Content-Type: application/json" -d "{ }"`

> Response
`{
  "connection_id": "8e1d9605-5843-4844-99d1-96141329e006",
  "invitation": {
    "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation",
    "@id": "1b62e664-a8d9-4c97-bb7a-2ba3b5329ebb",
    "recipientKeys": [
      "Gsc9q2FskuKYH2bAMnd3UkQadEkJ4QFwwA8RUdyGqsTo"
    ],
    "label": "faber.agent",
    "serviceEndpoint": "https://0639b9bd3d2a.ngrok.io"
  },
  "invitation_url": "https://0639b9bd3d2a.ngrok.io?c_i=eyJAdHlwZSI6ICJkaWQ6c292OkJ6Q2JzTlloTXJqSGlxWkRUVUFTSGc7c3BlYy9jb25uZWN0aW9ucy8xLjAvaW52aXRhdGlvbiIsICJAaWQiOiAiMWI2MmU2NjQtYThkOS00Yzk3LWJiN2EtMmJhM2I1MzI5ZWJiIiwgInJlY2lwaWVudEtleXMiOiBbIkdzYzlxMkZza3VLWUgyYkFNbmQzVWtRYWRFa0o0UUZ3d0E4UlVkeUdxc1RvIl0sICJsYWJlbCI6ICJmYWJlci5hZ2VudCIsICJzZXJ2aWNlRW5kcG9pbnQiOiAiaHR0cHM6Ly8wNjM5YjliZDNkMmEubmdyb2suaW8ifQ=="
}`

- Filter connections

> Request
`curl -X GET "http://localhost:8021/connections?tags=tag1" -H "accept: application/json"`

> Response
`{
  "results": [
    {
      "updated_at": "2021-05-20 12:06:41.865730Z",
      "created_at": "2021-05-20 12:06:41.865730Z",
      "accept": "manual",
      "rfc23_state": "invitation-sent",
      "their_role": "invitee",
      "routing_state": "none",
      "state": "invitation",
      "invitation_mode": "once",
      "connection_id": "8e1d9605-5843-4844-99d1-96141329e006",
      "invitation_key": "Gsc9q2FskuKYH2bAMnd3UkQadEkJ4QFwwA8RUdyGqsTo",
      "metadata": {
        "tags": [
          "tag1",
          "tag3"
        ]
      }
    }
  ]
}`

Based on @burdettadam idea, https://github.com/sicpa-dlab/aries-cloudagent-python/issues/49.