### PR TITLE
Add credential_revoked state

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -910,8 +910,11 @@ class CredentialManager:
         cred_rev_ids: Sequence[str]
     ) -> None:
         """
-        Update credential state on revocation using
-        revocation registry ID and credential revocation IDs
+        Update credentials state to credential_revoked
+
+        Args:
+            rev_reg_id: revocation registry ID
+            cred_rev_ids: list of credential revocation IDs
 
         Returns:
             None

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -904,13 +904,10 @@ class CredentialManager:
         return cred_ex_record
 
     async def revoke_credentials(
-        self,
-        session: ProfileSession,
-        rev_reg_id: str,
-        cred_rev_ids: Sequence[str]
+        self, session: ProfileSession, rev_reg_id: str, cred_rev_ids: Sequence[str]
     ) -> None:
         """
-        Update credentials state to credential_revoked
+        Update credentials state to credential_revoked.
 
         Args:
             rev_reg_id: revocation registry ID
@@ -924,9 +921,7 @@ class CredentialManager:
             try:
                 cred_ex_record = await (
                     V10CredentialExchange.retrieve_by_revocation(
-                        session,
-                        revoc_reg_id=rev_reg_id,
-                        revocation_id=cred_rev_id
+                        session, revoc_reg_id=rev_reg_id, revocation_id=cred_rev_id
                     )
                 )
                 cred_ex_record.state = V10CredentialExchange.STATE_CREDENTIAL_REVOKED

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -4,11 +4,11 @@ import asyncio
 import json
 import logging
 
-from typing import Mapping, Tuple, Sequence
+from typing import Mapping, Tuple
 
 from ....cache.base import BaseCache
 from ....core.error import BaseError
