### PR TITLE
DIF PE - VCHolder backend-specific tag_query building and handle no given_id credentials

### DIFF
--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -1032,14 +1032,9 @@ class DIFPresExchHandler:
             for descriptor_id in result.keys():
                 credential_list = result.get(descriptor_id)
                 for credential in credential_list:
-                    if credential.given_id:
-                        if credential.given_id not in cred_uid_descriptors:
-                            cred_uid_descriptors[credential.given_id] = {}
-                        cred_uid_descriptors[credential.given_id][descriptor_id] = {}
-                    else:
-                        if credential.record_id not in cred_uid_descriptors:
-                            cred_uid_descriptors[credential.record_id] = {}
-                        cred_uid_descriptors[credential.record_id][descriptor_id] = {}
+                    cred_id = credential.given_id or credential.record_id
+                    if cred_id:
+                        cred_uid_descriptors.setdefault(cred_id, {})[descriptor_id] = {}
 
             if len(result.keys()) != 0:
                 nested_result.append(result)
@@ -1094,27 +1089,17 @@ class DIFPresExchHandler:
 
                 if key in result:
                     for credential in result[key]:
-                        if credential.given_id and credential.given_id not in uid_dict:
+                        cred_id = credential.given_id or credential.record_id
+                        if cred_id and cred_id not in uid_dict:
                             merged_credentials.append(credential)
-                            uid_dict[credential.given_id] = {}
-                        elif (
-                            not credential.given_id
-                            and credential.record_id not in uid_dict
-                        ):
-                            merged_credentials.append(credential)
-                            uid_dict[credential.record_id] = {}
+                            uid_dict[cred_id] = {}
 
                 for credential in credentials:
-                    if credential.given_id and credential.given_id not in uid_dict:
-                        if (key + (credential.given_id)) not in exclude:
+                    cred_id = credential.given_id or credential.record_id
+                    if cred_id and cred_id not in uid_dict:
+                        if (key + cred_id) not in exclude:
                             merged_credentials.append(credential)
-                            uid_dict[credential.given_id] = {}
-                    elif (
-                        not credential.given_id and credential.record_id not in uid_dict
-                    ):
-                        if (key + (credential.record_id)) not in exclude:
-                            merged_credentials.append(credential)
-                            uid_dict[credential.record_id] = {}
+                            uid_dict[cred_id] = {}
                 result[key] = merged_credentials
         return result
 
@@ -1243,30 +1228,16 @@ class DIFPresExchHandler:
         for desc_id in sorted_desc_keys:
             credentials = dict_descriptor_creds.get(desc_id)
             for cred in credentials:
-                if cred.given_id:
-                    if cred.given_id not in dict_of_creds:
+                cred_id = cred.given_id or cred.record_id
+                if cred_id:
+                    if cred_id not in dict_of_creds:
                         result.append(cred)
-                        dict_of_creds[cred.given_id] = len(descriptors)
-                    if f"{cred.given_id}-{cred.given_id}" not in dict_of_descriptors:
+                        dict_of_creds[cred_id] = len(descriptors)
+                    if f"{cred_id}-{cred_id}" not in dict_of_descriptors:
                         descriptor_map = InputDescriptorMapping(
                             id=desc_id,
                             fmt="ldp_vp",
-                            path=(
-                                f"$.verifiableCredential[{dict_of_creds[cred.given_id]}]"
-                            ),
-                        )
-                        descriptors.append(descriptor_map)
-                else:
-                    if cred.record_id not in dict_of_creds:
-                        result.append(cred)
-                        dict_of_creds[cred.record_id] = len(descriptors)
-                    if f"{cred.record_id}-{cred.record_id}" not in dict_of_descriptors:
-                        descriptor_map = InputDescriptorMapping(
-                            id=desc_id,
-                            fmt="ldp_vp",
-                            path=(
-                                f"$.verifiableCredential[{dict_of_creds[cred.record_id]}]"
-                            ),
+                            path=(f"$.verifiableCredential[{dict_of_creds[cred_id]}]"),
                         )
                         descriptors.append(descriptor_map)
 

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -1214,7 +1214,7 @@ class DIFPresExchHandler:
 
     def check_if_cred_id_derived(self, id: str) -> bool:
         """Check if credential or credentialSubjet id is derived."""
-        if id.startswith("urn:") and "c14" in id:
+        if id.startswith("urn:bnid:_:c14n"):
             return True
         return False
 
@@ -1272,3 +1272,114 @@ class DIFPresExchHandler:
 
         descriptors = sorted(descriptors, key=lambda i: i.id)
         return (result, descriptors)
+
+    async def verify_received_pres(
+        self,
+        pd: PresentationDefinition,
+        pres: dict,
+    ):
+        """
+        Verify credentials received in presentation.
+
+        Args:
+            pres: received VerifiablePresentation
+            pd: PresentationDefinition
+        """
+        descriptor_map_list = pres.get("presentation_submission").get("descriptor_map")
+        input_descriptors = pd.input_descriptors
+        inp_desc_id_contraint_map = {}
+        for input_descriptor in input_descriptors:
+            inp_desc_id_contraint_map[input_descriptor.id] = input_descriptor.constraint
+        for desc_map_item in descriptor_map_list:
+            desc_map_item_id = desc_map_item.get("id")
+            constraint = inp_desc_id_contraint_map.get(desc_map_item_id)
+            desc_map_item_path = desc_map_item.get("path")
+            jsonpath = parse(desc_map_item_path)
+            match = jsonpath.find(pres)
+            if len(match) == 0:
+                raise DIFPresExchError(
+                    f"{desc_map_item_path} path in descriptor_map not applicable"
+                )
+            for match_item in match:
+                if not await self.apply_constraint_received_cred(
+                    constraint, match_item.value
+                ):
+                    raise DIFPresExchError(
+                        f"Constraint specified for {desc_map_item_id} does not "
+                        f"apply to the enclosed credential in {desc_map_item_path}"
+                    )
+
+    async def apply_constraint_received_cred(
+        self, constraint: Constraints, cred_dict: dict
+    ) -> bool:
+        """Evaluate constraint from the request against received credential."""
+        fields = constraint._fields
+        field_paths = []
+        credential = self.create_vcrecord(cred_dict)
+        for field in fields:
+            field_paths = field_paths + field.paths
+            if not await self.filter_by_field(field, credential):
+                return False
+        # Selective Disclosure check
+        if constraint.limit_disclosure == "required":
+            field_paths = set([path.replace("$.", "") for path in field_paths])
+            mandatory_paths = {
+                "@context",
+                "type",
+                "issuanceDate",
+                "issuer",
+                "proof",
+                "credentialSubject",
+                "id",
+            }
+            to_remove_from_field_paths = set()
+            nested_field_paths = {"credentialSubject": {"id", "type"}}
+            for field_path in field_paths:
+                if field_path.count(".") >= 1:
+                    split_field_path = field_path.split(".")
+                    key = ".".join(split_field_path[:-1])
+                    value = split_field_path[-1]
+                    nested_field_paths = self.build_nested_paths_dict(
+                        key, value, nested_field_paths
+                    )
+                    to_remove_from_field_paths.add(field_path)
+            for to_remove_path in to_remove_from_field_paths:
+                field_paths.remove(to_remove_path)
+
+            field_paths = set.union(mandatory_paths, field_paths)
+
+            for attrs in cred_dict.keys():
+                if attrs not in field_paths:
+                    return False
+            for nested_attr_key in nested_field_paths:
+                nested_attr_values = nested_field_paths[nested_attr_key]
+                split_nested_attr_key = nested_attr_key.split(".")
+                extracted_dict = self.nested_get(cred_dict, split_nested_attr_key)
+                for attrs in extracted_dict.keys():
+                    if attrs not in nested_attr_values:
+                        return False
+        return True
+
+    def nested_get(self, input_dict: dict, nested_key: Sequence[str]) -> dict:
+        """Return internal dict from nested input_dict given list of nested_key."""
+        internal_dict_value = input_dict
+        for k in nested_key:
+            internal_dict_value = internal_dict_value.get(k, None)
+        return internal_dict_value
+
+    def build_nested_paths_dict(
+        self, key: str, value: str, nested_field_paths: dict
+    ) -> dict:
+        """Build and return nested_field_paths dict."""
+        if key in nested_field_paths.keys():
+            nested_field_paths[key].add(value)
+        else:
+            nested_field_paths[key] = {value}
+        split_key = key.split(".")
+        if len(split_key) > 1:
+            nested_field_paths.update(
+                self.build_nested_paths_dict(
+                    ".".join(split_key[:-1]), split_key[-1], nested_field_paths
+                )
+            )
+        return nested_field_paths

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_data.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_data.py
@@ -49,6 +49,87 @@ def create_vcrecord(cred_dict: dict, expanded_types: list):
     )
 
 
