### PR TITLE
fix: use invitation key for connection query

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -331,6 +331,7 @@ async def connections_list(request: web.BaseRequest):
         "my_did",
         "their_did",
         "request_id",
+        "invitation_key"
     ):
         if param_name in request.query and request.query[param_name] != "":
             tag_filter[param_name] = request.query[param_name]

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -331,7 +331,7 @@ async def connections_list(request: web.BaseRequest):
         "my_did",
         "their_did",
         "request_id",
-        "invitation_key"
+        "invitation_key",
     ):
         if param_name in request.query and request.query[param_name] != "":
             tag_filter[param_name] = request.query[param_name]

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
@@ -31,7 +31,7 @@ class TestConnectionRoutes(AsyncTestCase):
             "invitation_id": "dummy",  # exercise tag filter assignment
             "their_role": ConnRecord.Role.REQUESTER.rfc160,
             "connection_protocol": ConnRecord.Protocol.RFC_0160.aries_protocol,
-            "invitation_key": "some-invitation-key"
+            "invitation_key": "some-invitation-key",
         }
 
         STATE_COMPLETED = ConnRecord.State.COMPLETED
@@ -89,15 +89,12 @@ class TestConnectionRoutes(AsyncTestCase):
                 await test_module.connections_list(self.request)
                 mock_conn_rec.query.assert_called_once_with(
                     ANY,
-                    {
-                        "invitation_id": "dummy",
-                        "invitation_key": "some-invitation-key"
-                    },
+                    {"invitation_id": "dummy", "invitation_key": "some-invitation-key"},
                     post_filter_positive={
                         "their_role": [v for v in ConnRecord.Role.REQUESTER.value],
                         "connection_protocol": ConnRecord.Protocol.RFC_0160.aries_protocol,
                     },
-                    alt=True
+                    alt=True,
                 )
                 mock_response.assert_called_once_with(
                     {


### PR DESCRIPTION
Signed-off-by: Timo Glastra <timo@animo.id>

Invitation key was not taken into account for get connections endpoint.

If possible, would like to get this in the upcoming 0.7.3 release :)