### PR TITLE
DIF PresExch - Specify record_ids per input_descriptors and bug fix indy requirement & affecting AATH test

### DIFF
--- a/aries_cloudagent/indy/models/pres_preview.py
+++ b/aries_cloudagent/indy/models/pres_preview.py
@@ -6,7 +6,7 @@ from typing import Mapping, Sequence
 
 from marshmallow import EXCLUDE, fields
 
-from ...ledger.indy import IndySdkLedger
+from ...ledger.base import BaseLedger
 from ...messaging.models.base import BaseModel, BaseModelSchema
 from ...messaging.util import canon
 from ...messaging.valid import INDY_CRED_DEF_ID, INDY_PREDICATE
@@ -294,7 +294,7 @@ class IndyPresPreview(BaseModel):
         name: str = None,
         version: str = None,
         nonce: str = None,
-        ledger: IndySdkLedger = None,
+        ledger: BaseLedger = None,
         non_revoc_intervals: Mapping[str, IndyNonRevocationInterval] = None,
     ) -> dict:
         """

--- a/aries_cloudagent/protocols/present_proof/dif/pres_request_schema.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_request_schema.py
@@ -31,13 +31,16 @@ class DIFPresSpecSchema(OpenAPISchema):
         ),
         required=False,
     )
-    record_ids = fields.List(
-        fields.Str(description="Record identifier"),
+    record_ids = fields.Dict(
         description=(
             (
-                "List of record_id to fetch stored "
-                "W3C credentials for presentation exchange"
+                "Mapping of input_descriptor id to list "
+                "of stored W3C credential record_id"
             )
+        ),
+        example=(
+            '{ "<input descriptor id_1>": ["<record id>", ...], '
+            '"<input descriptor id_2>": ["<record id>", ...]}'
         ),
         required=False,
     )

--- a/aries_cloudagent/protocols/present_proof/dif/pres_request_schema.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_request_schema.py
@@ -39,8 +39,10 @@ class DIFPresSpecSchema(OpenAPISchema):
             )
         ),
         example=(
-            '{ "<input descriptor id_1>": ["<record id>", ...], '
-            '"<input descriptor id_2>": ["<record id>", ...]}'
+            {
+                "<input descriptor id_1>": ["<record id_1>", "<record id_2>"],
+                "<input descriptor id_2>": ["<record id>"],
+            }
         ),
         required=False,
     )

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
@@ -190,60 +190,48 @@ class DIFPresFormatHandler(V20PresFormatHandler):
             holder = self._profile.inject(VCHolder)
             record_ids = set()
             credentials_list = []
-            if not limit_record_ids:
-                for input_descriptor in input_descriptors:
-                    expanded_types = set()
-                    schema_ids = set()
-                    for schema in input_descriptor.schemas:
-                        uri = schema.uri
-                        required = schema.required or True
-                        if required:
-                            # JSONLD Expanded URLs
-                            if "#" in uri:
-                                expanded_types.add(uri)
-                            else:
-                                schema_ids.add(uri)
-                    if len(schema_ids) == 0:
-                        schema_ids_list = None
-                    else:
-                        schema_ids_list = list(schema_ids)
-                    if len(expanded_types) == 0:
-                        expanded_types_list = None
-                    else:
-                        expanded_types_list = list(expanded_types)
-                        # Raise Exception if expanded type extracted from
-                        # CREDENTIALS_CONTEXT_V1_URL and
-                        # VERIFIABLE_CREDENTIAL_TYPE is the only schema.uri
-                        # specified in the presentation_definition.
-                        if len(expanded_types_list) == 1:
-                            if expanded_types_list[0] in [
-                                EXPANDED_TYPE_CREDENTIALS_CONTEXT_V1_VC_TYPE
-                            ]:
-                                raise V20PresFormatHandlerError(
-                                    "Only expanded type extracted from "
-                                    "CREDENTIALS_CONTEXT_V1_URL and "
-                                    "VERIFIABLE_CREDENTIAL_TYPE included "
-                                    "as the schema.uri"
-                                )
-                    search = holder.search_credentials(
-                        types=expanded_types_list,
-                        schema_ids=schema_ids_list,
-                    )
-                    # Defaults to page_size but would like to include all
-                    # For now, setting to 1000
-                    max_results = 1000
-                    records = await search.fetch(max_results)
-                    # Avoiding addition of duplicate records
-                    (
-                        vcrecord_list,
-                        vcrecord_ids_set,
-                    ) = await self.process_vcrecords_return_list(records, record_ids)
-                    record_ids = vcrecord_ids_set
-                    credentials_list = credentials_list + vcrecord_list
-            else:
-                records = []
-                for record_id in limit_record_ids:
-                    records.append(await holder.retrieve_credential_by_id(record_id))
+            for input_descriptor in input_descriptors:
+                expanded_types = set()
+                schema_ids = set()
+                for schema in input_descriptor.schemas:
+                    uri = schema.uri
+                    required = schema.required or True
+                    if required:
+                        # JSONLD Expanded URLs
+                        if "#" in uri:
+                            expanded_types.add(uri)
+                        else:
+                            schema_ids.add(uri)
+                if len(schema_ids) == 0:
+                    schema_ids_list = None
+                else:
+                    schema_ids_list = list(schema_ids)
+                if len(expanded_types) == 0:
+                    expanded_types_list = None
+                else:
+                    expanded_types_list = list(expanded_types)
+                    # Raise Exception if expanded type extracted from
+                    # CREDENTIALS_CONTEXT_V1_URL and
+                    # VERIFIABLE_CREDENTIAL_TYPE is the only schema.uri
+                    # specified in the presentation_definition.
+                    if len(expanded_types_list) == 1:
+                        if expanded_types_list[0] in [
+                            EXPANDED_TYPE_CREDENTIALS_CONTEXT_V1_VC_TYPE
+                        ]:
+                            raise V20PresFormatHandlerError(
+                                "Only expanded type extracted from "
+                                "CREDENTIALS_CONTEXT_V1_URL and "
+                                "VERIFIABLE_CREDENTIAL_TYPE included "
+                                "as the schema.uri"
+                            )
+                search = holder.search_credentials(
+                    types=expanded_types_list,
+                    schema_ids=schema_ids_list,
+                )
+                # Defaults to page_size but would like to include all
+                # For now, setting to 1000
+                max_results = 1000
+                records = await search.fetch(max_results)
                 # Avoiding addition of duplicate records
                 (
                     vcrecord_list,
@@ -275,6 +263,7 @@ class DIFPresFormatHandler(V20PresFormatHandler):
             domain=domain,
             pd=pres_definition,
             credentials=credentials_list,
+            records_filter=limit_record_ids,
         )
         return self.get_format_data(PRES_20, pres)
 

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
@@ -450,28 +450,30 @@ class TestDIFFormatHandler(AsyncTestCase):
     async def test_create_pres_prover_proof_spec_with_record_ids(self):
         dif_pres_spec = deepcopy(DIF_PRES_REQUEST_A)
         dif_pres_spec["issuer_id"] = "test123"
-        dif_pres_spec["record_ids"] = ["test1"]
-        cred = VCRecord(
-            contexts=[
-                "https://www.w3.org/2018/credentials/v1",
-                "https://www.w3.org/2018/credentials/examples/v1",
-            ],
-            expanded_types=[
-                "https://www.w3.org/2018/credentials#VerifiableCredential",
-                "https://example.org/examples#UniversityDegreeCredential",
-            ],
-            issuer_id="https://example.edu/issuers/565049",
-            subject_ids=[
-                "did:sov:LjgpST2rjsoxYegQDRm7EL",
-                "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL",
-            ],
-            proof_types=["BbsBlsSignature2020"],
-            schema_ids=["https://example.org/examples/degree.json"],
-            cred_value={"...": "..."},
-            given_id="http://example.edu/credentials/3732",
-            cred_tags={"some": "tag"},
-            record_id="test1",
-        )
+        dif_pres_spec["record_ids"] = {"test_input_descriptor_id": ["test1"]}
+        cred_list = [
+            VCRecord(
+                contexts=[
+                    "https://www.w3.org/2018/credentials/v1",
+                    "https://www.w3.org/2018/credentials/examples/v1",
+                ],
+                expanded_types=[
+                    "https://www.w3.org/2018/credentials#VerifiableCredential",
+                    "https://example.org/examples#UniversityDegreeCredential",
+                ],
+                issuer_id="https://example.edu/issuers/565049",
+                subject_ids=[
+                    "did:sov:LjgpST2rjsoxYegQDRm7EL",
+                    "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL",
+                ],
+                proof_types=["BbsBlsSignature2020"],
+                schema_ids=["https://example.org/examples/degree.json"],
+                cred_value={"...": "..."},
+                given_id="http://example.edu/credentials/3732",
+                cred_tags={"some": "tag"},
+                record_id="test1",
+            )
+        ]
         dif_pres_request = V20PresRequest(
             formats=[
                 V20PresFormat(
@@ -503,7 +505,11 @@ class TestDIFFormatHandler(AsyncTestCase):
         self.context.injector.bind_instance(
             VCHolder,
             async_mock.MagicMock(
-                retrieve_credential_by_id=async_mock.CoroutineMock(return_value=cred)
+                search_credentials=async_mock.MagicMock(
+                    return_value=async_mock.MagicMock(
+                        fetch=async_mock.CoroutineMock(return_value=cred_list)
+                    )
+                )
             ),
         )
 
@@ -514,6 +520,10 @@ class TestDIFFormatHandler(AsyncTestCase):
         ) as mock_create_vp:
             mock_create_vp.return_value = DIF_PRES
             output = await self.handler.create_pres(record, request_data)
+            assert isinstance(output[0], V20PresFormat) and isinstance(
+                output[1], AttachDecorator
+            )
+            assert output[1].data.json_ == DIF_PRES
 
     async def test_create_pres_no_challenge(self):
         dif_pres_req = deepcopy(DIF_PRES_REQUEST_B)

--- a/aries_cloudagent/protocols/present_proof/v2_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/routes.py
@@ -909,7 +909,19 @@ async def present_proof_send_presentation(request: web.BaseRequest):
     outbound_handler = request["outbound_message_router"]
     pres_ex_id = request.match_info["pres_ex_id"]
     body = await request.json()
-    fmt = V20PresFormat.Format.get([f for f in body][0]).api  # "indy" xor "dif"
+    if "dif" in body:
+        fmt = V20PresFormat.Format.get("dif").api
+    elif "indy" in body:
+        fmt = V20PresFormat.Format.get("indy").api
+    else:
+        raise web.HTTPBadRequest(
+            reason=(
+                "No presentation format specification provided, "
+                "either dif or indy must be included. "
+                "In case of DIF, if no additional specification "
+                'needs to be provided then include "dif": {}'
+            )
+        )
     comment = body.get("comment")
     pres_ex_record = None
     async with context.session() as session:

--- a/aries_cloudagent/protocols/present_proof/v2_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/tests/test_routes.py
@@ -1953,3 +1953,11 @@ class TestPresentProofRoutes(AsyncTestCase):
         assert len(returned_cred_list) == 1
         assert len(returned_record_ids) == 2
         assert returned_cred_list[0].record_id == "test2"
+
+    async def test_send_presentation_no_specification(self):
+        self.request.json = async_mock.CoroutineMock(return_value={"comment": "test"})
+        self.request.match_info = {
+            "pres_ex_id": "dummy",
+        }
+        with self.assertRaises(test_module.web.HTTPBadRequest):
+            await test_module.present_proof_send_presentation(self.request)

--- a/aries_cloudagent/vc/ld_proofs/constants.py
+++ b/aries_cloudagent/vc/ld_proofs/constants.py
@@ -13,7 +13,7 @@ SECURITY_PROOF_URL = "https://w3id.org/security#proof"
 SECURITY_SIGNATURE_URL = "https://w3id.org/security#signature"
 
 VERIFIABLE_CREDENTIAL_TYPE = "VerifiableCredential"
-VERIFIABLE_PRESENTATION_TYPE = "VerifiableCredential"
+VERIFIABLE_PRESENTATION_TYPE = "VerifiablePresentation"
 
 EXPANDED_TYPE_CREDENTIALS_CONTEXT_V1_VC_TYPE = (
     "https://www.w3.org/2018/credentials#VerifiableCredential"


### PR DESCRIPTION
- resolve #1237 
- Holder can now control which W3C credentials get applied to each `input_descriptor` in `presentation_definition`. 
```
{
    "<input descriptor id_1>": ["<record id_1>", "<record id_2>"],
    "<input descriptor id_2>": ["<record id>"],
}
``` 
- Fixes error which causes AATH present-proof-v2 to fail.