### PR TITLE
Fix bug with problem report 2.0 handler and message family

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v2_0/message_types.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/message_types.py
@@ -30,8 +30,7 @@ MESSAGE_TYPES = DIDCommPrefix.qualify_all(
         CRED_20_ISSUE: f"{PROTOCOL_PACKAGE}.messages.cred_issue.V20CredIssue",
         CRED_20_ACK: f"{PROTOCOL_PACKAGE}.messages.cred_ack.V20CredAck",
         CRED_20_PROBLEM_REPORT: (
-            f"{PROTOCOL_PACKAGE}.messages.cred_problem_report."
-            "IssueCredentialV20ProblemReport"
+            f"{PROTOCOL_PACKAGE}.messages.cred_problem_report.V20CredProblemReport"
         ),
     }
 )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_problem_report.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_problem_report.py
@@ -9,7 +9,7 @@ from ....problem_report.v1_0.message import ProblemReport, ProblemReportSchema
 from ..message_types import CRED_20_PROBLEM_REPORT, PROTOCOL_PACKAGE
 
 HANDLER_CLASS = (
-    f"{PROTOCOL_PACKAGE}.handlers.problem_report_handler.ProblemReportHandler"
+    f"{PROTOCOL_PACKAGE}.handlers.cred_problem_report_handler.CredProblemReportHandler"
 )
 
 


### PR DESCRIPTION
Fixes a bug caused by inconsistent naming that would result in problem reports not being handled correctly by the receiving agent for `issue-credential-2.0`.

I am surprised all the unit tests passed before: is there a testing pattern I should be looking into to add one, or is this something that will/should be caught by the test harness?