### PR TITLE
Fix for Test Harness --version issue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ autodoc_mock_imports = [
     "ecdsa",
     "indy_credx",
     "dateutil",
+    "packaging",
     "jsonpath_ng",
     "unflatten",
     "qrcode",

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ msgpack~=1.0
 prompt_toolkit~=2.0.9
 pynacl~=1.4.0
 requests~=2.25.0
+packaging~=20.4
 pyld~=2.0.3
 pyyaml~=5.4.0
 ConfigArgParse~=1.2.3


### PR DESCRIPTION
Signed-off-by: Shaanjot Gill <shaangill025@users.noreply.github.com>
```
aries_cloudagent/commands/upgrade.py
from packaging import version as package_version
ModuleNotFoundError: No module named 'packaging'
```