### PR TITLE
feat: add inject_or

### DIFF
--- a/aries_cloudagent/admin/request_context.py
+++ b/aries_cloudagent/admin/request_context.py
@@ -114,15 +114,15 @@ class AdminRequestContext:
     def _test_session(self) -> ProfileSession:
         session = self.profile.session(self._context)
 
-        def _inject(base_cls, required=True):
+        def _inject(base_cls):
             if session._active and base_cls in self.session_inject:
                 ret = self.session_inject[base_cls]
-                if ret is None and required:
+                if ret is None:
                     raise InjectionError(
                         "No instance provided for class: {}".format(base_cls.__name__)
                     )
                 return ret
-            return session._context.injector.inject(base_cls, required=required)
+            return session._context.injector.inject(base_cls)
 
         setattr(session, "inject", _inject)
         return session

--- a/aries_cloudagent/admin/request_context.py
+++ b/aries_cloudagent/admin/request_context.py
@@ -61,8 +61,6 @@ class AdminRequestContext:
         self,
         base_cls: Type[InjectType],
         settings: Mapping[str, object] = None,
-        *,
-        required: bool = True
     ) -> Optional[InjectType]:
         """
         Get the provided instance of a given class identifier.
@@ -75,7 +73,27 @@ class AdminRequestContext:
             An instance of the base class, or None
 
         """
-        return self._context.inject(base_cls, settings, required=required)
+        return self._context.inject(base_cls, settings)
+
+    def inject_or(
+        self,
+        base_cls: Type[InjectType],
+        settings: Mapping[str, object] = None,
+        default: Optional[InjectType] = None,
+    ) -> Optional[InjectType]:
+        """
+        Get the provided instance of a given class identifier or default if not found.
+
+        Args:
+            base_cls: The base class to retrieve an instance of
+            settings: An optional dict providing configuration to the provider
+            default: default return value if no instance is found
+
+        Returns:
+            An instance of the base class, or None
+
+        """
+        return self._context.inject_or(base_cls, settings, default)
 
     def update_settings(self, settings: Mapping[str, object]):
         """Update the current scope with additional settings."""

--- a/aries_cloudagent/admin/request_context.py
+++ b/aries_cloudagent/admin/request_context.py
@@ -124,7 +124,16 @@ class AdminRequestContext:
                 return ret
             return session._context.injector.inject(base_cls)
 
+        def _inject_or(base_cls, default=None):
+            if session._active and base_cls in self.session_inject:
+                ret = self.session_inject[base_cls]
+                if ret is None:
+                    ret = default
+                return ret
+            return session._context.injector.inject_or(base_cls, default)
+
         setattr(session, "inject", _inject)
+        setattr(session, "inject_or", _inject_or)
         return session
 
     def __repr__(self) -> str:

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -251,7 +251,7 @@ class AdminServer(BaseAdminServer):
         self.webhook_router = webhook_router
         self.websocket_queues = {}
         self.site = None
-        self.multitenant_manager = context.inject(MultitenantManager, required=False)
+        self.multitenant_manager = context.inject_or(MultitenantManager)
 
         self.server_paths = []
 
@@ -293,7 +293,7 @@ class AdminServer(BaseAdminServer):
 
             middlewares.append(check_token)
 
-        collector = self.context.inject(Collector, required=False)
+        collector = self.context.inject_or(Collector)
 
         if self.multitenant_manager:
 
@@ -393,7 +393,7 @@ class AdminServer(BaseAdminServer):
         self.server_paths = [route.path for route in server_routes]
         app.add_routes(server_routes)
 
-        plugin_registry = self.context.inject(PluginRegistry, required=False)
+        plugin_registry = self.context.inject_or(PluginRegistry)
         if plugin_registry:
             await plugin_registry.register_admin_routes(app)
 
@@ -445,11 +445,11 @@ class AdminServer(BaseAdminServer):
         runner = web.AppRunner(self.app)
         await runner.setup()
 
-        plugin_registry = self.context.inject(PluginRegistry, required=False)
+        plugin_registry = self.context.inject_or(PluginRegistry)
         if plugin_registry:
             plugin_registry.post_process_routes(self.app)
 
-        event_bus = self.context.inject(EventBus, required=False)
+        event_bus = self.context.inject_or(EventBus)
         if event_bus:
             event_bus.subscribe(EVENT_PATTERN_WEBHOOK, self._on_webhook_event)
             event_bus.subscribe(EVENT_PATTERN_RECORD, self._on_record_event)
@@ -548,7 +548,7 @@ class AdminServer(BaseAdminServer):
             The module list response
 
         """
-        registry = self.context.inject(PluginRegistry, required=False)
+        registry = self.context.inject_or(PluginRegistry)
         plugins = registry and sorted(registry.plugin_names) or []
         return web.json_response({"result": plugins})
 
@@ -602,7 +602,7 @@ class AdminServer(BaseAdminServer):
         """
         status = {"version": __version__}
         status["label"] = self.context.settings.get("default_label")
-        collector = self.context.inject(Collector, required=False)
+        collector = self.context.inject_or(Collector)
         if collector:
             status["timing"] = collector.results
         if self.conductor_stats:
@@ -622,7 +622,7 @@ class AdminServer(BaseAdminServer):
             The web response
 
         """
-        collector = self.context.inject(Collector, required=False)
+        collector = self.context.inject_or(Collector)
         if collector:
             collector.reset()
         return web.json_response({})

--- a/aries_cloudagent/admin/tests/test_request_context.py
+++ b/aries_cloudagent/admin/tests/test_request_context.py
@@ -22,4 +22,4 @@ class TestAdminRequestContext(AsyncTestCase):
         test_ctx = test_module.AdminRequestContext.test_context({Collector: None})
         async with test_ctx.session() as test_sesn:
             with self.assertRaises(test_module.InjectionError):
-                test_sesn.inject(Collector, required=True)
+                test_sesn.inject(Collector)

--- a/aries_cloudagent/askar/profile.py
+++ b/aries_cloudagent/askar/profile.py
@@ -67,7 +67,7 @@ class AskarProfile(Profile):
         if read_only:
             LOGGER.error("Note: setting ledger to read-only mode")
         genesis_transactions = self.settings.get("ledger.genesis_transactions")
-        cache = self.context.injector.inject(BaseCache, required=False)
+        cache = self.context.injector.inject_or(BaseCache)
         self.ledger_pool = IndyVdrLedgerPool(
             pool_name,
             keepalive=keepalive,

--- a/aries_cloudagent/config/injection_context.py
+++ b/aries_cloudagent/config/injection_context.py
@@ -109,8 +109,6 @@ class InjectionContext(BaseInjector):
         self,
         base_cls: Type[InjectType],
         settings: Mapping[str, object] = None,
-        *,
-        required: bool = True
     ) -> Optional[InjectType]:
         """
         Get the provided instance of a given class identifier.
