### PR TITLE
Add support for custom offers from the proposal

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
@@ -81,7 +81,7 @@ class V20CredFormatHandler(ABC):
 
     @abstractmethod
     async def create_offer(
-        self, cred_ex_record: V20CredExRecord, offer_data: V20CredProposal = None
+        self, cred_proposal_message: V20CredProposal
     ) -> CredFormatAttachment:
         """Create format specific credential offer attachment data."""
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
@@ -81,7 +81,7 @@ class V20CredFormatHandler(ABC):
 
     @abstractmethod
     async def create_offer(
-        self, cred_ex_record: V20CredExRecord, offer_data: Mapping = None
+        self, cred_ex_record: V20CredExRecord, offer_data: V20CredProposal = None
     ) -> CredFormatAttachment:
         """Create format specific credential offer attachment data."""
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
@@ -179,7 +179,7 @@ class IndyCredFormatHandler(V20CredFormatHandler):
         """
 
     async def create_offer(
-        self, cred_ex_record: V20CredExRecord, offer_data: Mapping = None
+        self, cred_ex_record: V20CredExRecord, offer_data: V20CredProposal = None
     ) -> CredFormatAttachment:
         """Create indy credential offer."""
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
@@ -179,15 +179,13 @@ class IndyCredFormatHandler(V20CredFormatHandler):
         """
 
     async def create_offer(
-        self, cred_ex_record: V20CredExRecord, offer_data: V20CredProposal = None
+        self, cred_proposal_message: V20CredProposal
     ) -> CredFormatAttachment:
         """Create indy credential offer."""
 
         issuer = self.profile.inject(IndyIssuer)
         ledger = self.profile.inject(BaseLedger)
         cache = self.profile.inject_or(BaseCache)
-
-        cred_proposal_message = cred_ex_record.cred_proposal
 
         cred_def_id = await self._match_sent_cred_def_id(
             cred_proposal_message.attachment(IndyCredFormatHandler.format)

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/tests/test_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/tests/test_handler.py
@@ -364,12 +364,6 @@ class TestV20IndyCredFormatHandler(AsyncTestCase):
             ],
         )
 
-        cred_ex_record = V20CredExRecord(
-            cred_ex_id="dummy-cxid",
-            role=V20CredExRecord.ROLE_ISSUER,
-            cred_proposal=cred_proposal.serialize(),
-        )
-
         cred_def_record = StorageRecord(
             CRED_DEF_SENT_RECORD_TYPE,
             CRED_DEF_ID,
@@ -389,7 +383,7 @@ class TestV20IndyCredFormatHandler(AsyncTestCase):
             return_value=json.dumps(INDY_OFFER)
         )
 
-        (cred_format, attachment) = await self.handler.create_offer(cred_ex_record)
+        (cred_format, attachment) = await self.handler.create_offer(cred_proposal)
 
         self.issuer.create_credential_offer.assert_called_once_with(CRED_DEF_ID)
 
@@ -403,7 +397,7 @@ class TestV20IndyCredFormatHandler(AsyncTestCase):
         assert attachment.data.base64
 
         self.issuer.create_credential_offer.reset_mock()
-        (cred_format, attachment) = await self.handler.create_offer(cred_ex_record)
+        (cred_format, attachment) = await self.handler.create_offer(cred_proposal)
         self.issuer.create_credential_offer.assert_not_called()
 
     async def test_create_offer_no_cache(self):
@@ -432,12 +426,6 @@ class TestV20IndyCredFormatHandler(AsyncTestCase):
             ],
         )
 
-        cred_ex_record = V20CredExRecord(
-            cred_ex_id="dummy-cxid",
-            role=V20CredExRecord.ROLE_ISSUER,
-            cred_proposal=cred_proposal.serialize(),
-        )
-
         cred_def_record = StorageRecord(
             CRED_DEF_SENT_RECORD_TYPE,
             CRED_DEF_ID,
@@ -461,7 +449,7 @@ class TestV20IndyCredFormatHandler(AsyncTestCase):
             return_value=json.dumps(INDY_OFFER)
         )
 
-        (cred_format, attachment) = await self.handler.create_offer(cred_ex_record)
+        (cred_format, attachment) = await self.handler.create_offer(cred_proposal)
 
         self.issuer.create_credential_offer.assert_called_once_with(CRED_DEF_ID)
 
@@ -500,12 +488,6 @@ class TestV20IndyCredFormatHandler(AsyncTestCase):
             ],
         )
 
-        cred_ex_record = V20CredExRecord(
-            cred_ex_id="dummy-cxid",
-            role=V20CredExRecord.ROLE_ISSUER,
-            cred_proposal=cred_proposal.serialize(),
-        )
-
         cred_def_record = StorageRecord(
             CRED_DEF_SENT_RECORD_TYPE,
             CRED_DEF_ID,
@@ -526,7 +508,7 @@ class TestV20IndyCredFormatHandler(AsyncTestCase):
         )
 
         with self.assertRaises(V20CredFormatError):
