### PR TITLE
Fix TypeError when calling credential_definitions_fix_cred_def_wallet…

### DIFF
--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -388,7 +388,7 @@ async def credential_definitions_fix_cred_def_wallet_record(request: web.BaseReq
 
     cred_def_id = request.match_info["cred_def_id"]
 
-    ledger = context.inject(BaseLedger, required=False)
+    ledger = context.inject_or(BaseLedger)
     if not ledger:
         reason = "No ledger available"
         if not context.settings.get_value("wallet.type"):


### PR DESCRIPTION
When calling `/credential-definitions/{cred_def_id}/write_record` in the Swagger UI, the call results in a `TypeError` (same reason as in  [PR 1494](https://github.com/hyperledger/aries-cloudagent-python/pull/1494)). So the correct line of code has to be

        ledger = context.inject_or(BaseLedger)

