### PR TITLE
Fix: DIF proof proposal when creating bound presentation request [Issue#1687]

### DIFF
--- a/aries_cloudagent/protocols/present_proof/dif/pres_proposal_schema.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_proposal_schema.py
@@ -3,7 +3,7 @@ from marshmallow import fields
 
 from ....messaging.models.openapi import OpenAPISchema
 
-from .pres_exch import InputDescriptorsSchema
+from .pres_exch import InputDescriptorsSchema, DIFOptionsSchema
 
 
 class DIFProofProposalSchema(OpenAPISchema):
@@ -14,5 +14,9 @@ class DIFProofProposalSchema(OpenAPISchema):
             InputDescriptorsSchema(),
             required=True,
         ),
+        required=False,
+    )
+    options = fields.Nested(
+        DIFOptionsSchema(),
         required=False,
     )

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
@@ -160,6 +160,8 @@ class DIFPresFormatHandler(V20PresFormatHandler):
         else:
             dif_proof_request["options"] = pres_proposal_dict["options"]
             del pres_proposal_dict["options"]
+            if "challenge" not in dif_proof_request.get("options"):
+                dif_proof_request["options"]["challenge"] = str(uuid4())
         dif_proof_request["presentation_definition"] = pres_proposal_dict
 
         return self.get_format_data(PRES_20_REQUEST, dif_proof_request)

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
@@ -151,9 +151,16 @@ class DIFPresFormatHandler(V20PresFormatHandler):
             A tuple (updated presentation exchange record, presentation request message)
 
         """
-        dif_proof_request = pres_ex_record.pres_proposal.attachment(
+        dif_proof_request = {}
+        pres_proposal_dict = pres_ex_record.pres_proposal.attachment(
             DIFPresFormatHandler.format
         )
+        if "options" not in pres_proposal_dict:
+            dif_proof_request["options"] = {"challenge": str(uuid4())}
+        else:
+            dif_proof_request["options"] = pres_proposal_dict["options"]
+            del pres_proposal_dict["options"]
+        dif_proof_request["presentation_definition"] = pres_proposal_dict
 
         return self.get_format_data(PRES_20_REQUEST, dif_proof_request)
 

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
@@ -341,9 +341,7 @@ class TestDIFFormatHandler(AsyncTestCase):
 
     async def test_create_bound_request_b(self):
         dif_proposal_dict = {
-            "options": {
-                "challenge": "test123"
-            },
+            "options": {"challenge": "test123"},
             "input_descriptors": [
                 {
                     "id": "citizenship_input_1",
@@ -365,7 +363,7 @@ class TestDIFFormatHandler(AsyncTestCase):
                         ],
                     },
                 }
-            ]
+            ],
         }
         dif_pres_proposal = V20PresProposal(
             formats=[

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
@@ -284,8 +284,66 @@ class TestDIFFormatHandler(AsyncTestCase):
         for suite in suites:
             assert type(suite) in types
 
-    async def test_create_bound_request(self):
+    async def test_create_bound_request_a(self):
         dif_proposal_dict = {
+            "input_descriptors": [
+                {
+                    "id": "citizenship_input_1",
+                    "name": "EU Driver's License",
+                    "group": ["A"],
+                    "schema": [
+                        {
+                            "uri": "https://www.w3.org/2018/credentials#VerifiableCredential"
+                        }
+                    ],
+                    "constraints": {
+                        "limit_disclosure": "required",
+                        "fields": [
+                            {
+                                "path": ["$.credentialSubject.givenName"],
+                                "purpose": "The claim must be from one of the specified issuers",
+                                "filter": {"type": "string", "enum": ["JOHN", "CAI"]},
+                            }
+                        ],
+                    },
+                }
+            ]
+        }
+        dif_pres_proposal = V20PresProposal(
+            formats=[
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20_PROPOSAL][
+                        V20PresFormat.Format.DIF.api
+                    ],
+                )
+            ],
+            proposals_attach=[
+                AttachDecorator.data_json(dif_proposal_dict, ident="dif")
+            ],
+        )
+        record = V20PresExRecord(
+            pres_ex_id="pxid",
+            thread_id="thid",
+            connection_id="conn_id",
+            initiator="init",
+            role="role",
+            state="state",
+            pres_proposal=dif_pres_proposal,
+            verified="false",
+            auto_present=True,
+            error_msg="error",
+        )
+        output = await self.handler.create_bound_request(pres_ex_record=record)
+        assert isinstance(output[0], V20PresFormat) and isinstance(
+            output[1], AttachDecorator
+        )
+
+    async def test_create_bound_request_b(self):
+        dif_proposal_dict = {
+            "options": {
+                "challenge": "test123"
+            },
             "input_descriptors": [
                 {
                     "id": "citizenship_input_1",

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
@@ -395,6 +395,62 @@ class TestDIFFormatHandler(AsyncTestCase):
             output[1], AttachDecorator
         )
 
+    async def test_create_bound_request_c(self):
+        dif_proposal_dict = {
+            "options": {"domain": "test123"},
+            "input_descriptors": [
+                {
+                    "id": "citizenship_input_1",
+                    "name": "EU Driver's License",
+                    "group": ["A"],
+                    "schema": [
+                        {
+                            "uri": "https://www.w3.org/2018/credentials#VerifiableCredential"
+                        }
+                    ],
+                    "constraints": {
+                        "limit_disclosure": "required",
+                        "fields": [
+                            {
+                                "path": ["$.credentialSubject.givenName"],
+                                "purpose": "The claim must be from one of the specified issuers",
+                                "filter": {"type": "string", "enum": ["JOHN", "CAI"]},
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+        dif_pres_proposal = V20PresProposal(
+            formats=[
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20_PROPOSAL][
+                        V20PresFormat.Format.DIF.api
+                    ],
+                )
+            ],
+            proposals_attach=[
+                AttachDecorator.data_json(dif_proposal_dict, ident="dif")
+            ],
+        )
+        record = V20PresExRecord(
+            pres_ex_id="pxid",
+            thread_id="thid",
+            connection_id="conn_id",
+            initiator="init",
+            role="role",
+            state="state",
+            pres_proposal=dif_pres_proposal,
+            verified="false",
+            auto_present=True,
+            error_msg="error",
+        )
+        output = await self.handler.create_bound_request(pres_ex_record=record)
+        assert isinstance(output[0], V20PresFormat) and isinstance(
+            output[1], AttachDecorator
+        )
+
     async def test_create_pres(self):
         dif_pres_request = V20PresRequest(
             formats=[

--- a/requirements.bbs.txt
+++ b/requirements.bbs.txt
@@ -1,1 +1,1 @@
-ursa-bbs-signatures~=1.0.1
+ursa-bbs-signatures==1.0.1


### PR DESCRIPTION
Signed-off-by: Shaanjot Gill <shaangill025@users.noreply.github.com>
- resolve #1687 
- So the validation for `/present-proof-v2.0/send-proposal` is working but the problem was that with `auto_respond_presentation_proposal` flag on it would create an invalid bound request from the proposal [`input_descriptors` was not enclosed in `presentation_definition`]. I am surprised that I didn't catch this earlier.
- @swcurran According to the [RFC](https://github.com/hyperledger/aries-rfcs/blob/main/features/0510-dif-pres-exch-attach/README.md#examples-propose-presentation), the `propose-presentation` message only expects `input_descriptors` and no `options` [for `challenge` and/or `domain`]. With auto flag, there will be no opportunity to add a domain to the request, so I have updated the schema to allow `options` in the `propose-presentation` message. `challenge` is always required for verifying presentation, if `options` is not specified then it is randomly assigned.