### PR TITLE
Auto-promote author did to public after endorsing

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -1820,7 +1820,6 @@ class EndorsementGroup(ArgumentGroup):
             if settings["endorser.author"]:
                 settings["endorser.auto_request"] = True
             else:
-                pass
                 raise ArgsParseError(
                     "Parameter --auto-request-endorsement should only be set for "
                     "transaction Authors"
@@ -1830,7 +1829,6 @@ class EndorsementGroup(ArgumentGroup):
             if settings["endorser.endorser"]:
                 settings["endorser.auto_endorse"] = True
             else:
-                pass
                 raise ArgsParseError(
                     "Parameter --auto-endorser-transactions should only be set for "
                     "transaction Endorsers"
@@ -1840,7 +1838,6 @@ class EndorsementGroup(ArgumentGroup):
             if settings["endorser.author"]:
                 settings["endorser.auto_write"] = True
             else:
-                pass
                 raise ArgsParseError(
                     "Parameter --auto-write-transactions should only be set for "
                     "transaction Authors"
@@ -1850,7 +1847,6 @@ class EndorsementGroup(ArgumentGroup):
             if settings["endorser.author"]:
                 settings["endorser.auto_create_rev_reg"] = True
             else:
-                pass
                 raise ArgsParseError(
                     "Parameter --auto-create-revocation-transactions should only be set "
                     "for transaction Authors"
@@ -1860,7 +1856,6 @@ class EndorsementGroup(ArgumentGroup):
             if settings["endorser.author"]:
                 settings["endorser.auto_promote_author_did"] = True
             else:
-                pass
                 raise ArgsParseError(
                     "Parameter --auto-promote-author-did should only be set "
                     "for transaction Authors"

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -1733,6 +1733,13 @@ class EndorsementGroup(ArgumentGroup):
             " the controller must invoke the endpoints required to create the"
             " revocation registry and assign to the cred def.)",
         )
+        parser.add_argument(
+            "--auto-promote-author-did",
+            action="store_true",
+            env_var="ACAPY_PROMOTE-AUTHOR-DID",
+            help="For Authors, specify whether to automatically promote"
+            " a DID to the wallet public DID after writing to the ledger.",
+        )
 
     def get_settings(self, args: Namespace):
         """Extract endorser settings."""
@@ -1742,6 +1749,7 @@ class EndorsementGroup(ArgumentGroup):
         settings["endorser.auto_endorse"] = False
         settings["endorser.auto_write"] = False
         settings["endorser.auto_create_rev_reg"] = False
+        settings["endorser.auto_promote_author_did"] = False
 
         if args.endorser_protocol_role:
             if args.endorser_protocol_role == ENDORSER_AUTHOR:
@@ -1823,6 +1831,16 @@ class EndorsementGroup(ArgumentGroup):
                 pass
                 raise ArgsParseError(
                     "Parameter --auto-create-revocation-transactions should only be set "
+                    "for transaction Authors"
+                )
+
+        if args.auto_promote_author_did:
+            if settings["endorser.author"]:
+                settings["endorser.auto_promote_author_did"] = True
+            else:
+                pass
+                raise ArgsParseError(
+                    "Parameter --auto-promote-author-did should only be set "
                     "for transaction Authors"
                 )
 

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -1691,6 +1691,17 @@ class EndorsementGroup(ArgumentGroup):
             ),
         )
         parser.add_argument(
+            "--endorser-endorse-with-did",
+            type=str,
+            metavar="<endorser-endorse-with-did>",
+            env_var="ACAPY_ENDORSER_ENDORSE_WITH_DID",
+            help=(
+                "For transaction Endorsers, specify the  DID to use to endorse "
+                "transactions.  The default (if not specified) is to use the "
+                "Endorser's Public DID."
+            ),
+        )
+        parser.add_argument(
             "--endorser-alias",
             type=str,
             metavar="<endorser-alias>",
@@ -1764,6 +1775,17 @@ class EndorsementGroup(ArgumentGroup):
                 raise ArgsParseError(
                     "Parameter --endorser-public-did should only be set for transaction "
                     "Authors"
+                )
+
+        if args.endorser_endorse_with_did:
+            if settings["endorser.endorser"]:
+                settings[
+                    "endorser.endorser_endorse_with_did"
+                ] = args.endorser_endorse_with_did
+            else:
+                raise ArgsParseError(
+                    "Parameter --endorser-endorse-with-did should only be set for "
+                    "transaction Endorsers"
                 )
 
         if args.endorser_alias:

--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -160,6 +160,7 @@ class BaseLedger(ABC, metaclass=ABCMeta):
     async def txn_endorse(
         self,
         request_json: str,
+        endorse_did: DIDInfo = None,
     ) -> str:
         """Endorse (sign) the provided transaction."""
 

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -291,13 +291,14 @@ class IndySdkLedger(BaseLedger):
     async def _endorse(
         self,
         request_json: str,
+        endorse_did: DIDInfo = None,
     ) -> str:
         if not self.pool.handle:
             raise ClosedPoolError(
                 f"Cannot endorse request with closed pool '{self.pool.name}'"
             )
 
-        public_info = await self.get_wallet_public_did()
+        public_info = endorse_did if endorse_did else await self.get_wallet_public_did()
         if not public_info:
             raise BadLedgerRequestError(
                 "Cannot endorse transaction without a public DID"
@@ -403,9 +404,10 @@ class IndySdkLedger(BaseLedger):
     async def txn_endorse(
         self,
         request_json: str,
+        endorse_did: DIDInfo = None,
     ) -> str:
         """Endorse a (signed) ledger transaction."""
-        return await self._endorse(request_json)
+        return await self._endorse(request_json, endorse_did=endorse_did)
 
     async def txn_submit(
         self,

--- a/aries_cloudagent/ledger/indy_vdr.py
+++ b/aries_cloudagent/ledger/indy_vdr.py
@@ -1351,6 +1351,7 @@ class IndyVdrLedger(BaseLedger):
     async def txn_endorse(
         self,
         request_json: str,
+        endorse_did: DIDInfo = None,
     ) -> str:
         """Endorse (sign) the provided transaction."""
         try:
@@ -1360,7 +1361,7 @@ class IndyVdrLedger(BaseLedger):
 
         async with self.profile.session() as session:
             wallet = session.inject(BaseWallet)
-            sign_did = await wallet.get_public_did()
+            sign_did = endorse_did if endorse_did else await wallet.get_public_did()
             if not sign_did:
                 raise BadLedgerRequestError(
                     "Cannot endorse transaction without a public DID"

--- a/aries_cloudagent/ledger/routes.py
+++ b/aries_cloudagent/ledger/routes.py
@@ -49,7 +49,7 @@ from .multiple_ledger.ledger_config_schema import (
 )
 from .endpoint_type import EndpointType
 from .error import BadLedgerRequestError, LedgerError, LedgerTransactionError
-from .util import notify_did_event
+from .util import notify_register_did_event
 
 
 class LedgerModulesResultSchema(OpenAPISchema):
@@ -316,10 +316,10 @@ async def register_ledger_nym(request: web.BaseRequest):
                 )
             )
 
-    meta_data = {"verkey": verkey, "alias": alias, "role": role}
+    meta_data = {"did": did, "verkey": verkey, "alias": alias, "role": role}
     if not create_transaction_for_endorser:
         # Notify event
-        await notify_did_event(context.profile, did, meta_data)
+        await notify_register_did_event(context.profile, did, meta_data)
         return web.json_response({"success": success})
     else:
         transaction_mgr = TransactionManager(context.profile)

--- a/aries_cloudagent/ledger/util.py
+++ b/aries_cloudagent/ledger/util.py
@@ -7,11 +7,11 @@ from ..core.profile import Profile
 
 TAA_ACCEPTED_RECORD_TYPE = "taa_accepted"
 
-DID_EVENT_PREFIX = "acapy::DID::"
+DID_EVENT_PREFIX = "acapy::REGISTER_DID::"
 EVENT_LISTENER_PATTERN = re.compile(f"^{DID_EVENT_PREFIX}(.*)?$")
 
 
-async def notify_did_event(profile: Profile, did: str, meta_data: dict):
+async def notify_register_did_event(profile: Profile, did: str, meta_data: dict):
     """Send notification for a DID post-process event."""
     await profile.notify(
         DID_EVENT_PREFIX + did,

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/manager.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/manager.py
@@ -205,6 +205,7 @@ class TransactionManager:
         self,
         transaction: TransactionRecord,
         state: str,
+        use_endorser_did: str = None,
     ):
         """
         Create a response to endorse a transaction.
@@ -234,10 +235,22 @@ class TransactionManager:
             wallet: BaseWallet = session.inject_or(BaseWallet)
             if not wallet:
                 raise StorageError("No wallet available")
-            endorser_did_info = await wallet.get_public_did()
+            endorser_did_info = None
+            override_did = (
+                use_endorser_did
+                if use_endorser_did
+                else session.context.settings.get_value(
+                    "endorser.endorser_endorse_with_did"
+                )
+            )
+            if override_did:
+                endorser_did_info = await wallet.get_local_did(override_did)
+            else:
+                endorser_did_info = await wallet.get_public_did()
             if not endorser_did_info:
                 raise StorageError(
-                    "Transaction cannot be endorsed as there is no Public DID in wallet"
+                    "Transaction cannot be endorsed as there is no Public DID in wallet "
+                    "or Endorser DID specified"
                 )
             endorser_did = endorser_did_info.did
             endorser_verkey = endorser_did_info.verkey
@@ -251,7 +264,9 @@ class TransactionManager:
                 raise LedgerError(reason=reason)
 
         async with ledger:
-            endorsed_msg = await shield(ledger.txn_endorse(transaction_json))
+            endorsed_msg = await shield(
+                ledger.txn_endorse(transaction_json, endorse_did=endorser_did_info)
+            )
 
         # need to return the endorsed msg or else the ledger will reject the
         # eventual transaction write

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/manager.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/manager.py
@@ -21,6 +21,7 @@ from ....revocation.util import (
 from ....storage.error import StorageError, StorageNotFoundError
 from ....transport.inbound.receipt import MessageReceipt
 from ....wallet.base import BaseWallet
+from ....wallet.util import notify_endorse_did_event
 
 from .messages.cancel_transaction import CancelTransaction
 from .messages.endorsed_transaction_response import EndorsedTransactionResponse
@@ -789,6 +790,11 @@ class TransactionManager:
                 await notify_revocation_tails_file_event(
                     self._profile, rev_reg_id, meta_data
                 )
+
+        elif ledger_response["result"]["txn"]["type"] == "1":
+            # write DID to ledger
+            did = ledger_response["result"]["txn"]["data"]["dest"]
+            await notify_endorse_did_event(self._profile, did, meta_data)
 
         else:
             # TODO unknown ledger transaction type, just ignore for now ...

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/routes.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/routes.py
@@ -800,11 +800,10 @@ async def on_startup_event(profile: Profile, event: Event):
                 value = {"endorser_did": endorser_did, "endorser_name": endorser_alias}
             await conn_record.metadata_set(session, key="endorser_info", value=value)
 
-    except Exception as e:
+    except Exception:
         # log the error, but continue
         LOGGER.exception(
             "Error accepting endorser invitation/configuring endorser connection: %s",
-            str(e),
         )
 
 

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/routes.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/routes.py
@@ -60,6 +60,15 @@ class TranIdMatchInfoSchema(OpenAPISchema):
     )
 
 
+class EndorserDIDInfoSchema(OpenAPISchema):
+    """Path parameters and validators for request Endorser DID."""
+
+    endorser_did = fields.Str(
+        description="Endorser DID",
+        required=False,
+    )
+
+
 class AssignTransactionJobsSchema(OpenAPISchema):
     """Assign transaction related jobs to connection record."""
 
@@ -289,6 +298,7 @@ async def transaction_create_request(request: web.BaseRequest):
     tags=["endorse-transaction"],
     summary="For Endorser to endorse a particular transaction record",
 )
+@querystring_schema(EndorserDIDInfoSchema())
 @match_info_schema(TranIdMatchInfoSchema())
 @response_schema(TransactionRecordSchema(), 200)
 async def endorse_transaction_response(request: web.BaseRequest):
@@ -305,6 +315,7 @@ async def endorse_transaction_response(request: web.BaseRequest):
     outbound_handler = request["outbound_message_router"]
 
     transaction_id = request.match_info["tran_id"]
+    endorser_did = request.query.get("endorser_did")
     try:
         async with context.profile.session() as session:
             transaction = await TransactionRecord.retrieve_by_id(
@@ -313,6 +324,7 @@ async def endorse_transaction_response(request: web.BaseRequest):
             connection_record = await ConnRecord.retrieve_by_id(
                 session, transaction.connection_id
             )
+            # provided DID is validated in the TransactionManager
 
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
@@ -341,6 +353,7 @@ async def endorse_transaction_response(request: web.BaseRequest):
         ) = await transaction_mgr.create_endorse_response(
             transaction=transaction,
             state=TransactionRecord.STATE_TRANSACTION_ENDORSED,
+            use_endorser_did=endorser_did,
         )
     except (IndyIssuerError, LedgerError) as err:
         raise web.HTTPBadRequest(reason=err.roll_up) from err

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -585,11 +585,10 @@ async def on_register_nym_event(profile: Profile, event: Event):
             await promote_wallet_public_did(
                 profile, profile.context, profile.session, did
             )
-        except Exception as e:
+        except Exception:
             # log the error, but continue
             LOGGER.exception(
                 "Error accepting endorser invitation/configuring endorser connection: %s",
-                str(e),
             )
 
 

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -7,7 +7,7 @@ from aiohttp_apispec import (
     request_schema,
     response_schema,
 )
-
+import logging
 from marshmallow import fields, validate
 
 from ..admin.request_context import AdminRequestContext
@@ -37,6 +37,8 @@ from .did_method import DIDMethod
 from .error import WalletError, WalletNotFoundError
 from .key_type import KeyType
 from .util import EVENT_LISTENER_PATTERN
+
+LOGGER = logging.getLogger(__name__)
 
 
 class WalletModuleResponseSchema(OpenAPISchema):
@@ -392,52 +394,68 @@ async def wallet_set_public_did(request: web.BaseRequest):
     did = request.query.get("did")
     if not did:
         raise web.HTTPBadRequest(reason="Request query must include DID")
-    wallet_id = context.settings.get("wallet.id")
 
     info: DIDInfo = None
     try:
-        ledger = context.profile.inject_or(BaseLedger)
-        if not ledger:
-            reason = "No ledger available"
-            if not context.settings.get_value("wallet.type"):
-                reason += ": missing wallet-type?"
-            raise web.HTTPForbidden(reason=reason)
-
-        async with ledger:
-            if not await ledger.get_key_for_did(did):
-                raise web.HTTPNotFound(reason=f"DID {did} is not posted to the ledger")
-        did_info: DIDInfo = None
-        async with context.session() as session:
-            wallet = session.inject_or(BaseWallet)
-            did_info = await wallet.get_local_did(did)
-            info = await wallet.set_public_did(did_info)
-        if info:
-            # Publish endpoint if necessary
-            endpoint = did_info.metadata.get("endpoint")
-
-            if not endpoint:
-                async with context.session() as session:
-                    wallet = session.inject_or(BaseWallet)
-                    endpoint = context.settings.get("default_endpoint")
-                    await wallet.set_did_endpoint(info.did, endpoint, ledger)
-
-            async with ledger:
-                await ledger.update_endpoint_for_did(info.did, endpoint)
-
-            # Multitenancy setup
-            multitenant_mgr = context.profile.inject_or(BaseMultitenantManager)
-            # Add multitenant relay mapping so implicit invitations are still routed
-            if multitenant_mgr and wallet_id:
-                await multitenant_mgr.add_key(
-                    wallet_id, info.verkey, skip_if_exists=True
-                )
-
+        info = await promote_wallet_public_did(
+            context.profile, context, context.session, did
+        )
+    except LookupError as err:
+        raise web.HTTPNotFound(reason=str(err)) from err
+    except PermissionError as err:
+        raise web.HTTPForbidden(reason=str(err)) from err
     except WalletNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
     except (LedgerError, WalletError) as err:
         raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     return web.json_response({"result": format_did_info(info)})
+
+
+async def promote_wallet_public_did(
+    profile: Profile, context: AdminRequestContext, session_fn, did: str
+) -> DIDInfo:
+    """Promote supplied DID to the wallet public DID."""
+
+    # if running in multitenant mode this will be the sub-wallet
+    wallet_id = context.settings.get("wallet.id")
+
+    info: DIDInfo = None
+    ledger = profile.inject_or(BaseLedger)
+    if not ledger:
+        reason = "No ledger available"
+        if not context.settings.get_value("wallet.type"):
+            reason += ": missing wallet-type?"
+        raise PermissionError(reason)
+
+    async with ledger:
+        if not await ledger.get_key_for_did(did):
+            raise LookupError(f"DID {did} is not posted to the ledger")
+    did_info: DIDInfo = None
+    async with session_fn() as session:
+        wallet = session.inject_or(BaseWallet)
+        did_info = await wallet.get_local_did(did)
+        info = await wallet.set_public_did(did_info)
+    if info:
+        # Publish endpoint if necessary
+        endpoint = did_info.metadata.get("endpoint")
+
+        if not endpoint:
+            async with session_fn() as session:
+                wallet = session.inject_or(BaseWallet)
+                endpoint = context.settings.get("default_endpoint")
+                await wallet.set_did_endpoint(info.did, endpoint, ledger)
+
+        async with ledger:
+            await ledger.update_endpoint_for_did(info.did, endpoint)
+
+        # Multitenancy setup
+        multitenant_mgr = profile.inject_or(BaseMultitenantManager)
+        # Add multitenant relay mapping so implicit invitations are still routed
+        if multitenant_mgr and wallet_id:
+            await multitenant_mgr.add_key(wallet_id, info.verkey, skip_if_exists=True)
+
+    return info
 
 
 @docs(
@@ -559,16 +577,20 @@ async def on_register_nym_event(profile: Profile, event: Event):
     """Handle any events we need to support."""
 
     # after the nym record is written, promote to wallet public DID
-    if is_author_role(profile) and profile.context.settings.get_value("endorser.auto_promote_author_did"):
+    if is_author_role(profile) and profile.context.settings.get_value(
+        "endorser.auto_promote_author_did"
+    ):
         did = event.payload["did"]
-        await promote_wallet_public_did(profile, did)
-
-
-async def promote_wallet_public_did(profile: Profile, did: str):
-    """Promote supplied DID to the wallet public DID."""
-
-    # TODO
-    pass
+        try:
+            await promote_wallet_public_did(
+                profile, profile.context, profile.session, did
+            )
+        except Exception as e:
+            # log the error, but continue
+            LOGGER.exception(
+                "Error accepting endorser invitation/configuring endorser connection: %s",
+                str(e),
+            )
 
 
 async def register(app: web.Application):

--- a/aries_cloudagent/wallet/util.py
+++ b/aries_cloudagent/wallet/util.py
@@ -1,10 +1,14 @@
 """Wallet utility functions."""
 
+import re
+
 import base58
 import base64
 
 import nacl.utils
 import nacl.bindings
+
+from ..core.profile import Profile
 
 
 def random_seed() -> bytes:
@@ -86,3 +90,15 @@ def abbr_verkey(full_verkey: str, did: str = None) -> str:
     """Given a full verkey and DID, return the abbreviated verkey."""
     did_len = len(b58_to_bytes(did.split(":")[-1])) if did else 16
     return f"~{bytes_to_b58(b58_to_bytes(full_verkey)[did_len:])}"
+
+
+DID_EVENT_PREFIX = "acapy::ENDORSE_DID::"
+EVENT_LISTENER_PATTERN = re.compile(f"^{DID_EVENT_PREFIX}(.*)?$")
+
+
+async def notify_endorse_did_event(profile: Profile, did: str, meta_data: dict):
+    """Send notification for a DID post-process event."""
+    await profile.notify(
+        DID_EVENT_PREFIX + did,
+        meta_data,
+    )

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -1341,7 +1341,8 @@ class EndorserAgent(DemoAgent):
         # author responds to a multi-use invitation
         if message["state"] == "request":
             self.endorser_connection_id = message["connection_id"]
-            self._connection_ready = asyncio.Future()
+            if not self._connection_ready:
+                self._connection_ready = asyncio.Future()
 
         # finish off the connection
         if message["connection_id"] == self.endorser_connection_id:
@@ -1418,10 +1419,10 @@ async def connect_wallet_to_endorser(agent, endorser_agent):
     # Generate an invitation
     log_msg("Generate endorser invite ...")
     endorser_agent._connection_ready = asyncio.Future()
-    endorser_connection = await endorser_agent.admin_POST(
-        "/connections/create-invitation"
+    endorser_agent.endorser_connection_id = None
+    endorser_connection = await endorser_agent.get_invite(
+        use_did_exchange=endorser_agent.use_did_exchange,
     )
-    endorser_agent.endorser_connection_id = endorser_connection["connection_id"]
 
     # accept the invitation
     log_msg("Accept endorser invite ...")

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -426,6 +426,7 @@ class DemoAgent:
                         ("--auto-request-endorsement",),
                         ("--auto-write-transactions",),
                         ("--auto-create-revocation-transactions",),
+                        ("--auto-promote-author-did"),
                         ("--endorser-alias", "endorser"),
                     ]
                 )


### PR DESCRIPTION
Adds a couple of options:

Author can specify to auto-promote DID to their public DID when they receive the endorsed transaction (and it is saved)

Endorser can use a different DID for endorsing than they use for their public DID (for connections) (can be specified globally by parameter, or can be specified when they call the endorse endpoint).
