### PR TITLE
Fix TypeError

### DIFF
--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -368,7 +368,7 @@ async def schemas_fix_schema_wallet_record(request: web.BaseRequest):
 
     schema_id = request.match_info["schema_id"]
 
-    ledger = context.inject(BaseLedger, required=False)
+    ledger = context.inject_or(BaseLedger)
     if not ledger:
         reason = "No ledger available"
         if not context.settings.get_value("wallet.type"):


### PR DESCRIPTION
When calling /schemas/{schema_id}/write_record, a server error 500 occurrs. The log output says

    TypeError: inject() got an unexpected keyword argument 'required'

Other code in this file seems to indicate that the proposed change is what is needed to prevent the error from being thrown.