### PR TITLE
fix: problem report handler for connection specific problems

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/messages/problem_report.py
+++ b/aries_cloudagent/protocols/connections/v1_0/messages/problem_report.py
@@ -7,7 +7,9 @@ from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
 from ..message_types import PROBLEM_REPORT
 
-HANDLER_CLASS = "aries_cloudagent.messaging.problem_report.handler.ProblemReportHandler"
+HANDLER_CLASS = (
+    "aries_cloudagent.protocols.problem_report.v1_0.handler.ProblemReportHandler"
+)
 
 
 class ProblemReportReason(Enum):


### PR DESCRIPTION
Appears to be an error leftover from when the problem report message definition was relocated.