### PR TITLE
fix: always notify if revocation record exists

### DIFF
--- a/aries_cloudagent/protocols/revocation_notification/v1_0/routes.py
+++ b/aries_cloudagent/protocols/revocation_notification/v1_0/routes.py
@@ -32,7 +32,6 @@ async def on_revocation_published(profile: Profile, event: Event):
     """Handle issuer revoke event."""
     LOGGER.debug("Sending notification of revocation to recipient: %s", event.payload)
 
-    should_notify = profile.settings.get("revocation.notify", False)
     responder = profile.inject(BaseResponder)
     crids = event.payload.get("crids") or []
 
@@ -46,10 +45,9 @@ async def on_revocation_published(profile: Profile, event: Event):
 
             for record in records:
                 await record.delete_record(session)
-                if should_notify:
-                    await responder.send(
-                        record.to_message(), connection_id=record.connection_id
-                    )
+                await responder.send(
+                    record.to_message(), connection_id=record.connection_id
+                )
 
     except StorageNotFoundError:
         LOGGER.info(

--- a/aries_cloudagent/protocols/revocation_notification/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/revocation_notification/v1_0/tests/test_routes.py
@@ -50,7 +50,6 @@ async def test_on_revocation_published(profile: Profile, responder: MockResponde
     event = Event(topic, {"rev_reg_id": "mock", "crids": ["mock"]})
 
     assert isinstance(profile.settings, Settings)
-    profile.settings["revocation.notify"] = True
 
     with mock.patch.object(test_module, "RevNotificationRecord", MockRec):
         await test_module.on_revocation_published(profile, event)
@@ -58,32 +57,6 @@ async def test_on_revocation_published(profile: Profile, responder: MockResponde
     MockRec.query_by_rev_reg_id.assert_called_once()
     mock_rec.delete_record.assert_called_once()
     assert responder.messages
-
-
-@pytest.mark.asyncio
-async def test_on_revocation_published_no_notify(
-    profile: Profile, responder: MockResponder
-):
-    """Test revocation published event handler."""
-    mock_rec = mock.MagicMock()
-    mock_rec.cred_rev_id = "mock"
-    mock_rec.delete_record = mock.CoroutineMock()
-
-    MockRec = mock.MagicMock()
-    MockRec.query_by_rev_reg_id = mock.CoroutineMock(return_value=[mock_rec])
-
-    topic = f"{REVOCATION_EVENT_PREFIX}{REVOCATION_PUBLISHED_EVENT}::mock"
-    event = Event(topic, {"rev_reg_id": "mock", "crids": ["mock"]})
-
-    assert isinstance(profile.settings, Settings)
-    profile.settings["revocation.notify"] = False
-
-    with mock.patch.object(test_module, "RevNotificationRecord", MockRec):
-        await test_module.on_revocation_published(profile, event)
-
-    MockRec.query_by_rev_reg_id.assert_called_once()
-    mock_rec.delete_record.assert_called_once()
-    assert not responder.messages
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Removes the check to notify in the `on_revocation_published` event handler. This check in the `on_revocation_published` would only take the global config option into account, meaning it doesn't matter if you provided `notify: true` in the `/revoke` endpoint.

A`RevNotificationRecord` is only created if a notification should be sent (either global agent config, or `notify` prop in the revoke endpoint). So if a record exists I think we can assume that a notification should be sent as otherwise the record wouldn't exist in the first place. Maybe I'm missing something?

https://github.com/hyperledger/aries-cloudagent-python/blob/681e9aab9a6f6d3e76484d02ccb969d3227bf34f/aries_cloudagent/revocation/manager.py#L116-L126

