### PR TITLE
fix: use named tuple instead of dataclass in mediation invite store

### DIFF
--- a/aries_cloudagent/protocols/coordinate_mediation/mediation_invite_store.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/mediation_invite_store.py
@@ -5,17 +5,15 @@ Handle storage and retrieval of mediation invites provided through arguments.
 Enables having the mediation invite config be the same
 for `provision` and `starting` commands.
 """
-import dataclasses
 import json
-from typing import Optional
+from typing import NamedTuple, Optional
 
 from aries_cloudagent.storage.base import BaseStorage
 from aries_cloudagent.storage.error import StorageNotFoundError
 from aries_cloudagent.storage.record import StorageRecord
 
 
-@dataclasses.dataclass
-class MediationInviteRecord:
+class MediationInviteRecord(NamedTuple):
     """A record to store mediation invites and their freshness."""
 
     invite: str


### PR DESCRIPTION
Dataclass wasn't added until python 3.7 and we're on 3.6. Not sure how this wasn't failing tests :thinking: we must have a backport package installed in the base image or similar but at any rate, I'm hopeful this will resolve issues @swcurran raised in #1473 for this module's doc generation.