+creds_with_no_id = [
+    create_vcrecord(
+        {
+            "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                "https://w3id.org/citizenship/v1",
+                "https://w3id.org/security/bbs/v1",
+            ],
+            "type": ["VerifiableCredential", "PermanentResidentCard"],
+            "issuer": "did:key:zUC72Q7XD4PE4CrMiDVXuvZng3sBvMmaGgNeTUJuzavH2BS7ThbHL9FhsZM9QYY5fqAQ4MB8M9oudz3tfuaX36Ajr97QRW7LBt6WWmrtESe6Bs5NYzFtLWEmeVtvRYVAgjFcJSa",
+            "name": "Permanent Resident Card",
+            "description": "Government of Example Permanent Resident Card.",
+            "issuanceDate": "2010-01-01T19:53:24Z",
+            "expirationDate": "2029-12-03T12:19:52Z",
+            "credentialSubject": {
+                "type": ["PermanentResident", "Person"],
+                "givenName": "TEST",
+                "familyName": "SMITH",
+                "gender": "Male",
+                "image": "data:image/png;base64,iVBORw0KGgokJggg==",
+                "residentSince": "2015-01-01",
+                "lprCategory": "C09",
+                "lprNumber": "999-999-999",
+                "commuterClassification": "C1",
+                "birthCountry": "Bahamas",
+                "birthDate": "1958-07-17",
+            },
+            "proof": {
+                "type": "BbsBlsSignature2020",
+                "verificationMethod": "did:key:zUC72Q7XD4PE4CrMiDVXuvZng3sBvMmaGgNeTUJuzavH2BS7ThbHL9FhsZM9QYY5fqAQ4MB8M9oudz3tfuaX36Ajr97QRW7LBt6WWmrtESe6Bs5NYzFtLWEmeVtvRYVAgjFcJSa#zUC72Q7XD4PE4CrMiDVXuvZng3sBvMmaGgNeTUJuzavH2BS7ThbHL9FhsZM9QYY5fqAQ4MB8M9oudz3tfuaX36Ajr97QRW7LBt6WWmrtESe6Bs5NYzFtLWEmeVtvRYVAgjFcJSa",
+                "created": "2019-12-11T03:50:55",
+                "proofPurpose": "assertionMethod",
+                "proofValue": "mMEjznbr4lN5xQT0OuLJ94pKSSBEwBxKNHBPxfjwhRq2NnDaTH/mb+PdPnmfUgKvA8h5hI9Ho3qfY8TWmJtLsYSmJFZoG/FARQuwJJbTW/tVZoA2FVVKZGEsGt2MHsr1z/W30cXnmRyQzgqh4lnhQg==",
+            },
+        },
+        [
+            "https://www.w3.org/2018/credentials#VerifiableCredential",
+            "https://w3id.org/citizenship#PermanentResidentCard",
+        ],
+    ),
+    create_vcrecord(
+        {
+            "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                "https://w3id.org/citizenship/v1",
+                "https://w3id.org/security/bbs/v1",
+            ],
+            "type": ["VerifiableCredential", "PermanentResidentCard"],
+            "issuer": "did:key:zUC72Q7XD4PE4CrMiDVXuvZng3sBvMmaGgNeTUJuzavH2BS7ThbHL9FhsZM9QYY5fqAQ4MB8M9oudz3tfuaX36Ajr97QRW7LBt6WWmrtESe6Bs5NYzFtLWEmeVtvRYVAgjFcJSa",
+            "name": "Permanent Resident Card",
+            "description": "Government of Example Permanent Resident Card.",
+            "issuanceDate": "2010-01-01T19:53:24Z",
+            "expirationDate": "2029-12-03T12:19:52Z",
+            "credentialSubject": {
+                "type": ["PermanentResident", "Person"],
+                "givenName": "TEST",
+                "familyName": "SMITH",
+                "gender": "Male",
+                "image": "data:image/png;base64,iVBORw0KGgokJggg==",
+                "residentSince": "2015-01-01",
+                "lprCategory": "C09",
+                "lprNumber": "999-999-999",
+                "commuterClassification": "C1",
+                "birthCountry": "Bahamas",
+                "birthDate": "1958-07-17",
+            },
+            "proof": {
+                "type": "BbsBlsSignature2020",
+                "verificationMethod": "did:key:zUC72Q7XD4PE4CrMiDVXuvZng3sBvMmaGgNeTUJuzavH2BS7ThbHL9FhsZM9QYY5fqAQ4MB8M9oudz3tfuaX36Ajr97QRW7LBt6WWmrtESe6Bs5NYzFtLWEmeVtvRYVAgjFcJSa#zUC72Q7XD4PE4CrMiDVXuvZng3sBvMmaGgNeTUJuzavH2BS7ThbHL9FhsZM9QYY5fqAQ4MB8M9oudz3tfuaX36Ajr97QRW7LBt6WWmrtESe6Bs5NYzFtLWEmeVtvRYVAgjFcJSa",
+                "created": "2019-12-11T03:50:55",
+                "proofPurpose": "assertionMethod",
+                "proofValue": "rf5LlOFiB5oAl/hSEeaN/H3vx+3AXVpL4O4abtLmYb1aUF+WBOX3HBx5SrTkcwUgJBAPNoFX9l2PVDjTGy/eCjDerDG0DN5ZR+YwjebcZeclzE3Yv2hsnan1M/OTAc9GTNWE3p9lXbRxHNvwTXX6ug==",
+            },
+        },
+        [
+            "https://www.w3.org/2018/credentials#VerifiableCredential",
+            "https://w3id.org/citizenship#PermanentResidentCard",
+        ],
+    ),
+]
+
 bbs_signed_cred_no_credsubjectid = [
     create_vcrecord(
         {
@@ -492,7 +573,7 @@ edd_jsonld_creds = [
     ),
 ]
 
-cred_list = [
+CRED_LIST = [
     {
         "@context": [
             "https://www.w3.org/2018/credentials/v1",
@@ -1275,7 +1356,7 @@ pres_exch_datetime_maximum_met = """
 
 def get_test_data():
     vc_record_list = []
-    for cred in cred_list:
+    for cred in CRED_LIST:
         vc_record_list.append(
             create_vcrecord(
                 cred,

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
@@ -3,6 +3,7 @@ import pytest
 
 from asynctest import mock as async_mock
 from copy import deepcopy
+from uuid import uuid4
 
 from .....core.in_memory import InMemoryProfile
 from .....did.did_key import DIDKey
@@ -46,6 +47,7 @@ from .test_data import (
     bbs_bls_number_filter_creds,
     bbs_signed_cred_no_credsubjectid,
     bbs_signed_cred_credsubjectid,
+    creds_with_no_id,
 )
 
 
@@ -1529,6 +1531,35 @@ class TestPresExchHandler:
             test_nested_result, {}
         )
 
+    @pytest.mark.asyncio
+    async def test_merge_nested_cred_no_id(self, profile):
+        dif_pres_exch_handler = DIFPresExchHandler(profile)
+        cred_list = deepcopy(creds_with_no_id)
+        cred_list[0].record_id = str(uuid4())
+        cred_list[1].record_id = str(uuid4())
+        test_nested_result = []
+        test_dict_1 = {}
+        test_dict_1["citizenship_input_1"] = [
+            cred_list[0],
+            cred_list[1],
+        ]
+        test_dict_2 = {}
+        test_dict_2["citizenship_input_2"] = [
+            cred_list[0],
+        ]
+        test_dict_3 = {}
+        test_dict_3["citizenship_input_2"] = [
+            cred_list[0],
+            cred_list[1],
+        ]
+        test_nested_result.append(test_dict_1)
+        test_nested_result.append(test_dict_2)
+        test_nested_result.append(test_dict_3)
+
+        tmp_result = await dif_pres_exch_handler.merge_nested_results(
+            test_nested_result, {}
+        )
+
     def test_subject_is_issuer(self, setup_tuple, profile):
         cred_list, pd_list = setup_tuple
         dif_pres_exch_handler = DIFPresExchHandler(profile)
@@ -2866,7 +2897,7 @@ class TestPresExchHandler:
         assert filtered_cred_list[1].record_id in record_id_list
 
     @pytest.mark.asyncio
-    async def test_create_vp_record_ids(self, profile, setup_tuple):
+    async def test_create_vp_record_ids(self, profile):
         dif_pres_exch_handler = DIFPresExchHandler(profile)
         test_pd_filter_with_only_num_type = """
             {
@@ -2923,3 +2954,52 @@ class TestPresExchHandler:
             records_filter=records_filter,
         )
         assert len(tmp_vp.get("verifiableCredential")) == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.ursa_bbs_signatures
+    async def test_multiple_applicable_creds_with_no_id(self, profile, setup_tuple):
+        dif_pres_exch_handler = DIFPresExchHandler(profile)
+        test_creds = deepcopy(creds_with_no_id)
+        test_creds[0].record_id = str(uuid4())
+        test_creds[1].record_id = str(uuid4())
+        cred_list, pd_list = setup_tuple
+
+        tmp_pd = pd_list[6]
+        tmp_vp = await dif_pres_exch_handler.create_vp(
+            credentials=test_creds,
+            pd=tmp_pd[0],
+            challenge="1f44d55f-f161-4938-a659-f8026467f126",
+        )
+        assert len(tmp_vp["verifiableCredential"]) == 2
+        assert (
+            tmp_vp.get("verifiableCredential")[0]
+            .get("credentialSubject")
+            .get("givenName")
+            == "TEST"
+        )
+        assert (
+            tmp_vp.get("verifiableCredential")[1]
+            .get("credentialSubject")
+            .get("givenName")
+            == "TEST"
+        )
+
+        tmp_pd = pd_list[1]
+        tmp_vp = await dif_pres_exch_handler.create_vp(
+            credentials=test_creds,
+            pd=tmp_pd[0],
+            challenge="1f44d55f-f161-4938-a659-f8026467f126",
+        )
+        assert len(tmp_vp["verifiableCredential"]) == 2
+        assert (
+            tmp_vp.get("verifiableCredential")[0]
+            .get("credentialSubject")
+            .get("givenName")
+            == "TEST"
+        )
+        assert (
+            tmp_vp.get("verifiableCredential")[1]
+            .get("credentialSubject")
+            .get("givenName")
+            == "TEST"
+        )

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
@@ -330,6 +330,15 @@ class DIFPresFormatHandler(V20PresFormatHandler):
         self, message: V20Pres, pres_ex_record: V20PresExRecord
     ) -> None:
         """Receive a presentation, from message in context on manager creation."""
+        dif_handler = DIFPresExchHandler(self._profile)
+        dif_proof = message.attachment(DIFPresFormatHandler.format)
+        proof_request = pres_ex_record.pres_request.attachment(
+            DIFPresFormatHandler.format
+        )
+        pres_definition = PresentationDefinition.deserialize(
+            proof_request.get("presentation_definition")
+        )
+        await dif_handler.verify_received_pres(pd=pres_definition, pres=dif_proof)
 
     async def verify_pres(self, pres_ex_record: V20PresExRecord) -> V20PresExRecord:
         """

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
@@ -189,7 +189,7 @@ class DIFPresFormatHandler(V20PresFormatHandler):
         dif_handler_proof_type = None
         try:
             holder = self._profile.inject(VCHolder)
-            holder.set_tag_query_to_dict()
+            holder.set_type_or_schema_query_to_dict()
             record_ids = set()
             credentials_list = []
             for input_descriptor in input_descriptors:
@@ -205,10 +205,10 @@ class DIFPresFormatHandler(V20PresFormatHandler):
                     else:
                         required = schema.required
                     if required:
-                        holder.build_tag_query(uri)
+                        holder.build_type_or_schema_query(uri)
                         tag_query_included = True
                 if not tag_query_included:
-                    holder.set_tag_query_to_none()
+                    holder.set_type_or_schema_query_to_none()
                 if limit_disclosure:
                     proof_type = [BbsBlsSignature2020.signature_type]
                     dif_handler_proof_type = BbsBlsSignature2020.signature_type

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
@@ -189,7 +189,6 @@ class DIFPresFormatHandler(V20PresFormatHandler):
         dif_handler_proof_type = None
         try:
             holder = self._profile.inject(VCHolder)
-            holder.set_type_or_schema_query_to_dict()
             record_ids = set()
             credentials_list = []
             for input_descriptor in input_descriptors:
@@ -197,7 +196,7 @@ class DIFPresFormatHandler(V20PresFormatHandler):
                 limit_disclosure = input_descriptor.constraint.limit_disclosure and (
                     input_descriptor.constraint.limit_disclosure == "required"
                 )
-                tag_query_included = False
+                uri_list = []
                 for schema in input_descriptor.schemas:
                     uri = schema.uri
                     if schema.required is None:
@@ -205,10 +204,9 @@ class DIFPresFormatHandler(V20PresFormatHandler):
                     else:
                         required = schema.required
                     if required:
-                        holder.build_type_or_schema_query(uri)
-                        tag_query_included = True
-                if not tag_query_included:
-                    holder.set_type_or_schema_query_to_none()
+                        uri_list.append(uri)
+                if len(uri_list) == 0:
+                    uri_list = None
                 if limit_disclosure:
                     proof_type = [BbsBlsSignature2020.signature_type]
                     dif_handler_proof_type = BbsBlsSignature2020.signature_type
@@ -287,7 +285,9 @@ class DIFPresFormatHandler(V20PresFormatHandler):
                             "BbsBlsSignature2020 and Ed25519Signature2018"
                             " signature types are supported"
                         )
-                search = holder.search_credentials(proof_types=proof_type)
+                search = holder.search_credentials(
+                    proof_types=proof_type, pd_uri_list=uri_list
+                )
                 # Defaults to page_size but would like to include all
                 # For now, setting to 1000
                 max_results = 1000

--- a/aries_cloudagent/protocols/present_proof/v2_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/routes.py
@@ -497,7 +497,7 @@ async def present_proof_credentials_list(request: web.BaseRequest):
                 "presentation_definition"
             ).get("input_descriptors")
             claim_fmt = dif_pres_request.get("presentation_definition").get("format")
-            dif_holder.set_tag_query_to_dict()
+            dif_holder.set_type_or_schema_query_to_dict()
             input_descriptors = []
             for input_desc_dict in input_descriptors_list:
                 input_descriptors.append(InputDescriptors.deserialize(input_desc_dict))
@@ -515,10 +515,10 @@ async def present_proof_credentials_list(request: web.BaseRequest):
                     else:
                         required = schema.required
                     if required:
-                        dif_holder.build_tag_query(uri)
+                        dif_holder.build_type_or_schema_query(uri)
                         tag_query_included = True
                 if not tag_query_included:
-                    dif_holder.set_tag_query_to_none()
+                    dif_holder.set_type_or_schema_query_to_none()
                 if limit_disclosure:
                     proof_type = [BbsBlsSignature2020.signature_type]
                 if claim_fmt:

--- a/aries_cloudagent/protocols/present_proof/v2_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/routes.py
@@ -574,8 +574,24 @@ async def present_proof_credentials_list(request: web.BaseRequest):
                                         "are supported"
                                     )
                                 )
-                            elif len(proof_types) == 1:
-                                proof_type = [proof_types[0]]
+                            else:
+                                for proof_format in proof_types:
+                                    if (
+                                        proof_format
+                                        == Ed25519Signature2018.signature_type
+                                    ):
+                                        proof_type = [
+                                            Ed25519Signature2018.signature_type
+                                        ]
+                                        break
+                                    elif (
+                                        proof_format
+                                        == BbsBlsSignature2020.signature_type
+                                    ):
+                                        proof_type = [
+                                            BbsBlsSignature2020.signature_type
+                                        ]
+                                        break
                     else:
                         raise web.HTTPBadRequest(
                             reason=(

--- a/aries_cloudagent/protocols/present_proof/v2_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/tests/test_routes.py
@@ -618,6 +618,86 @@ class TestPresentProofRoutes(AsyncTestCase):
                 ]
             )
 
+    async def test_present_proof_credentials_double_ldp_vp_claim_format(self):
+        self.request.match_info = {
+            "pres_ex_id": "123-456-789",
+        }
+        self.request.query = {"extra_query": {}}
+        test_pd = deepcopy(DIF_PROOF_REQ)
+        test_pd["presentation_definition"]["format"] = {
+            "ldp_vp": {"proof_type": ["BbsBlsSignature2020", "Ed25519Signature2018"]}
+        }
+        del test_pd["presentation_definition"]["input_descriptors"][0]["constraints"][
+            "limit_disclosure"
+        ]
+        returned_credentials = [
+            async_mock.MagicMock(cred_value={"name": "Credential1"}),
+            async_mock.MagicMock(cred_value={"name": "Credential2"}),
+        ]
+        self.profile.context.injector.bind_instance(
+            IndyHolder,
+            async_mock.MagicMock(
+                get_credentials_for_presentation_request_by_referent=(
+                    async_mock.CoroutineMock()
+                )
+            ),
+        )
+        self.profile.context.injector.bind_instance(
+            VCHolder,
+            async_mock.MagicMock(
+                search_credentials=async_mock.MagicMock(
+                    return_value=async_mock.MagicMock(
+                        fetch=async_mock.CoroutineMock(
+                            return_value=returned_credentials
+                        )
+                    )
+                )
+            ),
+        )
+        record = V20PresExRecord(
+            state="request-received",
+            role="prover",
+            pres_proposal=None,
+            pres_request={
+                "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/2.0/request-presentation",
+                "@id": "6ae00c6c-87fa-495a-b546-5f5953817c92",
+                "comment": "string",
+                "formats": [
+                    {
+                        "attach_id": "dif",
+                        "format": "dif/presentation-exchange/definitions@v1.0",
+                    }
+                ],
+                "request_presentations~attach": [
+                    {
+                        "@id": "dif",
+                        "mime-type": "application/json",
+                        "data": {"json": test_pd},
+                    }
+                ],
+                "will_confirm": True,
+            },
+            pres=None,
+            verified=None,
+            auto_present=False,
+            error_msg=None,
+        )
+
+        with async_mock.patch.object(
+            test_module, "V20PresExRecord", autospec=True
+        ) as mock_pres_ex_rec_cls, async_mock.patch.object(
+            test_module.web, "json_response", async_mock.MagicMock()
+        ) as mock_response:
+            mock_pres_ex_rec_cls.retrieve_by_id.return_value = record
+
+            await test_module.present_proof_credentials_list(self.request)
+            mock_response.assert_called_once_with(
+                [
+                    {"name": "Credential1", "record_id": ANY},
+                    {"name": "Credential2", "record_id": ANY},
+                ]
+            )
+
     async def test_present_proof_credentials_single_ldp_vp_error(self):
         self.request.match_info = {
             "pres_ex_id": "123-456-789",

--- a/aries_cloudagent/storage/in_memory.py
+++ b/aries_cloudagent/storage/in_memory.py
@@ -208,6 +208,14 @@ def tag_query_match(tags: dict, tag_query: dict) -> bool:
                     if tag_query_match(tags, opt):
                         chk = True
                         break
+            elif k == "$and":
+                if not isinstance(v, list):
+                    raise StorageSearchError("Expected list for $and filter value")
+                chk = False
+                for opt in v:
+                    if not tag_query_match(tags, opt):
+                        return False
+                chk = True
             elif k == "$not":
                 if not isinstance(v, dict):
                     raise StorageSearchError("Expected dict for $not filter value")

--- a/aries_cloudagent/storage/tests/test_in_memory_storage.py
+++ b/aries_cloudagent/storage/tests/test_in_memory_storage.py
@@ -265,6 +265,10 @@ class TestInMemoryTagQuery:
         assert "Expected dict for $not filter value" in str(excinfo.value)
 
         with pytest.raises(StorageSearchError) as excinfo:
+            tag_query_match(TAGS, {"$and": {"z": "-1"}})
+        assert "Expected list for $and filter value" in str(excinfo.value)
+
+        with pytest.raises(StorageSearchError) as excinfo:
             tag_query_match(TAGS, {"$near": {"z": "-1"}})
         assert "Unexpected filter operator" in str(excinfo.value)
 

--- a/aries_cloudagent/storage/vc_holder/base.py
+++ b/aries_cloudagent/storage/vc_holder/base.py
@@ -52,6 +52,24 @@ class VCHolder(ABC):
         """
 
     @abstractmethod
+    def set_tag_query_to_dict(self):
+        """Set tag_query to dict based upon specific backend."""
+
+    @abstractmethod
+    def set_tag_query_to_none(self):
+        """Set tag_query to None."""
+        self._tag_query = None
+
+    @abstractmethod
+    def build_tag_query(self, uri: str):
+        """
+        Build backend-specific tag_query.
+
+        Args:
+            uri: Schema uri to build a backend specific WQL query
+        """
+
+    @abstractmethod
     def search_credentials(
         self,
         contexts: Sequence[str] = None,

--- a/aries_cloudagent/storage/vc_holder/base.py
+++ b/aries_cloudagent/storage/vc_holder/base.py
@@ -52,20 +52,12 @@ class VCHolder(ABC):
         """
 
     @abstractmethod
-    def set_type_or_schema_query_to_dict(self):
-        """Set type_or_schema_query to dict."""
-
-    @abstractmethod
-    def set_type_or_schema_query_to_none(self):
-        """Set type_or_schema_query to None."""
-
-    @abstractmethod
-    def build_type_or_schema_query(self, uri: str):
+    def build_type_or_schema_query(self, uri_list: Sequence[str]) -> dict:
         """
-        Build backend-specific type_or_schema_query.
+        Build and return backend-specific type_or_schema_query.
 
         Args:
-            uri: Schema uri to build a backend specific WQL query
+            uri_list: List of schema uri from input_descriptor
         """
 
     @abstractmethod

--- a/aries_cloudagent/storage/vc_holder/base.py
+++ b/aries_cloudagent/storage/vc_holder/base.py
@@ -52,18 +52,17 @@ class VCHolder(ABC):
         """
 
     @abstractmethod
-    def set_tag_query_to_dict(self):
-        """Set tag_query to dict based upon specific backend."""
+    def set_type_or_schema_query_to_dict(self):
+        """Set type_or_schema_query to dict."""
 
     @abstractmethod
-    def set_tag_query_to_none(self):
-        """Set tag_query to None."""
-        self._tag_query = None
+    def set_type_or_schema_query_to_none(self):
+        """Set type_or_schema_query to None."""
 
     @abstractmethod
-    def build_tag_query(self, uri: str):
+    def build_type_or_schema_query(self, uri: str):
         """
-        Build backend-specific tag_query.
+        Build backend-specific type_or_schema_query.
 
         Args:
             uri: Schema uri to build a backend specific WQL query

--- a/aries_cloudagent/storage/vc_holder/in_memory.py
+++ b/aries_cloudagent/storage/vc_holder/in_memory.py
@@ -18,22 +18,22 @@ class InMemoryVCHolder(VCHolder):
         """Initialize the in-memory VC holder instance."""
         self._profile = profile
         self._store = InMemoryStorage(profile)
-        self._tag_query = None
+        self.type_or_schema_query = None
 
-    def set_tag_query_to_dict(self):
-        """Set tag_query to dict [in-memory backend]."""
-        self._tag_query = {"$and": []}
+    def set_type_or_schema_query_to_dict(self):
+        """Set type_or_schema_query to dict [in-memory backend]."""
+        self.type_or_schema_query = {"$and": []}
 
-    def set_tag_query_to_none(self):
-        """Set tag_query to None."""
-        self._tag_query = None
+    def set_type_or_schema_query_to_none(self):
+        """Set type_or_schema_query to None."""
+        self.type_or_schema_query = None
 
-    def build_tag_query(self, uri: str):
-        """Build in-memory backend specific tag_query."""
-        tag_query_or_list = []
-        tag_query_or_list.append({f"type:{uri}": "1"})
-        tag_query_or_list.append({f"schm:{uri}": "1"})
-        self._tag_query["$and"].append({"$or": tag_query_or_list})
+    def build_type_or_schema_query(self, uri: str):
+        """Build in-memory backend specific type_or_schema_query."""
+        tag_or_list = []
+        tag_or_list.append({f"type:{uri}": "1"})
+        tag_or_list.append({f"schm:{uri}": "1"})
+        self.type_or_schema_query["$and"].append({"$or": tag_or_list})
 
     async def store_credential(self, cred: VCRecord):
         """
@@ -129,9 +129,9 @@ class InMemoryVCHolder(VCHolder):
             query["given_id"] = given_id
         if tag_query:
             query.update(tag_query)
-        if self._tag_query:
-            query.update(self._tag_query)
-            self.set_tag_query_to_none()
+        if self.type_or_schema_query:
+            query.update(self.type_or_schema_query)
+            self.set_type_or_schema_query_to_none()
         search = self._store.search_records(VC_CRED_RECORD_TYPE, query)
         return InMemoryVCRecordSearch(search)
 

--- a/aries_cloudagent/storage/vc_holder/in_memory.py
+++ b/aries_cloudagent/storage/vc_holder/in_memory.py
@@ -22,11 +22,11 @@ class InMemoryVCHolder(VCHolder):
     def build_type_or_schema_query(self, uri_list: Sequence[str]) -> dict:
         """Build and return in-memory backend specific type_or_schema_query."""
         type_or_schema_query = {"$and": []}
-        tag_or_list = []
         for uri in uri_list:
+            tag_or_list = []
             tag_or_list.append({f"type:{uri}": "1"})
             tag_or_list.append({f"schm:{uri}": "1"})
-        type_or_schema_query["$and"].append({"$or": tag_or_list})
+            type_or_schema_query["$and"].append({"$or": tag_or_list})
         return type_or_schema_query
 
     async def store_credential(self, cred: VCRecord):

--- a/aries_cloudagent/storage/vc_holder/in_memory.py
+++ b/aries_cloudagent/storage/vc_holder/in_memory.py
@@ -131,6 +131,7 @@ class InMemoryVCHolder(VCHolder):
             query.update(tag_query)
         if self._tag_query:
             query.update(self._tag_query)
+            self.set_tag_query_to_none()
         search = self._store.search_records(VC_CRED_RECORD_TYPE, query)
         return InMemoryVCRecordSearch(search)
 

--- a/aries_cloudagent/storage/vc_holder/in_memory.py
+++ b/aries_cloudagent/storage/vc_holder/in_memory.py
@@ -18,6 +18,22 @@ class InMemoryVCHolder(VCHolder):
         """Initialize the in-memory VC holder instance."""
         self._profile = profile
         self._store = InMemoryStorage(profile)
+        self._tag_query = None
+
+    def set_tag_query_to_dict(self):
+        """Set tag_query to dict [aries-backend]."""
+        self._tag_query = {"$all_of": []}
+
+    def set_tag_query_to_none(self):
+        """Set tag_query to None."""
+        self._tag_query = None
+
+    def build_tag_query(self, uri: str):
+        """Build aries-specific tag_query."""
+        tag_query_or_list = []
+        tag_query_or_list.append({f"type:{uri}": "1"})
+        tag_query_or_list.append({f"schm:{uri}": "1"})
+        self._tag_query["$all_of"].append({"$exist": tag_query_or_list})
 
     async def store_credential(self, cred: VCRecord):
         """

--- a/aries_cloudagent/storage/vc_holder/in_memory.py
+++ b/aries_cloudagent/storage/vc_holder/in_memory.py
@@ -21,19 +21,19 @@ class InMemoryVCHolder(VCHolder):
         self._tag_query = None
 
     def set_tag_query_to_dict(self):
-        """Set tag_query to dict [aries-backend]."""
-        self._tag_query = {"$all_of": []}
+        """Set tag_query to dict [in-memory backend]."""
+        self._tag_query = {"$and": []}
 
     def set_tag_query_to_none(self):
         """Set tag_query to None."""
         self._tag_query = None
 
     def build_tag_query(self, uri: str):
-        """Build aries-specific tag_query."""
+        """Build in-memory backend specific tag_query."""
         tag_query_or_list = []
         tag_query_or_list.append({f"type:{uri}": "1"})
         tag_query_or_list.append({f"schm:{uri}": "1"})
-        self._tag_query["$all_of"].append({"$exist": tag_query_or_list})
+        self._tag_query["$and"].append({"$or": tag_query_or_list})
 
     async def store_credential(self, cred: VCRecord):
         """
@@ -129,6 +129,8 @@ class InMemoryVCHolder(VCHolder):
             query["given_id"] = given_id
         if tag_query:
             query.update(tag_query)
+        if self._tag_query:
+            query.update(self._tag_query)
         search = self._store.search_records(VC_CRED_RECORD_TYPE, query)
         return InMemoryVCRecordSearch(search)
 

--- a/aries_cloudagent/storage/vc_holder/indy.py
+++ b/aries_cloudagent/storage/vc_holder/indy.py
@@ -131,6 +131,7 @@ class IndySdkVCHolder(VCHolder):
             query.update(tag_query)
         if self._tag_query:
             query.update(self._tag_query)
+            self.set_tag_query_to_none()
         search = self._store.search_records(VC_CRED_RECORD_TYPE, query)
         return IndySdkVCRecordSearch(search)
 

--- a/aries_cloudagent/storage/vc_holder/indy.py
+++ b/aries_cloudagent/storage/vc_holder/indy.py
@@ -18,6 +18,22 @@ class IndySdkVCHolder(VCHolder):
         """Initialize the Indy-SDK VC holder instance."""
         self._wallet = wallet
         self._store = IndySdkStorage(wallet)
+        self._tag_query = None
+
+    def set_tag_query_to_dict(self):
+        """Set tag_query to dict [indy-backend]."""
+        self._tag_query = {"$and": []}
+
+    def set_tag_query_to_none(self):
+        """Set tag_query to None."""
+        self._tag_query = None
+
+    def build_tag_query(self, uri: str):
+        """Build indy-specific tag_query."""
+        tag_query_or_list = []
+        tag_query_or_list.append({f"type:{uri}": "1"})
+        tag_query_or_list.append({f"schm:{uri}": "1"})
+        self._tag_query["$and"].append({"$or": tag_query_or_list})
 
     async def store_credential(self, cred: VCRecord):
         """
@@ -113,6 +129,8 @@ class IndySdkVCHolder(VCHolder):
             query["given_id"] = given_id
         if tag_query:
             query.update(tag_query)
+        if self._tag_query:
+            query.update(self._tag_query)
         search = self._store.search_records(VC_CRED_RECORD_TYPE, query)
         return IndySdkVCRecordSearch(search)
 

--- a/aries_cloudagent/storage/vc_holder/indy.py
+++ b/aries_cloudagent/storage/vc_holder/indy.py
@@ -22,11 +22,11 @@ class IndySdkVCHolder(VCHolder):
     def build_type_or_schema_query(self, uri_list: Sequence[str]) -> dict:
         """Build and return indy-specific type_or_schema_query."""
         type_or_schema_query = {"$and": []}
-        tag_or_list = []
         for uri in uri_list:
+            tag_or_list = []
             tag_or_list.append({f"type:{uri}": "1"})
             tag_or_list.append({f"schm:{uri}": "1"})
-        type_or_schema_query["$and"].append({"$or": tag_or_list})
+            type_or_schema_query["$and"].append({"$or": tag_or_list})
         return type_or_schema_query
 
     async def store_credential(self, cred: VCRecord):

--- a/aries_cloudagent/storage/vc_holder/indy.py
+++ b/aries_cloudagent/storage/vc_holder/indy.py
@@ -18,22 +18,22 @@ class IndySdkVCHolder(VCHolder):
         """Initialize the Indy-SDK VC holder instance."""
         self._wallet = wallet
         self._store = IndySdkStorage(wallet)
-        self._tag_query = None
+        self.type_or_schema_query = None
 
-    def set_tag_query_to_dict(self):
-        """Set tag_query to dict [indy-backend]."""
-        self._tag_query = {"$and": []}
+    def set_type_or_schema_query_to_dict(self):
+        """Set type_or_schema_query to dict [indy-backend]."""
+        self.type_or_schema_query = {"$and": []}
 
-    def set_tag_query_to_none(self):
-        """Set tag_query to None."""
-        self._tag_query = None
+    def set_type_or_schema_query_to_none(self):
+        """Set type_or_schema_query to None."""
+        self.type_or_schema_query = None
 
-    def build_tag_query(self, uri: str):
-        """Build indy-specific tag_query."""
-        tag_query_or_list = []
-        tag_query_or_list.append({f"type:{uri}": "1"})
-        tag_query_or_list.append({f"schm:{uri}": "1"})
-        self._tag_query["$and"].append({"$or": tag_query_or_list})
+    def build_type_or_schema_query(self, uri: str):
+        """Build indy-specific type_or_schema_query."""
+        tag_or_list = []
+        tag_or_list.append({f"type:{uri}": "1"})
+        tag_or_list.append({f"schm:{uri}": "1"})
+        self.type_or_schema_query["$and"].append({"$or": tag_or_list})
 
     async def store_credential(self, cred: VCRecord):
         """
@@ -129,9 +129,9 @@ class IndySdkVCHolder(VCHolder):
             query["given_id"] = given_id
         if tag_query:
             query.update(tag_query)
-        if self._tag_query:
-            query.update(self._tag_query)
-            self.set_tag_query_to_none()
+        if self.type_or_schema_query:
+            query.update(self.type_or_schema_query)
+            self.set_type_or_schema_query_to_none()
         search = self._store.search_records(VC_CRED_RECORD_TYPE, query)
         return IndySdkVCRecordSearch(search)
 

--- a/aries_cloudagent/storage/vc_holder/indy.py
+++ b/aries_cloudagent/storage/vc_holder/indy.py
@@ -18,22 +18,16 @@ class IndySdkVCHolder(VCHolder):
         """Initialize the Indy-SDK VC holder instance."""
         self._wallet = wallet
         self._store = IndySdkStorage(wallet)
-        self.type_or_schema_query = None
 
-    def set_type_or_schema_query_to_dict(self):
-        """Set type_or_schema_query to dict [indy-backend]."""
-        self.type_or_schema_query = {"$and": []}
-
-    def set_type_or_schema_query_to_none(self):
-        """Set type_or_schema_query to None."""
-        self.type_or_schema_query = None
-
-    def build_type_or_schema_query(self, uri: str):
-        """Build indy-specific type_or_schema_query."""
+    def build_type_or_schema_query(self, uri_list: Sequence[str]) -> dict:
+        """Build and return indy-specific type_or_schema_query."""
+        type_or_schema_query = {"$and": []}
         tag_or_list = []
-        tag_or_list.append({f"type:{uri}": "1"})
-        tag_or_list.append({f"schm:{uri}": "1"})
-        self.type_or_schema_query["$and"].append({"$or": tag_or_list})
+        for uri in uri_list:
+            tag_or_list.append({f"type:{uri}": "1"})
+            tag_or_list.append({f"schm:{uri}": "1"})
+        type_or_schema_query["$and"].append({"$or": tag_or_list})
+        return type_or_schema_query
 
     async def store_credential(self, cred: VCRecord):
         """
@@ -92,6 +86,7 @@ class IndySdkVCHolder(VCHolder):
         proof_types: Sequence[str] = None,
         given_id: str = None,
         tag_query: Mapping = None,
+        pd_uri_list: Sequence[str] = None,
     ) -> "VCRecordSearch":
         """
         Start a new VC record search.
@@ -129,9 +124,8 @@ class IndySdkVCHolder(VCHolder):
             query["given_id"] = given_id
         if tag_query:
             query.update(tag_query)
-        if self.type_or_schema_query:
-            query.update(self.type_or_schema_query)
-            self.set_type_or_schema_query_to_none()
+        if pd_uri_list:
+            query.update(self.build_type_or_schema_query(pd_uri_list))
         search = self._store.search_records(VC_CRED_RECORD_TYPE, query)
         return IndySdkVCRecordSearch(search)
 

--- a/aries_cloudagent/storage/vc_holder/tests/test_in_memory_vc_holder.py
+++ b/aries_cloudagent/storage/vc_holder/tests/test_in_memory_vc_holder.py
@@ -48,16 +48,16 @@ class TestInMemoryVCHolder:
 
     @pytest.mark.asyncio
     async def test_tag_query(self, holder: VCHolder):
-        assert holder._tag_query is None
-        holder.set_tag_query_to_dict()
-        assert holder._tag_query == {"$and": []}
-        holder.build_tag_query(
+        assert holder.type_or_schema_query is None
+        holder.set_type_or_schema_query_to_dict()
+        assert holder.type_or_schema_query == {"$and": []}
+        holder.build_type_or_schema_query(
             "https://www.w3.org/2018/credentials#VerifiableCredential"
         )
-        holder.build_tag_query(
+        holder.build_type_or_schema_query(
             "https://example.org/examples#UniversityDegreeCredential"
         )
-        assert holder._tag_query == {
+        assert holder.type_or_schema_query == {
             "$and": [
                 {
                     "$or": [
@@ -88,12 +88,12 @@ class TestInMemoryVCHolder:
         rows = await search.fetch()
         assert rows == [record]
 
-        holder.set_tag_query_to_none()
-        assert holder._tag_query is None
+        holder.set_type_or_schema_query_to_none()
+        assert holder.type_or_schema_query is None
 
     @pytest.mark.asyncio
     async def test_tag_query_invalid_and_operator(self, holder: VCHolder):
-        holder._tag_query = {"$and": "test"}
+        holder.type_or_schema_query = {"$and": "test"}
         record = test_record()
         await holder.store_credential(record)
         with pytest.raises(StorageSearchError):
@@ -102,11 +102,11 @@ class TestInMemoryVCHolder:
 
     @pytest.mark.asyncio
     async def test_tag_query_valid_and_operator(self, holder: VCHolder):
-        holder.set_tag_query_to_dict()
-        holder.build_tag_query(
+        holder.set_type_or_schema_query_to_dict()
+        holder.build_type_or_schema_query(
             "https://www.w3.org/2018/credentials#VerifiableCredential"
         )
-        holder.build_tag_query(
+        holder.build_type_or_schema_query(
             "https://example.org/examples#UniversityDegreeCredential2"
         )
         record = test_record()

--- a/aries_cloudagent/storage/vc_holder/tests/test_in_memory_vc_holder.py
+++ b/aries_cloudagent/storage/vc_holder/tests/test_in_memory_vc_holder.py
@@ -48,16 +48,12 @@ class TestInMemoryVCHolder:
 
     @pytest.mark.asyncio
     async def test_tag_query(self, holder: VCHolder):
-        assert holder.type_or_schema_query is None
-        holder.set_type_or_schema_query_to_dict()
-        assert holder.type_or_schema_query == {"$and": []}
-        holder.build_type_or_schema_query(
-            "https://www.w3.org/2018/credentials#VerifiableCredential"
-        )
-        holder.build_type_or_schema_query(
-            "https://example.org/examples#UniversityDegreeCredential"
-        )
-        assert holder.type_or_schema_query == {
+        test_uri_list = [
+            "https://www.w3.org/2018/credentials#VerifiableCredential",
+            "https://example.org/examples#UniversityDegreeCredential",
+        ]
+        test_query = holder.build_type_or_schema_query(test_uri_list)
+        assert test_query == {
             "$and": [
                 {
                     "$or": [
@@ -84,35 +80,20 @@ class TestInMemoryVCHolder:
         record = test_record()
         await holder.store_credential(record)
 
-        search = holder.search_credentials()
+        search = holder.search_credentials(pd_uri_list=test_uri_list)
         rows = await search.fetch()
         assert rows == [record]
 
-        holder.set_type_or_schema_query_to_none()
-        assert holder.type_or_schema_query is None
-
-    @pytest.mark.asyncio
-    async def test_tag_query_invalid_and_operator(self, holder: VCHolder):
-        holder.type_or_schema_query = {"$and": "test"}
-        record = test_record()
-        await holder.store_credential(record)
-        with pytest.raises(StorageSearchError):
-            search = holder.search_credentials()
-            rows = await search.fetch()
-
     @pytest.mark.asyncio
     async def test_tag_query_valid_and_operator(self, holder: VCHolder):
-        holder.set_type_or_schema_query_to_dict()
-        holder.build_type_or_schema_query(
-            "https://www.w3.org/2018/credentials#VerifiableCredential"
-        )
-        holder.build_type_or_schema_query(
-            "https://example.org/examples#UniversityDegreeCredential2"
-        )
+        test_uri_list = [
+            "https://www.w3.org/2018/credentials#VerifiableCredential",
+            "https://example.org/examples#UniversityDegreeCredential2",
+        ]
         record = test_record()
         await holder.store_credential(record)
 
-        search = holder.search_credentials()
+        search = holder.search_credentials(pd_uri_list=test_uri_list)
         rows = await search.fetch()
         assert rows == []
 

--- a/aries_cloudagent/storage/vc_holder/tests/test_indy_vc_holder.py
+++ b/aries_cloudagent/storage/vc_holder/tests/test_indy_vc_holder.py
@@ -70,16 +70,12 @@ class TestIndySdkVCHolder(in_memory.TestInMemoryVCHolder):
     # run same test suite with different holder fixture
     @pytest.mark.asyncio
     async def test_tag_query(self, holder: VCHolder):
-        assert holder.type_or_schema_query is None
-        holder.set_type_or_schema_query_to_dict()
-        assert holder.type_or_schema_query == {"$and": []}
-        holder.build_type_or_schema_query(
-            "https://www.w3.org/2018/credentials#VerifiableCredential"
-        )
-        holder.build_type_or_schema_query(
-            "https://example.org/examples#UniversityDegreeCredential"
-        )
-        assert holder.type_or_schema_query == {
+        test_uri_list = [
+            "https://www.w3.org/2018/credentials#VerifiableCredential",
+            "https://example.org/examples#UniversityDegreeCredential",
+        ]
+        test_query = holder.build_type_or_schema_query(test_uri_list)
+        assert test_query == {
             "$and": [
                 {
                     "$or": [
@@ -106,9 +102,6 @@ class TestIndySdkVCHolder(in_memory.TestInMemoryVCHolder):
         record = test_record()
         await holder.store_credential(record)
 
-        search = holder.search_credentials()
+        search = holder.search_credentials(pd_uri_list=test_uri_list)
         rows = await search.fetch()
         assert rows == [record]
-
-        holder.set_type_or_schema_query_to_none()
-        assert holder.type_or_schema_query is None

--- a/aries_cloudagent/storage/vc_holder/tests/test_indy_vc_holder.py
+++ b/aries_cloudagent/storage/vc_holder/tests/test_indy_vc_holder.py
@@ -70,16 +70,16 @@ class TestIndySdkVCHolder(in_memory.TestInMemoryVCHolder):
     # run same test suite with different holder fixture
     @pytest.mark.asyncio
     async def test_tag_query(self, holder: VCHolder):
-        assert holder._tag_query is None
-        holder.set_tag_query_to_dict()
-        assert holder._tag_query == {"$and": []}
-        holder.build_tag_query(
+        assert holder.type_or_schema_query is None
+        holder.set_type_or_schema_query_to_dict()
+        assert holder.type_or_schema_query == {"$and": []}
+        holder.build_type_or_schema_query(
             "https://www.w3.org/2018/credentials#VerifiableCredential"
         )
-        holder.build_tag_query(
+        holder.build_type_or_schema_query(
             "https://example.org/examples#UniversityDegreeCredential"
         )
-        assert holder._tag_query == {
+        assert holder.type_or_schema_query == {
             "$and": [
                 {
                     "$or": [
@@ -110,5 +110,5 @@ class TestIndySdkVCHolder(in_memory.TestInMemoryVCHolder):
         rows = await search.fetch()
         assert rows == [record]
 
-        holder.set_tag_query_to_none()
-        assert holder._tag_query is None
+        holder.set_type_or_schema_query_to_none()
+        assert holder.type_or_schema_query is None

--- a/aries_cloudagent/storage/vc_holder/tests/test_indy_vc_holder.py
+++ b/aries_cloudagent/storage/vc_holder/tests/test_indy_vc_holder.py
@@ -7,8 +7,18 @@ from ....ledger.indy import IndySdkLedgerPool
 from ....wallet.indy import IndySdkWallet
 
 from ..base import VCHolder
+from ..vc_record import VCRecord
 
 from . import test_in_memory_vc_holder as in_memory
+
+
+VC_CONTEXT = "https://www.w3.org/2018/credentials/v1"
+VC_TYPE = "https://www.w3.org/2018/credentials#VerifiableCredential"
+VC_SUBJECT_ID = "did:example:ebfeb1f712ebc6f1c276e12ec21"
+VC_PROOF_TYPE = "Ed25519Signature2018"
+VC_ISSUER_ID = "https://example.edu/issuers/14"
+VC_SCHEMA_ID = "https://example.org/examples/degree.json"
+VC_GIVEN_ID = "http://example.edu/credentials/3732"
 
 
 async def make_profile():
@@ -35,7 +45,70 @@ async def holder():
     await profile.close()
 
 
+def test_record() -> VCRecord:
+    return VCRecord(
+        contexts=[
+            VC_CONTEXT,
+            "https://www.w3.org/2018/credentials/examples/v1",
+        ],
+        expanded_types=[
+            VC_TYPE,
+            "https://example.org/examples#UniversityDegreeCredential",
+        ],
+        schema_ids=[VC_SCHEMA_ID],
+        issuer_id=VC_ISSUER_ID,
+        subject_ids=[VC_SUBJECT_ID],
+        proof_types=[VC_PROOF_TYPE],
+        given_id=VC_GIVEN_ID,
+        cred_tags={"tag": "value"},
+        cred_value={"...": "..."},
+    )
+
+
 @pytest.mark.indy
 class TestIndySdkVCHolder(in_memory.TestInMemoryVCHolder):
     # run same test suite with different holder fixture
-    pass
+    @pytest.mark.asyncio
+    async def test_tag_query(self, holder: VCHolder):
+        assert holder._tag_query is None
+        holder.set_tag_query_to_dict()
+        assert holder._tag_query == {"$and": []}
+        holder.build_tag_query(
+            "https://www.w3.org/2018/credentials#VerifiableCredential"
+        )
+        holder.build_tag_query(
+            "https://example.org/examples#UniversityDegreeCredential"
+        )
+        assert holder._tag_query == {
+            "$and": [
+                {
+                    "$or": [
+                        {
+                            "type:https://www.w3.org/2018/credentials#VerifiableCredential": "1"
+                        },
+                        {
+                            "schm:https://www.w3.org/2018/credentials#VerifiableCredential": "1"
+                        },
+                    ]
+                },
+                {
+                    "$or": [
+                        {
+                            "type:https://example.org/examples#UniversityDegreeCredential": "1"
+                        },
+                        {
+                            "schm:https://example.org/examples#UniversityDegreeCredential": "1"
+                        },
+                    ]
+                },
+            ]
+        }
+        record = test_record()
+        await holder.store_credential(record)
+
+        search = holder.search_credentials()
+        rows = await search.fetch()
+        assert rows == [record]
+
+        holder.set_tag_query_to_none()
+        assert holder._tag_query is None


### PR DESCRIPTION
- Addresses the following from #1247, @andrewwhitehead will this meet the requirement? 
> As discussed, I think this tag filtering belongs in VCHolder so that it can be specialized for the specific backends, but it's fine to merge this as-is and I can revisit it later with the shared-components work. Most important is that it works for now.
- resolve #1253
- Verification mechanism to check if the received presentation matches against the `constraints` in `presentation_definition`