-            await self.handler.create_offer(cred_ex_record)
+            await self.handler.create_offer(cred_proposal)
 
     async def test_create_offer_no_matching_sent_cred_def(self):
         cred_proposal = V20CredProposal(
@@ -541,18 +523,12 @@ class TestV20IndyCredFormatHandler(AsyncTestCase):
             filters_attach=[AttachDecorator.data_base64({}, ident="0")],
         )
 
-        cred_ex_record = V20CredExRecord(
-            cred_ex_id="dummy-cxid",
-            role=V20CredExRecord.ROLE_ISSUER,
-            cred_proposal=cred_proposal.serialize(),
-        )
-
         self.issuer.create_credential_offer = async_mock.CoroutineMock(
             return_value=json.dumps(INDY_OFFER)
         )
 
         with self.assertRaises(V20CredFormatError) as context:
-            await self.handler.create_offer(cred_ex_record)
+            await self.handler.create_offer(cred_proposal)
         assert "Issuer has no operable cred def" in str(context.exception)
 
     async def test_receive_offer(self):

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
@@ -384,7 +384,7 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
         """Receive linked data proof credential proposal."""
 
     async def create_offer(
-        self, cred_ex_record: V20CredExRecord, offer_data: Mapping = None
+        self, cred_ex_record: V20CredExRecord, offer_data: V20CredProposal = None
     ) -> CredFormatAttachment:
         """Create linked data proof credential offer."""
         if not cred_ex_record.cred_proposal:
@@ -392,11 +392,12 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
                 "Cannot create linked data proof offer without proposal data"
             )
 
-        # Parse proposal. Data is stored in proposal if we received a proposal
+        # Parse offer data which is either a proposal or an offer.
+        # Data is stored in proposal if we received a proposal
         # but also when we create an offer (manager does some weird stuff)
-        offer_data = cred_ex_record.cred_proposal.attachment(
-            LDProofCredFormatHandler.format
-        )
+        credential_offer = offer_data if offer_data else cred_ex_record.cred_proposal
+
+        offer_data = credential_offer.attachment(LDProofCredFormatHandler.format)
         detail = LDProofVCDetail.deserialize(offer_data)
         detail = await self._prepare_detail(detail)
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
@@ -384,10 +384,10 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
         """Receive linked data proof credential proposal."""
 
     async def create_offer(
-        self, cred_ex_record: V20CredExRecord, offer_data: V20CredProposal = None
+        self, cred_proposal_message: V20CredProposal
     ) -> CredFormatAttachment:
         """Create linked data proof credential offer."""
-        if not cred_ex_record.cred_proposal:
+        if not cred_proposal_message:
             raise V20CredFormatError(
                 "Cannot create linked data proof offer without proposal data"
             )
@@ -395,9 +395,7 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
         # Parse offer data which is either a proposal or an offer.
         # Data is stored in proposal if we received a proposal
         # but also when we create an offer (manager does some weird stuff)
-        credential_offer = offer_data if offer_data else cred_ex_record.cred_proposal
-
-        offer_data = credential_offer.attachment(LDProofCredFormatHandler.format)
+        offer_data = cred_proposal_message.attachment(LDProofCredFormatHandler.format)
         detail = LDProofVCDetail.deserialize(offer_data)
         detail = await self._prepare_detail(detail)
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
@@ -402,18 +402,14 @@ class TestV20LDProofCredFormatHandler(AsyncTestCase):
         await self.handler.receive_proposal(cred_ex_record, cred_proposal_message)
 
     async def test_create_offer(self):
-        cred_ex_record = V20CredExRecord(
-            cred_ex_id="dummy-cxid",
-            role=V20CredExRecord.ROLE_ISSUER,
-            cred_proposal=self.cred_proposal,
-        )
-
         with async_mock.patch.object(
             LDProofCredFormatHandler,
             "_assert_can_issue_with_id_and_proof_type",
             async_mock.CoroutineMock(),
         ) as mock_can_issue:
-            (cred_format, attachment) = await self.handler.create_offer(cred_ex_record)
+            (cred_format, attachment) = await self.handler.create_offer(
+                self.cred_proposal
+            )
 
             mock_can_issue.assert_called_once_with(
                 LD_PROOF_VC_DETAIL["credential"]["issuer"],
@@ -444,23 +440,19 @@ class TestV20LDProofCredFormatHandler(AsyncTestCase):
             ],
         )
 
-        cred_ex_record = V20CredExRecord(cred_proposal=cred_proposal)
-
         with async_mock.patch.object(
             LDProofCredFormatHandler,
             "_assert_can_issue_with_id_and_proof_type",
             async_mock.CoroutineMock(),
         ):
-            (cred_format, attachment) = await self.handler.create_offer(cred_ex_record)
+            (cred_format, attachment) = await self.handler.create_offer(cred_proposal)
 
         # assert BBS url added to context
         assert SECURITY_CONTEXT_BBS_URL in attachment.content["credential"]["@context"]
 
     async def test_create_offer_x_no_proposal(self):
