### PR TITLE
fix: create static doc use empty endpoint if None

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -958,7 +958,7 @@ class ConnectionManager(BaseConnectionManager):
         did_doc = await self.create_did_document(
             their_info,
             None,
-            [their_endpoint],
+            [their_endpoint or ""],
             mediation_records=[base_mediation_record]
             if base_mediation_record
             else None,


### PR DESCRIPTION
This enables us to use the undelivered queue with static connections by not specifying the endpoint.