### PR TITLE
Allow public invites for alice/faber demo

### DIFF
--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -321,4 +321,5 @@ class DispatcherResponder(BaseResponder):
             "responder.send_webhook is deprecated; please use the event bus instead.",
             DeprecationWarning,
         )
+        print("Sending webhook for topic:", topic)
         await self._context.profile.notify("acapy::webhook::" + topic, payload)

--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -321,5 +321,4 @@ class DispatcherResponder(BaseResponder):
             "responder.send_webhook is deprecated; please use the event bus instead.",
             DeprecationWarning,
         )
-        print("Sending webhook for topic:", topic)
         await self._context.profile.notify("acapy::webhook::" + topic, payload)

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -54,7 +54,7 @@ from .models.invitation import InvitationRecord
 
 LOGGER = logging.getLogger(__name__)
 REUSE_WEBHOOK_TOPIC = "acapy::webhook::connection_reuse"
-REUSE_ACCEPTED_WEBHOOK_TOPIC = "acapy::webhook:connection_reuse_accepted"
+REUSE_ACCEPTED_WEBHOOK_TOPIC = "acapy::webhook::connection_reuse_accepted"
 
 
 class OutOfBandManagerError(BaseError):

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -96,7 +96,7 @@ class AriesAgent(DemoAgent):
         return self._connection_ready.done() and self._connection_ready.result()
 
     async def handle_oob_invitation(self, message):
-        print("handle_oob_invitation():", json.dumps(message))
+        print("handle_oob_invitation()")
         pass
 
     async def handle_connection_reuse(self, message):
@@ -624,7 +624,6 @@ class AgentContainer:
         self.multitenant = multitenant
         self.mediation = mediation
         self.use_did_exchange = use_did_exchange
-        print("Setting use_did_exchange:", self.use_did_exchange)
         self.wallet_type = wallet_type
         self.public_did = public_did
         self.seed = seed
@@ -827,13 +826,10 @@ class AgentContainer:
         for cred_attr in cred_attrs:
             if cred_attr["name"] in wallet_attrs:
                 if wallet_attrs[cred_attr["name"]] != cred_attr["value"]:
-                    print("Value doesn't match for:", cred_attr["name"])
                     matched = False
             else:
-                print("Attribute not found for:", cred_attr["name"])
                 matched = False
 
-        print("Matching credential received")
         return matched
 
     async def request_proof(self, proof_request):
@@ -885,12 +881,10 @@ class AgentContainer:
 
         if self.cred_type == CRED_FORMAT_INDY:
             # return verified status
-            print("Received proof:", self.agent.last_proof_received["verified"])
             return self.agent.last_proof_received["verified"]
 
         elif self.cred_type == CRED_FORMAT_JSON_LD:
             # return verified status
-            print("Received proof:", self.agent.last_proof_received["verified"])
             return self.agent.last_proof_received["verified"]
 
         else:

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -99,6 +99,16 @@ class AriesAgent(DemoAgent):
         print("handle_oob_invitation():", json.dumps(message))
         pass
 
+    async def handle_connection_reuse(self, message):
+        print("handle_connection_reuse():", json.dumps(message))
+        # TODO we are reusing an existing connection, set our status to the existing connection
+        pass
+
+    async def handle_connection_reuse_accepted(self, message):
+        print("handle_connection_reuse_accepted():", json.dumps(message))
+        # TODO we are reusing an existing connection, set our status to the existing connection
+        pass
+
     async def handle_connections(self, message):
         # a bit of a hack, but for the mediator connection self._connection_ready
         # will be None

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -100,14 +100,18 @@ class AriesAgent(DemoAgent):
         pass
 
     async def handle_connection_reuse(self, message):
-        print("handle_connection_reuse():", json.dumps(message))
-        # TODO we are reusing an existing connection, set our status to the existing connection
-        pass
+        # we are reusing an existing connection, set our status to the existing connection
+        if not self._connection_ready.done():
+            self.connection_id = message["connection_id"]
+            self.log("Connected")
+            self._connection_ready.set_result(True)
 
     async def handle_connection_reuse_accepted(self, message):
-        print("handle_connection_reuse_accepted():", json.dumps(message))
-        # TODO we are reusing an existing connection, set our status to the existing connection
-        pass
+        # we are reusing an existing connection, set our status to the existing connection
+        if not self._connection_ready.done():
+            self.connection_id = message["connection_id"]
+            self.log("Connected")
+            self._connection_ready.set_result(True)
 
     async def handle_connections(self, message):
         # a bit of a hack, but for the mediator connection self._connection_ready

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -96,6 +96,7 @@ class AriesAgent(DemoAgent):
         return self._connection_ready.done() and self._connection_ready.result()
 
     async def handle_oob_invitation(self, message):
+        print("handle_oob_invitation():", json.dumps(message))
         pass
 
     async def handle_connections(self, message):
@@ -506,6 +507,7 @@ class AriesAgent(DemoAgent):
         use_did_exchange: bool,
         auto_accept: bool = True,
         display_qr: bool = False,
+        reuse_connections: bool = False,
         wait: bool = False,
     ):
         self._connection_ready = asyncio.Future()
