### PR TITLE
fix: don't require push on outbound queue implementations

### DIFF
--- a/aries_cloudagent/transport/outbound/queue/base.py
+++ b/aries_cloudagent/transport/outbound/queue/base.py
@@ -38,10 +38,6 @@ class BaseOutboundQueue(ABC):
         """Stop the queue."""
 
     @abstractmethod
-    async def push(self, key: bytes, message: bytes):
-        """Push a ``message`` to queue on ``key``."""
-
-    @abstractmethod
     async def enqueue_message(
         self,
         payload: Union[str, bytes],


### PR DESCRIPTION
Requiring this method in concrete outbound classes should not be required -- this exact method signature is relevant only to redis. This probably should have been dropped with the outbound queue refactor but was missed.