### PR TITLE
Add "sent" key to both Schema and Cred Defs when using Endorsers

### DIFF
--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -269,10 +269,12 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
         meta_data["processing"]["auto_create_rev_reg"] = True
         await notify_cred_def_event(context.profile, cred_def_id, meta_data)
 
-        return web.json_response({
-            "sent": {"credential_definition_id": cred_def_id},
-            "credential_definition_id": cred_def_id,
-        })
+        return web.json_response(
+            {
+                "sent": {"credential_definition_id": cred_def_id},
+                "credential_definition_id": cred_def_id,
+            }
+        )
 
     # If the transaction is for the endorser, but the schema has already been created,
     # then we send back the schema since the transaction will fail to be created.
@@ -307,10 +309,12 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
 
             await outbound_handler(transaction_request, connection_id=connection_id)
 
-        return web.json_response({
-            "sent": {"credential_definition_id": cred_def_id},
-            "txn": transaction.serialize(),
-        })
+        return web.json_response(
+            {
+                "sent": {"credential_definition_id": cred_def_id},
+                "txn": transaction.serialize(),
+            }
+        )
 
 
 @docs(

--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -269,7 +269,10 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
         meta_data["processing"]["auto_create_rev_reg"] = True
         await notify_cred_def_event(context.profile, cred_def_id, meta_data)
 
-        return web.json_response({"credential_definition_id": cred_def_id})
+        return web.json_response({
+            "sent": {"credential_definition_id": cred_def_id},
+            "credential_definition_id": cred_def_id,
+        })
 
     # If the transaction is for the endorser, but the schema has already been created,
     # then we send back the schema since the transaction will fail to be created.

--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -271,6 +271,10 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
 
         return web.json_response({"credential_definition_id": cred_def_id})
 
+    # If the transaction is for the endorser, but the schema has already been created,
+    # then we send back the schema since the transaction will fail to be created.
+    elif "signed_txn" not in cred_def:
+        return web.json_response({"sent": {"credential_definition_id": cred_def_id}})
     else:
         meta_data["processing"]["auto_create_rev_reg"] = context.settings.get_value(
             "endorser.auto_create_rev_reg"

--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -304,7 +304,10 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
 
             await outbound_handler(transaction_request, connection_id=connection_id)
 
-        return web.json_response({"txn": transaction.serialize()})
+        return web.json_response({
+            "sent": {"credential_definition_id": cred_def_id},
+            "txn": transaction.serialize(),
+        })
 
 
 @docs(

--- a/aries_cloudagent/messaging/credential_definitions/tests/test_routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/tests/test_routes.py
@@ -81,7 +81,10 @@ class TestCredentialDefinitionRoutes(AsyncTestCase):
             )
             assert result == mock_response.return_value
             mock_response.assert_called_once_with(
-                {"credential_definition_id": CRED_DEF_ID}
+                {
+                    "sent": {"credential_definition_id": CRED_DEF_ID},
+                    "credential_definition_id": CRED_DEF_ID,
+                }
             )
 
     async def test_send_credential_definition_create_transaction_for_endorser(self):
@@ -126,7 +129,12 @@ class TestCredentialDefinitionRoutes(AsyncTestCase):
                 )
             )
             assert result == mock_response.return_value
