### PR TITLE
fix: using a default mediator

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -247,7 +247,7 @@ class ConnectionManager(BaseConnectionManager):
             # Save that this invitation was created with mediation
             async with self.profile.session() as session:
                 await connection.metadata_set(
-                    session, "mediation", {"id": mediation_id}
+                    session, "mediation", {"id": mediation_record.mediation_id}
                 )
 
             if keylist_updates:

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -323,7 +323,7 @@ class OutOfBandManager(BaseConnectionManager):
 
                 async with self.profile.session() as session:
                     await conn_rec.metadata_set(
-                        session, "mediation", {"id": mediation_id}
+                        session, "mediation", {"id": mediation_record.mediation_id}
                     )
 
                 if keylist_updates:


### PR DESCRIPTION
This fixes an error in the use of a default mediator in the connections and out of band protocols. The mediation ID was being saved as None instead of the retrieved default mediator value.