### PR TITLE
BUG FIX: set connections metadata

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -451,6 +451,8 @@ async def connections_metadata_set(request: web.BaseRequest):
         for key, value in body.get("metadata", {}).items():
             await record.metadata_set(session, key, value)
         result = await record.metadata_get_all(session)
+        record.metadata = result
+        await record.save(session)
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
     except BaseModelError as err:

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
@@ -245,9 +245,9 @@ class TestConnectionRoutes(AsyncTestCase):
                 await test_module.connections_metadata(self.request)
 
     async def test_connections_metadata_set(self):
-
         async def aux(*args, **kwargs):
             return None
+
         self.request.match_info = {"conn_id": "dummy"}
         mock_conn_rec = async_mock.MagicMock()
         self.request.json = async_mock.CoroutineMock(

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
@@ -245,6 +245,9 @@ class TestConnectionRoutes(AsyncTestCase):
                 await test_module.connections_metadata(self.request)
 
     async def test_connections_metadata_set(self):
+
+        async def aux(*args, **kwargs):
+            return None
         self.request.match_info = {"conn_id": "dummy"}
         mock_conn_rec = async_mock.MagicMock()
         self.request.json = async_mock.CoroutineMock(
@@ -263,6 +266,7 @@ class TestConnectionRoutes(AsyncTestCase):
             mock_conn_rec_retrieve_by_id.return_value = mock_conn_rec
             mock_metadata_get_all.return_value = {"hello": "world"}
 
+            mock_conn_rec.save.side_effect = aux
             await test_module.connections_metadata_set(self.request)
             mock_metadata_set.assert_called_once()
             mock_response.assert_called_once_with({"results": {"hello": "world"}})


### PR DESCRIPTION
Due https://github.com/hyperledger/aries-cloudagent-python/pull/1186#issuecomment-849452360 

There was a bug that does not save the metadata into the records once they were set.
This PR fixes that bug, updating the connections metadata everywhere.