### PR TITLE
check if did is already qualified

### DIFF
--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -286,8 +286,8 @@ class DIDXManager(BaseConnectionManager):
             ),
         )
         if (
-            conn_rec.their_public_did is not None and
-            conn_rec.their_public_did.startswith("did:")
+            conn_rec.their_public_did is not None
+            and conn_rec.their_public_did.startswith("did:")
         ):
             qualified_did = conn_rec.their_public_did
         else:

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -285,7 +285,14 @@ class DIDXManager(BaseConnectionManager):
                 filter(None, [base_mediation_record, mediation_record])
             ),
         )
-        pthid = conn_rec.invitation_msg_id or f"did:sov:{conn_rec.their_public_did}"
+        if (
+            conn_rec.their_public_did is not None and
+            conn_rec.their_public_did.startswith("did:")
+        ):
+            qualified_did = conn_rec.their_public_did
+        else:
+            qualified_did = f"did:sov:{conn_rec.their_public_did}"
+        pthid = conn_rec.invitation_msg_id or qualified_did
         attach = AttachDecorator.data_base64(did_doc.serialize())
         await attach.data.sign(my_info.verkey, wallet)
         if not my_label:

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -233,6 +233,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
 
             assert conn_rec
 
+    
     async def test_create_request_implicit_use_public_did(self):
 
         mediation_record = MediationRecord(

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -233,7 +233,6 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
 
             assert conn_rec
 
-    
     async def test_create_request_implicit_use_public_did(self):
 
         mediation_record = MediationRecord(


### PR DESCRIPTION
PR #1296 introduced a problem that  when the `pthid` got set to the public DID in a DIDX request with an already qualified DID it would still get prefixed with `did:sov`.


Signed-off-by: Woerner Dominic (RBCH/PJ-IOT) <dominic.woerner2@ch.bosch.com>