### PR TITLE
Fix bug when getting credentials on askar-profile

### DIFF
--- a/aries_cloudagent/indy/credx/holder.py
+++ b/aries_cloudagent/indy/credx/holder.py
@@ -255,7 +255,10 @@ class IndyCredxHolder(IndyHolder):
         result = []
 
         try:
-            rows = self._profile.store.scan(CATEGORY_CREDENTIAL, wql, start, count)
+            rows = self._profile.store.scan(
+                CATEGORY_CREDENTIAL, wql, start, count,
+                self._profile.settings.get("wallet.askar_profile"),
+            )
             async for row in rows:
                 cred = Credential.load(row.raw_value)
                 result.append(_make_cred_info(row.name, cred))
@@ -322,7 +325,8 @@ class IndyCredxHolder(IndyHolder):
                 tag_filter = {"$and": [tag_filter, extra_query]}
 
             rows = self._profile.store.scan(
-                CATEGORY_CREDENTIAL, tag_filter, start, count
+                CATEGORY_CREDENTIAL, tag_filter, start, count,
+                self._profile.settings.get("wallet.askar_profile"),
             )
             async for row in rows:
                 if row.name in creds:

--- a/aries_cloudagent/indy/credx/holder.py
+++ b/aries_cloudagent/indy/credx/holder.py
@@ -256,7 +256,10 @@ class IndyCredxHolder(IndyHolder):
 
         try:
             rows = self._profile.store.scan(
-                CATEGORY_CREDENTIAL, wql, start, count,
+                CATEGORY_CREDENTIAL,
+                wql,
+                start,
+                count,
                 self._profile.settings.get("wallet.askar_profile"),
             )
             async for row in rows:
@@ -325,7 +328,10 @@ class IndyCredxHolder(IndyHolder):
                 tag_filter = {"$and": [tag_filter, extra_query]}
 
             rows = self._profile.store.scan(
-                CATEGORY_CREDENTIAL, tag_filter, start, count,
+                CATEGORY_CREDENTIAL,
+                tag_filter,
+                start,
+                count,
                 self._profile.settings.get("wallet.askar_profile"),
             )
             async for row in rows:


### PR DESCRIPTION
This PR fixes bug when getting credentials under askar-profile environment.

### Environment
askar-profile

### Problem
After holder received credential from issuer, holder get empty results when getting credentials.

### Fix
Add `profile` parameter with `wallet.askar_profile` when scanning credentials


Thanks!

Signed-off-by: Ethan Sung <baegjae@gmail.com>