### PR TITLE
Add pre-commit as optional developer tool

### DIFF
--- a/.commitlint.config.js
+++ b/.commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional']
+};

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+---
+repos:
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v2.2.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        args: ["--config", ".commitlint.config.js"]
+        additional_dependencies: ['@commitlint/config-conventional']
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        stages: [commit]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.0
+    hooks:
+      - id: flake8
+        stages: [commit]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,21 @@ end-user and developer demos in the repo should include updates or extensions to
 If you would like to propose a significant change, please open an issue first to discuss the work with the community.
 
 Contributions are made pursuant to the Developer's Certificate of Origin, available at [https://developercertificate.org](https://developercertificate.org), and licensed under the Apache License, version 2.0 (Apache-2.0).
+
+## Development Tools
+
+### Pre-commit
+
+A configuration for [pre-commit](https://pre-commit.com/) is included in this repository. This is an optional tool to help contributors commit code that follows the formatting requirements enforced by the CI pipeline. Additionally, it can be used to help contributors write descriptive commit messages that can be parsed by changelog generators.
+
+On each commit, pre-commit hooks will run that verify the committed code complies with flake8 and is formatted with black. To install the flake8 and black checks:
+
+```
+$ pre-commit install
+```
+
+To install the commit message linter:
+
+```
+$ pre-commit install --hook-type commit-msg
+```

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -9,6 +9,7 @@ flake8==3.9.0
 flake8-docstrings==1.5.0
 flake8-rst==0.7.2
 pydocstyle==3.0.0
+pre-commit
 
 sphinx==1.8.4
 sphinx-rtd-theme>=0.4.3


### PR DESCRIPTION
This PR adds [pre-commit](https://pre-commit.com/) and associated configuration. This is more or less a tool for installing git hooks that check flake8 and black before committing. When used, this helps prevent follow up commits for formatting changes with black or correcting complaints from flake8.

There is also a configuration for installing hooks for checking that the commit message conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

It is possible to use the pre-commit hooks (flake8 and black) without the commit-msg hooks (commitlint) and vice-versa. Contributors can also ignore pre-commit altogether -- this is purely opt-in and must be explicitly installed.

Pre-commit is a pretty widely used tool in the python community and is analogous to [husky](https://typicode.github.io/husky/) in the javascript community. I've had these configuration files hanging out in my local fork of the ACA-Py repo and have been happily using them for more than a year.