### PR TITLE
Add outofband credential-offer

### DIFF
--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -29,6 +29,9 @@ from ...connections.v1_0.messages.connection_invitation import ConnectionInvitat
 from ...didcomm_prefix import DIDCommPrefix
 from ...didexchange.v1_0.manager import DIDXManager
 from ...issue_credential.v1_0.models.credential_exchange import V10CredentialExchange
+from ...issue_credential.v1_0.message_types import CREDENTIAL_OFFER
+from ...issue_credential.v1_0.manager import CredentialManager
+from ...issue_credential.v1_0.manager import CredentialOffer
 from ...issue_credential.v2_0.models.cred_ex_record import V20CredExRecord
 from ...present_proof.v1_0.manager import PresentationManager
 from ...present_proof.v1_0.message_types import PRESENTATION_REQUEST
@@ -570,12 +573,17 @@ class OutOfBandManager(BaseConnectionManager):
                             conn_rec=conn_rec,
                             trace=(invi_msg._trace is not None),
                         )
+                    elif unq_req_attach_type == CREDENTIAL_OFFER:
+                        await self._process_cred_offer_v1(
+                            req_attach=req_attach,
+                            conn_rec=conn_rec,
+                        )
                     else:
                         raise OutOfBandManagerError(
                             (
                                 "Unsupported requests~attach type "
                                 f"{req_attach.content['@type']}: must unqualify to"
-                                f"{PRESENTATION_REQUEST} or {PRES_20_REQUEST}"
+                                f"{PRESENTATION_REQUEST} or {PRES_20_REQUEST} or{CREDENTIAL_OFFER}"
                             )
                         )
             else:
@@ -741,6 +749,47 @@ class OutOfBandManager(BaseConnectionManager):
                 (
                     "Configuration sets auto_present false: cannot "
                     "respond automatically to presentation requests"
+                )
+            )
+
+    async def _process_cred_offer_v1(
+        self,
+        req_attach: AttachDecorator,
+        conn_rec: ConnRecord,       
+    ):
+        """
+        Create exchange for v1 cred offer attachment, auto-offer if configured.
+        Args:
+            req_attach: request attachment on invitation
+            service: service message from invitation
+            conn_rec: connection record
+        """
+        cred_mgr = CredentialManager(self._session.profile)
+        cred_offer_dict = req_attach.content
+
+        cred_offer_msg = CredentialOffer.deserialize(cred_offer_dict)
+        
+        # receive credential offer
+        cred_ex_record = await cred_mgr.receive_offer(message=cred_offer_msg, connection_id=conn_rec.connection_id)
+        if self._session.context.settings.get("debug.auto_respond_credential_offer"): 
+            cred_request_message = None
+            (_, cred_request_message) = await cred_mgr.create_request(
+                cred_ex_record= cred_ex_record,
+                holder_did=conn_rec.my_did,
+            )
+            responder = self._session.inject(BaseResponder, required=False)
+            if responder:
+                await responder.send(
+                    message=cred_request_message,
+                    target_list=await self.fetch_connection_targets(
+                        connection=conn_rec
+                    ),
+                )
+        else:
+            raise OutOfBandManagerError(
+                (
+                    "Configuration sets auto_offer false: cannot "
+                    "respond automatically to credential offers"
                 )
             )
 


### PR DESCRIPTION
The out of band protocol doesn't support the attachment type credential-offer yet. I added my code in outofband receive_invitation to receive a credential offer and send a credential request. 

The receive_offer and create_request functions worked perfectly , But I am facing a `connection_record not found error` while the issuer agent executes credential_request_handler script. I am including the logs below. 

`  

> File "/home/indy/aries_cloudagent/core/dispatcher.py", line 198, in handle_message
>     await handler(context, responder)
>   File "/home/indy/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_request_handler.py", line 39, in handle
>     context.message, context.connection_record.connection_id
>   File "/home/indy/aries_cloudagent/protocols/issue_credential/v1_0/manager.py", line 470, in receive_request
>     session, connection_id, message._thread_id
>   File "/home/indy/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py", line 206, in retrieve_by_connection_and_thread
>     {"connection_id": connection_id} if connection_id else None,
>   File "/home/indy/aries_cloudagent/messaging/models/base_record.py", line 250, in retrieve_by_tag_filter
>     cls.__name__, tag_filter, f", {post_filter}" if post_filter else ""
> aries_cloudagent.storage.error.StorageNotFoundError: V10CredentialExchange record not found for {'thread_id': '56ccbd83-3800-41a8-907c-fcbedeebb706'}, {'connection_id': '737ca643-7f05-470a-8b47-89fafb11a83d'}

`