@@ -123,7 +121,27 @@ class InjectionContext(BaseInjector):
             An instance of the base class, or None
 
         """
-        return self.injector.inject(base_cls, settings, required=required)
+        return self.injector.inject(base_cls, settings)
+
+    def inject_or(
+        self,
+        base_cls: Type[InjectType],
+        settings: Mapping[str, object] = None,
+        default: Optional[InjectType] = None,
+    ) -> Optional[InjectType]:
+        """
+        Get the provided instance of a given class identifier or default if not found.
+
+        Args:
+            base_cls: The base class to retrieve an instance of
+            settings: An optional dict providing configuration to the provider
+            default: default return value if no instance is found
+
+        Returns:
+            An instance of the base class, or None
+
+        """
+        return self.injector.inject_or(base_cls, settings, default)
 
     def copy(self) -> "InjectionContext":
         """Produce a copy of the injector instance."""

--- a/aries_cloudagent/config/injector.py
+++ b/aries_cloudagent/config/injector.py
@@ -88,7 +88,7 @@ class Injector(BaseInjector):
                 )
             )
 
-        return result or default
+        return result if result is not None else default
 
     def inject(
         self,

--- a/aries_cloudagent/config/injector.py
+++ b/aries_cloudagent/config/injector.py
@@ -51,19 +51,19 @@ class Injector(BaseInjector):
         """Find the provider associated with a class binding."""
         return self._providers.get(base_cls)
 
-    def inject(
+    def inject_or(
         self,
         base_cls: Type[InjectType],
         settings: Mapping[str, object] = None,
-        *,
-        required: bool = True,
+        default: Optional[InjectType] = None,
     ) -> Optional[InjectType]:
         """
-        Get the provided instance of a given class identifier.
+        Get the provided instance of a given class identifier or default if not found.
 
         Args:
-            cls: The base class to retrieve an instance of
-            params: An optional dict providing configuration to the provider
+            base_cls: The base class to retrieve an instance of
+            settings: An optional dict providing configuration to the provider
+            default: default return value if no instance is found
 
         Returns:
             An instance of the base class, or None
@@ -80,16 +80,36 @@ class Injector(BaseInjector):
             result = provider.provide(ext_settings, self)
         else:
             result = None
-        if result is None:
-            if required:
-                raise InjectionError(
-                    "No instance provided for class: {}".format(base_cls.__name__)
-                )
-        elif not isinstance(result, base_cls) and self.enforce_typing:
+
+        if result and not isinstance(result, base_cls) and self.enforce_typing:
             raise InjectionError(
                 "Provided instance does not implement the base class: {}".format(
                     base_cls.__name__
                 )
+            )
+
+        return result or default
+
+    def inject(
+        self,
+        base_cls: Type[InjectType],
+        settings: Mapping[str, object] = None,
+    ) -> InjectType:
+        """
+        Get the provided instance of a given class identifier.
+
+        Args:
+            cls: The base class to retrieve an instance of
+            params: An optional dict providing configuration to the provider
+
+        Returns:
+            An instance of the base class, or None
+
+        """
+        result = self.inject_or(base_cls, settings)
+        if result is None:
+            raise InjectionError(
+                "No instance provided for class: {}".format(base_cls.__name__)
             )
         return result
 

