### PR TITLE
DIF PE - is_holder property implementation - compliant with DIF spec

### DIFF
--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch.py
@@ -236,6 +236,7 @@ class DIFHolderSchema(BaseModelSchema):
             **UUID4,
         ),
         required=False,
+        data_key="field_id",
     )
     directive = fields.Str(
         description="Preference",

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch.py
@@ -236,7 +236,6 @@ class DIFHolderSchema(BaseModelSchema):
             **UUID4,
         ),
         required=False,
-        data_key="field_id",
     )
     directive = fields.Str(
         description="Preference",
@@ -384,6 +383,7 @@ class DIFField(BaseModel):
     def __init__(
         self,
         *,
+        id: str = None,
         paths: Sequence[str] = None,
         purpose: str = None,
         predicate: str = None,
@@ -394,6 +394,7 @@ class DIFField(BaseModel):
         self.purpose = purpose
         self.predicate = predicate
         self._filter = _filter
+        self.id = id
 
 
 class DIFFieldSchema(BaseModelSchema):
@@ -405,6 +406,7 @@ class DIFFieldSchema(BaseModelSchema):
         model_class = DIFField
         unknown = EXCLUDE
 
+    id = fields.Str(description="ID", required=False)
     paths = fields.List(
         fields.Str(description="Path", required=False),
         required=False,

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -193,7 +193,7 @@ class DIFPresExchHandler:
         else:
             reqd_key_type = KeyType.ED25519
         for cred in applicable_creds:
-            if len(cred.subject_ids) > 0:
+            if cred.subject_ids and len(cred.subject_ids) > 0:
                 if not issuer_id:
                     for cred_subject_id in cred.subject_ids:
                         if not cred_subject_id.startswith("urn:"):
@@ -1188,7 +1188,7 @@ class DIFPresExchHandler:
         submission_property = PresentationSubmission(
             id=str(uuid4()), definition_id=pd.id, descriptor_maps=descriptor_maps
         )
-        if self.is_holder and self.check_sign_pres(applicable_creds):
+        if self.is_holder:
             (
                 issuer_id,
                 filtered_creds_list,
@@ -1240,17 +1240,6 @@ class DIFPresExchHandler:
                     return signed_vp
             else:
                 return vp
-
-    def check_sign_pres(self, creds: Sequence[VCRecord]) -> bool:
-        """Check if applicable creds have CredentialSubject.id set."""
-        for cred in creds:
-            if (
-                cred.subject_ids
-                and len(cred.subject_ids) > 0
-                and not self.check_if_cred_id_derived(next(iter(cred.subject_ids)))
-            ):
-                return True
-        return False
 
     def check_if_cred_id_derived(self, id: str) -> bool:
         """Check if credential or credentialSubjet id is derived."""

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -38,6 +38,7 @@ from ....vc.ld_proofs.constants import (
 )
 from ....vc.vc_ld.prove import sign_presentation, create_presentation, derive_credential
 from ....wallet.base import BaseWallet, DIDInfo
+from ....wallet.did_method import DIDMethod
 from ....wallet.key_type import KeyType
 
 from .pres_exch import (
@@ -99,6 +100,7 @@ class DIFPresExchHandler:
             self.proof_type = Ed25519Signature2018.signature_type
         else:
             self.proof_type = proof_type
+        self.local_dids = None
 
     async def _get_issue_suite(
         self,
@@ -373,9 +375,23 @@ class DIFPresExchHandler:
                 continue
 
             applicable = False
+            is_holder_field_ids = self.field_ids_for_is_holder(constraints)
             for field in constraints._fields:
                 applicable = await self.filter_by_field(field, credential)
-                if applicable:
+                # is_holder with required directive requested for this field
+                if applicable and field.id and field.id in is_holder_field_ids:
+                    # Missing credentialSubject.id - cannot verify that holder of claim
+                    # is same as subject
+                    if not credential.subject_ids or len(credential.subject_ids) == 0:
+                        applicable = False
+                        break
+                    # Holder of claim is not same as the subject
+                    if not await self.process_constraint_holders(
+                        subject_ids=credential.subject_ids
+                    ):
+                        applicable = False
+                        break
+                if not applicable:
                     break
             if not applicable:
                 continue
@@ -399,6 +415,41 @@ class DIFPresExchHandler:
                     credential = self.create_vcrecord(signed_new_credential_dict)
             result.append(credential)
         return result
+
+    async def local_dids_list(self):
+        """Build a local DIDs list used to verify that holder controls subject ident."""
+        async with self.profile.session() as session:
+            wallet = session.inject(BaseWallet)
+            local_did_info_list = await wallet.get_local_dids()
+            self.local_dids = []
+            for did_info in local_did_info_list:
+                if did_info.method == DIDMethod.SOV:
+                    self.local_dids.append(f"did:sov:{did_info.did}")
+                else:
+                    self.local_dids.append(did_info.did)
+
+    def field_ids_for_is_holder(self, constraints: Constraints) -> Sequence[str]:
+        """Return list of field ids for whose subject holder verification is requested."""
+        reqd_field_ids = set()
+        if not constraints.holders:
+            reqd_field_ids = []
+            return reqd_field_ids
+        for holder in constraints.holders:
+            if holder.directive == "required":
+                reqd_field_ids = set.union(reqd_field_ids, set(holder.field_ids))
+        return list(reqd_field_ids)
+
+    async def process_constraint_holders(
+        self,
+        subject_ids: Sequence[str],
+    ) -> bool:
+        """Check if holder or subject of claim still controls the identifier."""
+        if not self.local_dids:
+            await self.local_dids_list()
+        for subject_id in subject_ids:
+            if subject_id not in self.local_dids:
+                return False
+        return True
 
     def create_vcrecord(self, cred_dict: dict) -> VCRecord:
         """Return VCRecord from a credential dict."""
@@ -1202,8 +1253,10 @@ class DIFPresExchHandler:
     def check_sign_pres(self, creds: Sequence[VCRecord]) -> bool:
         """Check if applicable creds have CredentialSubject.id set."""
         for cred in creds:
-            if len(cred.subject_ids) > 0 and not self.check_if_cred_id_derived(
-                next(iter(cred.subject_ids))
+            if (
+                cred.subject_ids
+                and len(cred.subject_ids) > 0
+                and not self.check_if_cred_id_derived(next(iter(cred.subject_ids)))
             ):
                 return True
         return False

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -100,6 +100,7 @@ class DIFPresExchHandler:
             self.proof_type = Ed25519Signature2018.signature_type
         else:
             self.proof_type = proof_type
+        self.is_holder = False
 
     async def _get_issue_suite(
         self,
@@ -436,6 +437,7 @@ class DIFPresExchHandler:
             try:
                 for subject_id in subject_ids:
                     await wallet.get_local_did(subject_id.replace("did:sov:", ""))
+                self.is_holder = True
                 return True
             except (WalletError, WalletNotFoundError):
                 return False
@@ -1186,7 +1188,7 @@ class DIFPresExchHandler:
         submission_property = PresentationSubmission(
             id=str(uuid4()), definition_id=pd.id, descriptor_maps=descriptor_maps
         )
-        if self.check_sign_pres(applicable_creds):
+        if self.is_holder and self.check_sign_pres(applicable_creds):
             (
                 issuer_id,
                 filtered_creds_list,

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -378,6 +378,9 @@ class DIFPresExchHandler:
             is_holder_field_ids = self.field_ids_for_is_holder(constraints)
             for field in constraints._fields:
                 applicable = await self.filter_by_field(field, credential)
+                # all fields in the constraint should be satisfied
+                if not applicable:
+                    break
                 # is_holder with required directive requested for this field
                 if applicable and field.id and field.id in is_holder_field_ids:
                     # Missing credentialSubject.id - cannot verify that holder of claim
@@ -391,11 +394,8 @@ class DIFPresExchHandler:
                     ):
                         applicable = False
                         break
-                if not applicable:
-                    break
             if not applicable:
                 continue
-
             if constraints.limit_disclosure == "required":
                 credential_dict = credential.cred_value
                 new_credential_dict = self.reveal_doc(

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_data.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_data.py
@@ -71,7 +71,7 @@ is_holder_pd = PresentationDefinition.deserialize(
                     "is_holder": [
                         {
                             "directive": "required",
-                            "field_ids": ["1f44d55f-f161-4938-a659-f8026467f126"],
+                            "field_id": ["1f44d55f-f161-4938-a659-f8026467f126"],
                         }
                     ],
                     "fields": [
@@ -84,6 +84,111 @@ is_holder_pd = PresentationDefinition.deserialize(
                                 "maximum": "2014-5-16",
                             },
                         }
+                    ],
+                },
+            }
+        ],
+    }
+)
+
+is_holder_pd_multiple_fields_included = PresentationDefinition.deserialize(
+    {
+        "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+        "submission_requirements": [
+            {
+                "name": "European Union Citizenship Proofs",
+                "rule": "all",
+                "from": "A",
+            }
+        ],
+        "input_descriptors": [
+            {
+                "id": "citizenship_input_1",
+                "group": ["A"],
+                "schema": [
+                    {"uri": "https://www.w3.org/2018/credentials#VerifiableCredential"},
+                    {"uri": "https://w3id.org/citizenship#PermanentResidentCard"},
+                ],
+                "constraints": {
+                    "is_holder": [
+                        {
+                            "directive": "required",
+                            "field_id": [
+                                "1f44d55f-f161-4938-a659-f8026467f126",
+                                "1f44d55f-f161-4938-a659-f8026467f127",
+                            ],
+                        }
+                    ],
+                    "fields": [
+                        {
+                            "id": "1f44d55f-f161-4938-a659-f8026467f126",
+                            "path": ["$.issuanceDate", "$.vc.issuanceDate"],
+                            "filter": {
+                                "type": "string",
+                                "format": "date",
+                                "maximum": "2014-5-16",
+                            },
+                        },
+                        {
+                            "id": "1f44d55f-f161-4938-a659-f8026467f127",
+                            "path": ["$.issuanceDate", "$.vc.issuanceDate"],
+                            "filter": {
+                                "type": "string",
+                                "format": "date",
+                                "minimum": "2005-5-16",
+                            },
+                        },
+                    ],
+                },
+            }
+        ],
+    }
+)
+
+is_holder_pd_multiple_fields_excluded = PresentationDefinition.deserialize(
+    {
+        "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+        "submission_requirements": [
+            {
+                "name": "European Union Citizenship Proofs",
+                "rule": "all",
+                "from": "A",
+            }
+        ],
+        "input_descriptors": [
+            {
+                "id": "citizenship_input_1",
+                "group": ["A"],
+                "schema": [
+                    {"uri": "https://www.w3.org/2018/credentials#VerifiableCredential"},
+                    {"uri": "https://w3id.org/citizenship#PermanentResidentCard"},
+                ],
+                "constraints": {
+                    "is_holder": [
+                        {
+                            "directive": "required",
+                            "field_id": ["1f44d55f-f161-4938-a659-f8026467f126"],
+                        }
+                    ],
+                    "fields": [
+                        {
+                            "id": "1f44d55f-f161-4938-a659-f8026467f126",
+                            "path": ["$.issuanceDate", "$.vc.issuanceDate"],
+                            "filter": {
+                                "type": "string",
+                                "format": "date",
+                                "maximum": "2014-5-16",
+                            },
+                        },
+                        {
+                            "id": "1f44d55f-f161-4938-a659-f8026467f127",
+                            "path": ["$.issuanceDate", "$.vc.issuanceDate"],
+                            "filter": {
+                                "type": "string",
+                                "format": "date",
+                                "minimum": "2005-5-16",
+                            },
+                        },
                     ],
                 },
             }

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_data.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_data.py
@@ -49,6 +49,48 @@ def create_vcrecord(cred_dict: dict, expanded_types: list):
     )
 
 
+is_holder_pd = PresentationDefinition.deserialize(
+    {
+        "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+        "submission_requirements": [
+            {
+                "name": "European Union Citizenship Proofs",
+                "rule": "all",
+                "from": "A",
+            }
+        ],
+        "input_descriptors": [
+            {
+                "id": "citizenship_input_1",
+                "group": ["A"],
+                "schema": [
+                    {"uri": "https://www.w3.org/2018/credentials#VerifiableCredential"},
+                    {"uri": "https://w3id.org/citizenship#PermanentResidentCard"},
+                ],
+                "constraints": {
+                    "is_holder": [
+                        {
+                            "directive": "required",
+                            "field_ids": ["1f44d55f-f161-4938-a659-f8026467f126"],
+                        }
+                    ],
+                    "fields": [
+                        {
+                            "id": "1f44d55f-f161-4938-a659-f8026467f126",
+                            "path": ["$.issuanceDate", "$.vc.issuanceDate"],
+                            "filter": {
+                                "type": "string",
+                                "format": "date",
+                                "maximum": "2014-5-16",
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+)
+
 creds_with_no_id = [
     create_vcrecord(
         {

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch.py
@@ -156,7 +156,7 @@ class TestPresExchSchemas(TestCase):
     def test_is_holder(self):
         test_json = """
             {
-                "field_ids": [
+                "field_id": [
                     "ce66380c-1990-4aec-b8b4-5d532e92a616",
                     "dd69e8a4-4cc0-4540-b34a-b4aa0e0d2214",
                     "d15802b4-eec8-45ef-b78f-e35125ac1bb8",

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch.py
@@ -142,10 +142,21 @@ class TestPresExchSchemas(TestCase):
         with self.assertRaises(BaseModelError) as cm:
             (SubmissionRequirements.deserialize(test_json)).serialize()
 
+    def test_submission_requirements_from_both_missing(self):
+        test_json = """
+            {
+                "name": "Citizenship Information",
+                "rule": "pick",
+                "count": 1
+            }
+        """
+        with self.assertRaises(BaseModelError) as cm:
+            (SubmissionRequirements.deserialize(test_json)).serialize()
+
     def test_is_holder(self):
         test_json = """
             {
-                "field_id": [
+                "field_ids": [
                     "ce66380c-1990-4aec-b8b4-5d532e92a616",
                     "dd69e8a4-4cc0-4540-b34a-b4aa0e0d2214",
                     "d15802b4-eec8-45ef-b78f-e35125ac1bb8",

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
@@ -49,6 +49,8 @@ from .test_data import (
     bbs_signed_cred_credsubjectid,
     creds_with_no_id,
     is_holder_pd,
+    is_holder_pd_multiple_fields_excluded,
+    is_holder_pd_multiple_fields_included,
 )
 
 
@@ -3070,7 +3072,7 @@ class TestPresExchHandler:
 
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
-    async def test_is_holder_valid(self, profile, setup_tuple):
+    async def test_is_holder_valid_a(self, profile, setup_tuple):
         context = profile.context
         context.update_settings({"debug.auto_respond_presentation_request": True})
         dif_pres_exch_handler = DIFPresExchHandler(
@@ -3086,7 +3088,35 @@ class TestPresExchHandler:
 
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
-    async def test_is_holder_invalid_a(self, profile, setup_tuple):
+    async def test_is_holder_valid_b(self, profile, setup_tuple):
+        dif_pres_exch_handler = DIFPresExchHandler(
+            profile, proof_type=BbsBlsSignature2020.signature_type
+        )
+        cred_list, pd_list = setup_tuple
+        tmp_vp = await dif_pres_exch_handler.create_vp(
+            credentials=cred_list,
+            pd=is_holder_pd_multiple_fields_included,
+            challenge="1f44d55f-f161-4938-a659-f8026467f126",
+        )
+        assert len(tmp_vp.get("verifiableCredential")) == 6
+
+    @pytest.mark.asyncio
+    @pytest.mark.ursa_bbs_signatures
+    async def test_is_holder_valid_c(self, profile, setup_tuple):
+        dif_pres_exch_handler = DIFPresExchHandler(
+            profile, proof_type=BbsBlsSignature2020.signature_type
+        )
+        cred_list, pd_list = setup_tuple
+        tmp_vp = await dif_pres_exch_handler.create_vp(
+            credentials=cred_list,
+            pd=is_holder_pd_multiple_fields_excluded,
+            challenge="1f44d55f-f161-4938-a659-f8026467f126",
+        )
+        assert len(tmp_vp.get("verifiableCredential")) == 6
+
+    @pytest.mark.asyncio
+    @pytest.mark.ursa_bbs_signatures
+    async def test_is_holder_subject_mismatch(self, profile, setup_tuple):
         dif_pres_exch_handler = DIFPresExchHandler(
             profile, proof_type=BbsBlsSignature2020.signature_type
         )
@@ -3104,7 +3134,7 @@ class TestPresExchHandler:
 
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
-    async def test_is_holder_invalid_b(self, profile, setup_tuple):
+    async def test_is_holder_missing_subject(self, profile, setup_tuple):
         dif_pres_exch_handler = DIFPresExchHandler(
             profile, proof_type=BbsBlsSignature2020.signature_type
         )


### PR DESCRIPTION
- resolve #1261
- I think this meets the following attributes from the DIF spec ~~but does not use the `is_holder` property to decide whether the `VP` should be signed or not. But in case, this is needed then this can be done with minimal changes/extension~~.
1. `Verify that the Holder or Subject of the Claim still controls the identifier [DID].` [Link](https://identity.foundation/presentation-exchange/#proof-of-identifier-control)
2. `Holder of  Claim is the same as the Subject of the attribute.` [Link](https://identity.foundation/presentation-exchange/#note-2) 