### PR TITLE
fix: error on deserializing conn record with protocol

### DIFF
--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -582,9 +582,7 @@ class ConnRecordSchema(BaseRecordSchema):
     connection_protocol = fields.Str(
         required=False,
         description="Connection protocol used",
-        validate=validate.OneOf(
-            [label for proto in ConnRecord.Protocol for label in proto.value]
-        ),
+        validate=validate.OneOf([proto.value for proto in ConnRecord.Protocol]),
         example=ConnRecord.Protocol.RFC_0160.aries_protocol,
     )
     rfc23_state = fields.Str(

--- a/aries_cloudagent/connections/models/tests/test_conn_record.py
+++ b/aries_cloudagent/connections/models/tests/test_conn_record.py
@@ -315,6 +315,17 @@ class TestConnRecord(AsyncTestCase):
         reser = deser.serialize()
         assert "initiator" not in reser
 
+    async def test_deserialize_connection_protocol(self):
+        record = ConnRecord(
+            state=ConnRecord.State.INIT,
+            my_did=self.test_did,
+            their_role=ConnRecord.Role.REQUESTER,
+            connection_protocol="connections/1.0",
+        )
+        ser = record.serialize()
+        deser = ConnRecord.deserialize(ser)
+        assert deser.connection_protocol == "connections/1.0"
+
     async def test_metadata_set_get(self):
         record = ConnRecord(
             my_did=self.test_did,


### PR DESCRIPTION
Fixes error when deserializing a connection record that has a `connection_protocol` value set:
```
marshmallow.exceptions.ValidationError: {'connection_protocol': ['Must be one of: c, o, n, n, e, c, t, i, o, n, s, /, 1, ., 0, d, i, d, e, x, c, h, a, n, g, e, /, 1, ., 0.']}
```