### PR TITLE
Remove indy-sdk dependency in IndyDidResolver

### DIFF
--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -61,6 +61,14 @@ class BaseLedger(ABC, metaclass=ABCMeta):
         """
 
     @abstractmethod
+    async def get_all_endpoints_for_did(self, did: str) -> dict:
+        """Fetch all endpoints for a ledger DID.
+
+        Args:
+            did: The DID to look up on the ledger or in the cache
+        """
+
+    @abstractmethod
     async def update_endpoint_for_did(
         self,
         did: str,

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -1209,7 +1209,7 @@ class IndySdkLedger(BaseLedger):
 
     async def get_revoc_reg_delta(
         self, revoc_reg_id: str, fro=0, to=None
-    ) -> (dict, int):
+    ) -> Tuple[dict, int]:
         """
         Look up a revocation registry delta by ID.
 

--- a/aries_cloudagent/resolver/default/indy.py
+++ b/aries_cloudagent/resolver/default/indy.py
@@ -10,8 +10,8 @@ from pydid.verification_method import Ed25519VerificationKey2018
 
 from ...config.injection_context import InjectionContext
 from ...core.profile import Profile
-from ...ledger.indy import IndySdkLedger, EndpointType
 from ...ledger.base import BaseLedger
+from ...ledger.endpoint_type import EndpointType
 from ...ledger.error import LedgerError
 from ...messaging.valid import IndyDID
 
@@ -19,7 +19,7 @@ from ..base import BaseDIDResolver, DIDNotFound, ResolverError, ResolverType
 
 
 class NoIndyLedger(ResolverError):
-    """Raised when there is no indy ledger instance configured."""
+    """Raised when there is no Indy ledger instance configured."""
 
 
 class IndyDIDResolver(BaseDIDResolver):
@@ -51,7 +51,7 @@ class IndyDIDResolver(BaseDIDResolver):
     async def _resolve(self, profile: Profile, did: str) -> dict:
         """Resolve an indy DID."""
         ledger = profile.inject(BaseLedger, required=False)
-        if not ledger or not isinstance(ledger, IndySdkLedger):
+        if not ledger:
             raise NoIndyLedger("No Indy ledger instance is configured.")
 
         try:

--- a/demo/runners/acme.py
+++ b/demo/runners/acme.py
@@ -8,12 +8,12 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))  # 
 
 from runners.support.agent import DemoAgent, default_genesis_txns  # noqa:E402
 from runners.support.utils import (  # noqa:E402
+    check_requires,
     log_msg,
     log_status,
     log_timer,
     prompt,
     prompt_loop,
-    require_indy,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -209,7 +209,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    require_indy()
+    check_requires(args)
 
     try:
         asyncio.get_event_loop().run_until_complete(main(args.port, args.timing))

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -28,13 +28,11 @@ from runners.support.agent import (  # noqa:E402
     SIG_TYPE_BLS,
 )
 from runners.support.utils import (  # noqa:E402
+    check_requires,
     log_json,
     log_msg,
     log_status,
     log_timer,
-    prompt,
-    prompt_loop,
-    require_indy,
 )
 
 
@@ -1019,7 +1017,7 @@ async def create_agent_with_args(args, ident: str = None):
             "DID-Exchange connection protocol is not (yet) compatible with mediation"
         )
 
-    require_indy()
+    check_requires(args)
 
     if "revocation" in args and args.revocation:
         tails_server_base_url = args.tails_server_base_url or os.getenv(
@@ -1242,7 +1240,7 @@ if __name__ == "__main__":
         except ImportError:
             print("pydevd_pycharm library was not found")
 
-    require_indy()
+    check_requires(args)
 
     tails_server_base_url = args.tails_server_base_url or os.getenv("PUBLIC_TAILS_URL")
 

--- a/demo/runners/alice.py
+++ b/demo/runners/alice.py
@@ -15,12 +15,12 @@ from runners.agent_container import (  # noqa:E402
     AriesAgent,
 )
 from runners.support.utils import (  # noqa:E402
+    check_requires,
     log_msg,
     log_status,
     log_timer,
     prompt,
     prompt_loop,
-    require_indy,
 )
 
 logging.basicConfig(level=logging.WARNING)
@@ -234,7 +234,7 @@ if __name__ == "__main__":
         except ImportError:
             print("pydevd_pycharm library was not found")
 
-    require_indy()
+    check_requires(args)
 
     try:
         asyncio.get_event_loop().run_until_complete(main(args))

--- a/demo/runners/performance.py
+++ b/demo/runners/performance.py
@@ -15,10 +15,10 @@ from runners.support.agent import (  # noqa:E402
     connect_wallet_to_mediator,
 )
 from runners.support.utils import (  # noqa:E402
+    check_requires,
     log_msg,
     log_timer,
     progress,
-    require_indy,
 )
 
 CRED_PREVIEW_TYPE = "https://didcomm.org/issue-credential/2.0/credential-preview"
@@ -658,7 +658,7 @@ if __name__ == "__main__":
     if args.ping:
         action = "ping"
 
-    require_indy()
+    check_requires(args)
 
     try:
         asyncio.get_event_loop().run_until_complete(

--- a/demo/runners/support/utils.py
+++ b/demo/runners/support/utils.py
@@ -234,14 +234,29 @@ def progress(*args, **kwargs):
     return ProgressBar(*args, **kwargs)
 
 
-def require_indy():
-    try:
-        from indy.libindy import _cdll
+def check_requires(args):
+    wtype = args.wallet_type or "indy"
 
-        _cdll()
-    except ImportError:
-        print("python3-indy module not installed")
-        sys.exit(1)
-    except OSError:
-        print("libindy shared library could not be loaded")
-        sys.exit(1)
+    if wtype == "indy":
+        try:
+            from indy.libindy import _cdll
+
+            _cdll()
+        except ImportError:
+            print("python3-indy module not installed")
+            sys.exit(1)
+        except OSError:
+            print("libindy shared library could not be loaded")
+            sys.exit(1)
+
+    elif wtype == "askar":
+        try:
+            from aries_askar.bindings import get_library
+
+            get_library()
+        except ImportError:
+            print("aries-askar module not installed")
+            sys.exit(1)
+        except OSError:
+            print("askar shared library could not be loaded")
+            sys.exit(1)


### PR DESCRIPTION
The `BaseLedger` interface ((it should really be called `IndyLedger`) is sufficient and allows indy-vdr to substitute.

This PR also changes the requirement checks in the demo agents to allow running without indy-sdk.