--- a/aries_cloudagent/config/ledger.py
+++ b/aries_cloudagent/config/ledger.py
@@ -63,7 +63,7 @@ async def ledger_config(
 
     session = await profile.session()
 
-    ledger = session.inject(BaseLedger, required=False)
+    ledger = session.inject_or(BaseLedger)
     if not ledger:
         LOGGER.info("Ledger instance not provided")
         return False

--- a/aries_cloudagent/config/provider.py
+++ b/aries_cloudagent/config/provider.py
@@ -129,7 +129,7 @@ class StatsProvider(BaseProvider):
         """Provide the object instance given a config and injector."""
         instance = self._provider.provide(config, injector)
         if self._methods:
-            collector: Collector = injector.inject(Collector, required=False)
+            collector: Collector = injector.inject_or(Collector)
             if collector:
                 collector.wrap(
                     instance, self._methods, ignore_missing=self._ignore_missing

--- a/aries_cloudagent/config/tests/test_injection_context.py
+++ b/aries_cloudagent/config/tests/test_injection_context.py
@@ -53,7 +53,7 @@ class TestInjectionContext(AsyncTestCase):
 
     async def test_inject_simple(self):
         """Test a basic injection."""
-        assert self.test_instance.inject(str, required=False) is None
+        assert self.test_instance.inject_or(str) is None
         with self.assertRaises(InjectionError):
             self.test_instance.inject(str)
         self.test_instance.injector.bind_instance(str, self.test_value)
@@ -65,10 +65,10 @@ class TestInjectionContext(AsyncTestCase):
     async def test_inject_scope(self):
         """Test a scoped injection."""
         context = self.test_instance.start_scope(self.test_scope)
-        assert context.inject(str, required=False) is None
+        assert context.inject_or(str) is None
         context.injector.bind_instance(str, self.test_value)
         assert context.inject(str) is self.test_value
-        assert self.test_instance.inject(str, required=False) is None
+        assert self.test_instance.inject_or(str) is None
         root = context.injector_for_scope(context.ROOT_SCOPE)
-        assert root.inject(str, required=False) is None
-        assert self.test_instance.inject(str, required=False) is None
+        assert root.inject_or(str) is None
+        assert self.test_instance.inject_or(str) is None

--- a/aries_cloudagent/config/tests/test_injector.py
+++ b/aries_cloudagent/config/tests/test_injector.py
@@ -139,3 +139,9 @@ class TestInjector(AsyncTestCase):
         i1 = self.test_instance.inject(MockInstance)
         i2 = self.test_instance.inject(MockInstance)
         assert i1 is i2
+
+    def test_falsey_still_returns(self):
+        """Test the injector still returns falsey values."""
+        self.test_instance.bind_instance(dict, dict())
+        assert self.test_instance.inject_or(dict) is not None
+        assert self.test_instance.inject(dict) is not None

--- a/aries_cloudagent/config/tests/test_injector.py
+++ b/aries_cloudagent/config/tests/test_injector.py
@@ -43,7 +43,7 @@ class TestInjector(AsyncTestCase):
 
     def test_inject_simple(self):
         """Test a basic injection."""
-        assert self.test_instance.inject(str, required=False) is None
+        assert self.test_instance.inject_or(str) is None
         with self.assertRaises(InjectionError):
             self.test_instance.inject(str)
         with self.assertRaises(ValueError):
@@ -75,7 +75,7 @@ class TestInjector(AsyncTestCase):
         self.test_instance.bind_provider(str, MockProvider(None))
         with self.assertRaises(InjectionError):
             self.test_instance.inject(str)
-        self.test_instance.inject(str, required=False)
+        self.test_instance.inject_or(str)
         self.test_instance.bind_provider(str, MockProvider(1))
         self.test_instance.clear_binding(str)
         assert self.test_instance.get_provider(str) is None

--- a/aries_cloudagent/config/tests/test_wallet.py
+++ b/aries_cloudagent/config/tests/test_wallet.py
@@ -37,8 +37,8 @@ class TestWalletConfig(AsyncTestCase):
             transaction=async_mock.CoroutineMock(return_value=self.session),
         )
 
-        def _inject(cls, required=True):
-            return self.injector.inject(cls, required=required)
+        def _inject(cls):
+            return self.injector.inject(cls)
 
         self.session.inject = _inject
         self.context = InjectionContext()

--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -121,7 +121,7 @@ class Conductor:
         self.dispatcher = Dispatcher(self.root_profile)
         await self.dispatcher.setup()
 
-        wire_format = context.inject(BaseWireFormat, required=False)
+        wire_format = context.inject_or(BaseWireFormat)
         if wire_format and hasattr(wire_format, "task_queue"):
             wire_format.task_queue = self.dispatcher.task_queue
 
@@ -159,7 +159,7 @@ class Conductor:
                 raise
 
         # Fetch stats collector, if any
-        collector = context.inject(Collector, required=False)
+        collector = context.inject_or(Collector)
         if collector:
             # add stats to our own methods
             collector.wrap(
@@ -358,7 +358,7 @@ class Conductor:
             shutdown.run(self.outbound_transport_manager.stop())
 
         # close multitenant profiles
-        multitenant_mgr = self.context.inject(MultitenantManager, required=False)
+        multitenant_mgr = self.context.inject_or(MultitenantManager)
         if multitenant_mgr:
             for profile in multitenant_mgr._instances.values():
                 shutdown.run(profile.close())

--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -57,7 +57,7 @@ class Dispatcher:
 
     async def setup(self):
         """Perform async instance setup."""
-        self.collector = self.profile.inject(Collector, required=False)
+        self.collector = self.profile.inject_or(Collector)
         max_active = int(os.getenv("DISPATCHER_MAX_ACTIVE", 50))
         self.task_queue = TaskQueue(
             max_active=max_active, timed=bool(self.collector), trace_fn=self.log_task

--- a/aries_cloudagent/core/profile.py
+++ b/aries_cloudagent/core/profile.py
@@ -78,8 +78,6 @@ class Profile(ABC):
         self,
         base_cls: Type[InjectType],
         settings: Mapping[str, object] = None,
-        *,
-        required: bool = True,
     ) -> Optional[InjectType]:
         """
         Get the provided instance of a given class identifier.
@@ -92,7 +90,27 @@ class Profile(ABC):
             An instance of the base class, or None
 
         """
-        return self._context.inject(base_cls, settings, required=required)
+        return self._context.inject(base_cls, settings)
+
+    def inject_or(
+        self,
+        base_cls: Type[InjectType],
+        settings: Mapping[str, object] = None,
+        default: Optional[InjectType] = None,
+    ) -> Optional[InjectType]:
+        """
+        Get the provided instance of a given class identifier or default if not found.
+
+        Args:
+            base_cls: The base class to retrieve an instance of
+            settings: An optional dict providing configuration to the provider
+            default: default return value if no instance is found
+
+        Returns:
+            An instance of the base class, or None
+
+        """
+        return self._context.inject_or(base_cls, settings, default)
 
     async def close(self):
         """Close the profile instance."""
@@ -237,8 +255,6 @@ class ProfileSession(ABC):
         self,
         base_cls: Type[InjectType],
         settings: Mapping[str, object] = None,
-        *,
-        required: bool = True,
     ) -> Optional[InjectType]:
         """
         Get the provided instance of a given class identifier.
@@ -253,7 +269,29 @@ class ProfileSession(ABC):
         """
         if not self._active:
             raise ProfileSessionInactiveError()
-        return self._context.inject(base_cls, settings, required=required)
+        return self._context.inject(base_cls, settings)
+
+    def inject_or(
+        self,
+        base_cls: Type[InjectType],
+        settings: Mapping[str, object] = None,
+        default: Optional[InjectType] = None,
+    ) -> Optional[InjectType]:
+        """
+        Get the provided instance of a given class identifier or default if not found.
+
+        Args:
+            base_cls: The base class to retrieve an instance of
+            settings: An optional dict providing configuration to the provider
+            default: default return value if no instance is found
+
+        Returns:
+            An instance of the base class, or None
+
+        """
+        if not self._active:
+            raise ProfileSessionInactiveError()
+        return self._context.inject_or(base_cls, settings, default)
 
     def __repr__(self) -> str:
         """Get a human readable string."""

--- a/aries_cloudagent/core/profile.py
+++ b/aries_cloudagent/core/profile.py
@@ -120,7 +120,7 @@ class Profile(ABC):
 
     async def notify(self, topic: str, payload: Any):
         """Signal an event."""
-        event_bus = self.inject(EventBus, required=False)
+        event_bus = self.inject_or(EventBus)
         if event_bus:
             await event_bus.notify(self, Event(topic, payload))
 

--- a/aries_cloudagent/core/tests/test_profile.py
+++ b/aries_cloudagent/core/tests/test_profile.py
@@ -34,14 +34,14 @@ class TestProfileSession(AsyncTestCase):
             await session.rollback()
         with self.assertRaises(ProfileSessionInactiveError):
             session.inject(dict)
-        assert profile.inject(dict, required=False) is None
+        assert profile.inject_or(dict) is None
 
         await session.__aenter__()
 
         self.assertEqual(session.active, True)
         session.context.injector.bind_instance(dict, dict())
-        assert session.inject(dict, required=False) is not None
-        assert profile.inject(dict, required=False) is None
+        assert session.inject_or(dict) is not None
+        assert profile.inject_or(dict) is None
 
         await session.__aexit__(None, None, None)
 

--- a/aries_cloudagent/holder/routes.py
+++ b/aries_cloudagent/holder/routes.py
@@ -207,7 +207,7 @@ async def credentials_revoked(request: web.BaseRequest):
     fro = request.query.get("from")
     to = request.query.get("to")
 
-    ledger = session.inject(BaseLedger, required=False)
+    ledger = session.inject_or(BaseLedger)
     if not ledger:
         reason = "No ledger available"
         if not context.settings.get_value("wallet.type"):

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -58,7 +58,7 @@ class IndySdkLedgerPoolProvider(BaseProvider):
             LOGGER.warning("Note: setting ledger to read-only mode")
 
         genesis_transactions = settings.get("ledger.genesis_transactions")
-        cache = injector.inject(BaseCache, required=False)
+        cache = injector.inject_or(BaseCache)
 
         ledger_pool = IndySdkLedgerPool(
             pool_name,

--- a/aries_cloudagent/ledger/routes.py
+++ b/aries_cloudagent/ledger/routes.py
@@ -170,7 +170,7 @@ async def register_ledger_nym(request: web.BaseRequest):
     """
     context: AdminRequestContext = request["context"]
     session = await context.session()
-    ledger = session.inject(BaseLedger, required=False)
+    ledger = session.inject_or(BaseLedger)
     if not ledger:
         reason = "No Indy ledger available"
         if not session.settings.get_value("wallet.type"):
@@ -226,7 +226,7 @@ async def get_nym_role(request: web.BaseRequest):
     """
     context: AdminRequestContext = request["context"]
     session = await context.session()
-    ledger = session.inject(BaseLedger, required=False)
+    ledger = session.inject_or(BaseLedger)
     if not ledger:
         reason = "No Indy ledger available"
         if not session.settings.get_value("wallet.type"):
@@ -260,7 +260,7 @@ async def rotate_public_did_keypair(request: web.BaseRequest):
     """
     context: AdminRequestContext = request["context"]
     session = await context.session()
-    ledger = session.inject(BaseLedger, required=False)
+    ledger = session.inject_or(BaseLedger)
     if not ledger:
         reason = "No Indy ledger available"
         if not session.settings.get_value("wallet.type"):
@@ -290,7 +290,7 @@ async def get_did_verkey(request: web.BaseRequest):
     """
     context: AdminRequestContext = request["context"]
     session = await context.session()
-    ledger = session.inject(BaseLedger, required=False)
+    ledger = session.inject_or(BaseLedger)
     if not ledger:
         reason = "No ledger available"
         if not session.settings.get_value("wallet.type"):
@@ -327,7 +327,7 @@ async def get_did_endpoint(request: web.BaseRequest):
     """
     context: AdminRequestContext = request["context"]
     session = await context.session()
-    ledger = session.inject(BaseLedger, required=False)
+    ledger = session.inject_or(BaseLedger)
     if not ledger:
         reason = "No Indy ledger available"
         if not session.settings.get_value("wallet.type"):
@@ -366,7 +366,7 @@ async def ledger_get_taa(request: web.BaseRequest):
     """
     context: AdminRequestContext = request["context"]
     session = await context.session()
-    ledger = session.inject(BaseLedger, required=False)
+    ledger = session.inject_or(BaseLedger)
     if not ledger:
         reason = "No Indy ledger available"
         if not session.settings.get_value("wallet.type"):
@@ -407,7 +407,7 @@ async def ledger_accept_taa(request: web.BaseRequest):
     """
     context: AdminRequestContext = request["context"]
     session = await context.session()
-    ledger = session.inject(BaseLedger, required=False)
+    ledger = session.inject_or(BaseLedger)
     if not ledger:
         reason = "No Indy ledger available"
         if not session.settings.get_value("wallet.type"):

--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -188,7 +188,7 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
             )
         endorser_did = endorser_info["endorser_did"]
 
-    ledger = context.inject(BaseLedger, required=False)
+    ledger = context.inject_or(BaseLedger)
     if not ledger:
         reason = "No ledger available"
         if not context.settings.get_value("wallet.type"):
@@ -337,7 +337,7 @@ async def credential_definitions_get_credential_definition(request: web.BaseRequ
 
     cred_def_id = request.match_info["cred_def_id"]
 
-    ledger = context.inject(BaseLedger, required=False)
+    ledger = context.inject_or(BaseLedger)
     if not ledger:
         reason = "No ledger available"
         if not context.settings.get_value("wallet.type"):

--- a/aries_cloudagent/messaging/jsonld/credential.py
+++ b/aries_cloudagent/messaging/jsonld/credential.py
@@ -85,7 +85,7 @@ async def jws_verify(session, verify_data, signature, public_key):
 async def sign_credential(session, credential, signature_options, verkey):
     """Sign Credential."""
 
-    document_loader = session.profile.inject(DocumentLoader, required=False)
+    document_loader = session.profile.inject_or(DocumentLoader)
     framed, verify_data_hex_string = create_verify_data(
         credential,
         signature_options,
@@ -99,7 +99,7 @@ async def sign_credential(session, credential, signature_options, verkey):
 async def verify_credential(session, doc, verkey):
     """Verify credential."""
 
-    document_loader = session.profile.inject(DocumentLoader, required=False)
+    document_loader = session.profile.inject_or(DocumentLoader)
     framed, verify_data_hex_string = create_verify_data(
         doc,
         doc["proof"],

--- a/aries_cloudagent/messaging/jsonld/credential.py
+++ b/aries_cloudagent/messaging/jsonld/credential.py
@@ -45,7 +45,7 @@ async def jws_sign(session, verify_data, verkey):
 
     jws_to_sign = create_jws(encoded_header, verify_data)
 
-    wallet = session.inject(BaseWallet, required=True)
+    wallet = session.inject(BaseWallet)
     signature = await wallet.sign_message(jws_to_sign, verkey)
 
     encoded_signature = bytes_to_b64(signature, urlsafe=True, pad=False)
@@ -74,7 +74,7 @@ async def jws_verify(session, verify_data, signature, public_key):
 
     jws_to_verify = create_jws(encoded_header, verify_data)
 
-    wallet = session.inject(BaseWallet, required=True)
+    wallet = session.inject(BaseWallet)
     verified = await wallet.verify_message(
         jws_to_verify, decoded_signature, public_key, KeyType.ED25519
     )

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -173,7 +173,7 @@ class BaseRecord(BaseModel):
         """
         if not cache_key:
             return
-        cache = session.inject(BaseCache, required=False)
+        cache = session.inject_or(BaseCache)
         if cache:
             return await cache.get(cache_key)
 
@@ -193,7 +193,7 @@ class BaseRecord(BaseModel):
 
         if not cache_key:
             return
-        cache = session.inject(BaseCache, required=False)
+        cache = session.inject_or(BaseCache)
         if cache:
             await cache.set(cache_key, value, ttl or cls.DEFAULT_CACHE_TTL)
 
@@ -209,7 +209,7 @@ class BaseRecord(BaseModel):
 
         if not cache_key:
             return
-        cache = session.inject(BaseCache, required=False)
+        cache = session.inject_or(BaseCache)
         if cache:
             await cache.clear(cache_key)
 

--- a/aries_cloudagent/messaging/request_context.py
+++ b/aries_cloudagent/messaging/request_context.py
@@ -192,8 +192,6 @@ class RequestContext:
         self,
         base_cls: Type[InjectType],
         settings: Mapping[str, object] = None,
-        *,
-        required: bool = True
     ) -> Optional[InjectType]:
         """
         Get the provided instance of a given class identifier.
@@ -206,7 +204,27 @@ class RequestContext:
             An instance of the base class, or None
 
         """
-        return self._context.inject(base_cls, settings, required=required)
+        return self._context.inject(base_cls, settings)
+
+    def inject_or(
+        self,
+        base_cls: Type[InjectType],
+        settings: Mapping[str, object] = None,
+        default: Optional[InjectType] = None,
+    ) -> Optional[InjectType]:
+        """
+        Get the provided instance of a given class identifier or default if not found.
+
+        Args:
+            base_cls: The base class to retrieve an instance of
+            settings: An optional dict providing configuration to the provider
+            default: default return value if no instance is found
+
+        Returns:
+            An instance of the base class, or None
+
+        """
+        return self._context.inject_or(base_cls, settings, default)
 
     def update_settings(self, settings: Mapping[str, object]):
         """Update the scope with additional settings."""

--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -186,7 +186,7 @@ async def schemas_send_schema(request: web.BaseRequest):
             )
         endorser_did = endorser_info["endorser_did"]
 
