### PR TITLE
Pin markupsafe at version 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ base58~=2.1.0
 deepmerge~=0.3.0
 ecdsa~=0.16.1
 Markdown~=3.1.1
+markupsafe==2.0.1
 marshmallow==3.5.1
 msgpack~=1.0
 prompt_toolkit~=2.0.9


### PR DESCRIPTION
Temporary fix due to breaking changes in the dependency.

The 2.2 branch of aiohttp-apispec requires Jinja2 < 3, while its 3.0 (beta) branch supports newer Jinja2 versions which would likely also bypass this issue. We can either test out the current beta or wait for a new release there.