### PR TITLE
Fix tails_local_path format

### DIFF
--- a/aries_cloudagent/indy/sdk/tests/test_util.py
+++ b/aries_cloudagent/indy/sdk/tests/test_util.py
@@ -57,7 +57,7 @@ class TestIndyUtils(AsyncTestCase):
         tails_local_path = tails_path("rev-reg-id")
         assert tails_local_path is None
 
-        tails_rr_dir = indy_client_dir(join("tails", "rev-reg-id"), create=True)
+        tails_rr_dir = indy_client_dir(join("tails", "rev-reg-id").replace(" ", "%20"), create=True)
         tails_local_path = tails_path("rev-reg-id")
         assert tails_local_path is None
 

--- a/aries_cloudagent/indy/util.py
+++ b/aries_cloudagent/indy/util.py
@@ -42,7 +42,7 @@ def indy_client_dir(subpath: str = None, create: bool = False) -> str:
 def tails_path(rev_reg_id: str) -> str:
     """Return path to indy tails file for input rev reg id."""
 
-    tails_dir = indy_client_dir(join("tails", rev_reg_id), create=False)
+    tails_dir = indy_client_dir(join("tails", rev_reg_id).replace(" ", "%20"), create=False)
     if not isdir(tails_dir):
         return None
 

--- a/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
+++ b/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
@@ -201,7 +201,7 @@ class IssuerRevRegRecord(BaseRecord):
         self.state = IssuerRevRegRecord.STATE_GENERATED
         self.tails_hash = self.revoc_reg_def.value.tails_hash
 
-        tails_dir = indy_client_dir(join("tails", self.revoc_reg_id), create=True)
+        tails_dir = indy_client_dir(join("tails", self.revoc_reg_id).replace(" ", "%20"), create=True)
         tails_path = join(tails_dir, self.tails_hash)
         move(join(tails_hopper_dir, self.tails_hash), tails_path)
         self.tails_local_path = tails_path

--- a/aries_cloudagent/revocation/models/revocation_registry.py
+++ b/aries_cloudagent/revocation/models/revocation_registry.py
@@ -146,7 +146,7 @@ class RevocationRegistry:
         if self._tails_local_path:
             return self._tails_local_path
 
-        tails_dir = indy_client_dir(join("tails", self.registry_id), create=False)
+        tails_dir = indy_client_dir(join("tails", self.registry_id).replace(" ", "%20"), create=False)
         return join(tails_dir, self._tails_hash)
 
     def has_local_tails_file(self) -> bool:

--- a/aries_cloudagent/revocation/models/tests/test_issuer_rev_reg_record.py
+++ b/aries_cloudagent/revocation/models/tests/test_issuer_rev_reg_record.py
@@ -111,7 +111,7 @@ class TestIssuerRevRegRecord(AsyncTestCase):
         assert rec.state == IssuerRevRegRecord.STATE_GENERATED
         assert rec.tails_hash == TAILS_HASH
         assert rec.tails_local_path == join(
-            indy_client_dir(join("tails", REV_REG_ID)), rec.tails_hash
+            indy_client_dir(join("tails", REV_REG_ID).replace(" ","%20")), rec.tails_hash
         )
         with self.assertRaises(RevocationError):
             await rec.set_tails_file_public_uri(self.profile, "dummy")


### PR DESCRIPTION
Signed-off-by: DaevMithran <daevmithran1999@gmail.com>

Issue is not fixed yet. Tried replacing the white spaces with %20 in tails_local_path. I'm not receiving error in swagger now. I'm receiving error in the logs. And it creates only one rev_reg instead of two now. Can anyone guide me on this?