-    ledger = context.inject(BaseLedger, required=False)
+    ledger = context.inject_or(BaseLedger)
     if not ledger:
         reason = "No ledger available"
         if not context.settings.get_value("wallet.type"):
@@ -276,7 +276,7 @@ async def schemas_get_schema(request: web.BaseRequest):
 
     schema_id = request.match_info["schema_id"]
 
-    ledger = context.inject(BaseLedger, required=False)
+    ledger = context.inject_or(BaseLedger)
     if not ledger:
         reason = "No ledger available"
         if not context.settings.get_value("wallet.type"):

--- a/aries_cloudagent/protocols/actionmenu/v1_0/controller.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/controller.py
@@ -16,6 +16,6 @@ class Controller:
     async def determine_roles(self, context: InjectionContext) -> Sequence[str]:
         """Determine what action menu roles are defined."""
 
-        service = context.inject(BaseMenuService, required=False)
+        service = context.inject_or(BaseMenuService)
         if service:
             return ["provider"]

--- a/aries_cloudagent/protocols/actionmenu/v1_0/handlers/menu_request_handler.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/handlers/menu_request_handler.py
@@ -26,7 +26,7 @@ class MenuRequestHandler(BaseHandler):
 
         self._logger.info("Received action menu request")
 
-        service: BaseMenuService = context.inject(BaseMenuService, required=False)
+        service: BaseMenuService = context.inject_or(BaseMenuService)
         if service:
             menu = await service.get_active_menu(
                 context.profile,

--- a/aries_cloudagent/protocols/actionmenu/v1_0/handlers/perform_handler.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/handlers/perform_handler.py
@@ -26,7 +26,7 @@ class PerformHandler(BaseHandler):
 
         self._logger.info("Received action menu perform request")
 
-        service: BaseMenuService = context.inject(BaseMenuService, required=False)
+        service: BaseMenuService = context.inject_or(BaseMenuService)
         if service:
             reply = await service.perform_menu_action(
                 context.profile,

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -132,7 +132,7 @@ class ConnectionManager(BaseConnectionManager):
         image_url = self._session.context.settings.get("image_url")
 
         # Multitenancy setup
-        multitenant_mgr = self._session.inject(MultitenantManager, required=False)
+        multitenant_mgr = self._session.inject_or(MultitenantManager)
         wallet_id = self._session.settings.get("wallet.id")
 
         if not my_label:
@@ -246,7 +246,7 @@ class ConnectionManager(BaseConnectionManager):
             )
 
             if keylist_updates:
-                responder = self._session.inject(BaseResponder, required=False)
+                responder = self._session.inject_or(BaseResponder)
                 await responder.send(
                     keylist_updates, connection_id=mediation_record.connection_id
                 )
@@ -336,7 +336,7 @@ class ConnectionManager(BaseConnectionManager):
 
         if connection.accept == ConnRecord.ACCEPT_AUTO:
             request = await self.create_request(connection, mediation_id=mediation_id)
-            responder = self._session.inject(BaseResponder, required=False)
+            responder = self._session.inject_or(BaseResponder)
             if responder:
                 await responder.send(request, connection_id=connection.connection_id)
                 # refetch connection for accurate state
@@ -377,7 +377,7 @@ class ConnectionManager(BaseConnectionManager):
             or_default=True,
         )
 
