### PR TITLE
Fix the inconsistency of invitation_msg_id between invitation and response

### DIFF
--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -500,9 +500,9 @@ class OutOfBandManager(BaseConnectionManager):
                             await conn_rec.metadata_delete(
                                 session=session, key="reuse_msg_state"
                             )
-                            # fetch connection record after handshake
-                            conn_rec = await ConnRecord.find_existing_connection(
-                                session=session, their_public_did=public_did
+                            # refetch connection for accurate state after handshake
+                            conn_rec = await ConnRecord.retrieve_by_id(
+                                session=session, record_id=conn_rec.connection_id
                             )
                 except asyncio.TimeoutError:
                     # If no reuse_accepted or problem_report message was received within

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -500,6 +500,10 @@ class OutOfBandManager(BaseConnectionManager):
                             await conn_rec.metadata_delete(
                                 session=session, key="reuse_msg_state"
                             )
+                            # fetch connection record after handshake
+                            conn_rec = await ConnRecord.find_existing_connection(
+                                session=session, their_public_did=public_did
+                            )
                 except asyncio.TimeoutError:
                     # If no reuse_accepted or problem_report message was received within
                     # the 15s timeout then a new connection to be created


### PR DESCRIPTION
Hi!
This PR fixes the inconsistency of invitation_msg_id between invitation and response when connection is reused.

### example of problem
`receive-invitation` with invitation
{"@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/out-of-band/1.0/invitation", "@id": "**6ccba5e9-2b8d-4071-bd91-0058d5187d79**", "services": ["did:sov:2ACCk6nnJQmaibXp5yiXZA"], ...

The response of `receive-invitation`
{"my_did": "VrN5qwVB7ewV43C679ekUx", "invitation_msg_id": "**a7753007-5e3f-4583-826b-ae94550fed15**", "their_public_did": "2ACCk6nnJQmaibXp5yiXZA", ...

### solution
Fetch the connection record after reuse handshake.

Thanks!

Signed-off-by: Ethan Sung <baegjae@gmail.com>