@@ -514,7 +516,11 @@ class AriesAgent(DemoAgent):
             log_status(
                 "#7 Create a connection to alice and print out the invite details"
             )
-            invi_rec = await self.get_invite(use_did_exchange, auto_accept)
+            invi_rec = await self.get_invite(
+                use_did_exchange,
+                auto_accept=auto_accept,
+                reuse_connections=reuse_connections,
+            )
 
         if display_qr:
             qr = QRCode(border=1)
@@ -589,6 +595,7 @@ class AgentContainer:
         aip: int = 20,
         arg_file: str = None,
         endorser_role: str = None,
+        reuse_connections: bool = False,
     ):
         # configuration parameters
         self.genesis_txns = genesis_txns
@@ -616,6 +623,7 @@ class AgentContainer:
                 self.public_did = True
                 self.cred_type = CRED_FORMAT_INDY
 
+        self.reuse_connections = reuse_connections
         self.exchange_tracing = False
 
         # local agent(s)
@@ -897,10 +905,18 @@ class AgentContainer:
         return terminated
 
     async def generate_invitation(
-        self, auto_accept: bool = True, display_qr: bool = False, wait: bool = False
+        self,
+        auto_accept: bool = True,
+        display_qr: bool = False,
+        reuse_connections: bool = False,
+        wait: bool = False,
     ):
         return await self.agent.generate_invitation(
-            self.use_did_exchange, auto_accept, display_qr, wait
+            self.use_did_exchange,
+            auto_accept=auto_accept,
+            display_qr=display_qr,
+            reuse_connections=reuse_connections,
+            wait=wait,
         )
 
     async def input_invitation(self, invite_details: dict, wait: bool = False):
@@ -1087,6 +1103,15 @@ def arg_parser(ident: str = None, port: int = 8020):
             "directly."
         ),
     )
+    if (not ident) or (ident != "alice"):
+        parser.add_argument(
+            "--reuse-connections",
+            action="store_true",
+            help=(
+                "Reuse connections by using Faber public key in the invite. "
+                "Only applicable for AIP 2.0 (OOB) connections."
+            ),
+        )
     parser.add_argument(
         "--arg-file",
         type=str,
@@ -1169,6 +1194,10 @@ async def create_agent_with_args(args, ident: str = None):
         f"Initializing demo agent {agent_ident} with AIP {aip} and credential type {cred_type}"
     )
 
+    reuse_connections = "reuse_connections" in args and args.reuse_connections
+    if reuse_connections and aip != 20:
+        raise Exception("Can only specify `--reuse-connections` with AIP 2.0")
+
     agent = AgentContainer(
         genesis_txns=genesis,
         genesis_txn_list=multi_ledger_config_path,
@@ -1188,6 +1217,7 @@ async def create_agent_with_args(args, ident: str = None):
         arg_file=arg_file,
         aip=aip,
         endorser_role=args.endorser_role,
+        reuse_connections=reuse_connections,
     )
 
     return agent

--- a/demo/runners/faber.py
+++ b/demo/runners/faber.py
@@ -427,7 +427,9 @@ async def main(args):
             raise Exception("Invalid credential type:" + faber_agent.cred_type)
 
         # generate an invitation for Alice
-        await faber_agent.generate_invitation(display_qr=True, wait=True)
+        await faber_agent.generate_invitation(
+            display_qr=True, reuse_connections=faber_agent.reuse_connections, wait=True
+        )
 
         exchange_tracing = False
         options = (
@@ -683,7 +685,11 @@ async def main(args):
                     "Creating a new invitation, please receive "
                     "and accept this invitation using Alice agent"
                 )
-                await faber_agent.generate_invitation(display_qr=True, wait=True)
+                await faber_agent.generate_invitation(
+                    display_qr=True,
+                    reuse_connections=faber_agent.reuse_connections,
+                    wait=True,
+                )
 
             elif option == "5" and faber_agent.revocation:
                 rev_reg_id = (await prompt("Enter revocation registry ID: ")).strip()

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -1194,7 +1194,6 @@ class DemoAgent:
                 invite,
                 params=params,
             )
-            print("Received invite connection:", json.dumps(connection))
         else:
             connection = await self.admin_POST(
                 "/connections/receive-invitation",

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -775,7 +775,6 @@ class DemoAgent:
             handler = f"handle_{topic}"
             wallet_id = headers.get("x-wallet-id")
             method = getattr(self, handler, None)
-            print("Handling:", handler, payload)
             if method:
                 EVENT_LOGGER.debug(
                     "Agent called controller webhook: %s%s%s%s",

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -333,6 +333,7 @@ class DemoAgent:
             ("--wallet-key", self.wallet_key),
             "--preserve-exchange-records",
             "--auto-provision",
+            "--public-invites",
         ]
         if self.aip == 20:
             result.append("--emit-new-didcomm-prefix")


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Addresses https://github.com/hyperledger/aries-cloudagent-python/issues/1571

Note - added a `--reuse-connections` parameter to faber - this will trigger faber to use a public did in the didexchange connection (and alice will always "reuse connection" if possible) and the connection indeed gets reused, however right now there are no webhooks for the "reuse" messages so the alice/faber controllers are getting hung ...
