### PR TITLE
chore: update pydid to ^0.3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pyld~=2.0.3
 pyyaml~=5.4.0
 ConfigArgParse~=1.2.3
 pyjwt~=1.7.1
-pydid~=0.3.2.post1
+pydid~=0.3.3
 jsonpath_ng==1.5.2
 pytz~=2021.1
 python-dateutil~=2.8.1


### PR DESCRIPTION
This should have a pretty minimal impact on things while enabling resolution of Documents with nonconforming `@context` attributes (spec defines that context must be a list of strings, some docs have embedded contexts). Also solves the bug mentioned in this comment from forever ago: https://github.com/hyperledger/aries-cloudagent-python/pull/1218#issuecomment-890591874