### PR TITLE
OOB- 0160 connection reuse fix

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -314,6 +314,7 @@ class ConnectionManager(BaseConnectionManager):
         connection = ConnRecord(
             invitation_key=invitation.recipient_keys and invitation.recipient_keys[0],
             their_label=invitation.label,
+            invitation_msg_id=invitation._id,
             their_role=ConnRecord.Role.RESPONDER.rfc160,
             state=ConnRecord.State.INVITATION.rfc160,
             accept=accept,


### PR DESCRIPTION
- Should fix `HandshakeReuse validation failed` error when trying to reuse 0160 connection [public_did]