### PR TITLE
Fix warnings when generating ReadTheDocs

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
@@ -68,7 +68,7 @@ class V10CredentialExchange(BaseExchangeRecord):
         ] = None,  # aries message: ..._dict for historic compat on all aries msgs
         credential_offer_dict: Union[Mapping, CredentialOffer] = None,  # aries message
         credential_offer: Union[Mapping, IndyCredAbstract] = None,  # indy artifact
-        credential_request: [Mapping, IndyCredRequest] = None,  # indy artifact
+        credential_request: Union[Mapping, IndyCredRequest] = None,  # indy artifact
         credential_request_metadata: Mapping = None,
         credential_id: str = None,
         raw_credential: Union[Mapping, IndyCredential] = None,  # indy cred as received

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
@@ -16,7 +16,7 @@ from ......messaging.decorators.attach_decorator import AttachDecorator
 from ......storage.vc_holder.base import VCHolder
 from ......storage.vc_holder.vc_record import VCRecord
 from ......vc.vc_ld import (
-    issue,
+    issue_vc as issue,
     verify_credential,
     VerifiableCredentialSchema,
     LDProof,

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch.py
@@ -16,7 +16,7 @@ from ....messaging.valid import (
     StrOrDictField,
     StrOrNumberField,
 )
-from ....vc.vc_ld.models import LinkedDataProofSchema
+from ....vc.vc_ld import LinkedDataProofSchema
 
 
 class ClaimFormat(BaseModel):

--- a/aries_cloudagent/protocols/present_proof/dif/pres_schema.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_schema.py
@@ -6,7 +6,7 @@ from ....messaging.valid import (
     UUID4,
     StrOrDictField,
 )
-from ....vc.vc_ld.models import LinkedDataProofSchema
+from ....vc.vc_ld import LinkedDataProofSchema
 
 from .pres_exch import PresentationSubmissionSchema
 

--- a/aries_cloudagent/vc/ld_proofs/__init__.py
+++ b/aries_cloudagent/vc/ld_proofs/__init__.py
@@ -1,23 +1,23 @@
 from .ld_proofs import sign, verify, derive
 from .proof_set import ProofSet
 from .purposes import (
-    ProofPurpose,
-    ControllerProofPurpose,
-    AuthenticationProofPurpose,
-    CredentialIssuancePurpose,
-    AssertionProofPurpose,
+    _ProofPurpose as ProofPurpose,
+    _ControllerProofPurpose as ControllerProofPurpose,
+    _AuthenticationProofPurpose as AuthenticationProofPurpose,
+    _CredentialIssuancePurpose as CredentialIssuancePurpose,
+    _AssertionProofPurpose as AssertionProofPurpose,
 )
 from .suites import (
-    LinkedDataProof,
-    LinkedDataSignature,
-    JwsLinkedDataSignature,
-    Ed25519Signature2018,
-    BbsBlsSignature2020,
-    BbsBlsSignatureProof2020,
+    _LinkedDataProof as LinkedDataProof,
+    _LinkedDataSignature as LinkedDataSignature,
+    _JwsLinkedDataSignature as JwsLinkedDataSignature,
+    _Ed25519Signature2018 as Ed25519Signature2018,
+    _BbsBlsSignature2020 as BbsBlsSignature2020,
+    _BbsBlsSignatureProof2020 as BbsBlsSignatureProof2020,
 )
 from .crypto import (
-    KeyPair,
-    WalletKeyPair,
+    _KeyPair as KeyPair,
+    _WalletKeyPair as WalletKeyPair,
 )
 from .document_loader import (
     DocumentLoader,

--- a/aries_cloudagent/vc/ld_proofs/crypto/__init__.py
+++ b/aries_cloudagent/vc/ld_proofs/crypto/__init__.py
@@ -1,4 +1,4 @@
-from .key_pair import KeyPair
-from .wallet_key_pair import WalletKeyPair
+from .key_pair import KeyPair as _KeyPair
+from .wallet_key_pair import WalletKeyPair as _WalletKeyPair
 
-__all__ = ["KeyPair", "WalletKeyPair"]
+__all__ = ["_KeyPair", "_WalletKeyPair"]

--- a/aries_cloudagent/vc/ld_proofs/ld_proofs.py
+++ b/aries_cloudagent/vc/ld_proofs/ld_proofs.py
@@ -4,8 +4,8 @@ from typing import List
 
 from .document_loader import DocumentLoaderMethod
 from .proof_set import ProofSet
-from .purposes import ProofPurpose
-from .suites import LinkedDataProof
+from .purposes import _ProofPurpose as ProofPurpose
+from .suites import _LinkedDataProof as LinkedDataProof
 from .validation_result import DocumentVerificationResult
 
 

--- a/aries_cloudagent/vc/ld_proofs/proof_set.py
+++ b/aries_cloudagent/vc/ld_proofs/proof_set.py
@@ -8,7 +8,7 @@ from .constants import SECURITY_CONTEXT_URL
 from .document_loader import DocumentLoaderMethod
 from .error import LinkedDataProofException
 from .purposes.proof_purpose import ProofPurpose
-from .suites import LinkedDataProof
+from .suites import _LinkedDataProof as LinkedDataProof
 from .validation_result import DocumentVerificationResult, ProofResult
 
 

--- a/aries_cloudagent/vc/ld_proofs/purposes/__init__.py
+++ b/aries_cloudagent/vc/ld_proofs/purposes/__init__.py
@@ -1,14 +1,17 @@
-from .proof_purpose import ProofPurpose
-
-from .assertion_proof_purpose import AssertionProofPurpose
-from .authentication_proof_purpose import AuthenticationProofPurpose
-from .controller_proof_purpose import ControllerProofPurpose
-from .credential_issuance_purpose import CredentialIssuancePurpose
+from .proof_purpose import ProofPurpose as _ProofPurpose
+from .assertion_proof_purpose import AssertionProofPurpose as _AssertionProofPurpose
+from .authentication_proof_purpose import (
+    AuthenticationProofPurpose as _AuthenticationProofPurpose,
+)
+from .controller_proof_purpose import ControllerProofPurpose as _ControllerProofPurpose
+from .credential_issuance_purpose import (
+    CredentialIssuancePurpose as _CredentialIssuancePurpose,
+)
 
 __all__ = [
-    "ProofPurpose",
-    "ControllerProofPurpose",
-    "AssertionProofPurpose",
-    "AuthenticationProofPurpose",
-    "CredentialIssuancePurpose",
+    "_ProofPurpose",
+    "_ControllerProofPurpose",
+    "_AssertionProofPurpose",
+    "_AuthenticationProofPurpose",
+    "_CredentialIssuancePurpose",
 ]

--- a/aries_cloudagent/vc/ld_proofs/suites/__init__.py
+++ b/aries_cloudagent/vc/ld_proofs/suites/__init__.py
@@ -1,15 +1,17 @@
-from .linked_data_proof import LinkedDataProof
-from .linked_data_signature import LinkedDataSignature
-from .jws_linked_data_signature import JwsLinkedDataSignature
-from .ed25519_signature_2018 import Ed25519Signature2018
-from .bbs_bls_signature_2020 import BbsBlsSignature2020
-from .bbs_bls_signature_proof_2020 import BbsBlsSignatureProof2020
+from .linked_data_proof import LinkedDataProof as _LinkedDataProof
+from .linked_data_signature import LinkedDataSignature as _LinkedDataSignature
+from .jws_linked_data_signature import JwsLinkedDataSignature as _JwsLinkedDataSignature
+from .ed25519_signature_2018 import Ed25519Signature2018 as _Ed25519Signature2018
+from .bbs_bls_signature_2020 import BbsBlsSignature2020 as _BbsBlsSignature2020
+from .bbs_bls_signature_proof_2020 import (
+    BbsBlsSignatureProof2020 as _BbsBlsSignatureProof2020,
+)
 
 __all__ = [
-    "LinkedDataProof",
-    "LinkedDataSignature",
-    "JwsLinkedDataSignature",
-    "Ed25519Signature2018",
-    "BbsBlsSignature2020",
-    "BbsBlsSignatureProof2020",
+    "_LinkedDataProof",
+    "_LinkedDataSignature",
+    "_JwsLinkedDataSignature",
+    "_Ed25519Signature2018",
+    "_BbsBlsSignature2020",
+    "_BbsBlsSignatureProof2020",
 ]

--- a/aries_cloudagent/vc/ld_proofs/suites/bbs_bls_signature_2020.py
+++ b/aries_cloudagent/vc/ld_proofs/suites/bbs_bls_signature_2020.py
@@ -6,10 +6,10 @@ from typing import List, Union
 
 from ....wallet.util import b64_to_bytes, bytes_to_b64
 
-from ..crypto import KeyPair
+from ..crypto import _KeyPair as KeyPair
 from ..document_loader import DocumentLoaderMethod
 from ..error import LinkedDataProofException
-from ..purposes import ProofPurpose
+from ..purposes import _ProofPurpose as ProofPurpose
 from ..validation_result import ProofResult
 
 from .bbs_bls_signature_2020_base import BbsBlsSignature2020Base

--- a/aries_cloudagent/vc/ld_proofs/suites/bbs_bls_signature_proof_2020.py
+++ b/aries_cloudagent/vc/ld_proofs/suites/bbs_bls_signature_proof_2020.py
@@ -24,11 +24,11 @@ if BbsBlsSignature2020Base.BBS_SUPPORTED:
 from ....utils.dependencies import assert_ursa_bbs_signatures_installed
 from ....wallet.util import b64_to_bytes, bytes_to_b64
 
-from ..crypto import KeyPair
+from ..crypto import _KeyPair as KeyPair
 from ..error import LinkedDataProofException
 from ..validation_result import ProofResult
 from ..document_loader import DocumentLoaderMethod
-from ..purposes import ProofPurpose
+from ..purposes import _ProofPurpose as ProofPurpose
 
 from .bbs_bls_signature_2020 import BbsBlsSignature2020
 from .linked_data_proof import DeriveProofResult

--- a/aries_cloudagent/vc/ld_proofs/suites/ed25519_signature_2018.py
+++ b/aries_cloudagent/vc/ld_proofs/suites/ed25519_signature_2018.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Union
 
-from ..crypto import KeyPair
+from ..crypto import _KeyPair as KeyPair
 
 from .jws_linked_data_signature import JwsLinkedDataSignature
 

--- a/aries_cloudagent/vc/ld_proofs/suites/jws_linked_data_signature.py
+++ b/aries_cloudagent/vc/ld_proofs/suites/jws_linked_data_signature.py
@@ -9,7 +9,7 @@ from pyld.jsonld import JsonLdProcessor
 
 from ....wallet.util import b64_to_bytes, bytes_to_b64, str_to_b64, b64_to_str
 
-from ..crypto import KeyPair
+from ..crypto import _KeyPair as KeyPair
 from ..document_loader import DocumentLoaderMethod
 from ..error import LinkedDataProofException
 

--- a/aries_cloudagent/vc/ld_proofs/suites/linked_data_proof.py
+++ b/aries_cloudagent/vc/ld_proofs/suites/linked_data_proof.py
@@ -11,7 +11,7 @@ from ..check import get_properties_without_context
 from ..constants import SECURITY_CONTEXT_URL
 from ..document_loader import DocumentLoaderMethod
 from ..error import LinkedDataProofException
-from ..purposes import ProofPurpose
+from ..purposes import _ProofPurpose as ProofPurpose
 from ..validation_result import ProofResult
 
 

--- a/aries_cloudagent/vc/ld_proofs/suites/linked_data_signature.py
+++ b/aries_cloudagent/vc/ld_proofs/suites/linked_data_signature.py
@@ -9,7 +9,7 @@ from typing import Union
 from ..constants import SECURITY_CONTEXT_URL
 from ..document_loader import DocumentLoaderMethod
 from ..error import LinkedDataProofException
-from ..purposes import ProofPurpose
+from ..purposes import _ProofPurpose as ProofPurpose
 from ..validation_result import ProofResult
 
 from .linked_data_proof import LinkedDataProof

--- a/aries_cloudagent/vc/vc_ld/__init__.py
+++ b/aries_cloudagent/vc/vc_ld/__init__.py
@@ -1,17 +1,17 @@
-from .issue import issue
+from .issue import issue as issue_vc
 from .verify import verify_presentation, verify_credential
 from .prove import create_presentation, sign_presentation, derive_credential
 from .validation_result import PresentationVerificationResult
 from .models import (
-    VerifiableCredential,
-    LDProof,
-    LinkedDataProofSchema,
-    VerifiableCredentialSchema,
-    CredentialSchema,
+    _VerifiableCredential as VerifiableCredential,
+    _LDProof as LDProof,
+    _LinkedDataProofSchema as LinkedDataProofSchema,
+    _VerifiableCredentialSchema as VerifiableCredentialSchema,
+    _CredentialSchema as CredentialSchema,
 )
 
 __all__ = [
-    "issue",
+    "issue_vc",
     "verify_presentation",
     "verify_credential",
     "create_presentation",

--- a/aries_cloudagent/vc/vc_ld/models/__init__.py
+++ b/aries_cloudagent/vc/vc_ld/models/__init__.py
@@ -1,17 +1,17 @@
 from .credential import (
-    VerifiableCredential,
-    VerifiableCredentialSchema,
-    CredentialSchema,
+    VerifiableCredential as _VerifiableCredential,
+    VerifiableCredentialSchema as _VerifiableCredentialSchema,
+    CredentialSchema as _CredentialSchema,
 )
 from .linked_data_proof import (
-    LDProof,
-    LinkedDataProofSchema,
+    LDProof as _LDProof,
+    LinkedDataProofSchema as _LinkedDataProofSchema,
 )
 
 __all__ = [
-    "VerifiableCredential",
-    "CredentialSchema",
-    "VerifiableCredentialSchema",
-    "LDProof",
-    "LinkedDataProofSchema",
+    "_VerifiableCredential",
+    "_CredentialSchema",
+    "_VerifiableCredentialSchema",
+    "_LDProof",
+    "_LinkedDataProofSchema",
 ]

--- a/aries_cloudagent/vc/vc_ld/tests/test_vc_ld.py
+++ b/aries_cloudagent/vc/vc_ld/tests/test_vc_ld.py
@@ -9,7 +9,7 @@ from ....wallet.in_memory import InMemoryWallet
 from ....core.in_memory import InMemoryProfile
 from ...ld_proofs import Ed25519Signature2018, WalletKeyPair, BbsBlsSignature2020
 from ...vc_ld import (
-    issue,
+    issue_vc as issue,
     verify_credential,
     create_presentation,
     sign_presentation,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,8 @@
 import os
 import sys
 
+from sphinx.domains.python import PythonDomain
+
 sys.path.insert(0, os.path.abspath(".."))
 
 autodoc_mock_imports = [
@@ -41,7 +43,6 @@ autodoc_mock_imports = [
     "dateutil",
     "jsonpath_ng",
     "unflatten",
-    "aries_cloudagent.vc",
 ]
 
 #    "aries_cloudagent.tests.test_conductor",
@@ -236,3 +237,15 @@ epub_exclude_files = ["search.html", "README.md"]
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {"https://docs.python.org/": None}
+
+# To supress cross-reference warnings
+# https://github.com/sphinx-doc/sphinx/issues/3866#issuecomment-768167824
+class PatchedPythonDomain(PythonDomain):
+    def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
+        if 'refspecific' in node:
+            del node['refspecific']
+        return super(PatchedPythonDomain, self).resolve_xref(
+            env, fromdocname, builder, typ, target, node, contnode)
+
+def setup(sphinx):
+    sphinx.add_domain(PatchedPythonDomain, override=True)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -242,10 +242,12 @@ intersphinx_mapping = {"https://docs.python.org/": None}
 # https://github.com/sphinx-doc/sphinx/issues/3866#issuecomment-768167824
 class PatchedPythonDomain(PythonDomain):
     def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
-        if 'refspecific' in node:
-            del node['refspecific']
+        if "refspecific" in node:
+            del node["refspecific"]
         return super(PatchedPythonDomain, self).resolve_xref(
-            env, fromdocname, builder, typ, target, node, contnode)
+            env, fromdocname, builder, typ, target, node, contnode
+        )
+
 
 def setup(sphinx):
     sphinx.add_domain(PatchedPythonDomain, override=True)


### PR DESCRIPTION
Signed-off-by: shaangill025 <gill.shaanjots@gmail.com>

- resolves #1506
- For duplicated object description, renamed references in `__init__.py`:
  - `vc.ld_proofs.crypto`, `vc.ld_proofs.purposes`, `vc.ld_proofs.suites` by adding a `_` when importing modules. Modified `vc.ld_proofs` to accomodate these changes
  -  `vc.vc_ld.models` by adding a `_` when importing modules. Modified `vc.vc_ld` accordingly
- For cross-reference warnings, adopted solution from [here](https://github.com/sphinx-doc/sphinx/issues/3866#issuecomment-768167824).
- Regarding`list not hashable` issue in `aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py`, I think there was a minor bug/typo, we had `credential_request: [Mapping, IndyCredRequest] = None` instead of `credential_request: Union[Mapping, IndyCredRequest] = None`.