### PR TITLE
Fix type mismatch error

### DIFF
--- a/aries_cloudagent/protocols/present_proof/v2_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/routes.py
@@ -561,7 +561,7 @@ async def present_proof_credentials_list(request: web.BaseRequest):
             pres_ex_record,
             outbound_handler,
         )
-    credentials = indy_credentials + dif_cred_value_list
+    credentials = list(indy_credentials) + dif_cred_value_list
     return web.json_response(credentials)
 
 


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Fix this error:

```
Alice      | Traceback (most recent call last):
Alice      |   File "/home/indy/.pyenv/versions/3.6.13/lib/python3.6/site-packages/aiohttp/web_protocol.py", line 422, in _handle_request
Alice      |     resp = await self._request_handler(request)
Alice      |   File "/home/indy/.pyenv/versions/3.6.13/lib/python3.6/site-packages/aiohttp/web_app.py", line 499, in _handle
Alice      |     resp = await handler(request)
Alice      |   File "/home/indy/.pyenv/versions/3.6.13/lib/python3.6/site-packages/aiohttp/web_middlewares.py", line 119, in impl
Alice      |     return await handler(request)
Alice      |   File "/home/indy/aries_cloudagent/admin/server.py", line 162, in ready_middleware
Alice      |     return await handler(request)
Alice      |   File "/home/indy/aries_cloudagent/admin/server.py", line 199, in debug_middleware
Alice      |     return await handler(request)
Alice      |   File "/home/indy/.pyenv/versions/3.6.13/lib/python3.6/site-packages/aiohttp_apispec/middlewares.py", line 45, in validation_middleware
Alice      |     return await handler(request)
Alice      |   File "/home/indy/aries_cloudagent/admin/server.py", line 366, in setup_context
Alice      |     return await task
Alice      |   File "/home/indy/aries_cloudagent/protocols/present_proof/v2_0/routes.py", line 566, in present_proof_credentials_list
Alice      |     credentials = indy_credentials + dif_cred_value_list
Alice      | TypeError: can only concatenate tuple (not "list") to tuple
```