-        cred_ex_record = async_mock.MagicMock(cred_proposal=None)
-
         with self.assertRaises(V20CredFormatError) as context:
-            await self.handler.create_offer(cred_ex_record)
+            await self.handler.create_offer(None)
         assert "Cannot create linked data proof offer without proposal data" in str(
             context.exception
         )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -227,7 +227,7 @@ class V20CredManager:
             if cred_format:
                 formats.append(
                     await cred_format.handler(self.profile).create_offer(
-                        cred_ex_record, cred_proposal_message
+                        cred_proposal_message
                     )
                 )
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -226,7 +226,9 @@ class V20CredManager:
 
             if cred_format:
                 formats.append(
-                    await cred_format.handler(self.profile).create_offer(cred_ex_record)
+                    await cred_format.handler(self.profile).create_offer(
+                        cred_ex_record, cred_proposal_message
+                    )
                 )
 
         if len(formats) == 0:

--- a/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
@@ -289,12 +289,13 @@ class V20CredBoundOfferRequestSchema(OpenAPISchema):
     @validates_schema
     def validate_fields(self, data, **kwargs):
         """Validate schema fields: need both filter and counter_preview or neither."""
-        if ("filter_" in data and "indy" in data["filter_"]) ^ (
-            "counter_preview" in data
-        ):
+        if (
+            "filter_" in data
+            and ("indy" in data["filter_"] or "ld_proof" in data["filter_"])
+        ) ^ ("counter_preview" in data):
             raise ValidationError(
                 f"V20CredBoundOfferRequestSchema\n{data}\nrequires "
-                "both indy filter and counter_preview or neither"
+                "both indy/ld_proof filter and counter_preview or neither"
             )
 
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_manager.py
@@ -358,7 +358,9 @@ class TestV20CredManager(AsyncTestCase):
             assert ret_cx_rec == cx_rec
             mock_save.assert_called_once()
 
-            mock_handler.return_value.create_offer.assert_called_once_with(cx_rec, cx_rec.cred_proposal)
+            mock_handler.return_value.create_offer.assert_called_once_with(
+                cx_rec.cred_proposal
+            )
 
             assert cx_rec.cred_ex_id == ret_cx_rec._id  # cover property
             assert cx_rec.thread_id == ret_offer._thread_id
@@ -431,7 +433,7 @@ class TestV20CredManager(AsyncTestCase):
             mock_save.assert_called_once()
 
             mock_handler.return_value.create_offer.assert_called_once_with(
-                cx_rec, cred_proposal
+                cred_proposal
             )
 
             assert cx_rec.thread_id == ret_offer._thread_id

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_manager.py
@@ -358,7 +358,7 @@ class TestV20CredManager(AsyncTestCase):
             assert ret_cx_rec == cx_rec
             mock_save.assert_called_once()
 
-            mock_handler.return_value.create_offer.assert_called_once_with(cx_rec)
+            mock_handler.return_value.create_offer.assert_called_once_with(cx_rec, cx_rec.cred_proposal)
 
             assert cx_rec.cred_ex_id == ret_cx_rec._id  # cover property
             assert cx_rec.thread_id == ret_offer._thread_id
@@ -430,7 +430,9 @@ class TestV20CredManager(AsyncTestCase):
             assert ret_cx_rec == cx_rec
             mock_save.assert_called_once()
 
-            mock_handler.return_value.create_offer.assert_called_once_with(cx_rec)
+            mock_handler.return_value.create_offer.assert_called_once_with(
+                cx_rec, cred_proposal
+            )
 
             assert cx_rec.thread_id == ret_offer._thread_id
             assert cx_rec.role == V20CredExRecord.ROLE_ISSUER

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
@@ -76,8 +76,12 @@ class TestV20CredRoutes(AsyncTestCase):
         schema.validate_fields(
             {"filter_": {"indy": {"issuer_did": TEST_DID}}, "counter_preview": {}}
         )
+        schema.validate_fields(
+            {"filter_": {"ld_proof": {"issuer_did": TEST_DID}}, "counter_preview": {}}
+        )
         with self.assertRaises(test_module.ValidationError):
             schema.validate_fields({"filter_": {"indy": {"issuer_did": TEST_DID}}})
+            schema.validate_fields({"filter_": {"ld_proof": {"issuer_did": TEST_DID}}})
             schema.validate_fields({"counter_preview": {}})
 
     async def test_credential_exchange_list(self):


### PR DESCRIPTION
## What is this PR for?

Currently, the issuer only has the ability to offer a credential that is the same as the one defined in a credential proposal. 
This PR enables the holder and issuer to negotiate about the credential via proposals and offers in order to agree on what credential the holder will receive.

### Backwards compatibility:

If the counter-offer is not defined/empty logic stays the same as It was before this change.