### PR TITLE
feat: query connections by their_public_did

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -187,7 +187,8 @@ class ConnectionsListQueryStringSchema(OpenAPISchema):
     )
     their_did = fields.Str(description="Their DID", required=False, **INDY_DID)
     their_public_did = fields.Str(
-        description="Their Public DID", required=False, **INDY_DID)
+        description="Their Public DID", required=False, **INDY_DID
+    )
     their_role = fields.Str(
         description="Their role in the connection protocol",
         required=False,
@@ -334,7 +335,7 @@ async def connections_list(request: web.BaseRequest):
         "their_did",
         "request_id",
         "invitation_key",
-        "their_public_did"
+        "their_public_did",
     ):
         if param_name in request.query and request.query[param_name] != "":
             tag_filter[param_name] = request.query[param_name]

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -186,6 +186,8 @@ class ConnectionsListQueryStringSchema(OpenAPISchema):
         ),
     )
     their_did = fields.Str(description="Their DID", required=False, **INDY_DID)
+    their_public_did = fields.Str(
+        description="Their Public DID", required=False, **INDY_DID)
     their_role = fields.Str(
         description="Their role in the connection protocol",
         required=False,
@@ -332,6 +334,7 @@ async def connections_list(request: web.BaseRequest):
         "their_did",
         "request_id",
         "invitation_key",
+        "their_public_did"
     ):
         if param_name in request.query and request.query[param_name] != "":
             tag_filter[param_name] = request.query[param_name]

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
@@ -32,6 +32,7 @@ class TestConnectionRoutes(AsyncTestCase):
             "their_role": ConnRecord.Role.REQUESTER.rfc160,
             "connection_protocol": ConnRecord.Protocol.RFC_0160.aries_protocol,
             "invitation_key": "some-invitation-key",
+            "their_public_did": "a_public_did"
         }
 
         STATE_COMPLETED = ConnRecord.State.COMPLETED
@@ -89,7 +90,7 @@ class TestConnectionRoutes(AsyncTestCase):
                 await test_module.connections_list(self.request)
                 mock_conn_rec.query.assert_called_once_with(
                     ANY,
-                    {"invitation_id": "dummy", "invitation_key": "some-invitation-key"},
+                    {"invitation_id": "dummy", "invitation_key": "some-invitation-key", "their_public_did": "a_public_did"},
                     post_filter_positive={
                         "their_role": [v for v in ConnRecord.Role.REQUESTER.value],
                         "connection_protocol": ConnRecord.Protocol.RFC_0160.aries_protocol,

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
@@ -32,7 +32,7 @@ class TestConnectionRoutes(AsyncTestCase):
             "their_role": ConnRecord.Role.REQUESTER.rfc160,
             "connection_protocol": ConnRecord.Protocol.RFC_0160.aries_protocol,
             "invitation_key": "some-invitation-key",
-            "their_public_did": "a_public_did"
+            "their_public_did": "a_public_did",
         }
 
         STATE_COMPLETED = ConnRecord.State.COMPLETED
@@ -90,7 +90,11 @@ class TestConnectionRoutes(AsyncTestCase):
                 await test_module.connections_list(self.request)
                 mock_conn_rec.query.assert_called_once_with(
                     ANY,
-                    {"invitation_id": "dummy", "invitation_key": "some-invitation-key", "their_public_did": "a_public_did"},
+                    {
+                        "invitation_id": "dummy",
+                        "invitation_key": "some-invitation-key",
+                        "their_public_did": "a_public_did",
+                    },
                     post_filter_positive={
                         "their_role": [v for v in ConnRecord.Role.REQUESTER.value],
                         "connection_protocol": ConnRecord.Protocol.RFC_0160.aries_protocol,


### PR DESCRIPTION
Now that `their_public_did` is saved as a tag (https://github.com/hyperledger/aries-cloudagent-python/pull/1543), we can use it to filter connections made with a specific public did.

This PR adds the filter option to the get all connections endpoint. Same as with #1453, this will only work for connections made after PR #1453 was merged or if the upgrade command has been run