### PR TITLE
Add RTD configs to get generator working

### DIFF
--- a/docs/readthedocs.yaml
+++ b/docs/readthedocs.yaml
@@ -1,0 +1,17 @@
+# Configuration for RTDs generation
+
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.7"
+
+# Build from the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Explicitly set the version of Python and its requirements
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+# Defining the exact versions for ReadTheDocs that will make sure things don't break
+sphinx==4.2.0
+sphinx_rtd_theme==1.0.0
+readthedocs-sphinx-search==0.1.1


### PR DESCRIPTION
Needed (I think) to get ReadTheDocs generation working again.  Currently not working because of a way that RTD works. Generation is no longer working because of a change in a default dependency, per [this bug report](https://gitanswer.com/build-failed-typeerror-generator-object-is-not-subscriptable-python-readthedocs-org-1036337375) and [guidance](https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#using-a-configuration-file).