### PR TITLE
Support generic public DIDs in DIDX request

### DIFF
--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -223,20 +223,6 @@ class JSONWebToken(Regexp):
         )
 
 
-class GenericDID(Regexp):
-    """Validate value against DID specification."""
-
-    EXAMPLE = "did:indy:idu:WgWxqztrNooG92RXvxSTWv"
-    PATTERN = re.compile(r"^did:([a-z0-9]+):((?:[a-zA-Z0-9._-]*:)*[a-zA-Z0-9._-]+)")
-
-    def __init__(self):
-        """Initializer."""
-
-        super().__init__(
-            GenericDID.PATTERN, error="Value {input} is not in W3C did format"
-        )
-
-
 class DIDKey(Regexp):
     """Validate value against DID key specification."""
 
@@ -755,22 +741,6 @@ class IndyOrKeyDID(Regexp):
         )
 
 
-class IndyOrGenericDID(Regexp):
-    """Indy or Generic DID class."""
-
-    PATTERN = "|".join(x.pattern for x in [GenericDID.PATTERN, IndyDID.PATTERN])
-    EXAMPLE = IndyDID.EXAMPLE
-
-    def __init__(
-        self,
-    ):
-        """Initializer."""
-        super().__init__(
-            IndyOrGenericDID.PATTERN,
-            error="Value {input} is not in generic did or indy did format",
-        )
-
-
 # Instances for marshmallow schema specification
 INT_EPOCH = {"validate": IntEpoch(), "example": IntEpoch.EXAMPLE}
 WHOLE_NUM = {"validate": WholeNumber(), "example": WholeNumber.EXAMPLE}
