### PR TITLE
Add cred_def_id to metadata when using an Endorser

### DIFF
--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -251,6 +251,7 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
     meta_data = {
         "context": {
             "schema_id": schema_id,
+            "cred_def_id": cred_def_id,
             "support_revocation": support_revocation,
             "novel": novel,
             "tag": tag,

--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -248,10 +248,12 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
     except (IndyIssuerError, LedgerError) as e:
         raise web.HTTPBadRequest(reason=e.message) from e
 
+    issuer_did = cred_def_id.split(":")[0]
     meta_data = {
         "context": {
             "schema_id": schema_id,
             "cred_def_id": cred_def_id,
+            "issuer_did": issuer_did,
             "support_revocation": support_revocation,
             "novel": novel,
             "tag": tag,
@@ -264,10 +266,6 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
 
     if not create_transaction_for_endorser:
         # Notify event
-        issuer_did = cred_def_id.split(":")[0]
-        meta_data["context"]["schema_id"] = schema_id
-        meta_data["context"]["cred_def_id"] = cred_def_id
-        meta_data["context"]["issuer_did"] = issuer_did
         meta_data["processing"]["auto_create_rev_reg"] = True
         await notify_cred_def_event(context.profile, cred_def_id, meta_data)
 


### PR DESCRIPTION
When publishing a new credential definition to the ledger (with the Author/Endorser workflow), the `cred_def_id` is nowhere to be found in the transaction response or the webhooks. I have moved the metadata definition lines for `cred_def_id` and `issuer_id` to the actual definition point for the metadata and have removed the redundant lines that were in an if block.