### PR TITLE
feat: set arbitrary plugin config value at cli

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -1,6 +1,7 @@
 """Command line option parsing."""
 
 import abc
+from functools import reduce
 from os import environ
 
 import yaml
@@ -484,12 +485,24 @@ class GeneralGroup(ArgumentGroup):
             dest="plugin_config",
             type=str,
             required=False,
-            env_var="ACAPY_PLUGINS_CONFIG",
-            help="Load YAML file path that defines external plugins configuration. "
-            "The plugin should be loaded first by --plugin arg. "
-            "Then the config file must be a key-value mapping. "
-            "The key is the plugin argument and "
-            "the value of the specific configuration for that plugin.",
+            env_var="ACAPY_PLUGIN_CONFIG",
+            help="Load YAML file path that defines external plugin configuration.",
+        )
+
+        parser.add_argument(
+            "-o",
+            "--plugin-config-value",
+            dest="plugin_config_values",
+            type=str,
+            nargs="+",
+            action="append",
+            required=False,
+            metavar="<KEY=VALUE>",
+            help=(
+                "Set an arbitrary plugin configuration option in the format "
+                "KEY=VALUE. Use dots in KEY to set deeply nested values, as in "
+                '"a.b.c=value". VALUE is parsed as yaml.'
+            ),
         )
 
         parser.add_argument(
@@ -564,6 +577,17 @@ class GeneralGroup(ArgumentGroup):
         if args.plugin_config:
             with open(args.plugin_config, "r") as stream:
                 settings["plugin_config"] = yaml.safe_load(stream)
+
+        if args.plugin_config_values:
+            if "plugin_config" not in settings:
+                settings["plugin_config"] = {}
+
+            for value_str in args.plugin_config_values:
+                key, value = value_str.split("=", maxsplit=1)
+                value = yaml.safe_load(value)
+                settings["plugin_config"].update(
+                    reduce(lambda v, k: {k: v}, key.split(".")[::-1], value)
+                )
 
         if args.storage_type:
             settings["storage_type"] = args.storage_type

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -2,8 +2,10 @@
 
 import abc
 from functools import reduce
+from itertools import chain
 from os import environ
 
+import deepmerge
 import yaml
 from configargparse import ArgumentParser, Namespace, YAMLConfigFileParser
 from typing import Type
@@ -582,11 +584,12 @@ class GeneralGroup(ArgumentGroup):
             if "plugin_config" not in settings:
                 settings["plugin_config"] = {}
 
-            for value_str in args.plugin_config_values:
+            for value_str in chain(*args.plugin_config_values):
                 key, value = value_str.split("=", maxsplit=1)
                 value = yaml.safe_load(value)
-                settings["plugin_config"].update(
-                    reduce(lambda v, k: {k: v}, key.split(".")[::-1], value)
+                deepmerge.always_merger.merge(
+                    settings["plugin_config"],
+                    reduce(lambda v, k: {k: v}, key.split(".")[::-1], value),
                 )
 
         if args.storage_type:

--- a/aries_cloudagent/config/tests/test_argparse.py
+++ b/aries_cloudagent/config/tests/test_argparse.py
@@ -288,3 +288,30 @@ class TestArgParse(AsyncTestCase):
                 ["--clear-default-mediator", "--default-mediator-id", "asdf"]
             )
             group.get_settings(args)
+
+    def test_plugin_config_value_parsing(self):
+        required_args = ["-e", "http://localhost:3000"]
+        parser = argparse.create_argument_parser()
+        group = argparse.GeneralGroup()
+        group.add_arguments(parser)
+        args = parser.parse_args(
+            [
+                *required_args,
+                "--plugin-config-value",
+                "a.b.c=test",
+                "a.b.d=one",
+                "--plugin-config-value",
+                "x.y.z=value",
+                "--plugin-config-value",
+                "a_dict={key: value}",
+                "--plugin-config-value",
+                "a_list=[one, two]",
+            ]
+        )
+        settings = group.get_settings(args)
+
+        assert settings["plugin_config"]["a"]["b"]["c"] == "test"
+        assert settings["plugin_config"]["a"]["b"]["d"] == "one"
+        assert settings["plugin_config"]["x"]["y"]["z"] == "value"
+        assert settings["plugin_config"]["a_dict"] == {"key": "value"}
+        assert settings["plugin_config"]["a_list"] == ["one", "two"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ apispec~=3.3.0
 async-timeout~=3.0.1
 aioredis~=1.3.1
 base58~=2.1.0
+deepmerge~=0.3.0
 ecdsa~=0.16.1
 Markdown~=3.1.1
 marshmallow==3.5.1


### PR DESCRIPTION
Doing a bit of spit balling.

We previously addressed the need for supplying configuration to plugins with the `--plugin-config` flag to load a yaml file into `settings` for use by plugins. We've found this feature to be quite helpful, especially in the case of loading multiple plugins (i.e. resolvers) that each require their own configuration. However, we have also found that it would be handy to be able to set or modify these values from the command line. So instead of having to modify the `plugin_config.yml` you're using to load the universal resolver plugin to point it to a different resolver instance, we could have a command line argument like the following:
```
--plugin-config-value http_uniresolver.endpoint=http://localhost:3000
```

Or perhaps a short form of:
```
-o http_uniresolver.endpoint=http://localhost:3000
```

With such a command line argument, we propose that dotted key values act as a shorthand for nesting values. For example, `a.b.c.d=value` becomes `{"a": {"b": {"c": {"d": "value"}}}}`. We also propose that the value be loaded as yaml to avoid parsing ourselves while still allowing us to express values more complicated than just strings and numbers.

Open to thoughts :slightly_smiling_face: 