### PR TITLE
Fix: OOB Invitation against Public DIDs

### DIFF
--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -214,7 +214,7 @@ class DIDKey(Regexp):
     """Validate value against DID key specification."""
 
     EXAMPLE = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
-    PATTERN = rf"^did:key:z[{B58}]+$"
+    PATTERN = re.compile(rf"^did:key:z[{B58}]+$")
 
     def __init__(self):
         """Initializer."""
@@ -242,7 +242,7 @@ class IndyDID(Regexp):
     """Validate value against indy DID."""
 
     EXAMPLE = "WgWxqztrNooG92RXvxSTWv"
-    PATTERN = rf"^(did:sov:)?[{B58}]{{21,22}}$"
+    PATTERN = re.compile(rf"^(did:sov:)?[{B58}]{{21,22}}$")
 
     def __init__(self):
         """Initializer."""
@@ -674,7 +674,7 @@ class CredentialSubject(Validator):
 class IndyOrKeyDID(Regexp):
     """Indy or Key DID class."""
 
-    PATTERN = re.compile("|".join([DIDKey.PATTERN, IndyDID.PATTERN]))
+    PATTERN = "|".join(x.pattern for x in [DIDKey.PATTERN, IndyDID.PATTERN])
     EXAMPLE = IndyDID.EXAMPLE
 
     def __init__(

--- a/aries_cloudagent/resolver/__init__.py
+++ b/aries_cloudagent/resolver/__init__.py
@@ -4,7 +4,8 @@ import logging
 
 from ..config.injection_context import InjectionContext
 from ..config.provider import ClassProvider
-from ..ledger.base import BaseLedger
+# from ..ledger.base import BaseLedger
+
 from .did_resolver_registry import DIDResolverRegistry
 
 LOGGER = logging.getLogger(__name__)
@@ -23,7 +24,8 @@ async def setup(context: InjectionContext):
     await key_resolver.setup(context)
     registry.register(key_resolver)
 
-    if context.inject(BaseLedger, required=False):
+    # ledger = context.inject(BaseLedger, required=False)
+    if not context.settings.get("ledger.disabled"):
         indy_resolver = ClassProvider(
             "aries_cloudagent.resolver.default.indy.IndyDIDResolver"
         ).provide(context.settings, context.injector)

--- a/aries_cloudagent/resolver/__init__.py
+++ b/aries_cloudagent/resolver/__init__.py
@@ -5,8 +5,6 @@ import logging
 from ..config.injection_context import InjectionContext
 from ..config.provider import ClassProvider
 
-# from ..ledger.base import BaseLedger
-
 from .did_resolver_registry import DIDResolverRegistry
 
 LOGGER = logging.getLogger(__name__)
@@ -25,7 +23,6 @@ async def setup(context: InjectionContext):
     await key_resolver.setup(context)
     registry.register(key_resolver)
 
-    # ledger = context.inject(BaseLedger, required=False)
     if not context.settings.get("ledger.disabled"):
         indy_resolver = ClassProvider(
             "aries_cloudagent.resolver.default.indy.IndyDIDResolver"

--- a/aries_cloudagent/resolver/__init__.py
+++ b/aries_cloudagent/resolver/__init__.py
@@ -4,6 +4,7 @@ import logging
 
 from ..config.injection_context import InjectionContext
 from ..config.provider import ClassProvider
+
 # from ..ledger.base import BaseLedger
 
 from .did_resolver_registry import DIDResolverRegistry

--- a/aries_cloudagent/resolver/default/indy.py
+++ b/aries_cloudagent/resolver/default/indy.py
@@ -3,8 +3,6 @@
 Resolution is performed using the IndyLedger class.
 """
 
-import re
-
 from typing import Sequence, Pattern
 
 from pydid import DID, DIDDocumentBuilder, VerificationSuite
@@ -49,7 +47,7 @@ class IndyDIDResolver(BaseDIDResolver):
     @property
     def supported_did_regex(self) -> Pattern:
         """Return supported_did_regex of Indy DID Resolver."""
-        return re.compile(IndyDID.PATTERN)
+        return IndyDID.PATTERN
 
     async def _resolve(self, profile: Profile, did: str) -> dict:
         """Resolve an indy DID."""

--- a/aries_cloudagent/resolver/default/indy.py
+++ b/aries_cloudagent/resolver/default/indy.py
@@ -3,7 +3,9 @@
 Resolution is performed using the IndyLedger class.
 """
 
-from typing import Sequence
+import re
+
+from typing import Sequence, Pattern
 
 from pydid import DID, DIDDocumentBuilder, VerificationSuite
 
@@ -12,6 +14,8 @@ from ...core.profile import Profile
 from ...ledger.indy import IndySdkLedger, EndpointType
 from ...ledger.base import BaseLedger
 from ...ledger.error import LedgerError
+from ...messaging.valid import IndyDID
+
 from ..base import BaseDIDResolver, DIDNotFound, ResolverError, ResolverType
 
 
@@ -35,8 +39,17 @@ class IndyDIDResolver(BaseDIDResolver):
 
     @property
     def supported_methods(self) -> Sequence[str]:
-        """Return supported methods of Indy DID Resolver."""
+        """
+        Return supported methods of Indy DID Resolver.
+
+        DEPRECATED: Use supported_did_regex instead.
+        """
         return ["sov"]
+
+    @property
+    def supported_did_regex(self) -> Pattern:
+        """Return supported_did_regex of Indy DID Resolver."""
+        return re.compile(IndyDID.PATTERN)
 
     async def _resolve(self, profile: Profile, did: str) -> dict:
         """Resolve an indy DID."""

--- a/aries_cloudagent/resolver/default/key.py
+++ b/aries_cloudagent/resolver/default/key.py
@@ -2,11 +2,15 @@
 
 Resolution is performed using the IndyLedger class.
 """
-from typing import Sequence
+import re
+
+from typing import Sequence, Pattern
 
 from ...did.did_key import DIDKey
 from ...config.injection_context import InjectionContext
 from ...core.profile import Profile
+from ...messaging.valid import DIDKey as DIDKeyType
+
 from ..base import BaseDIDResolver, DIDNotFound, ResolverType
 
 
@@ -22,8 +26,17 @@ class KeyDIDResolver(BaseDIDResolver):
 
     @property
     def supported_methods(self) -> Sequence[str]:
-        """Return supported methods of Key DID Resolver."""
+        """
+        Return supported methods of Key DID Resolver.
+
+        DEPRECATED: Use supported_did_regex instead.
+        """
         return ["key"]
+
+    @property
+    def supported_did_regex(self) -> Pattern:
+        """Return supported_did_regex of Key DID Resolver."""
+        return re.compile(DIDKeyType.PATTERN)
 
     async def _resolve(self, profile: Profile, did: str) -> dict:
         """Resolve a Key DID."""

--- a/aries_cloudagent/resolver/default/key.py
+++ b/aries_cloudagent/resolver/default/key.py
@@ -1,8 +1,7 @@
-"""Indy DID Resolver.
+"""Key DID Resolver.
 
 Resolution is performed using the IndyLedger class.
 """
-import re
 
 from typing import Sequence, Pattern
 
@@ -36,7 +35,7 @@ class KeyDIDResolver(BaseDIDResolver):
     @property
     def supported_did_regex(self) -> Pattern:
         """Return supported_did_regex of Key DID Resolver."""
-        return re.compile(DIDKeyType.PATTERN)
+        return DIDKeyType.PATTERN
 
     async def _resolve(self, profile: Profile, did: str) -> dict:
         """Resolve a Key DID."""

--- a/aries_cloudagent/resolver/default/tests/test_indy.py
+++ b/aries_cloudagent/resolver/default/tests/test_indy.py
@@ -1,18 +1,22 @@
 """Test IndyDIDResolver."""
 
 import pytest
+import re
+
 from asynctest import mock as async_mock
 
 from ....core.in_memory import InMemoryProfile
 from ....core.profile import Profile
 from ....ledger.base import BaseLedger
 from ....ledger.error import LedgerError
+from ....messaging.valid import IndyDID
+
 from ...base import DIDNotFound, ResolverError
 from .. import indy as test_module
 from ..indy import IndyDIDResolver
 
 # pylint: disable=W0621
-TEST_DID0 = "did:sov:123"
+TEST_DID0 = "did:sov:WgWxqztrNooG92RXvxSTWv"
 
 
 @pytest.fixture
@@ -44,9 +48,14 @@ def profile(ledger):
 async def test_supported_methods(profile, resolver: IndyDIDResolver):
     """Test the supported_methods."""
     assert resolver.supported_methods == ["sov"]
-    assert await resolver.supports(
-        profile, "did:sov:9KrtwYfHJpNRzErBeA7U6n1CAGxghgs4Xf5kYxbtGQ7541eM"
-    )
+    assert await resolver.supports(profile, TEST_DID0)
+
+
+@pytest.mark.asyncio
+async def test_supported_did_regex(profile, resolver: IndyDIDResolver):
+    """Test the supported_did_regex."""
+    assert resolver.supported_did_regex == re.compile(IndyDID.PATTERN)
+    assert await resolver.supports(profile, TEST_DID0)
 
 
 @pytest.mark.asyncio

--- a/aries_cloudagent/resolver/default/tests/test_indy.py
+++ b/aries_cloudagent/resolver/default/tests/test_indy.py
@@ -1,7 +1,6 @@
 """Test IndyDIDResolver."""
 
 import pytest
-import re
 
 from asynctest import mock as async_mock
 

--- a/aries_cloudagent/resolver/default/tests/test_indy.py
+++ b/aries_cloudagent/resolver/default/tests/test_indy.py
@@ -54,7 +54,7 @@ async def test_supported_methods(profile, resolver: IndyDIDResolver):
 @pytest.mark.asyncio
 async def test_supported_did_regex(profile, resolver: IndyDIDResolver):
     """Test the supported_did_regex."""
-    assert resolver.supported_did_regex == re.compile(IndyDID.PATTERN)
+    assert resolver.supported_did_regex == IndyDID.PATTERN
     assert await resolver.supports(profile, TEST_DID0)
 
 

--- a/aries_cloudagent/resolver/default/tests/test_key.py
+++ b/aries_cloudagent/resolver/default/tests/test_key.py
@@ -41,7 +41,7 @@ async def test_supported_methods(profile, resolver: KeyDIDResolver):
 @pytest.mark.asyncio
 async def test_supported_did_regex(profile, resolver: KeyDIDResolver):
     """Test the supported_did_regex."""
-    assert resolver.supported_did_regex == re.compile(DIDKey.PATTERN)
+    assert resolver.supported_did_regex == DIDKey.PATTERN
     assert await resolver.supports(
         profile,
         TEST_DID0,

--- a/aries_cloudagent/resolver/default/tests/test_key.py
+++ b/aries_cloudagent/resolver/default/tests/test_key.py
@@ -1,9 +1,12 @@
 """Test KeyDIDResolver."""
 
 import pytest
+import re
 
 from ....core.in_memory import InMemoryProfile
 from ....core.profile import Profile
+from ....messaging.valid import DIDKey
+
 from ...base import DIDNotFound
 from ..key import KeyDIDResolver
 
@@ -31,7 +34,17 @@ async def test_supported_methods(profile, resolver: KeyDIDResolver):
     assert resolver.supported_methods == ["key"]
     assert await resolver.supports(
         profile,
-        "did:key:UG9saXRlbmVzcyBpcyB0aGUgZmlyc3QgdGhpbmcgcGVvcGxlIGxvc2Ugb25jZSB0aGV5IGdldCB0aGUgcG93ZXIu",
+        TEST_DID0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_supported_did_regex(profile, resolver: KeyDIDResolver):
+    """Test the supported_did_regex."""
+    assert resolver.supported_did_regex == re.compile(DIDKey.PATTERN)
+    assert await resolver.supports(
+        profile,
+        TEST_DID0,
     )
 
 

--- a/aries_cloudagent/resolver/default/tests/test_key.py
+++ b/aries_cloudagent/resolver/default/tests/test_key.py
@@ -1,7 +1,6 @@
 """Test KeyDIDResolver."""
 
 import pytest
-import re
 
 from ....core.in_memory import InMemoryProfile
 from ....core.profile import Profile

--- a/aries_cloudagent/resolver/tests/test_base.py
+++ b/aries_cloudagent/resolver/tests/test_base.py
@@ -1,6 +1,8 @@
 """Test Base DID Resolver methods."""
 
 import pytest
+import re
+
 from asynctest import mock as async_mock
 from pydid import DIDDocument
 
@@ -19,6 +21,10 @@ class ExampleDIDResolver(BaseDIDResolver):
     @property
     def supported_methods(self):
         return ["test"]
+
+    @property
+    def supported_did_regex(self):
+        return re.compile("^did:example:[a-zA-Z0-9_.-]+$")
 
     async def _resolve(self, profile, did) -> DIDDocument:
         return DIDDocument("did:example:123")
@@ -51,8 +57,8 @@ def test_native_on_non_native(non_native_resolver):
 
 @pytest.mark.asyncio
 async def test_supports(profile, native_resolver):
-    assert await native_resolver.supports(profile, "did:test:basdfasdfas") is True
-    assert await native_resolver.supports(profile, "not supported") is False
+    assert not await native_resolver.supports(profile, "did:test:basdfasdfas")
+    assert await native_resolver.supports(profile, "did:example:WgWxqztrNooG92RXvxSTWv")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Now able to create and receive OOB invitations against public DIDs.
- Fixes not being able to load `IndyDIDResolver`.
- Implement `supported_did_regex` in `KeyDIDResolver` and `IndyDIDResolver`.