### PR TITLE
unprotect liveness and readiness endpoints

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -273,6 +273,8 @@ class AdminServer(BaseAdminServer):
                     "/api/docs/swagger.json",
                     "/favicon.ico",
                     "/ws",  # ws handler checks authentication
+                    "/status/live",
+                    "/status/ready",
                 ]
                 or path.startswith("/static/swagger/")
             )


### PR DESCRIPTION
Currently liveness and readiness endpoints are protected by api key, it's difficult to provide agent status to external probs without revealing the key in clear text. Suggest to make the two endpoints unprotected.