@@ -783,10 +753,10 @@ NUM_STR_NATURAL = {
 INDY_REV_REG_SIZE = {"validate": IndyRevRegSize(), "example": IndyRevRegSize.EXAMPLE}
 JWS_HEADER_KID = {"validate": JWSHeaderKid(), "example": JWSHeaderKid.EXAMPLE}
 JWT = {"validate": JSONWebToken(), "example": JSONWebToken.EXAMPLE}
-GENERIC_DID = {"validate": GenericDID(), "example": GenericDID.EXAMPLE}
 DID_KEY = {"validate": DIDKey(), "example": DIDKey.EXAMPLE}
 DID_POSTURE = {"validate": DIDPosture(), "example": DIDPosture.EXAMPLE}
 INDY_DID = {"validate": IndyDID(), "example": IndyDID.EXAMPLE}
+GENERIC_DID = {"validate": DIDValidation(), "example": DIDValidation.EXAMPLE}
 INDY_RAW_PUBLIC_KEY = {
     "validate": IndyRawPublicKey(),
     "example": IndyRawPublicKey.EXAMPLE,
@@ -828,8 +798,4 @@ CREDENTIAL_SUBJECT = {
 INDY_OR_KEY_DID = {
     "validate": IndyOrKeyDID(),
     "example": IndyOrKeyDID.EXAMPLE,
-}
-INDY_OR_GENERIC_DID = {
-    "validate": IndyOrGenericDID(),
-    "example": IndyOrGenericDID.EXAMPLE,
 }

--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -223,6 +223,20 @@ class JSONWebToken(Regexp):
         )
 
 
+class GenericDID(Regexp):
+    """Validate value against DID specification."""
+
+    EXAMPLE = "did:indy:idu:WgWxqztrNooG92RXvxSTWv"
+    PATTERN = re.compile(r"^did:([a-z0-9]+):((?:[a-zA-Z0-9._-]*:)*[a-zA-Z0-9._-]+)")
+
+    def __init__(self):
+        """Initializer."""
+
+        super().__init__(
+            GenericDID.PATTERN, error="Value {input} is not in W3C did format"
+        )
+
+
 class DIDKey(Regexp):
     """Validate value against DID key specification."""
 
@@ -741,6 +755,22 @@ class IndyOrKeyDID(Regexp):
         )
 
 
+class IndyOrGenericDID(Regexp):
+    """Indy or Generic DID class."""
+
+    PATTERN = "|".join(x.pattern for x in [GenericDID.PATTERN, IndyDID.PATTERN])
+    EXAMPLE = IndyDID.EXAMPLE
+
+    def __init__(
+        self,
+    ):
+        """Initializer."""
+        super().__init__(
+            IndyOrGenericDID.PATTERN,
+            error="Value {input} is not in generic did or indy did format",
+        )
+
+
 # Instances for marshmallow schema specification
 INT_EPOCH = {"validate": IntEpoch(), "example": IntEpoch.EXAMPLE}
 WHOLE_NUM = {"validate": WholeNumber(), "example": WholeNumber.EXAMPLE}
@@ -753,6 +783,7 @@ NUM_STR_NATURAL = {
 INDY_REV_REG_SIZE = {"validate": IndyRevRegSize(), "example": IndyRevRegSize.EXAMPLE}
 JWS_HEADER_KID = {"validate": JWSHeaderKid(), "example": JWSHeaderKid.EXAMPLE}
 JWT = {"validate": JSONWebToken(), "example": JSONWebToken.EXAMPLE}
+GENERIC_DID = {"validate": GenericDID(), "example": GenericDID.EXAMPLE}
 DID_KEY = {"validate": DIDKey(), "example": DIDKey.EXAMPLE}
 DID_POSTURE = {"validate": DIDPosture(), "example": DIDPosture.EXAMPLE}
 INDY_DID = {"validate": IndyDID(), "example": IndyDID.EXAMPLE}
@@ -797,4 +828,8 @@ CREDENTIAL_SUBJECT = {
 INDY_OR_KEY_DID = {
     "validate": IndyOrKeyDID(),
     "example": IndyOrKeyDID.EXAMPLE,
+}
+INDY_OR_GENERIC_DID = {
+    "validate": IndyOrGenericDID(),
+    "example": IndyOrGenericDID.EXAMPLE,
 }

--- a/aries_cloudagent/protocols/didexchange/v1_0/routes.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/routes.py
@@ -17,7 +17,7 @@ from ....admin.request_context import AdminRequestContext
 from ....connections.models.conn_record import ConnRecord, ConnRecordSchema
 from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
-from ....messaging.valid import ENDPOINT, INDY_OR_GENERIC_DID, UUIDFour, UUID4
+from ....messaging.valid import ENDPOINT, GENERIC_DID, UUIDFour, UUID4
 from ....storage.error import StorageError, StorageNotFoundError
 from ....wallet.error import WalletError
 
@@ -41,8 +41,8 @@ class DIDXCreateRequestImplicitQueryStringSchema(OpenAPISchema):
     their_public_did = fields.Str(
         required=True,
         allow_none=False,
-        description="Public DID to which to request connection",
-        **INDY_OR_GENERIC_DID,
+        description="Qualified public DID to which to request connection",
+        **GENERIC_DID,
     )
     my_endpoint = fields.Str(description="My URL endpoint", required=False, **ENDPOINT)
     my_label = fields.Str(

--- a/aries_cloudagent/protocols/didexchange/v1_0/routes.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/routes.py
@@ -17,7 +17,7 @@ from ....admin.request_context import AdminRequestContext
 from ....connections.models.conn_record import ConnRecord, ConnRecordSchema
 from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
-from ....messaging.valid import ENDPOINT, INDY_DID, UUIDFour, UUID4
+from ....messaging.valid import ENDPOINT, INDY_OR_GENERIC_DID, UUIDFour, UUID4
 from ....storage.error import StorageError, StorageNotFoundError
 from ....wallet.error import WalletError
 
@@ -42,7 +42,7 @@ class DIDXCreateRequestImplicitQueryStringSchema(OpenAPISchema):
         required=True,
         allow_none=False,
         description="Public DID to which to request connection",
-        **INDY_DID,
+        **INDY_OR_GENERIC_DID,
     )
     my_endpoint = fields.Str(description="My URL endpoint", required=False, **ENDPOINT)
     my_label = fields.Str(


### PR DESCRIPTION
Be more permissive in validation of target public DID in `didexchange/create-request`.
Public DIDs are resolved using the resolver interface which supports additional DID methods besides `did:sov` (e.g. `did:web`).

Only question is if we should still allow unqualified DIDs.