### PR TITLE
Fix DIFPresFormatHandler returning invalid V20PresExRecord on presentation verification

### DIFF
--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
@@ -1,5 +1,6 @@
 """V2.0 present-proof dif presentation-exchange format handler."""
 
+import json
 import logging
 
 from marshmallow import RAISE
@@ -475,5 +476,5 @@ class DIFPresFormatHandler(V20PresFormatHandler):
                 document_loader=self._profile.inject(DocumentLoader),
                 challenge=challenge,
             )
-            pres_ex_record.verified = pres_ver_result.verified
+            pres_ex_record.verified = json.dumps(pres_ver_result.verified)
             return pres_ex_record


### PR DESCRIPTION
We noticed that a `V20PresExRecord` which is returned by the present-proof v2.0 `/verify-presentation` endpoint does not match its schema when DIF format is used to request a presentation. Because of this, parsing it into a Kotlin class fails:
`com.squareup.moshi.JsonDataException: Expected one of [true, false] but was True at path $.verified`

Fixed this by applying json.dumps() when setting `pres_ex_record.verified` - just like it's done in the indy handler.

However, couldn't `verified` be a boolean instead of a string? I found comments in the schema and in the indy handler saying it has to be a string to be used as a tag (that was my takeaway at least ;) ), but I couldn't find where it is actually declared or used that way.

Signed-off-by: Roman Reinert <roman.reinert@gematik.de>