-            mock_response.assert_called_once_with({"txn": {"...": "..."}})
+            mock_response.assert_called_once_with(
+                {
+                    "sent": {"credential_definition_id": CRED_DEF_ID},
+                    "txn": {"...": "..."},
+                }
+            )
 
     async def test_send_credential_definition_create_transaction_for_endorser_storage_x(
         self,

--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -259,7 +259,10 @@ async def schemas_send_schema(request: web.BaseRequest):
     if not create_transaction_for_endorser:
         # Notify event
         await notify_schema_event(context.profile, schema_id, meta_data)
-        return web.json_response({"schema_id": schema_id, "schema": schema_def})
+        return web.json_response({
+            "sent": {"schema_id": schema_id, "schema": schema_def},
+            "schema_id": schema_id, "schema": schema_def
+        })
 
     # If the transaction is for the endorser, but the schema has already been created,
     # then we send back the schema since the transaction will fail to be created.

--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -261,6 +261,10 @@ async def schemas_send_schema(request: web.BaseRequest):
         await notify_schema_event(context.profile, schema_id, meta_data)
         return web.json_response({"schema_id": schema_id, "schema": schema_def})
 
+    # If the transaction is for the endorser, but the schema has already been created,
+    # then we send back the schema since the transaction will fail to be created.
+    elif "signed_txn" not in schema_def:
+        return web.json_response({"sent": {"schema_id": schema_id, "schema": schema_def}})
     else:
         transaction_mgr = TransactionManager(context.profile)
         try:

--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -259,15 +259,20 @@ async def schemas_send_schema(request: web.BaseRequest):
     if not create_transaction_for_endorser:
         # Notify event
         await notify_schema_event(context.profile, schema_id, meta_data)
-        return web.json_response({
-            "sent": {"schema_id": schema_id, "schema": schema_def},
-            "schema_id": schema_id, "schema": schema_def
-        })
+        return web.json_response(
+            {
+                "sent": {"schema_id": schema_id, "schema": schema_def},
+                "schema_id": schema_id,
+                "schema": schema_def,
+            }
+        )
 
     # If the transaction is for the endorser, but the schema has already been created,
     # then we send back the schema since the transaction will fail to be created.
     elif "signed_txn" not in schema_def:
-        return web.json_response({"sent": {"schema_id": schema_id, "schema": schema_def}})
+        return web.json_response(
+            {"sent": {"schema_id": schema_id, "schema": schema_def}}
+        )
     else:
         transaction_mgr = TransactionManager(context.profile)
         try:
@@ -293,10 +298,12 @@ async def schemas_send_schema(request: web.BaseRequest):
 
             await outbound_handler(transaction_request, connection_id=connection_id)
 
-        return web.json_response({
-            "sent": {"schema_id": schema_id, "schema": schema_def},
-            "txn": transaction.serialize(),
-        })
+        return web.json_response(
+            {
+                "sent": {"schema_id": schema_id, "schema": schema_def},
+                "txn": transaction.serialize(),
+            }
+        )
 
 
 @docs(

--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -290,7 +290,10 @@ async def schemas_send_schema(request: web.BaseRequest):
 
             await outbound_handler(transaction_request, connection_id=connection_id)
 
-        return web.json_response({"txn": transaction.serialize()})
+        return web.json_response({
+            "sent": {"schema_id": schema_id, "schema": schema_def},
+            "txn": transaction.serialize(),
+        })
 
 
 @docs(

--- a/aries_cloudagent/messaging/schemas/tests/test_routes.py
+++ b/aries_cloudagent/messaging/schemas/tests/test_routes.py
@@ -70,6 +70,13 @@ class TestSchemaRoutes(AsyncTestCase):
             assert result == mock_response.return_value
             mock_response.assert_called_once_with(
                 {
+                    "sent": {
+                        "schema_id": SCHEMA_ID,
+                        "schema": {
+                            "schema": "def",
+                            "signed_txn": "...",
+                        },
+                    },
                     "schema_id": SCHEMA_ID,
                     "schema": {
                         "schema": "def",
@@ -116,7 +123,18 @@ class TestSchemaRoutes(AsyncTestCase):
             )
             result = await test_module.schemas_send_schema(self.request)
             assert result == mock_response.return_value
-            mock_response.assert_called_once_with({"txn": {"...": "..."}})
+            mock_response.assert_called_once_with(
+                {
+                    "sent": {
+                        "schema_id": SCHEMA_ID,
+                        "schema": {
+                            "schema": "def",
+                            "signed_txn": "...",
+                        },
+                    },
+                    "txn": {"...": "..."},
+                }
+            )
 
     async def test_send_schema_create_transaction_for_endorser_storage_x(self):
         self.request.json = async_mock.CoroutineMock(


### PR DESCRIPTION
As an Author, if I attempt to publish duplicate schemas or credential definitions, I get a trace stack returned to me complaining about how the `signed_txn` key does not exist. While I adding a response for that situation (to just return the schema ID/ Cred Def ID instead of an error), I noticed that we were never populating the `"sent"` key in our responses to controllers. I have standardized the responses to follow the OpenAPI Schema and included the `"sent"` key.