### PR TITLE
Connection protocol used in ConnRecord

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -28,6 +28,7 @@ from ...coordinate_mediation.v1_0.manager import MediationManager
 
 from ...coordinate_mediation.v1_0.models.mediation_record import MediationRecord
 
+from .message_types import ARIES_PROTOCOL as CONN_PROTO
 from .messages.connection_invitation import ConnectionInvitation
 from .messages.connection_request import ConnectionRequest
 from .messages.connection_response import ConnectionResponse
@@ -214,6 +215,7 @@ class ConnectionManager(BaseConnectionManager):
             accept=accept,
             invitation_mode=invitation_mode,
             alias=alias,
+            connection_protocol=CONN_PROTO,
         )
 
         await connection.save(self._session, reason="Created new invitation")
@@ -320,6 +322,7 @@ class ConnectionManager(BaseConnectionManager):
             accept=accept,
             alias=alias,
             their_public_did=their_public_did,
+            connection_protocol=CONN_PROTO,
         )
 
         await connection.save(
@@ -517,6 +520,7 @@ class ConnectionManager(BaseConnectionManager):
                     state=ConnRecord.State.INVITATION.rfc160,
                     accept=connection.accept,
                     their_role=connection.their_role,
+                    connection_protocol=CONN_PROTO,
                 )
 
                 await new_connection.save(
@@ -585,6 +589,7 @@ class ConnectionManager(BaseConnectionManager):
                     else ConnRecord.ACCEPT_MANUAL
                 ),
                 state=ConnRecord.State.REQUEST.rfc160,
+                connection_protocol=CONN_PROTO,
             )
 
             await connection.save(
@@ -907,6 +912,7 @@ class ConnectionManager(BaseConnectionManager):
             their_label=their_label,
             state=ConnRecord.State.COMPLETED.rfc160,
             alias=alias,
+            connection_protocol=CONN_PROTO,
         )
         await connection.save(self._session, reason="Created new static connection")
 

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -194,6 +194,14 @@ class ConnectionsListQueryStringSchema(OpenAPISchema):
         ),
         example=ConnRecord.Role.REQUESTER.rfc160,
     )
+    connection_protocol = fields.Str(
+        description="Connection protocol used",
+        required=False,
+        validate=validate.OneOf(
+            [proto.aries_protocol for proto in ConnRecord.Protocol]
+        ),
+        example=ConnRecord.Protocol.RFC_0160.aries_protocol,
+    )
 
 
 class CreateInvitationQueryStringSchema(OpenAPISchema):
@@ -338,6 +346,8 @@ async def connections_list(request: web.BaseRequest):
         post_filter["their_role"] = [
             v for v in ConnRecord.Role.get(request.query["their_role"]).value
         ]
+    if request.query.get("connection_protocol"):
+        post_filter["connection_protocol"] = request.query["connection_protocol"]
 
     session = await context.session()
     try:

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
@@ -29,6 +29,7 @@ class TestConnectionRoutes(AsyncTestCase):
         self.request.query = {
             "invitation_id": "dummy",  # exercise tag filter assignment
             "their_role": ConnRecord.Role.REQUESTER.rfc160,
+            "connection_protocol": ConnRecord.Protocol.RFC_0160.aries_protocol,
         }
 
         STATE_COMPLETED = ConnRecord.State.COMPLETED

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -26,6 +26,7 @@ from ...out_of_band.v1_0.messages.invitation import (
 )
 from ...out_of_band.v1_0.messages.service import Service as OOBService
 
+from .message_types import ARIES_PROTOCOL as DIDX_PROTO
 from .messages.complete import DIDXComplete
 from .messages.request import DIDXRequest
 from .messages.response import DIDXResponse
@@ -123,6 +124,7 @@ class DIDXManager(BaseConnectionManager):
             accept=accept,
             alias=alias,
             their_public_did=their_public_did,
+            connection_protocol=DIDX_PROTO,
         )
 
         await conn_rec.save(
@@ -184,6 +186,7 @@ class DIDXManager(BaseConnectionManager):
             accept=None,
             alias=my_label,
             their_public_did=their_public_did,
+            connection_protocol=DIDX_PROTO,
         )
         request = await self.create_request(  # saves and updates conn_rec
             conn_rec=conn_rec,
@@ -387,6 +390,7 @@ class DIDXManager(BaseConnectionManager):
                     state=ConnRecord.State.REQUEST.rfc23,
                     accept=conn_rec.accept,
                     their_role=conn_rec.their_role,
+                    connection_protocol=DIDX_PROTO,
                 )
 
                 await new_conn_rec.save(
@@ -480,6 +484,7 @@ class DIDXManager(BaseConnectionManager):
                 invitation_msg_id=None,
                 request_id=request._id,
                 state=ConnRecord.State.REQUEST.rfc23,
+                connection_protocol=DIDX_PROTO,
             )
             await conn_rec.save(
                 self._session, reason="Received connection request from public DID"

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -201,6 +201,10 @@ class OutOfBandManager(BaseConnectionManager):
         handshake_protocols = [
             DIDCommPrefix.qualify_current(hsp.name) for hsp in hs_protos or []
         ] or None
+        connection_protocol = (
+            hs_protos[0].name if hs_protos and len(hs_protos) >= 1 else None
+        )
+
         if public:
             if not self._session.settings.get("public_invites"):
                 raise OutOfBandManagerError("Public invitations are not enabled")
@@ -231,6 +235,7 @@ class OutOfBandManager(BaseConnectionManager):
                 state=ConnRecord.State.INVITATION.rfc23,
                 accept=ConnRecord.ACCEPT_AUTO if accept else ConnRecord.ACCEPT_MANUAL,
                 alias=alias,
+                connection_protocol=connection_protocol,
             )
 
             await conn_rec.save(self._session, reason="Created new invitation")
@@ -268,6 +273,7 @@ class OutOfBandManager(BaseConnectionManager):
                 accept=ConnRecord.ACCEPT_AUTO if accept else ConnRecord.ACCEPT_MANUAL,
                 invitation_mode=invitation_mode,
                 alias=alias,
+                connection_protocol=connection_protocol,
             )
             await conn_rec.save(self._session, reason="Created new connection")
 


### PR DESCRIPTION
- Now able to tell if a ConnRecord was created using `0160`, `0023` and `0023 with didcomm v2 envelope` [in future]
- Should fix AATH connection tests, as `connection_protocol` can be used instead of relying on `missing invitation_msg_id` which is no longer the case as to support connection_reuse [`RFC 0434`]