-        multitenant_mgr = self._session.inject(MultitenantManager, required=False)
+        multitenant_mgr = self._session.inject_or(MultitenantManager)
         wallet_id = self._session.settings.get("wallet.id")
         base_mediation_record = None
 
@@ -437,7 +437,7 @@ class ConnectionManager(BaseConnectionManager):
         # Notify mediator of keylist changes
         if keylist_updates and mediation_record:
             # send a update keylist message with new recipient keys.
-            responder = self._session.inject(BaseResponder, required=False)
+            responder = self._session.inject_or(BaseResponder)
             await responder.send(
                 keylist_updates, connection_id=mediation_record.connection_id
             )
@@ -474,7 +474,7 @@ class ConnectionManager(BaseConnectionManager):
         my_info = None
 
         # Multitenancy setup
-        multitenant_mgr = self._session.inject(MultitenantManager, required=False)
+        multitenant_mgr = self._session.inject_or(MultitenantManager)
         wallet_id = self._session.settings.get("wallet.id")
         wallet = self._session.inject(BaseWallet)
 
@@ -602,14 +602,14 @@ class ConnectionManager(BaseConnectionManager):
         # Send keylist updates to mediator
         mediation_record = await mediation_record_if_id(self._session, mediation_id)
         if keylist_updates and mediation_record:
-            responder = self._session.inject(BaseResponder, required=False)
+            responder = self._session.inject_or(BaseResponder)
             await responder.send(
                 keylist_updates, connection_id=mediation_record.connection_id
             )
 
         if connection.accept == ConnRecord.ACCEPT_AUTO:
             response = await self.create_response(connection, mediation_id=mediation_id)
-            responder = self._session.inject(BaseResponder, required=False)
+            responder = self._session.inject_or(BaseResponder)
             if responder:
                 await responder.send_reply(
                     response, connection_id=connection.connection_id
@@ -651,7 +651,7 @@ class ConnectionManager(BaseConnectionManager):
         mediation_record = await mediation_record_if_id(self._session, mediation_id)
 
         # Multitenancy setup
-        multitenant_mgr = self._session.inject(MultitenantManager, required=False)
+        multitenant_mgr = self._session.inject_or(MultitenantManager)
         wallet_id = self._session.settings.get("wallet.id")
         base_mediation_record = None
 
@@ -722,7 +722,7 @@ class ConnectionManager(BaseConnectionManager):
 
         # Update mediator if necessary
         if keylist_updates and mediation_record:
-            responder = self._session.inject(BaseResponder, required=False)
+            responder = self._session.inject_or(BaseResponder)
             await responder.send(
                 keylist_updates, connection_id=mediation_record.connection_id
             )
@@ -881,7 +881,7 @@ class ConnectionManager(BaseConnectionManager):
         wallet = self._session.inject(BaseWallet)
 
         # Multitenancy setup
-        multitenant_mgr = self._session.inject(MultitenantManager, required=False)
+        multitenant_mgr = self._session.inject_or(MultitenantManager)
         wallet_id = self._session.settings.get("wallet.id")
         base_mediation_record = None
 
@@ -1008,7 +1008,7 @@ class ConnectionManager(BaseConnectionManager):
                 f"connection_by_verkey::{receipt.sender_verkey}"
                 f"::{receipt.recipient_verkey}"
             )
-            cache = self._session.inject(BaseCache, required=False)
+            cache = self._session.inject_or(BaseCache)
             if cache:
                 async with cache.acquire(cache_key) as entry:
                     if entry.result:
