### PR TITLE
Fix error when connection request is received (askar, public invitation)

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -589,7 +589,9 @@ class ConnectionManager(BaseConnectionManager):
         elif not self.profile.settings.get("public_invites"):
             raise ConnectionManagerError("Public invitations are not enabled")
         else:  # request from public did
-            my_info = await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519)
+            async with self.profile.session() as session:
+                wallet = session.inject(BaseWallet)
+                my_info = await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519)
             # send update-keylist message with new recipient keys
             keylist_updates = await mediation_mgr.add_key(
                 my_info.verkey, keylist_updates


### PR DESCRIPTION
This PR fixes error when connection request is received with public invitation under askar

### Environment
- connections/1.0 protocol
- public invitation
- askar

### Problem
Faber (invitation creator) encountered error below, when connection request was received.
```
2021-11-22 17:39:38,849 aries_cloudagent.core.dispatcher ERROR Handler error: Dispatcher.handle_message
Traceback (most recent call last):
  File "/Users/baegjae/src/aries-cloudagent-python/aries_cloudagent/core/dispatcher.py", line 197, in handle_message
    await handler(context, responder)
  File "/Users/baegjae/src/aries-cloudagent-python/aries_cloudagent/protocols/connections/v1_0/handlers/connection_request_handler.py", line 41, in handle
    await mgr.receive_request(
  File "/Users/baegjae/src/aries-cloudagent-python/aries_cloudagent/protocols/connections/v1_0/manager.py", line 592, in receive_request
    my_info = await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519)
  File "/Users/baegjae/src/aries-cloudagent-python/aries_cloudagent/wallet/askar.py", line 199, in create_local_did
    await self._session.handle.insert_key(
AttributeError: 'NoneType' object has no attribute 'insert_key'
```

`wallet` was inactive (=handle was None) when creating local did.

### Fix
This PR make `wallet` active to create local did.


Signed-off-by: Ethan Sung <baegjae@gmail.com>