### PR TITLE
Remove request_id from inviter connection record

### DIFF
--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -492,7 +492,7 @@ class DIDXManager(BaseConnectionManager):
                 conn_rec.alias = alias
             conn_rec.their_did = request.did
             conn_rec.state = ConnRecord.State.REQUEST.rfc23
-            conn_rec.request_id = request._id
+            # conn_rec.request_id = request._id
             async with self.profile.session() as session:
                 await conn_rec.save(
                     session, reason="Received connection request from invitation"
@@ -533,7 +533,7 @@ class DIDXManager(BaseConnectionManager):
                 their_role=ConnRecord.Role.REQUESTER.rfc23,
                 invitation_key=connection_key,
                 invitation_msg_id=None,
-                request_id=request._id,
+                # request_id=request._id,
                 state=ConnRecord.State.REQUEST.rfc23,
                 connection_protocol=DIDX_PROTO,
             )

--- a/demo/demo-args.yaml
+++ b/demo/demo-args.yaml
@@ -8,7 +8,11 @@ inbound-transport:
   - [http, 0.0.0.0, 8030]
   - [ws, 0.0.0.0, 8040]
 outbound-transport: http
-endpoint: http://192.168.0.48:8030
+endpoint: http://127.0.0.1:8030
 admin-insecure-mode: true
 admin: [0.0.0.0, 8031]
 no-ledger: true
+wallet-type: indy
+wallet-name: testwallet
+wallet-key: key
+auto-provision: true


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Addresses issue https://github.com/hyperledger/aries-cloudagent-python/issues/1541

Tested in alice/faber, there are some error messages on the faber side however the connection (didexchange) is established and can be used for issuing credentials and requesting proofs.

Not sure what is the issue of removing `request_id` from the inviter connection record, or why it's required for didexchange but not connections protocol.
