### PR TITLE
Support indy 1.16 predicate restrictions

### DIFF
--- a/aries_cloudagent/protocols/present_proof/v2_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/manager.py
@@ -558,6 +558,11 @@ class V20PresManager:
                 req_pred = Predicate.get(proof_req_pred_spec["p_type"])
                 req_value = proof_req_pred_spec["p_value"]
                 req_restrictions = proof_req_pred_spec.get("restrictions", {})
+                for req_restriction in req_restrictions:
+                    for k in [k for k in req_restriction]:  # cannot modify en passant
+                        if k.startswith("attr::"):
+                            req_restriction.pop(k)  # let indy-sdk reject mismatch here
+
                 sub_proof_index = pred_spec["sub_proof_index"]
                 for ge_proof in proof["proof"]["proofs"][sub_proof_index][
                     "primary_proof"

--- a/aries_cloudagent/protocols/present_proof/v2_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/tests/test_manager.py
@@ -1099,6 +1099,79 @@ class TestV20PresManager(AsyncTestCase):
             save_ex.assert_called_once()
             assert px_rec_out.state == (V20PresExRecord.STATE_PRESENTATION_RECEIVED)
 
+    async def test_receive_pres_receive_pred_value_mismatch_punt_to_indy(self):
+        connection_record = async_mock.MagicMock(connection_id=CONN_ID)
+        pres_proposal = V20PresProposal(
+            formats=[
+                V20PresFormat(
+                    attach_id="indy",
+                    format_=ATTACHMENT_FORMAT[PRES_20_PROPOSAL][
+                        V20PresFormat.Format.INDY.api
+                    ],
+                )
+            ],
+            proposals_attach=[
+                AttachDecorator.data_base64(INDY_PROOF_REQ_NAME, ident="indy")
+            ],
+        )
+        indy_proof_req = deepcopy(INDY_PROOF_REQ_NAME)
+        indy_proof_req["requested_predicates"]["0_highscore_GE_uuid"]["restrictions"][
+            0
+        ]["attr::player::value"] = "impostor"
+        pres_request = V20PresRequest(
+            formats=[
+                V20PresFormat(
+                    attach_id="indy",
+                    format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
+                        V20PresFormat.Format.INDY.api
+                    ],
+                )
+            ],
+            request_presentations_attach=[
+                AttachDecorator.data_base64(indy_proof_req, ident="indy")
+            ],
+        )
+        pres = V20Pres(
+            formats=[
+                V20PresFormat(
+                    attach_id="indy",
+                    format_=ATTACHMENT_FORMAT[PRES_20][V20PresFormat.Format.INDY.api],
+                )
+            ],
+            presentations_attach=[
+                AttachDecorator.data_base64(INDY_PROOF, ident="indy")
+            ],
+        )
+
+        px_rec_dummy = V20PresExRecord(
+            pres_proposal=pres_proposal.serialize(),
+            pres_request=pres_request.serialize(),
+        )
+
+        # cover by_format property
+        by_format = px_rec_dummy.by_format
+
+        assert by_format.get("pres_proposal").get("indy") == INDY_PROOF_REQ_NAME
+        assert by_format.get("pres_request").get("indy") == indy_proof_req
+
+        with async_mock.patch.object(
+            V20PresExRecord, "save", autospec=True
+        ) as save_ex, async_mock.patch.object(
+            V20PresExRecord, "retrieve_by_tag_filter", autospec=True
+        ) as retrieve_ex, async_mock.patch.object(
+            self.profile,
+            "session",
+            async_mock.MagicMock(return_value=self.profile.session()),
+        ) as session:
+            retrieve_ex.side_effect = [
+                StorageNotFoundError("no such record"),  # cover out-of-band
+                px_rec_dummy,
+            ]
+            px_rec_out = await self.manager.receive_pres(pres, connection_record)
+            assert retrieve_ex.call_count == 2
+            save_ex.assert_called_once()
+            assert px_rec_out.state == (V20PresExRecord.STATE_PRESENTATION_RECEIVED)
+
     async def test_receive_pres_bait_and_switch_attr_name(self):
         connection_record = async_mock.MagicMock(connection_id=CONN_ID)
         indy_proof_req = deepcopy(INDY_PROOF_REQ_NAME)


### PR DESCRIPTION
Still to work out:
* general WQL (+ `"$and"`) for restrictions in proof request requested attributes/predicates
* not necessarily relying on these being a list: they can be a (WQL statement) dict or a list of (WQL statement) dicts, each (WQL statement) dict possibly being its own compound WQL statement; e.g., this is a valid restriction:
```
{
  "$and": [
    {
      "$or": [
        {
          "schema_name": "membership"
        },
        {
          "schema_name": "members"
        }
      ]
    },
    {
      "$neq": {
        "schema_version": "0.1"
      }
    },
    {
      "issuer_did": "abc123"
    },
    {
      "$not": {
        "$in": {
          "attr::name::value": [
            "joe",
            "dolly",
            "bill"
          ]
        }
      }
    }
  ]
}
```