### PR TITLE
Update get/set_did_public to use a storage record pointer

### DIFF
--- a/aries_cloudagent/config/base.py
+++ b/aries_cloudagent/config/base.py
@@ -5,7 +5,7 @@ from typing import Mapping, Optional, Type, TypeVar
 
 from ..core.error import BaseError
 
-InjectType = TypeVar("Inject")
+InjectType = TypeVar("InjectType")
 
 
 class ConfigError(BaseError):

--- a/aries_cloudagent/core/tests/test_event_bus.py
+++ b/aries_cloudagent/core/tests/test_event_bus.py
@@ -27,7 +27,7 @@ def event():
     yield event
 
 
-class TestProcessor:
+class MockProcessor:
     def __init__(self):
         self.context = None
         self.event = None
@@ -39,7 +39,7 @@ class TestProcessor:
 
 @pytest.fixture
 def processor():
-    yield TestProcessor()
+    yield MockProcessor()
 
 
 def test_event(event):
@@ -77,7 +77,7 @@ def test_unsub_unsubbed_processor(event_bus: EventBus, processor):
     """Test unsubscribing an unsubscribed processor does not error."""
     event_bus.unsubscribe(re.compile(".*"), processor)
     event_bus.subscribe(re.compile(".*"), processor)
-    another_processor = TestProcessor()
+    another_processor = MockProcessor()
     event_bus.unsubscribe(re.compile(".*"), another_processor)
 
 
