### PR TITLE
Profile for base outbound transport class

### DIFF
--- a/aries_cloudagent/transport/outbound/base.py
+++ b/aries_cloudagent/transport/outbound/base.py
@@ -7,6 +7,7 @@ from typing import Union
 from ...core.profile import Profile
 from ...utils.stats import Collector
 
+from ...core.profile import Profile
 from ..error import TransportError
 from ..wire_format import BaseWireFormat
 
@@ -14,10 +15,13 @@ from ..wire_format import BaseWireFormat
 class BaseOutboundTransport(ABC):
     """Base outbound transport class."""
 
-    def __init__(self, wire_format: BaseWireFormat = None) -> None:
+    def __init__(
+        self, wire_format: BaseWireFormat = None, root_profile: Profile = None
+    ) -> None:
         """Initialize a `BaseOutboundTransport` instance."""
         self._collector = None
         self._wire_format = wire_format
+        self.root_profile: Profile = root_profile
 
     @property
     def collector(self) -> Collector:

--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -172,7 +172,7 @@ class OutboundTransportManager:
 
     async def start_transport(self, transport_id: str):
         """Start a registered transport."""
-        transport = self.registered_transports[transport_id]()
+        transport = self.registered_transports[transport_id](root_profile=self.profile)
         transport.collector = self.context.inject_or(Collector)
         await transport.start()
         self.running_transports[transport_id] = transport


### PR DESCRIPTION
When developing plugins for different transports it becomes difficult to do things without having access to the context profile provides. This pr adds root_profile to the base class of outbound transport which is passed in from the outbound transport manager. 

changes:
 - aries_cloudagent/transport/outbound/base.py
     - added class attribute to store profile called root_profile with supporting code
 - aries_cloudagent/transport/outbound/manager.py
     - updated the class creation to take the manager profile
     
Signed-off-by: Adam Burdett <burdettadam@gmail.com>