### PR TITLE
Fix auto connection response not being properly mediated

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/handlers/connection_request_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/connection_request_handler.py
@@ -42,7 +42,9 @@ class ConnectionRequestHandler(BaseHandler):
             )
 
             if connection.accept == ConnRecord.ACCEPT_AUTO:
-                response = await mgr.create_response(connection)
+                response = await mgr.create_response(
+                    connection, mediation_id=mediation_id
+                )
                 await responder.send_reply(
                     response, connection_id=connection.connection_id
                 )

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -248,7 +248,9 @@ class ConnectionManager(BaseConnectionManager):
             # Save that this invitation was created with mediation
             async with self.profile.session() as session:
                 await connection.metadata_set(
-                    session, "mediation", {"id": mediation_record.mediation_id}
+                    session,
+                    MediationManager.METADATA_KEY,
+                    {MediationManager.METADATA_ID: mediation_record.mediation_id},
                 )
 
             if keylist_updates:

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/manager.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/manager.py
@@ -58,6 +58,8 @@ class MediationManager:
     DEFAULT_MEDIATOR_RECORD_TYPE = "default_mediator"
     SEND_REQ_AFTER_CONNECTION = "send_mediation_request_on_connection"
     SET_TO_DEFAULT_ON_GRANTED = "set_to_default_on_granted"
+    METADATA_KEY = "mediation"
+    METADATA_ID = "id"
 
     def __init__(self, profile: Profile):
         """Initialize Mediation Manager.

--- a/aries_cloudagent/protocols/didexchange/v1_0/handlers/request_handler.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/handlers/request_handler.py
@@ -2,9 +2,8 @@
 
 from .....connections.models.conn_record import ConnRecord
 from .....messaging.base_handler import BaseHandler, BaseResponder, RequestContext
-
+from ....coordinate_mediation.v1_0.manager import MediationManager
 from ....problem_report.v1_0.message import ProblemReport
-
 from ..manager import DIDXManager, DIDXManagerError
 from ..messages.request import DIDXRequest
 
@@ -27,15 +26,14 @@ class DIDXRequestHandler(BaseHandler):
         profile = context.profile
         mgr = DIDXManager(profile)
 
+        mediation_id = None
         if context.connection_record:
             async with profile.session() as session:
                 mediation_metadata = await context.connection_record.metadata_get(
-                    session, "mediation", {}
+                    session, MediationManager.METADATA_KEY, {}
                 )
-        else:
-            mediation_metadata = {}
+            mediation_id = mediation_metadata.get(MediationManager.METADATA_ID)
 
-        mediation_id = mediation_metadata.get("id")
         try:
             conn_rec = await mgr.receive_request(
                 request=context.message,

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -325,7 +325,9 @@ class OutOfBandManager(BaseConnectionManager):
 
                 async with self.profile.session() as session:
                     await conn_rec.metadata_set(
-                        session, "mediation", {"id": mediation_record.mediation_id}
+                        session,
+                        MediationManager.METADATA_KEY,
+                        {MediationManager.METADATA_ID: mediation_record.mediation_id},
                     )
 
                 if keylist_updates:


### PR DESCRIPTION
Connection responses associated with an invite that was created with mediation were not properly reporting the mediators endpoint and keys when automatically sent after receiving a connection request. This PR fixes this issue and also does some minor code clean up.