-from ....core.profile import Profile, ProfileSession
+from ....core.profile import Profile
 from ....indy.holder import IndyHolder, IndyHolderError
 from ....indy.issuer import IndyIssuer, IndyIssuerRevocationRegistryFullError
 from ....ledger.multiple_ledger.ledger_requests_executor import (
@@ -902,33 +902,6 @@ class CredentialManager:
                 await cred_ex_record.delete_record(session)  # all done: delete
 
         return cred_ex_record
-
-    async def revoke_credentials(
-        self, session: ProfileSession, rev_reg_id: str, cred_rev_ids: Sequence[str]
-    ) -> None:
-        """
-        Update credentials state to credential_revoked.
-
-        Args:
-            rev_reg_id: revocation registry ID
-            cred_rev_ids: list of credential revocation IDs
-
-        Returns:
-            None
-
-        """
-        for cred_rev_id in cred_rev_ids:
-            try:
-                cred_ex_record = await (
-                    V10CredentialExchange.retrieve_by_revocation(
-                        session, revoc_reg_id=rev_reg_id, revocation_id=cred_rev_id
-                    )
-                )
-                cred_ex_record.state = V10CredentialExchange.STATE_CREDENTIAL_REVOKED
-                await cred_ex_record.save(session, reason="revoke credential")
-
-            except StorageNotFoundError:
-                pass
 
     async def receive_problem_report(
         self, message: CredentialProblemReport, connection_id: str

--- a/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
@@ -50,6 +50,7 @@ class V10CredentialExchange(BaseExchangeRecord):
     STATE_ISSUED = "credential_issued"
     STATE_CREDENTIAL_RECEIVED = "credential_received"
     STATE_ACKED = "credential_acked"
+    STATE_CREDENTIAL_REVOKED = "credential_revoked"
 
     def __init__(
         self,

--- a/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
@@ -37,7 +37,7 @@ class V10CredentialExchange(BaseExchangeRecord):
     TAG_NAMES = {
         "~thread_id" if UNENCRYPTED_TAGS else "thread_id",
         "revoc_reg_id",
-        "revocation_id"
+        "revocation_id",
     }
 
     INITIATOR_SELF = "self"
@@ -284,7 +284,7 @@ class V10CredentialExchange(BaseExchangeRecord):
     async def retrieve_by_revocation(
         cls, session: ProfileSession, revoc_reg_id: str, revocation_id: str
     ) -> "V10CredentialExchange":
-        """Retrieve a credential exchange record by revocation registry ID and credential revocation ID."""
+        """Retrieve a credential record by revocation registry and revocation ID."""
         record = await cls.retrieve_by_tag_filter(
             session,
             {"revoc_reg_id": revoc_reg_id},

--- a/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
@@ -34,11 +34,7 @@ class V10CredentialExchange(BaseExchangeRecord):
     RECORD_TYPE = "credential_exchange_v10"
     RECORD_ID_NAME = "credential_exchange_id"
     RECORD_TOPIC = "issue_credential"
-    TAG_NAMES = {
-        "~thread_id" if UNENCRYPTED_TAGS else "thread_id",
-        "revoc_reg_id",
-        "revocation_id",
-    }
+    TAG_NAMES = {"~thread_id"} if UNENCRYPTED_TAGS else {"thread_id"}
 
     INITIATOR_SELF = "self"
     INITIATOR_EXTERNAL = "external"
@@ -278,18 +274,6 @@ class V10CredentialExchange(BaseExchangeRecord):
                 {"connection_id": connection_id} if connection_id else None,
             )
             await cls.set_cached_key(session, cache_key, record.credential_exchange_id)
-        return record
-
-    @classmethod
-    async def retrieve_by_revocation(
-        cls, session: ProfileSession, revoc_reg_id: str, revocation_id: str
-    ) -> "V10CredentialExchange":
-        """Retrieve a credential record by revocation registry and revocation ID."""
-        record = await cls.retrieve_by_tag_filter(
-            session,
-            {"revoc_reg_id": revoc_reg_id},
-            {"revocation_id": revocation_id},
-        )
         return record
 
     def __eq__(self, other: Any) -> bool:

--- a/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
@@ -34,7 +34,11 @@ class V10CredentialExchange(BaseExchangeRecord):
     RECORD_TYPE = "credential_exchange_v10"
     RECORD_ID_NAME = "credential_exchange_id"
     RECORD_TOPIC = "issue_credential"
-    TAG_NAMES = {"~thread_id" if UNENCRYPTED_TAGS else "thread_id", "revoc_reg_id", "revocation_id"}
+    TAG_NAMES = {
+        "~thread_id" if UNENCRYPTED_TAGS else "thread_id",
+        "revoc_reg_id",
+        "revocation_id"
+    }
 
     INITIATOR_SELF = "self"
     INITIATOR_EXTERNAL = "external"
@@ -282,9 +286,9 @@ class V10CredentialExchange(BaseExchangeRecord):
     ) -> "V10CredentialExchange":
         """Retrieve a credential exchange record by revocation registry ID and credential revocation ID."""
         record = await cls.retrieve_by_tag_filter(
-                session,
-                {"revoc_reg_id": revoc_reg_id},
-                {"revocation_id": revocation_id},
+            session,
+            {"revoc_reg_id": revoc_reg_id},
+            {"revocation_id": revocation_id},
         )
         return record
 

--- a/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
@@ -34,7 +34,7 @@ class V10CredentialExchange(BaseExchangeRecord):
     RECORD_TYPE = "credential_exchange_v10"
     RECORD_ID_NAME = "credential_exchange_id"
     RECORD_TOPIC = "issue_credential"
-    TAG_NAMES = {"~thread_id"} if UNENCRYPTED_TAGS else {"thread_id"}
+    TAG_NAMES = {"~thread_id" if UNENCRYPTED_TAGS else "thread_id", "revoc_reg_id", "revocation_id"}
 
     INITIATOR_SELF = "self"
     INITIATOR_EXTERNAL = "external"
@@ -274,6 +274,18 @@ class V10CredentialExchange(BaseExchangeRecord):
                 {"connection_id": connection_id} if connection_id else None,
             )
             await cls.set_cached_key(session, cache_key, record.credential_exchange_id)
+        return record
+
+    @classmethod
+    async def retrieve_by_revocation(
+        cls, session: ProfileSession, revoc_reg_id: str, revocation_id: str
+    ) -> "V10CredentialExchange":
+        """Retrieve a credential exchange record by revocation registry ID and credential revocation ID."""
+        record = await cls.retrieve_by_tag_filter(
+                session,
+                {"revoc_reg_id": revoc_reg_id},
+                {"revocation_id": revocation_id},
+        )
         return record
 
     def __eq__(self, other: Any) -> bool:

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
@@ -50,6 +50,7 @@ class V20CredExRecord(BaseExchangeRecord):
     STATE_ISSUED = "credential-issued"
     STATE_CREDENTIAL_RECEIVED = "credential-received"
     STATE_DONE = "done"
+    STATE_CREDENTIAL_REVOKED = "credential-revoked"
 
     def __init__(
         self,

--- a/aries_cloudagent/revocation/manager.py
+++ b/aries_cloudagent/revocation/manager.py
@@ -19,6 +19,7 @@ from ..protocols.issue_credential.v1_0.manager import (
     CredentialManager as V10CredManager,
 )
 
+
 class RevocationManagerError(BaseError):
     """Revocation manager error."""
 

--- a/aries_cloudagent/revocation/manager.py
+++ b/aries_cloudagent/revocation/manager.py
@@ -15,8 +15,9 @@ from .indy import IndyRevocation
 from .models.issuer_cred_rev_record import IssuerCredRevRecord
 from .models.issuer_rev_reg_record import IssuerRevRegRecord
 from .util import notify_pending_cleared_event, notify_revocation_published_event
-from ..protocols.issue_credential.v1_0.manager import CredentialManager as V10CredManager
-
+from ..protocols.issue_credential.v1_0.manager import (
+    CredentialManager as V10CredManager,
+)
 
 class RevocationManagerError(BaseError):
     """Revocation manager error."""
@@ -134,7 +135,9 @@ class RevocationManager:
                 async with self._profile.session() as session:
                     await issuer_rr_rec.clear_pending(session)
                     credential_manager = V10CredManager(self._profile)
-                    await credential_manager.revoke_credentials(session, rev_reg_id, [cred_rev_id])
+                    await credential_manager.revoke_credentials(
+                        session, rev_reg_id, [cred_rev_id]
+                    )
                 await notify_revocation_published_event(
                     self._profile, rev_reg_id, [cred_rev_id]
                 )
@@ -202,7 +205,9 @@ class RevocationManager:
                     await txn.commit()
                     credential_manager = V10CredManager(self._profile)
                     async with self._profile.session() as session:
-                        await credential_manager.revoke_credentials(session, issuer_rr_rec.revoc_reg_id, crids)
+                        await credential_manager.revoke_credentials(
+                            session, issuer_rr_rec.revoc_reg_id, crids
+                        )
                     await notify_revocation_published_event(
                         self._profile, issuer_rr_rec.revoc_reg_id, crids
                     )

--- a/aries_cloudagent/revocation/manager.py
+++ b/aries_cloudagent/revocation/manager.py
@@ -15,6 +15,9 @@ from .indy import IndyRevocation
 from .models.issuer_cred_rev_record import IssuerCredRevRecord
 from .models.issuer_rev_reg_record import IssuerRevRegRecord
 from .util import notify_pending_cleared_event, notify_revocation_published_event
+from ..protocols.issue_credential.v1_0.models.credential_exchange import V10CredentialExchange
+from ..protocols.issue_credential.v1_0.routes import credential_exchange_retrieve
+from ..protocols.issue_credential.v1_0.manager import CredentialManagerError
 
 
 class RevocationManagerError(BaseError):
@@ -65,6 +68,23 @@ class RevocationManager:
                 "No issuer credential revocation record found for "
                 f"credential exchange id {cred_ex_id}"
             ) from err
+
+        try:
+            async with self._profile.session() as session:
+                cred_ex_record = await V10CredentialExchange.retrieve_by_id(
+                    session, cred_ex_id
+                )
+        except StorageNotFoundError as err:
+            raise CredentialManagerError(
+                "No issuer credential exchange record found for "
+                f"credential exchange id {cred_ex_id}"
+            ) from err
+
+        cred_ex_record.state = V10CredentialExchange.STATE_CREDENTIAL_REVOKED
+        async with self._profile.session() as session:
+            # FIXME - re-fetch record to check state, apply transactional update
+            await cred_ex_record.save(session, reason="revoke credential")
+
         return await self.revoke_credential(
             rev_reg_id=rec.rev_reg_id,
             cred_rev_id=rec.cred_rev_id,

--- a/aries_cloudagent/revocation/manager.py
+++ b/aries_cloudagent/revocation/manager.py
@@ -15,8 +15,11 @@ from .indy import IndyRevocation
 from .models.issuer_cred_rev_record import IssuerCredRevRecord
 from .models.issuer_rev_reg_record import IssuerRevRegRecord
 from .util import notify_pending_cleared_event, notify_revocation_published_event
-from ..protocols.issue_credential.v1_0.manager import (
-    CredentialManager as V10CredManager,
+from ..protocols.issue_credential.v1_0.models.credential_exchange import (
+    V10CredentialExchange,
+)
+from ..protocols.issue_credential.v2_0.models.cred_ex_record import (
+    V20CredExRecord,
 )
 
 
@@ -135,10 +138,7 @@ class RevocationManager:
                 await issuer_rr_rec.send_entry(self._profile)
                 async with self._profile.session() as session:
                     await issuer_rr_rec.clear_pending(session)
-                    credential_manager = V10CredManager(self._profile)
-                    await credential_manager.revoke_credentials(
-                        session, rev_reg_id, [cred_rev_id]
-                    )
+                await self.set_cred_revoked_state(rev_reg_id, [cred_rev_id])
                 await notify_revocation_published_event(
                     self._profile, rev_reg_id, [cred_rev_id]
                 )
@@ -204,11 +204,7 @@ class RevocationManager:
                     result[issuer_rr_rec.revoc_reg_id] = published
                     await issuer_rr_rec.clear_pending(txn, published)
                     await txn.commit()
-                    credential_manager = V10CredManager(self._profile)
-                    async with self._profile.session() as session:
-                        await credential_manager.revoke_credentials(
-                            session, issuer_rr_rec.revoc_reg_id, crids
-                        )
+                    await self.set_cred_revoked_state(issuer_rr_rec.revoc_reg_id, crids)
                     await notify_revocation_published_event(
                         self._profile, issuer_rr_rec.revoc_reg_id, crids
                     )
@@ -258,3 +254,50 @@ class RevocationManager:
             await txn.commit()
 
         return result
+
+    async def set_cred_revoked_state(
+        self, rev_reg_id: str, cred_rev_ids: Sequence[str]
+    ) -> None:
+        """
+        Update credentials state to credential_revoked.
+
+        Args:
+            rev_reg_id: revocation registry ID
+            cred_rev_ids: list of credential revocation IDs
+
+        Returns:
+            None
+
+        """
+        for cred_rev_id in cred_rev_ids:
+            async with self._profile.session() as session:
+                try:
+                    rev_rec = await IssuerCredRevRecord.retrieve_by_ids(
+                        session, rev_reg_id, cred_rev_id
+                    )
+                    try:
+                        cred_ex_record = await V10CredentialExchange.retrieve_by_id(
+                            session, rev_rec.cred_ex_id
+                        )
+                        cred_ex_record.state = (
+                            V10CredentialExchange.STATE_CREDENTIAL_REVOKED
+                        )
+                        await cred_ex_record.save(session, reason="revoke credential")
+
+                    except StorageNotFoundError:
+                        try:
+                            cred_ex_record = await V20CredExRecord.retrieve_by_id(
+                                session, rev_rec.cred_ex_id
+                            )
+                            cred_ex_record.state = (
+                                V20CredExRecord.STATE_CREDENTIAL_REVOKED
+                            )
+                            await cred_ex_record.save(
+                                session, reason="revoke credential"
+                            )
+
+                        except StorageNotFoundError:
+                            pass
+
+                except StorageNotFoundError:
+                    pass


### PR DESCRIPTION
Pull request for [Issue: 1539](https://github.com/hyperledger/aries-cloudagent-python/issues/1539)
@swcurran  Added the credential_revoked state. 
For now I have considered only issue-credential 1.0, I should check for the record in V20CredentialExchange too.
Will do it soon. If you have any suggestions on my approach please comment below.

Questions:
- Is it required raise an error if the credential record doesn't exist? 
- The credential state should be changed only after publishing revocation.
   When publish is set to pending, what is the best way to implement this?. I'm planning to create retrieve credential records using rev_reg_id and cred_rev_id