### PR TITLE
Add an optional parameter '--ledger-socks-proxy'

### DIFF
--- a/aries_cloudagent/askar/profile.py
+++ b/aries_cloudagent/askar/profile.py
@@ -63,6 +63,7 @@ class AskarProfile(Profile):
         pool_name = self.settings.get("ledger.pool_name", "default")
         keepalive = int(self.settings.get("ledger.keepalive", 5))
         read_only = bool(self.settings.get("ledger.read_only", False))
+        socks_proxy = self.settings.get("ledger.socks_proxy")
         if read_only:
             LOGGER.error("Note: setting ledger to read-only mode")
         genesis_transactions = self.settings.get("ledger.genesis_transactions")
@@ -73,6 +74,7 @@ class AskarProfile(Profile):
             cache=cache,
             genesis_transactions=genesis_transactions,
             read_only=read_only,
+            socks_proxy=socks_proxy,
         )
 
     def bind_providers(self):

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -655,6 +655,21 @@ class LedgerGroup(ArgumentGroup):
             env_var="ACAPY_LEDGER_KEEP_ALIVE",
             help="Specifies how many seconds to keep the ledger open. Default: 5",
         )
+        parser.add_argument(
+            "--ledger-socks-proxy",
+            type=str,
+            dest="ledger_socks_proxy",
+            metavar="<host:port>",
+            required=False,
+            env_var="ACAPY_LEDGER_SOCKS_PROXY",
+            help=(
+                "Specifies the socks proxy (NOT http proxy) hostname and port in format "
+                "'hostname:port'. This is an optional parameter to be passed to ledger "
+                "pool configuration and ZMQ in case if aca-py is running "
+                "in a corporate/private network behind a corporate proxy and will "
+                "connect to the public (outside of corporate network) ledger pool"
+            ),
+        )
 
     def get_settings(self, args: Namespace) -> dict:
         """Extract ledger settings."""
@@ -678,6 +693,8 @@ class LedgerGroup(ArgumentGroup):
                 settings["ledger.pool_name"] = args.ledger_pool_name
             if args.ledger_keepalive:
                 settings["ledger.keepalive"] = args.ledger_keepalive
+            if args.ledger_socks_proxy:
+                settings["ledger.socks_proxy"] = args.ledger_socks_proxy
 
         return settings
 

--- a/aries_cloudagent/ledger/indy_vdr.py
+++ b/aries_cloudagent/ledger/indy_vdr.py
@@ -79,6 +79,7 @@ class IndyVdrLedgerPool:
         cache_duration: int = 600,
         genesis_transactions: str = None,
         read_only: bool = False,
+        socks_proxy: str = None,
     ):
         """
         Initialize an IndyLedger instance.
@@ -90,6 +91,7 @@ class IndyVdrLedgerPool:
             cache_duration: The TTL for ledger cache entries
             genesis_transactions: The ledger genesis transaction as a string
             read_only: Prevent any ledger write operations
+            socks_proxy: Specifies socks proxy for ZMQ to connect to ledger pool
         """
         self.ref_count = 0
         self.ref_lock = asyncio.Lock()
@@ -105,6 +107,7 @@ class IndyVdrLedgerPool:
         self.init_config = bool(genesis_transactions)
         self.taa_cache: str = None
         self.read_only: bool = read_only
+        self.socks_proxy: str = socks_proxy
 
     @property
     def cfg_path(self) -> Path:
@@ -188,7 +191,7 @@ class IndyVdrLedgerPool:
             txns = self.genesis_txns
             cached = False
 
-        self.handle = await open_pool(transactions=txns)
+        self.handle = await open_pool(transactions=txns, socks_proxy=self.socks_proxy)
         upd_txns = _normalize_txns(await self.handle.get_transactions())
         if not cached or upd_txns != txns:
             try:


### PR DESCRIPTION
Add an optional parameter '--ledger-socks-proxy' to specify the socks proxy and pass it on to pool configuration
implementation for issue #1341 

**Attention**! This pull request requires the newest versions of INDY-SDK and INDY-VDR (s. issue)

Signed-off-by: Vitalij Reicherdt <vitalij.reicherdt@commerzbank.com>