### PR TITLE
AIP-2 base64url consistency

### DIFF
--- a/aries_cloudagent/messaging/decorators/attach_decorator.py
+++ b/aries_cloudagent/messaging/decorators/attach_decorator.py
@@ -571,6 +571,7 @@ class AttachDecorator(BaseModel):
         cls,
         mapping: Mapping,
         *,
+        flag_aip2: bool = False,
         ident: str = None,
         description: str = None,
         filename: str = None,
@@ -590,8 +591,13 @@ class AttachDecorator(BaseModel):
             filename: optional attachment filename
             lastmod_time: optional attachment last modification time
             byte_count: optional attachment byte count
+            flag_aip2: whether attach base64url encoded data
 
         """
+        if flag_aip2:
+            b64_attach = bytes_to_b64(json.dumps(mapping).encode(), urlsafe=True)
+        else:
+            b64_attach = bytes_to_b64(json.dumps(mapping).encode())
         return AttachDecorator(
             ident=ident or str(uuid.uuid4()),
             description=description,
@@ -599,9 +605,7 @@ class AttachDecorator(BaseModel):
             mime_type="application/json",
             lastmod_time=lastmod_time,
             byte_count=byte_count,
-            data=AttachDecoratorData(
-                base64_=bytes_to_b64(json.dumps(mapping).encode())
-            ),
+            data=AttachDecoratorData(base64_=b64_attach),
         )
 
     @classmethod

--- a/aries_cloudagent/messaging/decorators/attach_decorator.py
+++ b/aries_cloudagent/messaging/decorators/attach_decorator.py
@@ -571,7 +571,7 @@ class AttachDecorator(BaseModel):
         cls,
         mapping: Mapping,
         *,
-        flag_aip2: bool = False,
+        aip2_flag: bool = False,
         ident: str = None,
         description: str = None,
         filename: str = None,
@@ -591,10 +591,10 @@ class AttachDecorator(BaseModel):
             filename: optional attachment filename
             lastmod_time: optional attachment last modification time
             byte_count: optional attachment byte count
-            flag_aip2: whether attach base64url encoded data
+            aip2_flag: whether attach base64url encoded data
 
         """
-        if flag_aip2:
+        if aip2_flag:
             b64_attach = bytes_to_b64(json.dumps(mapping).encode(), urlsafe=True)
         else:
             b64_attach = bytes_to_b64(json.dumps(mapping).encode())

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -275,10 +275,11 @@ class DIDXManager(BaseConnectionManager):
             ),
         )
         pthid = conn_rec.invitation_msg_id or f"did:sov:{conn_rec.their_public_did}"
-        if self._session.profile.settings.get(
+        # if self._session.profile.settings.get_value("aip_version", 1) >= 2:
+        if self._session.profile.settings.get_value(
             "emit_new_didcomm_mime_type"
-        ) and self._session.profile.get("emit_new_didcomm_prefix"):
-            attach = AttachDecorator.data_base64(did_doc.serialize(), flag_aip2=True)
+        ) and self._session.profile.settings.get_value("emit_new_didcomm_prefix"):
+            attach = AttachDecorator.data_base64(did_doc.serialize(), aip2_flag=True)
         else:
             attach = AttachDecorator.data_base64(did_doc.serialize())
         await attach.data.sign(my_info.verkey, wallet)
@@ -597,10 +598,11 @@ class DIDXManager(BaseConnectionManager):
                 filter(None, [base_mediation_record, mediation_record])
             ),
         )
-        if self._session.profile.settings.get(
+        # if self._session.profile.settings.get_value("aip_version", 1) >= 2:
+        if self._session.profile.settings.get_value(
             "emit_new_didcomm_mime_type"
-        ) and self._session.profile.get("emit_new_didcomm_prefix"):
-            attach = AttachDecorator.data_base64(did_doc.serialize(), flag_aip2=True)
+        ) and self._session.profile.settings.get_value("emit_new_didcomm_prefix"):
+            attach = AttachDecorator.data_base64(did_doc.serialize(), aip2_flag=True)
         else:
             attach = AttachDecorator.data_base64(did_doc.serialize())
         await attach.data.sign(conn_rec.invitation_key, wallet)

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -275,7 +275,12 @@ class DIDXManager(BaseConnectionManager):
             ),
         )
         pthid = conn_rec.invitation_msg_id or f"did:sov:{conn_rec.their_public_did}"
-        attach = AttachDecorator.data_base64(did_doc.serialize())
+        if self._session.profile.settings.get(
+            "emit_new_didcomm_mime_type"
+        ) and self._session.profile.get("emit_new_didcomm_prefix"):
+            attach = AttachDecorator.data_base64(did_doc.serialize(), flag_aip2=True)
+        else:
+            attach = AttachDecorator.data_base64(did_doc.serialize())
         await attach.data.sign(my_info.verkey, wallet)
         if not my_label:
             my_label = self._session.settings.get("default_label")
@@ -592,7 +597,12 @@ class DIDXManager(BaseConnectionManager):
                 filter(None, [base_mediation_record, mediation_record])
             ),
         )
-        attach = AttachDecorator.data_base64(did_doc.serialize())
+        if self._session.profile.settings.get(
+            "emit_new_didcomm_mime_type"
+        ) and self._session.profile.get("emit_new_didcomm_prefix"):
+            attach = AttachDecorator.data_base64(did_doc.serialize(), flag_aip2=True)
+        else:
+            attach = AttachDecorator.data_base64(did_doc.serialize())
         await attach.data.sign(conn_rec.invitation_key, wallet)
         response = DIDXResponse(did=my_info.did, did_doc_attach=attach)
         # Assign thread information

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -287,7 +287,14 @@ class CredentialManager:
         credential_offer_message = CredentialOffer(
             comment=comment,
             credential_preview=credential_preview,
-            offers_attach=[CredentialOffer.wrap_indy_offer(credential_offer)],
+            offers_attach=[
+                (
+                    CredentialOffer.wrap_indy_offer(credential_offer, flag_aip2=True)
+                    if self._profile.settings.get("emit_new_didcomm_mime_type")
+                    and self._profile.get("emit_new_didcomm_prefix")
+                    else CredentialOffer.wrap_indy_offer(credential_offer)
+                )
+            ],
         )
 
         credential_offer_message._thread = {"thid": cred_ex_record.thread_id}
@@ -437,7 +444,16 @@ class CredentialManager:
 
         credential_request_message = CredentialRequest(
             requests_attach=[
-                CredentialRequest.wrap_indy_cred_req(cred_ex_record.credential_request)
+                (
+                    CredentialRequest.wrap_indy_cred_req(
+                        cred_ex_record.credential_request, flag_aip2=True
+                    )
+                    if self._profile.settings.get("emit_new_didcomm_mime_type")
+                    and self._profile.get("emit_new_didcomm_prefix")
+                    else CredentialRequest.wrap_indy_cred_req(
+                        cred_ex_record.credential_request
+                    )
+                )
             ]
         )
         credential_request_message._thread = {"thid": cred_ex_record.thread_id}
@@ -660,7 +676,14 @@ class CredentialManager:
         credential_message = CredentialIssue(
             comment=comment,
             credentials_attach=[
-                CredentialIssue.wrap_indy_credential(cred_ex_record.credential)
+                (
+                    CredentialIssue.wrap_indy_credential(
+                        cred_ex_record.credential, flag_aip2=True
+                    )
+                    if self._profile.settings.get("emit_new_didcomm_mime_type")
+                    and self._profile.get("emit_new_didcomm_prefix")
+                    else CredentialIssue.wrap_indy_credential(cred_ex_record.credential)
+                )
             ],
         )
         credential_message._thread = {"thid": cred_ex_record.thread_id}

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -289,9 +289,10 @@ class CredentialManager:
             credential_preview=credential_preview,
             offers_attach=[
                 (
-                    CredentialOffer.wrap_indy_offer(credential_offer, flag_aip2=True)
-                    if self._profile.settings.get("emit_new_didcomm_mime_type")
-                    and self._profile.get("emit_new_didcomm_prefix")
+                    CredentialOffer.wrap_indy_offer(credential_offer, aip2_flag=True)
+                    # if self._profile.settings.get_value("aip_version", 1) >= 2
+                    if self._profile.settings.get_value("emit_new_didcomm_mime_type")
+                    and self._profile.settings.get_value("emit_new_didcomm_prefix")
                     else CredentialOffer.wrap_indy_offer(credential_offer)
                 )
             ],
