### PR TITLE
Fix AttributeError

### DIFF
--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -411,7 +411,7 @@ async def credential_definitions_fix_cred_def_wallet_record(request: web.BaseReq
             },
         )
         if 0 == len(found):
-            await ledger.add_cred_def_non_secrets_record(
+            await add_cred_def_non_secrets_record(
                 session.profile, schema_id, iss_did, cred_def_id
             )
 


### PR DESCRIPTION
Follow-up error after [PR 1515](https://github.com/hyperledger/aries-cloudagent-python/pull/1515). When calling `/credential-definitions/{cred_def_id}/write_record` in the Swagger UI, the call results in:

    AttributeError: 'IndySdkLedger' object has no attribute 'add_cred_def_non_secrets_record'

The code attempts to call `add_cred_def_non_secrets_record` on the `ledger` instance which doesn't have such a method. Instead, the actual method is in `routes.py` itself and should just be called there.
