### PR TITLE
OOB: Fixes issues with multiple public explicit invitation and unused 0160 connection

### DIFF
--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -323,6 +323,25 @@ class ConnRecord(BaseRecord):
         return await cls.retrieve_by_tag_filter(session, tag_filter, post_filter)
 
     @classmethod
+    async def retrieve_by_invitation_msg_id(
+        cls, session: ProfileSession, invitation_msg_id: str, their_role: str = None
+    ) -> "ConnRecord":
+        """Retrieve a connection record by invitation_msg_id.
+
+        Args:
+            session: The active profile session
+            invitation_msg_id: Invitation message identifier
+            initiator: Filter by the initiator value
+        """
+        post_filter = {
+            "state": cls.State.INVITATION.rfc160,
+            "invitation_msg_id": invitation_msg_id,
+        }
+        if their_role:
+            post_filter["their_role"] = cls.Role.get(their_role).rfc160
+        return await cls.query(session, post_filter_positive=post_filter)
+
+    @classmethod
     async def retrieve_by_request_id(
         cls, session: ProfileSession, request_id: str
     ) -> "ConnRecord":

--- a/aries_cloudagent/connections/models/tests/test_conn_record.py
+++ b/aries_cloudagent/connections/models/tests/test_conn_record.py
@@ -178,6 +178,29 @@ class TestConnRecord(AsyncTestCase):
                 their_role=ConnRecord.Role.REQUESTER.rfc23,
             )
 
+    async def test_retrieve_by_invitation_msg_id(self):
+        record = ConnRecord(
+            my_did=self.test_did,
+            their_did=self.test_target_did,
+            their_role=ConnRecord.Role.RESPONDER.rfc160,
+            state=ConnRecord.State.INVITATION.rfc160,
+            invitation_msg_id="test123",
+        )
+        await record.save(self.session)
+        results = await ConnRecord.retrieve_by_invitation_msg_id(
+            session=self.session,
+            invitation_msg_id="test123",
+            their_role=ConnRecord.Role.RESPONDER.rfc160,
+        )
+        assert len(results) == 1
+        assert results[0] == record
+        results = await ConnRecord.retrieve_by_invitation_msg_id(
+            session=self.session,
+            invitation_msg_id="test123",
+            their_role=ConnRecord.Role.REQUESTER.rfc160,
+        )
+        assert len(results) == 0
+
     async def test_retrieve_by_request_id(self):
         record = ConnRecord(
             my_did=self.test_did,

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -507,8 +507,8 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
                 mock_conn_rec_cls.retrieve_by_id = async_mock.CoroutineMock(
                     return_value=async_mock.MagicMock(save=async_mock.CoroutineMock())
                 )
-                mock_conn_rec_cls.retrieve_by_invitation_key = async_mock.CoroutineMock(
-                    return_value=mock_conn_record
+                mock_conn_rec_cls.retrieve_by_invitation_msg_id = (
+                    async_mock.CoroutineMock(return_value=[mock_conn_record])
                 )
                 mock_conn_rec_cls.return_value = mock_conn_record
 
@@ -783,8 +783,8 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
                     save=async_mock.CoroutineMock(),
                 )
                 mock_conn_rec_cls.return_value = mock_conn_record
-                mock_conn_rec_cls.retrieve_by_invitation_key = async_mock.CoroutineMock(
-                    return_value=mock_conn_record
+                mock_conn_rec_cls.retrieve_by_invitation_msg_id = (
+                    async_mock.CoroutineMock(return_value=[mock_conn_record])
                 )
 
                 mock_did_posture.get = async_mock.MagicMock(
@@ -890,8 +890,8 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
                     save=async_mock.CoroutineMock(),
                 )
                 mock_conn_rec_cls.return_value = mock_conn_record
-                mock_conn_rec_cls.retrieve_by_invitation_key = async_mock.CoroutineMock(
-                    return_value=mock_conn_record
+                mock_conn_rec_cls.retrieve_by_invitation_msg_id = (
+                    async_mock.CoroutineMock(return_value=[mock_conn_record])
                 )
                 mock_did_doc_from_json.return_value = async_mock.MagicMock(
                     did="wrong-did"
@@ -950,8 +950,8 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
                     save=async_mock.CoroutineMock(),
                 )
                 mock_conn_rec_cls.return_value = mock_conn_record
-                mock_conn_rec_cls.retrieve_by_invitation_key = async_mock.CoroutineMock(
-                    return_value=mock_conn_record
+                mock_conn_rec_cls.retrieve_by_invitation_msg_id = (
+                    async_mock.CoroutineMock(return_value=[mock_conn_record])
                 )
 
                 mock_did_posture.get = async_mock.MagicMock(
@@ -1068,8 +1068,8 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
                     save=async_mock.CoroutineMock(),
                 )
                 mock_conn_rec_cls.return_value = mock_conn_record
-                mock_conn_rec_cls.retrieve_by_invitation_key = async_mock.CoroutineMock(
-                    return_value=mock_conn_record
+                mock_conn_rec_cls.retrieve_by_invitation_msg_id = (
+                    async_mock.CoroutineMock(return_value=[mock_conn_record])
                 )
 
                 mock_did_posture.get = async_mock.MagicMock(
@@ -1306,8 +1306,8 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
                     retrieve_request=async_mock.CoroutineMock(),
                 )
                 mock_conn_rec_cls.return_value = mock_conn_rec
-                mock_conn_rec_cls.retrieve_by_invitation_key = async_mock.CoroutineMock(
-                    side_effect=StorageNotFoundError()
+                mock_conn_rec_cls.retrieve_by_invitation_msg_id = (
+                    async_mock.CoroutineMock(return_value=[])
                 )
 
                 mock_did_posture.get = async_mock.MagicMock(


### PR DESCRIPTION
Signed-off-by: Shaanjot Gill <gill.shaanjots@gmail.com>
- resolves #1524
- Updated `ConnectionManager` and `DIDXManager` to look up `ConnRecord` by `invitation_msg_id`
- Also fixes the issue, when an OOB invitation [`0160` and with public DID] is accepted by the invitee, on the inviter side, a new `ConnRecord` is created and activated, and the original `ConnRecord` created along with the invitation remains unused.