@@ -446,10 +447,11 @@ class CredentialManager:
             requests_attach=[
                 (
                     CredentialRequest.wrap_indy_cred_req(
-                        cred_ex_record.credential_request, flag_aip2=True
+                        cred_ex_record.credential_request, aip2_flag=True
                     )
-                    if self._profile.settings.get("emit_new_didcomm_mime_type")
-                    and self._profile.get("emit_new_didcomm_prefix")
+                    # if self._profile.settings.get_value("aip_version", 1) >= 2
+                    if self._profile.settings.get_value("emit_new_didcomm_mime_type")
+                    and self._profile.settings.get_value("emit_new_didcomm_prefix")
                     else CredentialRequest.wrap_indy_cred_req(
                         cred_ex_record.credential_request
                     )
@@ -678,10 +680,11 @@ class CredentialManager:
             credentials_attach=[
                 (
                     CredentialIssue.wrap_indy_credential(
-                        cred_ex_record.credential, flag_aip2=True
+                        cred_ex_record.credential, aip2_flag=True
                     )
-                    if self._profile.settings.get("emit_new_didcomm_mime_type")
-                    and self._profile.get("emit_new_didcomm_prefix")
+                    # if self._profile.settings.get_value("aip_version", 1) >= 2
+                    if self._profile.settings.get_value("emit_new_didcomm_mime_type")
+                    and self._profile.settings.get_value("emit_new_didcomm_prefix")
                     else CredentialIssue.wrap_indy_credential(cred_ex_record.credential)
                 )
             ],

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_issue.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_issue.py
@@ -60,13 +60,13 @@ class CredentialIssue(AgentMessage):
 
     @classmethod
     def wrap_indy_credential(
-        cls, indy_cred: dict, flag_aip2: bool = False
+        cls, indy_cred: dict, aip2_flag: bool = False
     ) -> AttachDecorator:
         """Convert an indy credential offer to an attachment decorator."""
         return AttachDecorator.data_base64(
             mapping=indy_cred,
             ident=ATTACH_DECO_IDS[CREDENTIAL_ISSUE],
-            flag_aip2=flag_aip2,
+            aip2_flag=aip2_flag,
         )
 
 

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_issue.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_issue.py
@@ -59,10 +59,14 @@ class CredentialIssue(AgentMessage):
         return self.credentials_attach[index].content
 
     @classmethod
-    def wrap_indy_credential(cls, indy_cred: dict) -> AttachDecorator:
+    def wrap_indy_credential(
+        cls, indy_cred: dict, flag_aip2: bool = False
+    ) -> AttachDecorator:
         """Convert an indy credential offer to an attachment decorator."""
         return AttachDecorator.data_base64(
-            mapping=indy_cred, ident=ATTACH_DECO_IDS[CREDENTIAL_ISSUE]
+            mapping=indy_cred,
+            ident=ATTACH_DECO_IDS[CREDENTIAL_ISSUE],
+            flag_aip2=flag_aip2,
         )
 
 

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_offer.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_offer.py
@@ -63,10 +63,14 @@ class CredentialOffer(AgentMessage):
         return self.offers_attach[index].content
 
     @classmethod
-    def wrap_indy_offer(cls, indy_offer: dict) -> AttachDecorator:
+    def wrap_indy_offer(
+        cls, indy_offer: dict, flag_aip2: bool = False
+    ) -> AttachDecorator:
         """Convert an indy credential offer to an attachment decorator."""
         return AttachDecorator.data_base64(
-            mapping=indy_offer, ident=ATTACH_DECO_IDS[CREDENTIAL_OFFER]
+            mapping=indy_offer,
+            ident=ATTACH_DECO_IDS[CREDENTIAL_OFFER],
+            flag_aip2=flag_aip2,
         )
 
 

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_offer.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_offer.py
@@ -64,13 +64,13 @@ class CredentialOffer(AgentMessage):
 
     @classmethod
     def wrap_indy_offer(
-        cls, indy_offer: dict, flag_aip2: bool = False
+        cls, indy_offer: dict, aip2_flag: bool = False
     ) -> AttachDecorator:
         """Convert an indy credential offer to an attachment decorator."""
         return AttachDecorator.data_base64(
             mapping=indy_offer,
             ident=ATTACH_DECO_IDS[CREDENTIAL_OFFER],
-            flag_aip2=flag_aip2,
+            aip2_flag=aip2_flag,
         )
 
 

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_request.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_request.py
@@ -60,10 +60,14 @@ class CredentialRequest(AgentMessage):
         return self.requests_attach[index].content
 
     @classmethod
-    def wrap_indy_cred_req(cls, indy_cred_req: dict) -> AttachDecorator:
+    def wrap_indy_cred_req(
+        cls, indy_cred_req: dict, flag_aip2: bool = False
+    ) -> AttachDecorator:
         """Convert an indy credential request to an attachment decorator."""
         return AttachDecorator.data_base64(
-            mapping=indy_cred_req, ident=ATTACH_DECO_IDS[CREDENTIAL_REQUEST]
+            mapping=indy_cred_req,
+            ident=ATTACH_DECO_IDS[CREDENTIAL_REQUEST],
+            flag_aip2=flag_aip2,
         )
 
 

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_request.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_request.py
@@ -61,13 +61,13 @@ class CredentialRequest(AgentMessage):
 
     @classmethod
     def wrap_indy_cred_req(
-        cls, indy_cred_req: dict, flag_aip2: bool = False
+        cls, indy_cred_req: dict, aip2_flag: bool = False
     ) -> AttachDecorator:
         """Convert an indy credential request to an attachment decorator."""
         return AttachDecorator.data_base64(
             mapping=indy_cred_req,
             ident=ATTACH_DECO_IDS[CREDENTIAL_REQUEST],
-            flag_aip2=flag_aip2,
+            aip2_flag=aip2_flag,
         )
 
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
@@ -104,7 +104,8 @@ class V20CredFormatHandler(ABC):
             CredFormatAttachment: Credential format and attachment data objects
 
         """
-        flag_aip2 = self.profile.settings.get(
+        # aip2_flag = (self.profile.settings.get("aip_version", 1) >= 2)
+        aip2_flag = self.profile.settings.get(
             "emit_new_didcomm_mime_type"
         ) and self.profile.settings.get("emit_new_didcomm_prefix")
         return (
@@ -114,9 +115,9 @@ class V20CredFormatHandler(ABC):
             ),
             (
                 AttachDecorator.data_base64(
-                    data, ident=self.format.api, flag_aip2=flag_aip2
+                    data, ident=self.format.api, aip2_flag=aip2_flag
                 )
-                if flag_aip2
+                if aip2_flag
                 else AttachDecorator.data_base64(data, ident=self.format.api)
             ),
         )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
@@ -104,12 +104,21 @@ class V20CredFormatHandler(ABC):
             CredFormatAttachment: Credential format and attachment data objects
 
         """
+        flag_aip2 = self.profile.settings.get(
+            "emit_new_didcomm_mime_type"
+        ) and self.profile.settings.get("emit_new_didcomm_prefix")
         return (
             V20CredFormat(
                 attach_id=self.format.api,
                 format_=self.get_format_identifier(message_type),
             ),
-            AttachDecorator.data_base64(data, ident=self.format.api),
+            (
+                AttachDecorator.data_base64(
+                    data, ident=self.format.api, flag_aip2=flag_aip2
+                )
+                if flag_aip2
+                else AttachDecorator.data_base64(data, ident=self.format.api)
+            ),
         )
 
     @abstractclassmethod

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
@@ -102,7 +102,6 @@ class IndyCredFormatHandler(V20CredFormatHandler):
         """Create indy credential proposal."""
         if proposal_data is None:
             proposal_data = {}
-
         return self.get_format_data(CRED_20_PROPOSAL, proposal_data)
 
     async def receive_proposal(

--- a/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
@@ -356,7 +356,7 @@ class V20CredExIdMatchInfoSchema(OpenAPISchema):
     )
 
 
-def _formats_filters(filt_spec: Mapping, flag_aip2: bool = False) -> Mapping:
+def _formats_filters(filt_spec: Mapping, aip2_flag: bool = False) -> Mapping:
     """Break out formats and filters for v2.0 cred proposal messages."""
 
     return (
@@ -371,9 +371,9 @@ def _formats_filters(filt_spec: Mapping, flag_aip2: bool = False) -> Mapping:
             "filters_attach": [
                 (
                     AttachDecorator.data_base64(
-                        filt_by_fmt, ident=fmt_api, flag_aip2=flag_aip2
+                        filt_by_fmt, ident=fmt_api, aip2_flag=aip2_flag
                     )
-                    if flag_aip2
+                    if aip2_flag
                     else AttachDecorator.data_base64(filt_by_fmt, ident=fmt_api)
                 )
                 for (fmt_api, filt_by_fmt) in filt_spec.items()
@@ -516,9 +516,10 @@ async def credential_exchange_create(request: web.BaseRequest):
     if not filt_spec:
         raise web.HTTPBadRequest(reason="Missing filter")
     trace_msg = body.get("trace")
-    flag_aip2 = context.profile.settings.get(
+    # aip2_flag = (context.profile.settings.get_value("aip_version", 1) >= 2)
+    aip2_flag = context.profile.settings.get_value(
         "emit_new_didcomm_mime_type"
-    ) and context.profile.get("emit_new_didcomm_prefix")
+    ) and context.profile.settings.get_value("emit_new_didcomm_prefix")
 
     try:
         # Not all formats use credential preview
@@ -528,7 +529,7 @@ async def credential_exchange_create(request: web.BaseRequest):
         cred_proposal = V20CredProposal(
             comment=comment,
             credential_preview=cred_preview,
-            **_formats_filters(filt_spec, flag_aip2=flag_aip2),
+            **_formats_filters(filt_spec, aip2_flag=aip2_flag),
         )
         cred_proposal.assign_trace_decorator(
             context.settings,
@@ -596,9 +597,10 @@ async def credential_exchange_send(request: web.BaseRequest):
     preview_spec = body.get("credential_preview")
     auto_remove = body.get("auto_remove")
     trace_msg = body.get("trace")
-    flag_aip2 = context.profile.settings.get(
+    # aip2_flag = (context.profile.settings.get_value("aip_version", 1) >= 2)
+    aip2_flag = context.profile.settings.get_value(
         "emit_new_didcomm_mime_type"
-    ) and context.profile.get("emit_new_didcomm_prefix")
+    ) and context.profile.settings.get_value("emit_new_didcomm_prefix")
 
     conn_record = None
     cred_ex_record = None
@@ -617,7 +619,7 @@ async def credential_exchange_send(request: web.BaseRequest):
         cred_proposal = V20CredProposal(
             comment=comment,
             credential_preview=cred_preview,
-            **_formats_filters(filt_spec, flag_aip2=flag_aip2),
+            **_formats_filters(filt_spec, aip2_flag=aip2_flag),
         )
         cred_proposal.assign_trace_decorator(
             context.settings,
@@ -761,13 +763,14 @@ async def _create_free_offer(
     """Create a credential offer and related exchange record."""
 
     cred_preview = V20CredPreview.deserialize(preview_spec) if preview_spec else None
-    flag_aip2 = profile.settings.get("emit_new_didcomm_mime_type") and profile.get(
-        "emit_new_didcomm_prefix"
-    )
+    # aip2_flag = (profile.settings.get_value("aip_version", 1) >= 2)
+    aip2_flag = profile.settings.get_value(
+        "emit_new_didcomm_mime_type"
+    ) and profile.settings.get_value("emit_new_didcomm_prefix")
     cred_proposal = V20CredProposal(
         comment=comment,
         credential_preview=cred_preview,
-        **_formats_filters(filt_spec, flag_aip2=flag_aip2),
+        **_formats_filters(filt_spec, aip2_flag=aip2_flag),
     )
     cred_proposal.assign_trace_decorator(
         profile.settings,
@@ -1012,9 +1015,10 @@ async def credential_exchange_send_bound_offer(request: web.BaseRequest):
     preview_spec = body.get("counter_preview")
 
     cred_ex_id = request.match_info["cred_ex_id"]
-    flag_aip2 = context.profile.settings.get(
+    # aip2_flag = (context.profile.settings.get_value("aip_version", 1) >= 2)
+    aip2_flag = context.profile.settings.get_value(
         "emit_new_didcomm_mime_type"
-    ) and context.profile.get("emit_new_didcomm_prefix")
+    ) and context.profile.settings.get_value("emit_new_didcomm_prefix")
 
     cred_ex_record = None
     conn_record = None
@@ -1048,7 +1052,7 @@ async def credential_exchange_send_bound_offer(request: web.BaseRequest):
             counter_proposal=V20CredProposal(
                 comment=None,
                 credential_preview=(V20CredPreview.deserialize(preview_spec)),
-                **_formats_filters(filt_spec, flag_aip2=flag_aip2),
+                **_formats_filters(filt_spec, aip2_flag=aip2_flag),
             )
             if preview_spec
             else None,
@@ -1120,9 +1124,10 @@ async def credential_exchange_send_free_request(request: web.BaseRequest):
         raise web.HTTPBadRequest(reason="Missing filter")
     auto_remove = body.get("auto_remove")
     trace_msg = body.get("trace")
-    flag_aip2 = context.profile.settings.get(
+    # aip2_flag = (context.profile.settings.get_value("aip_version", 1) >= 2)
+    aip2_flag = context.profile.settings.get_value(
         "emit_new_didcomm_mime_type"
-    ) and context.profile.get("emit_new_didcomm_prefix")
+    ) and context.profile.settings.get_value("emit_new_didcomm_prefix")
 
     conn_record = None
     cred_ex_record = None
@@ -1141,7 +1146,7 @@ async def credential_exchange_send_free_request(request: web.BaseRequest):
 
         cred_proposal = V20CredProposal(
             comment=comment,
-            **_formats_filters(filt_spec, flag_aip2=flag_aip2),
+            **_formats_filters(filt_spec, aip2_flag=aip2_flag),
         )
 
         cred_ex_record = V20CredExRecord(

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
@@ -1302,13 +1302,14 @@ class TestV20CredRoutes(AsyncTestCase):
             mock_response.assert_called_once_with(mock_cx_rec.serialize.return_value)
 
     async def test_credential_exchange_send_free_request_aip2(self):
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "filter": {"ld_proof": {"credential": {}, "options": {}}},
-            }
-        )
         self.context.profile.settings.set_value("emit_new_didcomm_mime_type", True)
         self.context.profile.settings.set_value("emit_new_didcomm_prefix", True)
+        self.request.json = async_mock.CoroutineMock(
+            return_value={
+                "filter": {"ld_proof": LD_PROOF_VC_DETAIL},
+            }
+        )
+
         with async_mock.patch.object(
             test_module, "ConnRecord", autospec=True
         ) as mock_conn_rec, async_mock.patch.object(

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
@@ -271,6 +271,38 @@ class TestV20CredRoutes(AsyncTestCase):
 
             mock_response.assert_called_once_with(mock_cx_rec.serialize.return_value)
 
+    async def test_credential_exchange_create_aip2(self):
+        self.request.json = async_mock.CoroutineMock()
+        self.context.profile.settings.set_value("emit_new_didcomm_mime_type", True)
+        self.context.profile.settings.set_value("emit_new_didcomm_prefix", True)
+        with async_mock.patch.object(
+            test_module, "ConnRecord", autospec=True
+        ) as mock_connection_record, async_mock.patch.object(
+            test_module, "V20CredManager", autospec=True
+        ) as mock_cred_mgr, async_mock.patch.object(
+            test_module.V20CredPreview, "deserialize", autospec=True
+        ) as mock_cred_preview_deser, async_mock.patch.object(
+            test_module.web, "json_response"
+        ) as mock_response:
+            mock_cred_mgr.return_value.create_offer = async_mock.CoroutineMock()
+
+            mock_cred_mgr.return_value.create_offer.return_value = (
+                async_mock.CoroutineMock(),
+                async_mock.CoroutineMock(),
+            )
+
+            mock_cx_rec = async_mock.MagicMock()
+            mock_cred_offer = async_mock.MagicMock()
+
+            mock_cred_mgr.return_value.prepare_send.return_value = (
+                mock_cx_rec,
+                mock_cred_offer,
+            )
+
+            await test_module.credential_exchange_create(self.request)
+
+            mock_response.assert_called_once_with(mock_cx_rec.serialize.return_value)
+
     async def test_credential_exchange_create_x(self):
         self.request.json = async_mock.CoroutineMock()
 
@@ -316,6 +348,38 @@ class TestV20CredRoutes(AsyncTestCase):
     async def test_credential_exchange_send(self):
         self.request.json = async_mock.CoroutineMock()
 
+        with async_mock.patch.object(
+            test_module, "ConnRecord", autospec=True
+        ) as mock_conn_rec, async_mock.patch.object(
+            test_module, "V20CredManager", autospec=True
+        ) as mock_cred_mgr, async_mock.patch.object(
+            test_module.V20CredPreview, "deserialize", autospec=True
+        ) as mock_cred_preview_deser, async_mock.patch.object(
+            test_module.web, "json_response"
+        ) as mock_response:
+            mock_cred_mgr.return_value.create_offer = async_mock.CoroutineMock()
+
+            mock_cred_mgr.return_value.create_offer.return_value = (
+                async_mock.CoroutineMock(),
+                async_mock.CoroutineMock(),
+            )
+
+            mock_cx_rec = async_mock.MagicMock()
+            mock_cred_offer = async_mock.MagicMock()
+
+            mock_cred_mgr.return_value.prepare_send.return_value = (
+                mock_cx_rec,
+                mock_cred_offer,
+            )
+
+            await test_module.credential_exchange_send(self.request)
+
+            mock_response.assert_called_once_with(mock_cx_rec.serialize.return_value)
+
+    async def test_credential_exchange_send_aip2(self):
+        self.request.json = async_mock.CoroutineMock()
+        self.context.profile.settings.set_value("emit_new_didcomm_mime_type", True)
+        self.context.profile.settings.set_value("emit_new_didcomm_prefix", True)
         with async_mock.patch.object(
             test_module, "ConnRecord", autospec=True
         ) as mock_conn_rec, async_mock.patch.object(
@@ -825,6 +889,40 @@ class TestV20CredRoutes(AsyncTestCase):
 
             mock_response.assert_called_once_with(mock_cx_rec.serialize.return_value)
 
+    async def test_credential_exchange_send_free_offer_aip2(self):
+        self.request.json = async_mock.CoroutineMock(
+            return_value={
+                "auto_issue": False,
+                "credential_preview": {
+                    "attributes": [{"name": "hello", "value": "world"}]
+                },
+                "filter": {"indy": {"schema_version": "1.0"}},
+            }
+        )
+        self.context.profile.settings.set_value("emit_new_didcomm_mime_type", True)
+        self.context.profile.settings.set_value("emit_new_didcomm_prefix", True)
+
+        with async_mock.patch.object(
+            test_module, "ConnRecord", autospec=True
+        ) as mock_conn_rec, async_mock.patch.object(
+            test_module, "V20CredManager", autospec=True
+        ) as mock_cred_mgr, async_mock.patch.object(
+            test_module.web, "json_response"
+        ) as mock_response:
+
+            mock_cred_mgr.return_value.create_offer = async_mock.CoroutineMock()
+
+            mock_cx_rec = async_mock.MagicMock()
+
+            mock_cred_mgr.return_value.create_offer.return_value = (
+                mock_cx_rec,
+                async_mock.MagicMock(),
+            )
+
+            await test_module.credential_exchange_send_free_offer(self.request)
+
+            mock_response.assert_called_once_with(mock_cx_rec.serialize.return_value)
+
     async def test_credential_exchange_send_free_offer_no_filter(self):
         self.request.json = async_mock.CoroutineMock(
             return_value={
@@ -904,6 +1002,39 @@ class TestV20CredRoutes(AsyncTestCase):
         self.request.json = async_mock.CoroutineMock(return_value={})
         self.request.match_info = {"cred_ex_id": "dummy"}
 
+        with async_mock.patch.object(
+            test_module, "ConnRecord", autospec=True
+        ) as mock_conn_rec, async_mock.patch.object(
+            test_module, "V20CredManager", autospec=True
+        ) as mock_cred_mgr, async_mock.patch.object(
+            test_module, "V20CredExRecord", autospec=True
+        ) as mock_cls_cx_rec, async_mock.patch.object(
+            test_module.web, "json_response"
+        ) as mock_response:
+
+            mock_cls_cx_rec.retrieve_by_id = async_mock.CoroutineMock()
+            mock_cls_cx_rec.retrieve_by_id.return_value.state = (
+                test_module.V20CredExRecord.STATE_PROPOSAL_RECEIVED
+            )
+
+            mock_cred_mgr.return_value.create_offer = async_mock.CoroutineMock()
+
+            mock_cx_rec = async_mock.MagicMock()
+
+            mock_cred_mgr.return_value.create_offer.return_value = (
+                mock_cx_rec,
+                async_mock.MagicMock(),
+            )
+
+            await test_module.credential_exchange_send_bound_offer(self.request)
+
+            mock_response.assert_called_once_with(mock_cx_rec.serialize.return_value)
+
+    async def test_credential_exchange_send_bound_offer_aip2(self):
+        self.request.json = async_mock.CoroutineMock(return_value={})
+        self.request.match_info = {"cred_ex_id": "dummy"}
+        self.context.profile.settings.set_value("emit_new_didcomm_mime_type", True)
+        self.context.profile.settings.set_value("emit_new_didcomm_prefix", True)
         with async_mock.patch.object(
             test_module, "ConnRecord", autospec=True
         ) as mock_conn_rec, async_mock.patch.object(
@@ -1147,6 +1278,35 @@ class TestV20CredRoutes(AsyncTestCase):
             }
         )
 
+        with async_mock.patch.object(
+            test_module, "ConnRecord", autospec=True
+        ) as mock_conn_rec, async_mock.patch.object(
+            test_module, "V20CredManager", autospec=True
+        ) as mock_cred_mgr, async_mock.patch.object(
+            test_module.web, "json_response"
+        ) as mock_response:
+
+            mock_cred_mgr.return_value.create_request = async_mock.CoroutineMock()
+
+            mock_cx_rec = async_mock.MagicMock()
+
+            mock_cred_mgr.return_value.create_request.return_value = (
+                mock_cx_rec,
+                async_mock.MagicMock(),
+            )
+
+            await test_module.credential_exchange_send_free_request(self.request)
+
+            mock_response.assert_called_once_with(mock_cx_rec.serialize.return_value)
+
+    async def test_credential_exchange_send_free_request_aip2(self):
+        self.request.json = async_mock.CoroutineMock(
+            return_value={
+                "filter": {"ld_proof": {"credential": {}, "options": {}}},
+            }
+        )
+        self.context.profile.settings.set_value("emit_new_didcomm_mime_type", True)
+        self.context.profile.settings.set_value("emit_new_didcomm_prefix", True)
         with async_mock.patch.object(
             test_module, "ConnRecord", autospec=True
         ) as mock_conn_rec, async_mock.patch.object(

--- a/aries_cloudagent/protocols/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/manager.py
@@ -150,10 +150,13 @@ class PresentationManager:
                     AttachDecorator.data_base64(
                         mapping=indy_proof_request,
                         ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
-                        flag_aip2=True,
+                        aip2_flag=True,
                     )
-                    if self._profile.settings.get("emit_new_didcomm_mime_type")
-                    and self._profile.get("emit_new_didcomm_prefix")
+                    # if self._profile.settings.get_value("aip_version", 1) >= 2
+                    if (
+                        self._profile.settings.get_value("emit_new_didcomm_mime_type")
+                        and self._profile.settings.get_value("emit_new_didcomm_prefix")
+                    )
                     else AttachDecorator.data_base64(
                         mapping=indy_proof_request,
                         ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
@@ -440,10 +443,13 @@ class PresentationManager:
                     AttachDecorator.data_base64(
                         mapping=indy_proof,
                         ident=ATTACH_DECO_IDS[PRESENTATION],
-                        flag_aip2=True,
+                        aip2_flag=True,
                     )
-                    if self._profile.settings.get("emit_new_didcomm_mime_type")
-                    and self._profile.get("emit_new_didcomm_prefix")
+                    # if self._profile.settings.get_value("aip_version", 1) >= 2
+                    if (
+                        self._profile.settings.get_value("emit_new_didcomm_mime_type")
+                        and self._profile.settings.get_value("emit_new_didcomm_prefix")
+                    )
                     else AttachDecorator.data_base64(
                         mapping=indy_proof, ident=ATTACH_DECO_IDS[PRESENTATION]
                     )

--- a/aries_cloudagent/protocols/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/manager.py
@@ -146,9 +146,18 @@ class PresentationManager:
         presentation_request_message = PresentationRequest(
             comment=comment,
             request_presentations_attach=[
-                AttachDecorator.data_base64(
-                    mapping=indy_proof_request,
-                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+                (
+                    AttachDecorator.data_base64(
+                        mapping=indy_proof_request,
+                        ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+                        flag_aip2=True,
+                    )
+                    if self._profile.settings.get("emit_new_didcomm_mime_type")
+                    and self._profile.get("emit_new_didcomm_prefix")
+                    else AttachDecorator.data_base64(
+                        mapping=indy_proof_request,
+                        ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+                    )
                 )
             ],
         )
@@ -427,8 +436,17 @@ class PresentationManager:
         presentation_message = Presentation(
             comment=comment,
             presentations_attach=[
-                AttachDecorator.data_base64(
-                    mapping=indy_proof, ident=ATTACH_DECO_IDS[PRESENTATION]
+                (
+                    AttachDecorator.data_base64(
+                        mapping=indy_proof,
+                        ident=ATTACH_DECO_IDS[PRESENTATION],
+                        flag_aip2=True,
+                    )
+                    if self._profile.settings.get("emit_new_didcomm_mime_type")
+                    and self._profile.get("emit_new_didcomm_prefix")
+                    else AttachDecorator.data_base64(
+                        mapping=indy_proof, ident=ATTACH_DECO_IDS[PRESENTATION]
+                    )
                 )
             ],
         )

--- a/aries_cloudagent/protocols/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/routes.py
@@ -446,15 +446,26 @@ async def presentation_exchange_create_request(request: web.BaseRequest):
 
     comment = body.get("comment")
     indy_proof_request = body.get("proof_request")
+    flag_aip2 = context.profile.settings.get(
+        "emit_new_didcomm_mime_type"
+    ) and context.profile.get("emit_new_didcomm_prefix")
     if not indy_proof_request.get("nonce"):
         indy_proof_request["nonce"] = await generate_pr_nonce()
 
     presentation_request_message = PresentationRequest(
         comment=comment,
         request_presentations_attach=[
-            AttachDecorator.data_base64(
-                mapping=indy_proof_request,
-                ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+            (
+                AttachDecorator.data_base64(
+                    mapping=indy_proof_request,
+                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+                    flag_aip2=flag_aip2,
+                )
+                if flag_aip2
+                else AttachDecorator.data_base64(
+                    mapping=indy_proof_request,
+                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+                )
             )
         ],
     )
@@ -525,15 +536,26 @@ async def presentation_exchange_send_free_request(request: web.BaseRequest):
 
     comment = body.get("comment")
     indy_proof_request = body.get("proof_request")
+    flag_aip2 = context.profile.settings.get(
+        "emit_new_didcomm_mime_type"
+    ) and context.profile.get("emit_new_didcomm_prefix")
     if not indy_proof_request.get("nonce"):
         indy_proof_request["nonce"] = await generate_pr_nonce()
 
     presentation_request_message = PresentationRequest(
         comment=comment,
         request_presentations_attach=[
-            AttachDecorator.data_base64(
-                mapping=indy_proof_request,
-                ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+            (
+                AttachDecorator.data_base64(
+                    mapping=indy_proof_request,
+                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+                    flag_aip2=flag_aip2,
+                )
+                if flag_aip2
+                else AttachDecorator.data_base64(
+                    mapping=indy_proof_request,
+                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+                )
             )
         ],
     )

--- a/aries_cloudagent/protocols/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/routes.py
@@ -446,9 +446,10 @@ async def presentation_exchange_create_request(request: web.BaseRequest):
 
     comment = body.get("comment")
     indy_proof_request = body.get("proof_request")
-    flag_aip2 = context.profile.settings.get(
+    # aip2_flag = (context.profile.settings.get_value("aip_version", 1) >= 2)
+    aip2_flag = context.profile.settings.get_value(
         "emit_new_didcomm_mime_type"
-    ) and context.profile.get("emit_new_didcomm_prefix")
+    ) and context.profile.settings.get_value("emit_new_didcomm_prefix")
     if not indy_proof_request.get("nonce"):
         indy_proof_request["nonce"] = await generate_pr_nonce()
 
@@ -459,9 +460,9 @@ async def presentation_exchange_create_request(request: web.BaseRequest):
                 AttachDecorator.data_base64(
                     mapping=indy_proof_request,
                     ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
-                    flag_aip2=flag_aip2,
+                    aip2_flag=aip2_flag,
                 )
-                if flag_aip2
+                if aip2_flag
                 else AttachDecorator.data_base64(
                     mapping=indy_proof_request,
                     ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
@@ -536,9 +537,10 @@ async def presentation_exchange_send_free_request(request: web.BaseRequest):
 
     comment = body.get("comment")
     indy_proof_request = body.get("proof_request")
-    flag_aip2 = context.profile.settings.get(
+    # aip2_flag = (context.profile.settings.get_value("aip_version", 1) >= 2)
+    aip2_flag = context.profile.settings.get_value(
         "emit_new_didcomm_mime_type"
-    ) and context.profile.get("emit_new_didcomm_prefix")
+    ) and context.profile.settings.get_value("emit_new_didcomm_prefix")
     if not indy_proof_request.get("nonce"):
         indy_proof_request["nonce"] = await generate_pr_nonce()
 
@@ -549,9 +551,9 @@ async def presentation_exchange_send_free_request(request: web.BaseRequest):
                 AttachDecorator.data_base64(
                     mapping=indy_proof_request,
                     ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
-                    flag_aip2=flag_aip2,
+                    aip2_flag=aip2_flag,
                 )
-                if flag_aip2
+                if aip2_flag
                 else AttachDecorator.data_base64(
                     mapping=indy_proof_request,
                     ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],

--- a/aries_cloudagent/protocols/present_proof/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/tests/test_routes.py
@@ -476,6 +476,62 @@ class TestProofRoutes(AsyncTestCase):
                     mock_presentation_exchange.serialize.return_value
                 )
 
+    async def test_presentation_exchange_create_request_aip2(self):
+        self.profile.settings.set_value("emit_new_didcomm_mime_type", True)
+        self.profile.settings.set_value("emit_new_didcomm_prefix", True)
+        self.request.json = async_mock.CoroutineMock(
+            return_value={"comment": "dummy", "proof_request": {}}
+        )
+
+        with async_mock.patch(
+            "aries_cloudagent.protocols.present_proof.v1_0.manager.PresentationManager",
+            autospec=True,
+        ) as mock_presentation_manager, async_mock.patch(
+            "aries_cloudagent.indy.sdk.models.pres_preview.IndyPresPreview",
+            autospec=True,
+        ) as mock_preview, async_mock.patch.object(
+            test_module, "PresentationRequest", autospec=True
+        ) as mock_presentation_request, async_mock.patch(
+            "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
+            autospec=True,
+        ) as mock_attach_decorator, async_mock.patch(
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
+            autospec=True,
+        ) as mock_presentation_exchange, async_mock.patch(
+            "aries_cloudagent.indy.util.generate_pr_nonce",
+            autospec=True,
+        ) as mock_generate_nonce:
+
+            # Since we are mocking import
+            importlib.reload(test_module)
+
+            mock_generate_nonce = async_mock.CoroutineMock()
+
+            mock_attach_decorator.data_base64 = async_mock.MagicMock(
+                return_value=mock_attach_decorator
+            )
+            mock_presentation_exchange.serialize = async_mock.MagicMock()
+            mock_presentation_exchange.serialize.return_value = {
+                "thread_id": "sample-thread-id"
+            }
+            mock_mgr = async_mock.MagicMock(
+                create_exchange_for_request=async_mock.CoroutineMock(
+                    return_value=mock_presentation_exchange
+                )
+            )
+            mock_presentation_manager.return_value = mock_mgr
+
+            with async_mock.patch.object(
+                test_module.web, "json_response"
+            ) as mock_response:
+                await test_module.presentation_exchange_create_request(self.request)
+                mock_response.assert_called_once_with(
+                    mock_presentation_exchange.serialize.return_value
+                )
+
     async def test_presentation_exchange_create_request_x(self):
         self.request.json = async_mock.CoroutineMock(
             return_value={"comment": "dummy", "proof_request": {}}
@@ -521,6 +577,71 @@ class TestProofRoutes(AsyncTestCase):
                 await test_module.presentation_exchange_create_request(self.request)
 
     async def test_presentation_exchange_send_free_request(self):
+        self.request.json = async_mock.CoroutineMock(
+            return_value={
+                "connection_id": "dummy",
+                "comment": "dummy",
+                "proof_request": {},
+            }
+        )
+
+        with async_mock.patch(
+            "aries_cloudagent.connections.models.conn_record.ConnRecord",
+            autospec=True,
+        ) as mock_connection_record, async_mock.patch(
+            "aries_cloudagent.protocols.present_proof.v1_0.manager.PresentationManager",
+            autospec=True,
+        ) as mock_presentation_manager, async_mock.patch(
+            "aries_cloudagent.indy.util.generate_pr_nonce",
+            autospec=True,
+        ) as mock_generate_nonce, async_mock.patch(
+            "aries_cloudagent.indy.sdk.models.pres_preview.IndyPresPreview",
+            autospec=True,
+        ) as mock_preview, async_mock.patch.object(
+            test_module, "PresentationRequest", autospec=True
+        ) as mock_presentation_request, async_mock.patch(
+            "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
+            autospec=True,
+        ) as mock_attach_decorator, async_mock.patch(
+            (
+                "aries_cloudagent.protocols.present_proof.v1_0."
+                "models.presentation_exchange.V10PresentationExchange"
+            ),
+            autospec=True,
+        ) as mock_presentation_exchange:
+
+            # Since we are mocking import
+            importlib.reload(test_module)
+
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock(
+                return_value=mock_connection_record
+            )
+            mock_attach_decorator.data_base64 = async_mock.MagicMock(
+                return_value=mock_attach_decorator
+            )
+            mock_presentation_exchange.serialize = async_mock.MagicMock()
+            mock_presentation_exchange.serialize.return_value = {
+                "thread_id": "sample-thread-id"
+            }
+
+            mock_mgr = async_mock.MagicMock(
+                create_exchange_for_request=async_mock.CoroutineMock(
+                    return_value=mock_presentation_exchange
+                )
+            )
+            mock_presentation_manager.return_value = mock_mgr
+
+            with async_mock.patch.object(
+                test_module.web, "json_response"
+            ) as mock_response:
+                await test_module.presentation_exchange_send_free_request(self.request)
+                mock_response.assert_called_once_with(
+                    mock_presentation_exchange.serialize.return_value
+                )
+
+    async def test_presentation_exchange_send_free_request_aip2(self):
+        self.profile.settings.set_value("emit_new_didcomm_mime_type", True)
+        self.profile.settings.set_value("emit_new_didcomm_prefix", True)
         self.request.json = async_mock.CoroutineMock(
             return_value={
                 "connection_id": "dummy",

--- a/aries_cloudagent/protocols/present_proof/v2_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/manager.py
@@ -158,9 +158,18 @@ class V20PresManager:
                 )
             ],
             request_presentations_attach=[
-                AttachDecorator.data_base64(
-                    mapping=indy_proof_request,
-                    ident="indy",
+                (
+                    AttachDecorator.data_base64(
+                        mapping=indy_proof_request,
+                        ident="indy",
+                        flag_aip2=True,
+                    )
+                    if self._profile.settings.get("emit_new_didcomm_mime_type")
+                    and self._profile.get("emit_new_didcomm_prefix")
+                    else AttachDecorator.data_base64(
+                        mapping=indy_proof_request,
+                        ident="indy",
+                    )
                 )
             ],
         )
@@ -441,7 +450,14 @@ class V20PresManager:
                 )
             ],
             presentations_attach=[
-                AttachDecorator.data_base64(mapping=indy_proof, ident="indy")
+                (
+                    AttachDecorator.data_base64(
+                        mapping=indy_proof, ident="indy", flag_aip2=True
+                    )
+                    if self._profile.settings.get("emit_new_didcomm_mime_type")
+                    and self._profile.get("emit_new_didcomm_prefix")
+                    else AttachDecorator.data_base64(mapping=indy_proof, ident="indy")
+                )
             ],
         )
 
@@ -460,9 +476,18 @@ class V20PresManager:
                 ),
             ],
             presentations_attach=[
-                AttachDecorator.data_base64(
-                    mapping=indy_proof,
-                    ident="indy",
+                (
+                    AttachDecorator.data_base64(
+                        mapping=indy_proof,
+                        ident="indy",
+                        flag_aip2=True,
+                    )
+                    if self._profile.settings.get("emit_new_didcomm_mime_type")
+                    and self._profile.get("emit_new_didcomm_prefix")
+                    else AttachDecorator.data_base64(
+                        mapping=indy_proof,
+                        ident="indy",
+                    )
                 )
             ],
         ).serialize()

--- a/aries_cloudagent/protocols/present_proof/v2_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/manager.py
@@ -162,10 +162,13 @@ class V20PresManager:
                     AttachDecorator.data_base64(
                         mapping=indy_proof_request,
                         ident="indy",
-                        flag_aip2=True,
+                        aip2_flag=True,
                     )
-                    if self._profile.settings.get("emit_new_didcomm_mime_type")
-                    and self._profile.get("emit_new_didcomm_prefix")
+                    # if self._profile.settings.get_value("aip_version", 1) >= 2
+                    if (
+                        self._profile.settings.get_value("emit_new_didcomm_mime_type")
+                        and self._profile.settings.get_value("emit_new_didcomm_prefix")
+                    )
                     else AttachDecorator.data_base64(
                         mapping=indy_proof_request,
                         ident="indy",
@@ -452,10 +455,13 @@ class V20PresManager:
             presentations_attach=[
                 (
                     AttachDecorator.data_base64(
-                        mapping=indy_proof, ident="indy", flag_aip2=True
+                        mapping=indy_proof, ident="indy", aip2_flag=True
                     )
-                    if self._profile.settings.get("emit_new_didcomm_mime_type")
-                    and self._profile.get("emit_new_didcomm_prefix")
+                    # if self._profile.settings.get_value("aip_version", 1) >= 2
+                    if (
+                        self._profile.settings.get_value("emit_new_didcomm_mime_type")
+                        and self._profile.settings.get_value("emit_new_didcomm_prefix")
+                    )
                     else AttachDecorator.data_base64(mapping=indy_proof, ident="indy")
                 )
             ],
@@ -480,10 +486,13 @@ class V20PresManager:
                     AttachDecorator.data_base64(
                         mapping=indy_proof,
                         ident="indy",
-                        flag_aip2=True,
+                        aip2_flag=True,
                     )
-                    if self._profile.settings.get("emit_new_didcomm_mime_type")
-                    and self._profile.get("emit_new_didcomm_prefix")
+                    # if self._profile.settings.get_value("aip_version", 1) >= 2
+                    if (
+                        self._profile.settings.get_value("emit_new_didcomm_mime_type")
+                        and self._profile.settings.get_value("emit_new_didcomm_prefix")
+                    )
                     else AttachDecorator.data_base64(
                         mapping=indy_proof,
                         ident="indy",

--- a/aries_cloudagent/protocols/present_proof/v2_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/routes.py
@@ -321,7 +321,7 @@ async def _add_nonce(indy_proof_request: Mapping) -> Mapping:
 
 
 def _formats_attach(
-    by_format: Mapping, msg_type: str, spec: str, flag_aip2: bool = False
+    by_format: Mapping, msg_type: str, spec: str, aip2_flag: bool = False
 ) -> Mapping:
     """Break out formats and proposals/requests/presentations for v2.0 messages."""
 
@@ -336,9 +336,9 @@ def _formats_attach(
         f"{spec}_attach": [
             (
                 AttachDecorator.data_base64(
-                    mapping=item_by_fmt, ident=fmt_api, flag_aip2=flag_aip2
+                    mapping=item_by_fmt, ident=fmt_api, aip2_flag=aip2_flag
                 )
-                if flag_aip2
+                if aip2_flag
                 else AttachDecorator.data_base64(mapping=item_by_fmt, ident=fmt_api)
             )
             for (fmt_api, item_by_fmt) in by_format.items()
@@ -519,9 +519,10 @@ async def present_proof_send_proposal(request: web.BaseRequest):
     connection_id = body.get("connection_id")
 
     pres_proposal = body.get("presentation_proposal")
-    flag_aip2 = context.profile.settings.get(
+    # aip2_flag = (context.profile.settings.get_value("aip_version", 1) >= 2)
+    aip2_flag = context.profile.settings.get_value(
         "emit_new_didcomm_mime_type"
-    ) and context.profile.get("emit_new_didcomm_prefix")
+    ) and context.profile.settings.get_value("emit_new_didcomm_prefix")
     conn_record = None
     async with context.session() as session:
         try:
@@ -529,7 +530,7 @@ async def present_proof_send_proposal(request: web.BaseRequest):
             pres_proposal_message = V20PresProposal(
                 comment=comment,
                 **_formats_attach(
-                    pres_proposal, PRES_20_PROPOSAL, "proposals", flag_aip2=flag_aip2
+                    pres_proposal, PRES_20_PROPOSAL, "proposals", aip2_flag=aip2_flag
                 ),
             )
         except (BaseModelError, StorageError) as err:
@@ -607,9 +608,10 @@ async def present_proof_create_request(request: web.BaseRequest):
 
     comment = body.get("comment")
     pres_request_spec = body.get("presentation_request")
-    flag_aip2 = context.profile.settings.get(
+    # aip2_flag = (context.profile.settings.get_value("aip_version", 1) >= 2)
+    aip2_flag = context.profile.settings.get_value(
         "emit_new_didcomm_mime_type"
-    ) and context.profile.get("emit_new_didcomm_prefix")
+    ) and context.profile.settings.get_value("emit_new_didcomm_prefix")
     if pres_request_spec and V20PresFormat.Format.INDY.api in pres_request_spec:
         await _add_nonce(pres_request_spec[V20PresFormat.Format.INDY.api])
 
@@ -620,7 +622,7 @@ async def present_proof_create_request(request: web.BaseRequest):
             pres_request_spec,
             PRES_20_REQUEST,
             "request_presentations",
-            flag_aip2=flag_aip2,
+            aip2_flag=aip2_flag,
         ),
     )
     trace_msg = body.get("trace")
@@ -690,9 +692,10 @@ async def present_proof_send_free_request(request: web.BaseRequest):
 
     comment = body.get("comment")
     pres_request_spec = body.get("presentation_request")
-    flag_aip2 = context.profile.settings.get(
+    # aip2_flag = (context.profile.settings.get_value("aip_version", 1) >= 2)
+    aip2_flag = context.profile.settings.get_value(
         "emit_new_didcomm_mime_type"
-    ) and context.profile.get("emit_new_didcomm_prefix")
+    ) and context.profile.settings.get_value("emit_new_didcomm_prefix")
     if pres_request_spec and V20PresFormat.Format.INDY.api in pres_request_spec:
         await _add_nonce(pres_request_spec[V20PresFormat.Format.INDY.api])
     pres_request_message = V20PresRequest(
@@ -702,7 +705,7 @@ async def present_proof_send_free_request(request: web.BaseRequest):
             pres_request_spec,
             PRES_20_REQUEST,
             "request_presentations",
-            flag_aip2=flag_aip2,
+            aip2_flag=aip2_flag,
         ),
     )
     trace_msg = body.get("trace")

--- a/aries_cloudagent/protocols/present_proof/v2_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/routes.py
@@ -320,7 +320,9 @@ async def _add_nonce(indy_proof_request: Mapping) -> Mapping:
     return indy_proof_request
 
 
-def _formats_attach(by_format: Mapping, msg_type: str, spec: str) -> Mapping:
+def _formats_attach(
+    by_format: Mapping, msg_type: str, spec: str, flag_aip2: bool = False
+) -> Mapping:
     """Break out formats and proposals/requests/presentations for v2.0 messages."""
 
     return {
@@ -332,7 +334,13 @@ def _formats_attach(by_format: Mapping, msg_type: str, spec: str) -> Mapping:
             for fmt_api in by_format
         ],
         f"{spec}_attach": [
-            AttachDecorator.data_base64(mapping=item_by_fmt, ident=fmt_api)
+            (
+                AttachDecorator.data_base64(
+                    mapping=item_by_fmt, ident=fmt_api, flag_aip2=flag_aip2
+                )
+                if flag_aip2
+                else AttachDecorator.data_base64(mapping=item_by_fmt, ident=fmt_api)
+            )
             for (fmt_api, item_by_fmt) in by_format.items()
         ],
     }
@@ -511,13 +519,18 @@ async def present_proof_send_proposal(request: web.BaseRequest):
     connection_id = body.get("connection_id")
 
     pres_proposal = body.get("presentation_proposal")
+    flag_aip2 = context.profile.settings.get(
+        "emit_new_didcomm_mime_type"
+    ) and context.profile.get("emit_new_didcomm_prefix")
     conn_record = None
     async with context.session() as session:
         try:
             conn_record = await ConnRecord.retrieve_by_id(session, connection_id)
             pres_proposal_message = V20PresProposal(
                 comment=comment,
-                **_formats_attach(pres_proposal, PRES_20_PROPOSAL, "proposals"),
+                **_formats_attach(
+                    pres_proposal, PRES_20_PROPOSAL, "proposals", flag_aip2=flag_aip2
+                ),
             )
         except (BaseModelError, StorageError) as err:
             return await internal_error(
@@ -594,13 +607,21 @@ async def present_proof_create_request(request: web.BaseRequest):
 
     comment = body.get("comment")
     pres_request_spec = body.get("presentation_request")
+    flag_aip2 = context.profile.settings.get(
+        "emit_new_didcomm_mime_type"
+    ) and context.profile.get("emit_new_didcomm_prefix")
     if pres_request_spec and V20PresFormat.Format.INDY.api in pres_request_spec:
         await _add_nonce(pres_request_spec[V20PresFormat.Format.INDY.api])
 
     pres_request_message = V20PresRequest(
         comment=comment,
         will_confirm=True,
-        **_formats_attach(pres_request_spec, PRES_20_REQUEST, "request_presentations"),
+        **_formats_attach(
+            pres_request_spec,
+            PRES_20_REQUEST,
+            "request_presentations",
+            flag_aip2=flag_aip2,
+        ),
     )
     trace_msg = body.get("trace")
     pres_request_message.assign_trace_decorator(
@@ -669,12 +690,20 @@ async def present_proof_send_free_request(request: web.BaseRequest):
 
     comment = body.get("comment")
     pres_request_spec = body.get("presentation_request")
+    flag_aip2 = context.profile.settings.get(
+        "emit_new_didcomm_mime_type"
+    ) and context.profile.get("emit_new_didcomm_prefix")
     if pres_request_spec and V20PresFormat.Format.INDY.api in pres_request_spec:
         await _add_nonce(pres_request_spec[V20PresFormat.Format.INDY.api])
     pres_request_message = V20PresRequest(
         comment=comment,
         will_confirm=True,
-        **_formats_attach(pres_request_spec, PRES_20_REQUEST, "request_presentations"),
+        **_formats_attach(
+            pres_request_spec,
+            PRES_20_REQUEST,
+            "request_presentations",
+            flag_aip2=flag_aip2,
+        ),
     )
     trace_msg = body.get("trace")
     pres_request_message.assign_trace_decorator(

--- a/aries_cloudagent/protocols/present_proof/v2_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/tests/test_routes.py
@@ -396,6 +396,40 @@ class TestPresentProofRoutes(AsyncTestCase):
                 mock_px_rec_inst.serialize.return_value
             )
 
+    async def test_present_proof_send_proposal_aip2(self):
+        self.profile.settings.set_value("emit_new_didcomm_mime_type", True)
+        self.profile.settings.set_value("emit_new_didcomm_prefix", True)
+        self.request.json = async_mock.CoroutineMock(
+            return_value={
+                "connection_id": "dummy-conn-id",
+                "presentation_proposal": {
+                    V20PresFormat.Format.INDY.api: INDY_PROOF_REQ
+                },
+            }
+        )
+
+        with async_mock.patch.object(
+            test_module, "ConnRecord", autospec=True
+        ) as mock_conn_rec, async_mock.patch.object(
+            test_module, "V20PresManager", autospec=True
+        ) as mock_pres_mgr, async_mock.patch.object(
+            test_module, "V20PresExRecord", autospec=True
+        ) as mock_pres_ex_rec_cls, async_mock.patch.object(
+            test_module.web, "json_response", async_mock.MagicMock()
+        ) as mock_response:
+            mock_conn_rec.retrieve_by_id = async_mock.CoroutineMock(
+                return_value=async_mock.MagicMock(is_ready=True)
+            )
+            mock_px_rec_inst = async_mock.MagicMock()
+            mock_pres_mgr.return_value.create_exchange_for_proposal = (
+                async_mock.CoroutineMock(return_value=mock_px_rec_inst)
+            )
+
+            await test_module.present_proof_send_proposal(self.request)
+            mock_response.assert_called_once_with(
+                mock_px_rec_inst.serialize.return_value
+            )
+
     async def test_present_proof_send_proposal_no_conn_record(self):
         self.request.json = async_mock.CoroutineMock()
 
@@ -474,6 +508,43 @@ class TestPresentProofRoutes(AsyncTestCase):
                 mock_px_rec_inst.serialize.return_value
             )
 
+    async def test_present_proof_create_request_aip2(self):
+        self.profile.settings.set_value("emit_new_didcomm_mime_type", True)
+        self.profile.settings.set_value("emit_new_didcomm_prefix", True)
+        indy_proof_req = deepcopy(INDY_PROOF_REQ)
+        indy_proof_req.pop("nonce")  # exercise _add_nonce()
+
+        self.request.json = async_mock.CoroutineMock(
+            return_value={
+                "comment": "dummy",
+                "presentation_request": {V20PresFormat.Format.INDY.api: indy_proof_req},
+            }
+        )
+
+        with async_mock.patch.object(
+            test_module, "V20PresManager", autospec=True
+        ) as mock_pres_mgr_cls, async_mock.patch.object(
+            test_module, "V20PresRequest", autospec=True
+        ) as mock_pres_request, async_mock.patch.object(
+            test_module.web, "json_response", async_mock.MagicMock()
+        ) as mock_response:
+            mock_px_rec_inst = async_mock.MagicMock(
+                serialize=async_mock.MagicMock(
+                    return_value={"thread_id": "sample-thread-id"}
+                )
+            )
+            mock_pres_mgr_inst = async_mock.MagicMock(
+                create_exchange_for_request=async_mock.CoroutineMock(
+                    return_value=mock_px_rec_inst
+                )
+            )
+            mock_pres_mgr_cls.return_value = mock_pres_mgr_inst
+
+            await test_module.present_proof_create_request(self.request)
+            mock_response.assert_called_once_with(
+                mock_px_rec_inst.serialize.return_value
+            )
+
     async def test_present_proof_create_request_x(self):
         self.request.json = async_mock.CoroutineMock(
             return_value={
@@ -501,6 +572,45 @@ class TestPresentProofRoutes(AsyncTestCase):
                 await test_module.present_proof_create_request(self.request)
 
     async def test_present_proof_send_free_request(self):
+        self.request.json = async_mock.CoroutineMock(
+            return_value={
+                "connection_id": "dummy",
+                "comment": "dummy",
+                "presentation_request": {V20PresFormat.Format.INDY.api: INDY_PROOF_REQ},
+            }
+        )
+
+        with async_mock.patch.object(
+            test_module, "ConnRecord", autospec=True
+        ) as mock_conn_rec_cls, async_mock.patch.object(
+            test_module, "V20PresManager", autospec=True
+        ) as mock_pres_mgr_cls, async_mock.patch.object(
+            test_module, "V20PresRequest", autospec=True
+        ) as mock_pres_request, async_mock.patch.object(
+            test_module, "V20PresExRecord", autospec=True
+        ) as mock_pres_ex_rec_cls, async_mock.patch.object(
+            test_module.web, "json_response", async_mock.MagicMock()
+        ) as mock_response:
+            mock_conn_rec_cls.retrieve_by_id = async_mock.CoroutineMock()
+            mock_px_rec_inst = async_mock.MagicMock(
+                serialize=async_mock.MagicMock({"thread_id": "sample-thread-id"})
+            )
+
+            mock_pres_mgr_inst = async_mock.MagicMock(
+                create_exchange_for_request=async_mock.CoroutineMock(
+                    return_value=mock_px_rec_inst
+                )
+            )
+            mock_pres_mgr_cls.return_value = mock_pres_mgr_inst
+
+            await test_module.present_proof_send_free_request(self.request)
+            mock_response.assert_called_once_with(
+                mock_px_rec_inst.serialize.return_value
+            )
+
+    async def test_present_proof_send_free_request_aip2(self):
+        self.profile.settings.set_value("emit_new_didcomm_mime_type", True)
+        self.profile.settings.set_value("emit_new_didcomm_prefix", True)
         self.request.json = async_mock.CoroutineMock(
             return_value={
                 "connection_id": "dummy",


### PR DESCRIPTION
- In regards to decoding, we handle base64 permissively, passing `urlsafe` as `True`.
- If `emit_new_didcomm_mime_type` and `emit_new_didcomm_prefix` arguments are set, send everything as base64url [updates `data_base64` accordingly] else leave eveything as it is.
closes #1108