@@ -1092,7 +1092,7 @@ class ConnectionManager(BaseConnectionManager):
         """
         if not connection_id:
             connection_id = connection.connection_id
-        cache = self._session.inject(BaseCache, required=False)
+        cache = self._session.inject_or(BaseCache)
         cache_key = f"connection_target::{connection_id}"
         if cache:
             async with cache.acquire(cache_key) as entry:

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/handlers/mediation_grant_handler.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/handlers/mediation_grant_handler.py
@@ -33,7 +33,7 @@ class MediationGrantHandler(BaseHandler):
             await mgr.request_granted(record, context.message)
 
             # Multitenancy setup
-            multitenant_mgr = context.profile.inject(MultitenantManager, required=False)
+            multitenant_mgr = context.profile.inject_or(MultitenantManager)
             wallet_id = context.profile.settings.get("wallet.id")
 
             if multitenant_mgr and wallet_id:

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -142,7 +142,7 @@ class DIDXManager(BaseConnectionManager):
 
         if conn_rec.accept == ConnRecord.ACCEPT_AUTO:
             request = await self.create_request(conn_rec, mediation_id=mediation_id)
-            responder = self._session.inject(BaseResponder, required=False)
+            responder = self._session.inject_or(BaseResponder)
             if responder:
                 await responder.send_reply(
                     request,
@@ -208,7 +208,7 @@ class DIDXManager(BaseConnectionManager):
         conn_rec.request_id = request._id
         conn_rec.state = ConnRecord.State.REQUEST.rfc23
         await conn_rec.save(self._session, reason="Created connection request")
-        responder = self._session.inject(BaseResponder, required=False)
+        responder = self._session.inject_or(BaseResponder)
         if responder:
             await responder.send(request, connection_id=conn_rec.connection_id)
 
@@ -246,7 +246,7 @@ class DIDXManager(BaseConnectionManager):
         base_mediation_record = None
 
         # Multitenancy setup
-        multitenant_mgr = self._session.inject(MultitenantManager, required=False)
+        multitenant_mgr = self._session.inject_or(MultitenantManager)
         wallet_id = self._session.settings.get("wallet.id")
         if multitenant_mgr and wallet_id:
             base_mediation_record = await multitenant_mgr.get_default_mediator()
@@ -311,7 +311,7 @@ class DIDXManager(BaseConnectionManager):
 
         # Notify Mediator
         if keylist_updates and mediation_record:
-            responder = self._session.inject(BaseResponder, required=False)
+            responder = self._session.inject_or(BaseResponder)
             await responder.send(
                 keylist_updates, connection_id=mediation_record.connection_id
             )
@@ -357,7 +357,7 @@ class DIDXManager(BaseConnectionManager):
         wallet = self._session.inject(BaseWallet)
 
         # Multitenancy setup
-        multitenant_mgr = self._session.inject(MultitenantManager, required=False)
+        multitenant_mgr = self._session.inject_or(MultitenantManager)
         wallet_id = self._session.settings.get("wallet.id")
 
         # Determine what key will need to sign the response
@@ -514,7 +514,7 @@ class DIDXManager(BaseConnectionManager):
         # Send keylist updates to mediator
         mediation_record = await mediation_record_if_id(self._session, mediation_id)
         if keylist_updates and mediation_record:
-            responder = self._session.inject(BaseResponder, required=False)
+            responder = self._session.inject_or(BaseResponder)
             await responder.send(
                 keylist_updates, connection_id=mediation_record.connection_id
             )
@@ -525,7 +525,7 @@ class DIDXManager(BaseConnectionManager):
                 my_endpoint,
                 mediation_id=mediation_id,
             )
-            responder = self._session.inject(BaseResponder, required=False)
+            responder = self._session.inject_or(BaseResponder)
             if responder:
                 await responder.send_reply(
                     response, connection_id=conn_rec.connection_id
@@ -568,7 +568,7 @@ class DIDXManager(BaseConnectionManager):
         base_mediation_record = None
 
         # Multitenancy setup
-        multitenant_mgr = self._session.inject(MultitenantManager, required=False)
+        multitenant_mgr = self._session.inject_or(MultitenantManager)
         wallet_id = self._session.settings.get("wallet.id")
         if multitenant_mgr and wallet_id:
             base_mediation_record = await multitenant_mgr.get_default_mediator()
@@ -629,7 +629,7 @@ class DIDXManager(BaseConnectionManager):
 
         # Update Mediator if necessary
         if keylist_updates and mediation_record:
-            responder = self._session.inject(BaseResponder, required=False)
+            responder = self._session.inject_or(BaseResponder)
             await responder.send(
                 keylist_updates, connection_id=mediation_record.connection_id
             )
@@ -737,7 +737,7 @@ class DIDXManager(BaseConnectionManager):
         # create and send connection-complete message
         complete = DIDXComplete()
         complete.assign_thread_from(response)
-        responder = self._session.inject(BaseResponder, required=False)
+        responder = self._session.inject_or(BaseResponder)
         if responder:
             await responder.send_reply(complete, connection_id=conn_rec.connection_id)
 

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/routes.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/routes.py
@@ -1,6 +1,7 @@
 """Endorse Transaction handling admin routes."""
 
 import json
+from typing import Optional
 
 from aiohttp import web
 from aiohttp_apispec import (
@@ -292,7 +293,7 @@ async def endorse_transaction_response(request: web.BaseRequest):
     outbound_handler = request["outbound_message_router"]
     session = await context.session()
 
-    wallet: BaseWallet = session.inject(BaseWallet, required=False)
+    wallet: BaseWallet = session.inject_or(BaseWallet)
 
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")
@@ -337,7 +338,7 @@ async def endorse_transaction_response(request: web.BaseRequest):
     transaction_mgr = TransactionManager(session)
     transaction_json = transaction.messages_attach[0]["data"]["json"]
 
-    ledger = context.inject(BaseLedger, required=False)
+    ledger = context.inject_or(BaseLedger)
     if not ledger:
         reason = "No ledger available"
         if not context.settings.get_value("wallet.type"):
@@ -394,7 +395,7 @@ async def refuse_transaction_response(request: web.BaseRequest):
     outbound_handler = request["outbound_message_router"]
     session = await context.session()
 
-    wallet: BaseWallet = session.inject(BaseWallet, required=False)
+    wallet: Optional[BaseWallet] = session.inject_or(BaseWallet)
 
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")

--- a/aries_cloudagent/protocols/introduction/v0_1/handlers/invitation_handler.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/handlers/invitation_handler.py
@@ -1,5 +1,6 @@
 """Handler for incoming invitation messages."""
 
+from typing import Optional
 from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
@@ -22,8 +23,8 @@ class InvitationHandler(BaseHandler):
         if not context.connection_ready:
             raise HandlerException("No connection established for invitation message")
 
-        service: BaseIntroductionService = context.inject(
-            BaseIntroductionService, required=False
+        service: Optional[BaseIntroductionService] = context.inject_or(
+            BaseIntroductionService
         )
         if service:
             await service.return_invitation(

--- a/aries_cloudagent/protocols/introduction/v0_1/handlers/tests/test_invitation_handler.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/handlers/tests/test_invitation_handler.py
@@ -46,7 +46,7 @@ class TestInvitationHandler(AsyncTestCase):
 
         responder = MockResponder()
         with async_mock.patch.object(
-            self.context, "inject", async_mock.MagicMock()
+            self.context, "inject_or", async_mock.MagicMock()
         ) as mock_ctx_inject:
             mock_ctx_inject.return_value = async_mock.MagicMock(
                 return_invitation=async_mock.CoroutineMock()

--- a/aries_cloudagent/protocols/introduction/v0_1/routes.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/routes.py
@@ -1,6 +1,7 @@
 """Introduction service admin routes."""
 
 import logging
+from typing import Optional
 
 from aiohttp import web
 from aiohttp_apispec import docs, match_info_schema, querystring_schema, response_schema
@@ -64,8 +65,8 @@ async def introduction_start(request: web.BaseRequest):
     target_connection_id = request.query.get("target_connection_id")
     message = request.query.get("message")
 
-    service: BaseIntroductionService = context.inject(
-        BaseIntroductionService, required=False
+    service: Optional[BaseIntroductionService] = context.inject_or(
+        BaseIntroductionService
     )
     if not service:
         raise web.HTTPForbidden(reason="Introduction service not available")

--- a/aries_cloudagent/protocols/introduction/v0_1/tests/test_routes.py
+++ b/aries_cloudagent/protocols/introduction/v0_1/tests/test_routes.py
@@ -64,7 +64,7 @@ class TestIntroductionRoutes(AsyncTestCase):
         mock_conn_rec.serialize = async_mock.MagicMock()
 
         with async_mock.patch.object(
-            self.context, "inject", async_mock.MagicMock()
+            self.context, "inject_or", async_mock.MagicMock()
         ) as mock_ctx_inject, async_mock.patch.object(
             test_module.web, "json_response"
         ) as mock_response:
@@ -104,7 +104,7 @@ class TestIntroductionRoutes(AsyncTestCase):
         mock_conn_rec.serialize = async_mock.MagicMock()
 
         with async_mock.patch.object(
-            self.context, "inject", async_mock.MagicMock()
+            self.context, "inject_or", async_mock.MagicMock()
         ) as mock_ctx_inject:
             mock_ctx_inject.return_value = async_mock.MagicMock(
                 start_introduction=async_mock.CoroutineMock(

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -273,7 +273,7 @@ class CredentialManager:
 
         credential_offer = None
         cache_key = f"credential_offer::{cred_def_id}"
-        cache = self._profile.inject(BaseCache, required=False)
+        cache = self._profile.inject_or(BaseCache)
         if cache:
             async with cache.acquire(cache_key) as entry:
                 if entry.result:
@@ -419,7 +419,7 @@ class CredentialManager:
                 f"credential_request::{credential_definition_id}::{holder_did}::{nonce}"
             )
             cred_req_result = None
-            cache = self._profile.inject(BaseCache, required=False)
+            cache = self._profile.inject_or(BaseCache)
             if cache:
                 async with cache.acquire(cache_key) as entry:
                     if entry.result:
@@ -826,7 +826,7 @@ class CredentialManager:
         except StorageError as err:
             LOGGER.exception(err)  # holder still owes an ack: carry on
 
-        responder = self._profile.inject(BaseResponder, required=False)
+        responder = self._profile.inject_or(BaseResponder)
         if responder:
             await responder.send_reply(
                 credential_ack_message,

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
@@ -185,7 +185,7 @@ class IndyCredFormatHandler(V20CredFormatHandler):
 
         issuer = self.profile.inject(IndyIssuer)
         ledger = self.profile.inject(BaseLedger)
-        cache = self.profile.inject(BaseCache, required=False)
+        cache = self.profile.inject_or(BaseCache)
 
         cred_proposal_message = cred_ex_record.cred_proposal
 
@@ -267,7 +267,7 @@ class IndyCredFormatHandler(V20CredFormatHandler):
 
         cache_key = f"credential_request::{cred_def_id}::{holder_did}::{nonce}"
         cred_req_result = None
-        cache = self.profile.inject(BaseCache, required=False)
+        cache = self.profile.inject_or(BaseCache)
         if cache:
             async with cache.acquire(cache_key) as entry:
                 if entry.result:

--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -649,7 +649,7 @@ class V20CredManager:
         except StorageError as err:
             LOGGER.exception(err)  # holder still owes an ack: carry on
 
-        responder = self._profile.inject(BaseResponder, required=False)
+        responder = self._profile.inject_or(BaseResponder)
         if responder:
             await responder.send_reply(
                 cred_ack_message,

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -139,7 +139,7 @@ class OutOfBandManager(BaseConnectionManager):
         wallet = self._session.inject(BaseWallet)
 
         # Multitenancy setup
-        multitenant_mgr = self._session.inject(MultitenantManager, required=False)
+        multitenant_mgr = self._session.inject_or(MultitenantManager)
         wallet_id = self._session.settings.get("wallet.id")
 
         accept = bool(
@@ -315,7 +315,7 @@ class OutOfBandManager(BaseConnectionManager):
                 )
 
                 if keylist_updates:
-                    responder = self._session.inject(BaseResponder, required=False)
+                    responder = self._session.inject_or(BaseResponder)
                     await responder.send(
                         keylist_updates, connection_id=mediation_record.connection_id
                     )
@@ -707,7 +707,7 @@ class OutOfBandManager(BaseConnectionManager):
                     )
                 ),
             )
-            responder = self._session.inject(BaseResponder, required=False)
+            responder = self._session.inject_or(BaseResponder)
             if responder:
                 await responder.send(
                     message=presentation_message,
@@ -768,7 +768,7 @@ class OutOfBandManager(BaseConnectionManager):
                     f", pres_ex_record: {pres_ex_record.pres_ex_id}"
                 ),
             )
-            responder = self._session.inject(BaseResponder, required=False)
+            responder = self._session.inject_or(BaseResponder)
             if responder:
                 await responder.send(
                     message=pres_msg,
@@ -812,7 +812,7 @@ class OutOfBandManager(BaseConnectionManager):
                     cred_ex_record=cred_ex_record,
                     holder_did=conn_rec.my_did,
                 )
-                responder = self._session.inject(BaseResponder, required=False)
+                responder = self._session.inject_or(BaseResponder)
                 if responder:
                     await responder.send(
                         message=cred_request_message,
@@ -856,7 +856,7 @@ class OutOfBandManager(BaseConnectionManager):
                     cred_ex_record=cred_ex_record,
                     holder_did=conn_rec.my_did,
                 )
-                responder = self._session.inject(BaseResponder, required=False)
+                responder = self._session.inject_or(BaseResponder)
                 if responder:
                     await responder.send(
                         message=cred_request_message,
@@ -971,7 +971,7 @@ class OutOfBandManager(BaseConnectionManager):
             connection_targets = await self.fetch_connection_targets(
                 connection=conn_record
             )
-            responder = self._session.inject(BaseResponder, required=False)
+            responder = self._session.inject_or(BaseResponder)
             if responder:
                 await responder.send(
                     message=reuse_msg,
@@ -1021,7 +1021,7 @@ class OutOfBandManager(BaseConnectionManager):
             conn_record = await self.find_existing_connection(
                 tag_filter=tag_filter, post_filter=post_filter
             )
-            responder = self._session.inject(BaseResponder, required=False)
+            responder = self._session.inject_or(BaseResponder)
             if conn_record is not None:
                 # For ConnRecords created using did-exchange
                 reuse_accept_msg = HandshakeReuseAccept()

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
@@ -76,7 +76,7 @@ def profile():
 @pytest.fixture(scope="class")
 async def setup_tuple(profile):
     async with profile.session() as session:
-        wallet = session.inject(BaseWallet, required=False)
+        wallet = session.inject_or(BaseWallet)
         await wallet.create_local_did(
             method=DIDMethod.SOV, key_type=KeyType.ED25519, did="WgWxqztrNooG92RXvxSTWv"
         )

--- a/aries_cloudagent/protocols/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/manager.py
@@ -426,7 +426,7 @@ class PresentationManager:
             presentation_exchange_record: presentation exchange record with thread id
 
         """