@@ -101,7 +101,7 @@ async def test_sub_notify_error_logged_and_exec_continues(
     def _raise_exception(context, event):
         raise Exception()
 
-    processor = TestProcessor()
+    processor = MockProcessor()
     bad_processor = _raise_exception
     event_bus.subscribe(re.compile(".*"), bad_processor)
     event_bus.subscribe(re.compile(".*"), processor)
@@ -147,7 +147,7 @@ async def test_sub_notify_no_match(event_bus: EventBus, context, event, processo
 @pytest.mark.asyncio
 async def test_sub_notify_only_one(event_bus: EventBus, context, event, processor):
     """Test only one subscriber is called when pattern matches only one."""
-    processor1 = TestProcessor()
+    processor1 = MockProcessor()
     event_bus.subscribe(re.compile(".*"), processor)
     event_bus.subscribe(re.compile("^$"), processor1)
     await event_bus.notify(context, event)
@@ -160,7 +160,7 @@ async def test_sub_notify_only_one(event_bus: EventBus, context, event, processo
 @pytest.mark.asyncio
 async def test_sub_notify_both(event_bus: EventBus, context, event, processor):
     """Test both subscribers are called when pattern matches both."""
-    processor1 = TestProcessor()
+    processor1 = MockProcessor()
     event_bus.subscribe(re.compile(".*"), processor)
     event_bus.subscribe(re.compile("anything"), processor1)
     await event_bus.notify(context, event)

--- a/aries_cloudagent/wallet/base.py
+++ b/aries_cloudagent/wallet/base.py
@@ -7,7 +7,6 @@ from ..ledger.base import BaseLedger
 from ..ledger.endpoint_type import EndpointType
 from .error import WalletError
 
-from .did_posture import DIDPosture
 from .did_info import DIDInfo, KeyInfo
 from .key_type import KeyType
 from .did_method import DIDMethod
@@ -122,8 +121,6 @@ class BaseWallet(ABC):
         """
         Create and store a new public DID.
 
-        Implicitly flags all other dids as not public.
-
         Args:
             seed: Optional seed to use for DID
             did: The DID to use
@@ -133,72 +130,32 @@ class BaseWallet(ABC):
             The created `DIDInfo`
 
         """
-        if method != DIDMethod.SOV:
-            raise WalletError("Creating public did is only allowed for did:sov dids")
-
-        # validate key_type
-        if not method.supports_key_type(key_type):
-            raise WalletError(
-                f"Invalid key type {key_type.key_type} for method {method.method_name}"
-            )
-
-        metadata = DIDPosture.PUBLIC.metadata
-        dids = await self.get_local_dids()
-        for info in dids:
-            info_meta = info.metadata
-            info_meta["public"] = False
-            await self.replace_local_did_metadata(info.did, info_meta)
-        return await self.create_local_did(
+        metadata = metadata or {}
+        metadata.setdefault("posted", True)
+        did_info = await self.create_local_did(
             method=method, key_type=key_type, seed=seed, did=did, metadata=metadata
         )
+        return await self.set_public_did(did_info)
 
+    @abstractmethod
     async def get_public_did(self) -> DIDInfo:
         """
         Retrieve the public DID.
 
         Returns:
-            The created `DIDInfo`
+            The currently public `DIDInfo`, if any
 
         """
 
-        dids = await self.get_local_dids()
-        for info in dids:
-            if info.metadata.get("public"):
-                return info
-
-        return None
-
-    async def set_public_did(self, did: str) -> DIDInfo:
+    @abstractmethod
+    async def set_public_did(self, did: Union[str, DIDInfo]) -> DIDInfo:
         """
         Assign the public DID.
 
         Returns:
-            The created `DIDInfo`
+            The updated `DIDInfo`
 
         """
-
-        did_info = await self.get_local_did(did)
-        if did_info.method != DIDMethod.SOV:
-            raise WalletError("Setting public did is only allowed for did:sov dids")
-
-        # will raise an exception if not found
-        info = None if did is None else await self.get_local_did(did)
-
-        public = await self.get_public_did()
-        if public and info and public.did == info.did:
-            info = public
-        else:
-            if public:
-                metadata = public.metadata.copy()
-                del metadata["public"]
-                await self.replace_local_did_metadata(public.did, metadata)
-
-            if info:
-                metadata = {**info.metadata, **DIDPosture.PUBLIC.metadata}
-                await self.replace_local_did_metadata(info.did, metadata)
-                info = await self.get_local_did(info.did)
-
-        return info
 
     @abstractmethod
     async def get_local_dids(self) -> Sequence[DIDInfo]:
@@ -251,23 +208,21 @@ class BaseWallet(ABC):
 
     async def get_posted_dids(self) -> Sequence[DIDInfo]:
         """
-        Get list of defined posted DIDs, excluding public DID.
+        Get list of defined posted DIDs.
 
         Returns:
             A list of `DIDInfo` instances
 
         """
         return [
-            info
-            for info in await self.get_local_dids()
-            if info.metadata.get("posted") and not info.metadata.get("public")
+            info for info in await self.get_local_dids() if info.metadata.get("posted")
         ]
 
     async def set_did_endpoint(
         self,
         did: str,
         endpoint: str,
-        ledger: BaseLedger,
+        _ledger: BaseLedger,
         endpoint_type: EndpointType = None,
     ):
         """
@@ -284,7 +239,7 @@ class BaseWallet(ABC):
         did_info = await self.get_local_did(did)
 
         if did_info.method != DIDMethod.SOV:
-            raise WalletError("Setting did endpoint is only allowed for did:sov dids")
+            raise WalletError("Setting DID endpoint is only allowed for did:sov DIDs")
         metadata = {**did_info.metadata}
         if not endpoint_type:
             endpoint_type = EndpointType.ENDPOINT

--- a/aries_cloudagent/wallet/indy.py
+++ b/aries_cloudagent/wallet/indy.py
@@ -1,6 +1,5 @@
 """Indy implementation of BaseWallet interface."""
 
-from aries_cloudagent.storage.record import StorageRecord
 import json
 
 from typing import List, Sequence, Tuple, Union
@@ -20,6 +19,7 @@ from ..ledger.endpoint_type import EndpointType
 from ..ledger.error import LedgerConfigError
 from ..storage.indy import IndySdkStorage
 from ..storage.error import StorageDuplicateError, StorageNotFoundError
+from ..storage.record import StorageRecord
 
 from .base import BaseWallet
 from .crypto import (

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -207,10 +207,9 @@ async def wallet_did_list(request: web.BaseRequest):
     filter_posture = DIDPosture.get(request.query.get("posture"))
     filter_key_type = KeyType.from_key_type(request.query.get("key_type"))
     results = []
-    public_did_info = await wallet.get_public_did()
-    posted_did_infos = await wallet.get_posted_dids()
 
     if filter_posture is DIDPosture.PUBLIC:
+        public_did_info = await wallet.get_public_did()
         if (
             public_did_info
             and (not filter_verkey or public_did_info.verkey == filter_verkey)
@@ -221,6 +220,7 @@ async def wallet_did_list(request: web.BaseRequest):
             results.append(format_did_info(public_did_info))
     elif filter_posture is DIDPosture.POSTED:
         results = []
+        posted_did_infos = await wallet.get_posted_dids()
         for info in posted_did_infos:
             if (
                 (not filter_verkey or info.verkey == filter_verkey)
@@ -401,7 +401,7 @@ async def wallet_set_public_did(request: web.BaseRequest):
                 raise web.HTTPNotFound(reason=f"DID {did} is not posted to the ledger")
 
         did_info = await wallet.get_local_did(did)
-        info = await wallet.set_public_did(did)
+        info = await wallet.set_public_did(did_info)
         if info:
             # Publish endpoint if necessary
             endpoint = did_info.metadata.get("endpoint")

--- a/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
@@ -344,7 +344,6 @@ class TestInMemoryWallet:
             self.test_sov_did,
             self.test_metadata,
         )
-        assert not info.metadata.get("public")
         assert not info.metadata.get("posted")
 
         posted = await wallet.get_posted_dids()
@@ -354,22 +353,24 @@ class TestInMemoryWallet:
             DIDMethod.SOV,
             KeyType.ED25519,
         )
-        assert info_public.metadata.get("public")
         assert info_public.metadata.get("posted")
+        posted = await wallet.get_posted_dids()
+        assert posted[0].did == info_public.did
 
         # test replace
         info_replace = await wallet.create_public_did(
             DIDMethod.SOV,
             KeyType.ED25519,
         )
-        assert info_replace.metadata.get("public")
         assert info_replace.metadata.get("posted")
         info_check = await wallet.get_local_did(info_public.did)
-        assert not info_check.metadata.get("public")
         assert info_check.metadata.get("posted")
 
         posted = await wallet.get_posted_dids()
-        assert posted and posted[0].did == info_public.did
+        assert len(posted) == 2 and set(p.did for p in posted) == {
+            info_public.did,
+            info_replace.did,
+        }
 
     @pytest.mark.asyncio
     async def test_create_public_did_x_not_sov(self, wallet: InMemoryWallet):
@@ -378,7 +379,7 @@ class TestInMemoryWallet:
                 DIDMethod.KEY,
                 KeyType.ED25519,
             )
-        assert "Creating public did is only allowed for did:sov dids" in str(
+        assert "Setting public DID is only allowed for did:sov DIDs" in str(
             context.value
         )
 
@@ -402,7 +403,6 @@ class TestInMemoryWallet:
             self.test_sov_did,
             self.test_metadata,
         )
-        assert not info.metadata.get("public")
 
         with pytest.raises(WalletNotFoundError):
             await wallet.set_public_did("55GkHamhTU1ZbTbV2ab9DF")
@@ -410,21 +410,17 @@ class TestInMemoryWallet:
         # test assign
         info_same = await wallet.set_public_did(info.did)
         assert info_same.did == info.did
-        assert info_same.metadata.get("public")
 
         info_new = await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519)
         assert info_new.did != info_same.did
-        assert not info_new.metadata.get("public")
 
         loc = await wallet.get_local_did(self.test_sov_did)
         pub = await wallet.set_public_did(loc.did)
         assert pub.did == loc.did
-        assert pub.metadata.get("public") == loc.metadata.get("public")
 
         # test replace
         info_final = await wallet.set_public_did(info_new.did)
         assert info_final.did == info_new.did
-        assert info_final.metadata.get("public")
 
     @pytest.mark.asyncio
     async def test_set_public_did_x_not_sov(self, wallet: InMemoryWallet):
@@ -434,7 +430,7 @@ class TestInMemoryWallet:
         )
         with pytest.raises(WalletError) as context:
             await wallet.set_public_did(info.did)
-        assert "Setting public did is only allowed for did:sov dids" in str(
+        assert "Setting public DID is only allowed for did:sov DIDs" in str(
             context.value
         )
 
@@ -609,6 +605,6 @@ class TestInMemoryWallet:
                 "https://google.com",
                 {},
             )
-        assert "Setting did endpoint is only allowed for did:sov dids" in str(
+        assert "Setting DID endpoint is only allowed for did:sov DIDs" in str(
             context.value
         )

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -380,9 +380,7 @@ class TestWalletRoutes(AsyncTestCase):
                 KeyType.ED25519,
             )
             result = await test_module.wallet_set_public_did(self.request)
-            self.wallet.set_public_did.assert_awaited_once_with(
-                self.request.query["did"]
-            )
+            self.wallet.set_public_did.assert_awaited_once()
             json_response.assert_called_once_with(
                 {
                     "result": {
@@ -533,9 +531,7 @@ class TestWalletRoutes(AsyncTestCase):
                 KeyType.ED25519,
             )
             result = await test_module.wallet_set_public_did(self.request)
-            self.wallet.set_public_did.assert_awaited_once_with(
-                self.request.query["did"]
-            )
+            self.wallet.set_public_did.assert_awaited_once()
             json_response.assert_called_once_with(
                 {
                     "result": {
@@ -575,9 +571,7 @@ class TestWalletRoutes(AsyncTestCase):
             self.wallet.get_local_did.return_value = did_info
             self.wallet.set_public_did.return_value = did_info
             result = await test_module.wallet_set_public_did(self.request)
-            self.wallet.set_public_did.assert_awaited_once_with(
-                self.request.query["did"]
-            )
+            self.wallet.set_public_did.assert_awaited_once()
             self.wallet.set_did_endpoint.assert_awaited_once_with(
                 did_info.did, "https://default_endpoint.com", ledger
             )


### PR DESCRIPTION
This should be much faster when there are many DIDs stored in the wallet.

The 'public' DID metadata property is now generally ignored except when auto-upgrading an existing wallet. The `get_posted_dids` method is updated to NOT filter the public DID, as it did previously.

Includes a couple fixes for warnings when running tests.