-        responder = self._profile.inject(BaseResponder, required=False)
+        responder = self._profile.inject_or(BaseResponder)
 
         if responder:
             presentation_ack_message = PresentationAck()

--- a/aries_cloudagent/protocols/present_proof/v2_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/manager.py
@@ -376,7 +376,7 @@ class V20PresManager:
             pres_ex_record: presentation exchange record with thread id
 
         """
-        responder = self._profile.inject(BaseResponder, required=False)
+        responder = self._profile.inject_or(BaseResponder)
 
         if responder:
             pres_ack_message = V20PresAck()

--- a/aries_cloudagent/resolver/__init__.py
+++ b/aries_cloudagent/resolver/__init__.py
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 
 async def setup(context: InjectionContext):
     """Set up default resolvers."""
-    registry = context.inject(DIDResolverRegistry, required=False)
+    registry = context.inject_or(DIDResolverRegistry)
     if not registry:
         LOGGER.warning("No DID Resolver Registry instance found in context")
         return

--- a/aries_cloudagent/resolver/default/indy.py
+++ b/aries_cloudagent/resolver/default/indy.py
@@ -41,7 +41,7 @@ class IndyDIDResolver(BaseDIDResolver):
 
     async def _resolve(self, profile: Profile, did: str) -> dict:
         """Resolve an indy DID."""
-        ledger = profile.inject(BaseLedger, required=False)
+        ledger = profile.inject_or(BaseLedger)
         if not ledger:
             raise NoIndyLedger("No Indy ledger instance is configured.")
 

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -709,7 +709,7 @@ async def upload_tails_file(request: web.BaseRequest):
 
     rev_reg_id = request.match_info["rev_reg_id"]
 
-    tails_server = context.inject(BaseTailsServer, required=False)
+    tails_server = context.inject_or(BaseTailsServer)
     if not tails_server:
         raise web.HTTPForbidden(reason="No tails server configured")
 

--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -173,7 +173,7 @@ class OutboundTransportManager:
     async def start_transport(self, transport_id: str):
         """Start a registered transport."""
         transport = self.registered_transports[transport_id]()
-        transport.collector = self.context.inject(Collector, required=False)
+        transport.collector = self.context.inject_or(Collector)
         await transport.start()
         self.running_transports[transport_id] = transport
 

--- a/aries_cloudagent/transport/pack_format.py
+++ b/aries_cloudagent/transport/pack_format.py
@@ -108,7 +108,7 @@ class PackWireFormat(BaseWireFormat):
         receipt: MessageReceipt,
     ):
         """Look up the wallet instance and perform the message unpack."""
-        wallet = session.inject(BaseWallet, required=False)
+        wallet = session.inject_or(BaseWallet)
         if not wallet:
             raise WireFormatParseError("Wallet not defined in profile session")
 
@@ -170,7 +170,7 @@ class PackWireFormat(BaseWireFormat):
         if not sender_key or not recipient_keys:
             raise WireFormatEncodeError("Cannot pack message without associated keys")
 
-        wallet = session.inject(BaseWallet, required=False)
+        wallet = session.inject_or(BaseWallet)
         if not wallet:
             raise WireFormatEncodeError("No wallet instance")
 

--- a/aries_cloudagent/vc/ld_proofs/document_loader.py
+++ b/aries_cloudagent/vc/ld_proofs/document_loader.py
@@ -28,7 +28,7 @@ class DocumentLoader:
         """
         self.profile = profile
         self.resolver = profile.inject(DIDResolver)
-        self.cache = profile.inject(BaseCache, required=False)
+        self.cache = profile.inject_or(BaseCache)
         self.requests_loader = requests.requests_document_loader()
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         self.cache_ttl = cache_ttl

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -198,7 +198,7 @@ async def wallet_did_list(request: web.BaseRequest):
     """
     context: AdminRequestContext = request["context"]
     session = await context.session()
-    wallet = session.inject(BaseWallet, required=False)
+    wallet = session.inject_or(BaseWallet)
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")
     filter_did = request.query.get("did")
@@ -323,7 +323,7 @@ async def wallet_create_did(request: web.BaseRequest):
         )
 
     session = await context.session()
-    wallet = session.inject(BaseWallet, required=False)
+    wallet = session.inject_or(BaseWallet)
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")
     try:
@@ -350,7 +350,7 @@ async def wallet_get_public_did(request: web.BaseRequest):
     """
     context: AdminRequestContext = request["context"]
     session = await context.session()
-    wallet = session.inject(BaseWallet, required=False)
+    wallet = session.inject_or(BaseWallet)
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")
     try:
@@ -377,7 +377,7 @@ async def wallet_set_public_did(request: web.BaseRequest):
     """
     context: AdminRequestContext = request["context"]
     session = await context.session()
-    wallet = session.inject(BaseWallet, required=False)
+    wallet = session.inject_or(BaseWallet)
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")
     did = request.query.get("did")
@@ -385,11 +385,11 @@ async def wallet_set_public_did(request: web.BaseRequest):
         raise web.HTTPBadRequest(reason="Request query must include DID")
 
     # Multitenancy setup
-    multitenant_mgr = session.inject(MultitenantManager, required=False)
+    multitenant_mgr = session.inject_or(MultitenantManager)
     wallet_id = session.settings.get("wallet.id")
 
     try:
-        ledger = session.inject(BaseLedger, required=False)
+        ledger = session.inject_or(BaseLedger)
         if not ledger:
             reason = "No ledger available"
             if not session.settings.get_value("wallet.type"):
@@ -441,7 +441,7 @@ async def wallet_set_did_endpoint(request: web.BaseRequest):
     """
     context: AdminRequestContext = request["context"]
     session = await context.session()
-    wallet = session.inject(BaseWallet, required=False)
+    wallet = session.inject_or(BaseWallet)
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")
 
@@ -453,7 +453,7 @@ async def wallet_set_did_endpoint(request: web.BaseRequest):
     )
 
     try:
-        ledger = session.inject(BaseLedger, required=False)
+        ledger = session.inject_or(BaseLedger)
         await wallet.set_did_endpoint(did, endpoint, ledger, endpoint_type)
     except WalletNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
@@ -481,7 +481,7 @@ async def wallet_get_did_endpoint(request: web.BaseRequest):
     """
     context: AdminRequestContext = request["context"]
     session = await context.session()
-    wallet = session.inject(BaseWallet, required=False)
+    wallet = session.inject_or(BaseWallet)
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")
     did = request.query.get("did")
@@ -514,7 +514,7 @@ async def wallet_rotate_did_keypair(request: web.BaseRequest):
     """
     context: AdminRequestContext = request["context"]
     session = await context.session()
-    wallet = session.inject(BaseWallet, required=False)
+    wallet = session.inject_or(BaseWallet)
     if not wallet:
         raise web.HTTPForbidden(reason="No wallet available")
     did = request.query.get("did")


### PR DESCRIPTION
This PR removes the `required` parameter from `Injector.inject` and introduces `inject_or` that mimics the behavior of `inject(..., required=False)`. The reasoning for this change is that type checkers take issue with using the result of `inject(..., required=True)` when the signature says that it could still be `None`. For example:

```python
storage = context.inject(BaseStorage)
records = await storage.find_all_records(...)
```
Yields the error `"find_all_records" is not a known member of "None"` when using pyright, even though we know that the call will have resulted in an error if it was actually `None`.

This PR is mostly a proposal and does not yet fix the 109 or so instances of `inject(..., required=False)` that should be switched to `inject_or`. Open to suggestions or alternatives.