### PR TITLE
Multi-tenancy stale wallet clean up

### DIFF
--- a/aries_cloudagent/admin/tests/test_admin_server.py
+++ b/aries_cloudagent/admin/tests/test_admin_server.py
@@ -198,10 +198,9 @@ class TestAdminServer(AsyncTestCase):
         context = InjectionContext()
         context.injector.bind_instance(ProtocolRegistry, ProtocolRegistry())
         context.injector.bind_instance(GoalCodeRegistry, GoalCodeRegistry())
-        profile = InMemoryProfile.test_profile()
         context.injector.bind_instance(
             test_module.BaseMultitenantManager,
-            test_module.BaseMultitenantManager(profile),
+            async_mock.MagicMock(spec=test_module.BaseMultitenantManager),
         )
         await DefaultContextBuilder().load_plugins(context)
         server = self.get_admin_server(

--- a/aries_cloudagent/askar/tests/test_profile.py
+++ b/aries_cloudagent/askar/tests/test_profile.py
@@ -55,10 +55,10 @@ class TestProfile(AsyncTestCase):
         profile = "profileId"
 
         with mock.patch("aries_cloudagent.askar.profile.AskarProfile") as AskarProfile:
-            askar_profile = AskarProfile(None, True)
+            askar_profile = AskarProfile(None, True, profile_id=profile)
+            askar_profile.profile_id = profile
             askar_profile_transaction = mock.MagicMock()
             askar_profile.store.transaction.return_value = askar_profile_transaction
-            askar_profile.context.settings.get.return_value = profile
 
             transactionProfile = test_module.AskarProfileSession(askar_profile, True)
 
@@ -70,10 +70,10 @@ class TestProfile(AsyncTestCase):
         profile = "profileId"
 
         with mock.patch("aries_cloudagent.askar.profile.AskarProfile") as AskarProfile:
-            askar_profile = AskarProfile(None, False)
+            askar_profile = AskarProfile(None, False, profile_id=profile)
+            askar_profile.profile_id = profile
             askar_profile_session = mock.MagicMock()
             askar_profile.store.session.return_value = askar_profile_session
-            askar_profile.context.settings.get.return_value = profile
 
             sessionProfile = test_module.AskarProfileSession(askar_profile, False)
 

--- a/aries_cloudagent/askar/tests/test_profile.py
+++ b/aries_cloudagent/askar/tests/test_profile.py
@@ -28,7 +28,7 @@ class TestProfile(AsyncTestCase):
             "wallet.askar_profile": profile_id,
             "ledger.genesis_transactions": mock.MagicMock(),
         }
-        askar_profile = AskarProfile(openStore, context)
+        askar_profile = AskarProfile(openStore, context, profile_id=profile_id)
         remove_profile_stub = asyncio.Future()
         remove_profile_stub.set_result(True)
         openStore.store.remove_profile.return_value = remove_profile_stub
@@ -63,9 +63,6 @@ class TestProfile(AsyncTestCase):
             transactionProfile = test_module.AskarProfileSession(askar_profile, True)
 
             assert transactionProfile._opener == askar_profile_transaction
-            askar_profile.context.settings.get.assert_called_once_with(
-                "wallet.askar_profile"
-            )
             askar_profile.store.transaction.assert_called_once_with(profile)
 
     @pytest.mark.asyncio
@@ -81,7 +78,4 @@ class TestProfile(AsyncTestCase):
             sessionProfile = test_module.AskarProfileSession(askar_profile, False)
 
             assert sessionProfile._opener == askar_profile_session
-            askar_profile.context.settings.get.assert_called_once_with(
-                "wallet.askar_profile"
-            )
             askar_profile.store.session.assert_called_once_with(profile)

--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -495,7 +495,7 @@ class Conductor:
         # close multitenant profiles
         multitenant_mgr = self.context.inject_or(BaseMultitenantManager)
         if multitenant_mgr:
-            for profile in multitenant_mgr._instances.values():
+            for profile in multitenant_mgr.open_profiles:
                 shutdown.run(profile.close())
 
         if self.root_profile:

--- a/aries_cloudagent/core/profile.py
+++ b/aries_cloudagent/core/profile.py
@@ -4,6 +4,7 @@ import logging
 
 from abc import ABC, abstractmethod
 from typing import Any, Mapping, Optional, Type
+from weakref import finalize
 
 from .event_bus import EventBus, Event
 from ..config.base import InjectionError
@@ -114,6 +115,18 @@ class Profile(ABC):
 
     async def close(self):
         """Close the profile instance."""
+
+    def finalizer(self) -> Optional[finalize]:
+        """Create and return a finalizer for the profile or None.
+
+        None is returned if no special handling is required to close the profile.
+
+        Finalizers enable automatic clean up of wallet profiles when all references to
+        the profile expire.
+
+        See docs for weakref.finalize for more details on the behavior of finalizers.
+        """
+        return None
 
     async def remove(self):
         """Remove the profile."""

--- a/aries_cloudagent/core/tests/test_conductor.py
+++ b/aries_cloudagent/core/tests/test_conductor.py
@@ -918,15 +918,19 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             await conductor.setup()
             multitenant_mgr = conductor.context.inject(BaseMultitenantManager)
 
-            multitenant_mgr._instances = {
-                "test1": async_mock.MagicMock(close=async_mock.CoroutineMock()),
-                "test2": async_mock.MagicMock(close=async_mock.CoroutineMock()),
-            }
+            multitenant_mgr._profiles.put(
+                "test1",
+                async_mock.MagicMock(close=async_mock.CoroutineMock()),
+            )
+            multitenant_mgr._profiles.put(
+                "test2",
+                async_mock.MagicMock(close=async_mock.CoroutineMock()),
+            )
 
             await conductor.stop()
 
-            multitenant_mgr._instances["test1"].close.assert_called_once_with()
-            multitenant_mgr._instances["test2"].close.assert_called_once_with()
+            multitenant_mgr._profiles.profiles["test1"].close.assert_called_once_with()
+            multitenant_mgr._profiles.profiles["test2"].close.assert_called_once_with()
 
 
 def get_invite_store_mock(

--- a/aries_cloudagent/core/tests/test_conductor.py
+++ b/aries_cloudagent/core/tests/test_conductor.py
@@ -27,6 +27,7 @@ from ...protocols.coordinate_mediation.v1_0.models.mediation_record import (
 )
 from ...resolver.did_resolver import DIDResolver, DIDResolverRegistry
 from ...multitenant.base import BaseMultitenantManager
+from ...multitenant.manager import MultitenantManager
 from ...storage.base import BaseStorage
 from ...storage.error import StorageNotFoundError
 from ...transport.inbound.message import InboundMessage
@@ -917,6 +918,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
 
             await conductor.setup()
             multitenant_mgr = conductor.context.inject(BaseMultitenantManager)
+            assert isinstance(multitenant_mgr, MultitenantManager)
 
             multitenant_mgr._profiles.put(
                 "test1",

--- a/aries_cloudagent/multitenant/askar_profile_manager.py
+++ b/aries_cloudagent/multitenant/askar_profile_manager.py
@@ -1,5 +1,6 @@
 """Manager for askar profile multitenancy mode."""
 
+from typing import Iterable, Optional, cast
 from ..core.profile import (
     Profile,
 )
@@ -15,13 +16,23 @@ class AskarProfileMultitenantManager(BaseMultitenantManager):
 
     DEFAULT_MULTIENANT_WALLET_NAME = "multitenant_sub_wallet"
 
-    def __init__(self, profile: Profile):
+    def __init__(self, profile: Profile, multitenant_profile: AskarProfile = None):
         """Initialize askar profile multitenant Manager.
 
         Args:
             profile: The base profile for this manager
         """
         super().__init__(profile)
+        self._multitenant_profile: Optional[AskarProfile] = multitenant_profile
+
+    @property
+    def open_profiles(self) -> Iterable[Profile]:
+        """Return iterator over open profiles.
+
+        Only the core multitenant profile is considered open.
+        """
+        if self._multitenant_profile:
+            yield self._multitenant_profile
 
     async def get_wallet_profile(
         self,
@@ -33,6 +44,13 @@ class AskarProfileMultitenantManager(BaseMultitenantManager):
     ) -> Profile:
         """Get Askar profile for a wallet record.
 
+        An object of type AskarProfile is returned but this should not be
+        confused with the underlying profile mechanism provided by Askar that
+        enables multiple "profiles" to share a wallet. Usage of this mechanism
+        is what causes this implementation of BaseMultitenantManager.get_wallet_profile
+        to look different from others, especially since no explicit clean up is
+        required for profiles that are no longer in use.
+
         Args:
             base_context: Base context to extend from
             wallet_record: Wallet record to get the context for
@@ -42,12 +60,10 @@ class AskarProfileMultitenantManager(BaseMultitenantManager):
             Profile: Profile for the wallet record
 
         """
-        multitenant_wallet_name = (
-            base_context.settings.get("multitenant.wallet_name")
-            or self.DEFAULT_MULTIENANT_WALLET_NAME
-        )
-
-        if multitenant_wallet_name not in self._instances:
+        if not self._multitenant_profile:
+            multitenant_wallet_name = base_context.settings.get(
+                "multitenant.wallet_name", self.DEFAULT_MULTIENANT_WALLET_NAME
+            )
             context = base_context.copy()
             sub_wallet_settings = {
                 "wallet.recreate": False,
@@ -65,13 +81,14 @@ class AskarProfileMultitenantManager(BaseMultitenantManager):
             context.settings = context.settings.extend(sub_wallet_settings)
 
             profile, _ = await wallet_config(context, provision=False)
-            self._instances[multitenant_wallet_name] = profile
+            self._multitenant_profile = cast(AskarProfile, profile)
 
-        multitenant_wallet = self._instances[multitenant_wallet_name]
-        profile_context = multitenant_wallet.context.copy()
+        profile_context = self._multitenant_profile.context.copy()
 
         if provision:
-            await multitenant_wallet.store.create_profile(wallet_record.wallet_id)
+            await self._multitenant_profile.store.create_profile(
+                wallet_record.wallet_id
+            )
 
         extra_settings = {
             "admin.webhook_urls": self.get_webhook_urls(base_context, wallet_record),
@@ -82,7 +99,13 @@ class AskarProfileMultitenantManager(BaseMultitenantManager):
             wallet_record.settings
         ).extend(extra_settings)
 
-        return AskarProfile(multitenant_wallet.opened, profile_context)
+        assert self._multitenant_profile.opened
+
+        return AskarProfile(
+            self._multitenant_profile.opened,
+            profile_context,
+            profile_id=wallet_record.wallet_id,
+        )
 
     async def remove_wallet_profile(self, profile: Profile):
         """Remove the wallet profile instance.

--- a/aries_cloudagent/multitenant/base.py
+++ b/aries_cloudagent/multitenant/base.py
@@ -1,10 +1,10 @@
 """Manager for multitenancy."""
 
 import logging
-from abc import abstractmethod
+from abc import abstractmethod, ABC, abstractproperty
 
 import jwt
-from typing import List, Optional, cast
+from typing import Iterable, List, Optional, cast
 
 from ..core.profile import (
     Profile,
@@ -34,7 +34,7 @@ class MultitenantManagerError(BaseError):
     """Generic multitenant error."""
 
 
-class BaseMultitenantManager:
+class BaseMultitenantManager(ABC):
     """Base class for handling multitenancy."""
 
     def __init__(self, profile: Profile):
@@ -47,7 +47,10 @@ class BaseMultitenantManager:
         if not profile:
             raise MultitenantManagerError("Missing profile")
 
-        self._instances: dict[str, Profile] = {}
+    @abstractproperty
+    def open_profiles(self) -> Iterable[Profile]:
+        """Return iterator over open profiles."""
+        ...
 
     async def get_default_mediator(self) -> Optional[MediationRecord]:
         """Retrieve the default mediator used for subwallet routing.
@@ -211,7 +214,7 @@ class BaseMultitenantManager:
         wallet_id: str,
         new_settings: dict,
     ) -> WalletRecord:
-        """Update a existing wallet and wallet record.
+        """Update an existing wallet record.
 
         Args:
             wallet_id: The wallet id of the wallet record
@@ -226,18 +229,6 @@ class BaseMultitenantManager:
             wallet_record = await WalletRecord.retrieve_by_id(session, wallet_id)
             wallet_record.update_settings(new_settings)
             await wallet_record.save(session)
-
-        # update profile only if loaded
-        if wallet_id in self._instances:
-            profile = self._instances[wallet_id]
-            profile.settings.update(wallet_record.settings)
-
-            extra_settings = {
-                "admin.webhook_urls": self.get_webhook_urls(
-                    self._profile.context, wallet_record
-                ),
-            }
-            profile.settings.update(extra_settings)
 
         return wallet_record
 

--- a/aries_cloudagent/multitenant/cache.py
+++ b/aries_cloudagent/multitenant/cache.py
@@ -1,0 +1,94 @@
+"""Cache for multitenancy profiles."""
+
+import logging
+import sys
+from collections import OrderedDict
+from typing import Optional
+
+from ..core.profile import Profile
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ProfileCache:
+    """Profile cache that caches based on LRU strategy."""
+
+    def __init__(self, capacity: int):
+        """Initialize ProfileCache.
+
+        Args:
+            capacity: The capacity of the cache. If capacity is exceeded
+                      profiles are closed.
+        """
+
+        self.profiles: OrderedDict[str, Profile] = OrderedDict()
+        self.capacity = capacity
+
+    async def _cleanup(self):
+        for (key, profile) in self.profiles.items():
+            # When ref count is 4 we can assume the profile is not referenced
+            # 1 = profiles dict
+            # 2 = self.profiles.items()
+            # 3 = profile above
+            # 4 = sys.getrefcount
+            if sys.getrefcount(profile) <= 4:
+                LOGGER.debug(f"closing profile with id {key}")
+                del self.profiles[key]
+                await profile.close()
+
+                if len(self.profiles) <= self.capacity:
+                    break
+
+    def get(self, key: str) -> Optional[Profile]:
+        """Get profile with associated key from cache.
+
+        Args:
+            key (str): the key to get the profile for.
+
+        Returns:
+            Optional[Profile]: Profile if found in cache.
+
+        """
+        if key not in self.profiles:
+            return None
+        else:
+            self.profiles.move_to_end(key)
+            return self.profiles[key]
+
+    def has(self, key: str) -> bool:
+        """Check whether there is a profile with associated key in the cache.
+
+        Args:
+            key (str): the key to check for a profile
+
+        Returns:
+            bool: Whether the key exists in the cache
+
+        """
+        return key in self.profiles
+
+    async def put(self, key: str, value: Profile) -> None:
+        """Add profile with associated key to the cache.
+
+        If new profile exceeds the cache capacity least recently used profiles
+        that are not used will be removed from the cache.
+
+        Args:
+            key (str): the key to set
+            value (Profile): the profile to set
+        """
+        self.profiles[key] = value
+        self.profiles.move_to_end(key)
+        LOGGER.debug(f"setting profile with id {key} in profile cache")
+
+        if len(self.profiles) > self.capacity:
+            LOGGER.debug(f"profile limit of {self.capacity} reached. cleaning...")
+            await self._cleanup()
+
+    def remove(self, key: str):
+        """Remove profile with associated key from the cache.
+
+        Args:
+            key (str): The key to remove from the cache.
+        """
+        del self.profiles[key]

--- a/aries_cloudagent/multitenant/cache.py
+++ b/aries_cloudagent/multitenant/cache.py
@@ -51,7 +51,7 @@ class ProfileCache:
         """
         return key in self.profiles
 
-    async def put(self, key: str, value: Profile) -> None:
+    def put(self, key: str, value: Profile) -> None:
         """Add profile with associated key to the cache.
 
         If new profile exceeds the cache capacity least recently used profiles

--- a/aries_cloudagent/multitenant/manager.py
+++ b/aries_cloudagent/multitenant/manager.py
@@ -1,5 +1,6 @@
 """Manager for multitenancy."""
 
+from typing import Iterable
 from ..core.profile import (
     Profile,
 )
@@ -7,6 +8,8 @@ from ..config.wallet import wallet_config
 from ..config.injection_context import InjectionContext
 from ..wallet.models.wallet_record import WalletRecord
 from ..multitenant.base import BaseMultitenantManager
+
+from .cache import ProfileCache
 
 
 class MultitenantManager(BaseMultitenantManager):
@@ -19,6 +22,11 @@ class MultitenantManager(BaseMultitenantManager):
             profile: The profile for this manager
         """
         super().__init__(profile)
+        self._profiles = ProfileCache(100)
+
+    def open_profiles(self) -> Iterable[Profile]:
+        """Return iterator over open profiles."""
+        yield from self._profiles.profiles.values()
 
     async def get_wallet_profile(
         self,
@@ -40,7 +48,8 @@ class MultitenantManager(BaseMultitenantManager):
 
         """
         wallet_id = wallet_record.wallet_id
-        if wallet_id not in self._instances:
+        profile = self._profiles.get(wallet_id)
+        if not profile:
             # Extend base context
             context = base_context.copy()
 
@@ -68,9 +77,37 @@ class MultitenantManager(BaseMultitenantManager):
 
             # MTODO: add ledger config
             profile, _ = await wallet_config(context, provision=provision)
-            self._instances[wallet_id] = profile
+            self._profiles.put(wallet_id, profile)
 
-        return self._instances[wallet_id]
+        return profile
+
+    async def update_wallet(self, wallet_id: str, new_settings: dict) -> WalletRecord:
+        """Update an existing wallet and wallet record.
+
+        Args:
+            wallet_id: The wallet id of the wallet record
+            new_settings: The context settings to be updated for this wallet
+
+        Returns:
+            WalletRecord: The updated wallet record
+
+        """
+        wallet_record = await super().update_wallet(wallet_id, new_settings)
+
+        # Wallet record has been updated but profile settings in memory must
+        # also be refreshed; update profile only if loaded
+        profile = self._profiles.get(wallet_id)
+        if profile:
+            profile.settings.update(wallet_record.settings)
+
+            extra_settings = {
+                "admin.webhook_urls": self.get_webhook_urls(
+                    self._profile.context, wallet_record
+                ),
+            }
+            profile.settings.update(extra_settings)
+
+        return wallet_record
 
     async def remove_wallet_profile(self, profile: Profile):
         """Remove the wallet profile instance.
@@ -79,6 +116,6 @@ class MultitenantManager(BaseMultitenantManager):
             profile: The wallet profile instance
 
         """
-        wallet_id = profile.settings.get("wallet.id")
-        del self._instances[wallet_id]
+        wallet_id = profile.settings.get_str("wallet.id")
+        self._profiles.remove(wallet_id)
         await profile.remove()

--- a/aries_cloudagent/multitenant/manager.py
+++ b/aries_cloudagent/multitenant/manager.py
@@ -24,6 +24,7 @@ class MultitenantManager(BaseMultitenantManager):
         super().__init__(profile)
         self._profiles = ProfileCache(100)
 
+    @property
     def open_profiles(self) -> Iterable[Profile]:
         """Return iterator over open profiles."""
         yield from self._profiles.profiles.values()

--- a/aries_cloudagent/multitenant/tests/test_askar_profile_manager.py
+++ b/aries_cloudagent/multitenant/tests/test_askar_profile_manager.py
@@ -43,79 +43,61 @@ class TestAskarProfileMultitenantManager(AsyncTestCase):
 
         with async_mock.patch(
             "aries_cloudagent.multitenant.askar_profile_manager.wallet_config"
-        ) as wallet_config:
-            with async_mock.patch(
-                "aries_cloudagent.multitenant.askar_profile_manager.AskarProfile"
-            ) as AskarProfile:
-                sub_wallet_profile_context = InjectionContext()
-                sub_wallet_profile = AskarProfile(None, None)
-                sub_wallet_profile.context.copy.return_value = (
-                    sub_wallet_profile_context
-                )
+        ) as wallet_config, async_mock.patch(
+            "aries_cloudagent.multitenant.askar_profile_manager.AskarProfile",
+        ) as AskarProfile:
+            sub_wallet_profile_context = InjectionContext()
+            sub_wallet_profile = AskarProfile(None, None)
+            sub_wallet_profile.context.copy.return_value = sub_wallet_profile_context
 
-                def side_effect(context, provision):
-                    sub_wallet_profile.name = askar_profile_mock_name
-                    return sub_wallet_profile, None
+            def side_effect(context, provision):
+                sub_wallet_profile.name = askar_profile_mock_name
+                return sub_wallet_profile, None
 
-                wallet_config.side_effect = side_effect
+            wallet_config.side_effect = side_effect
 
-                profile = await self.manager.get_wallet_profile(
-                    self.profile.context, wallet_record
-                )
+            profile = await self.manager.get_wallet_profile(
+                self.profile.context, wallet_record
+            )
 
-                assert profile.name == askar_profile_mock_name
-                wallet_config.assert_called_once()
-                wallet_config_settings_argument = wallet_config.call_args[0][0].settings
-                assert (
-                    wallet_config_settings_argument.get("wallet.name")
-                    == self.DEFAULT_MULTIENANT_WALLET_NAME
-                )
-                assert wallet_config_settings_argument.get("wallet.id") == None
-                assert wallet_config_settings_argument.get("auto_provision") == True
-                assert wallet_config_settings_argument.get("wallet.type") == "askar"
-                AskarProfile.assert_called_with(
-                    sub_wallet_profile.opened, sub_wallet_profile_context
-                )
-                assert (
-                    sub_wallet_profile_context.settings.get("wallet.seed")
-                    == "test_seed"
-                )
-                assert (
-                    sub_wallet_profile_context.settings.get("wallet.rekey")
-                    == "test_rekey"
-                )
-                assert (
-                    sub_wallet_profile_context.settings.get("wallet.name")
-                    == "test_name"
-                )
-                assert (
-                    sub_wallet_profile_context.settings.get("wallet.type")
-                    == "test_type"
-                )
-                assert sub_wallet_profile_context.settings.get("mediation.open") == True
-                assert (
-                    sub_wallet_profile_context.settings.get("mediation.invite")
-                    == "http://invite.com"
-                )
-                assert (
-                    sub_wallet_profile_context.settings.get("mediation.default_id")
-                    == "24a96ef5"
-                )
-                assert (
-                    sub_wallet_profile_context.settings.get("mediation.clear") == True
-                )
-                assert (
-                    sub_wallet_profile_context.settings.get("wallet.id")
-                    == wallet_record.wallet_id
-                )
-                assert (
-                    sub_wallet_profile_context.settings.get("wallet.name")
-                    == "test_name"
-                )
-                assert (
-                    sub_wallet_profile_context.settings.get("wallet.askar_profile")
-                    == wallet_record.wallet_id
-                )
+            assert profile.name == askar_profile_mock_name
+            wallet_config.assert_called_once()
+            wallet_config_settings_argument = wallet_config.call_args[0][0].settings
+            assert (
+                wallet_config_settings_argument.get("wallet.name")
+                == self.DEFAULT_MULTIENANT_WALLET_NAME
+            )
+            assert wallet_config_settings_argument.get("wallet.id") == None
+            assert wallet_config_settings_argument.get("auto_provision") == True
+            assert wallet_config_settings_argument.get("wallet.type") == "askar"
+            AskarProfile.assert_called_with(
+                sub_wallet_profile.opened, sub_wallet_profile_context, profile_id="test"
+            )
+            assert sub_wallet_profile_context.settings.get("wallet.seed") == "test_seed"
+            assert (
+                sub_wallet_profile_context.settings.get("wallet.rekey") == "test_rekey"
+            )
+            assert sub_wallet_profile_context.settings.get("wallet.name") == "test_name"
+            assert sub_wallet_profile_context.settings.get("wallet.type") == "test_type"
+            assert sub_wallet_profile_context.settings.get("mediation.open") == True
+            assert (
+                sub_wallet_profile_context.settings.get("mediation.invite")
+                == "http://invite.com"
+            )
+            assert (
+                sub_wallet_profile_context.settings.get("mediation.default_id")
+                == "24a96ef5"
+            )
+            assert sub_wallet_profile_context.settings.get("mediation.clear") == True
+            assert (
+                sub_wallet_profile_context.settings.get("wallet.id")
+                == wallet_record.wallet_id
+            )
+            assert sub_wallet_profile_context.settings.get("wallet.name") == "test_name"
+            assert (
+                sub_wallet_profile_context.settings.get("wallet.askar_profile")
+                == wallet_record.wallet_id
+            )
 
     async def test_get_wallet_profile_should_create_profile(self):
         wallet_record = WalletRecord(wallet_id="test", settings={})
@@ -128,9 +110,7 @@ class TestAskarProfileMultitenantManager(AsyncTestCase):
             sub_wallet_profile = AskarProfile(None, None)
             sub_wallet_profile.context.copy.return_value = InjectionContext()
             sub_wallet_profile.store.create_profile.return_value = create_profile_stub
-            self.manager._instances[
-                self.DEFAULT_MULTIENANT_WALLET_NAME
-            ] = sub_wallet_profile
+            self.manager._multitenant_profile = sub_wallet_profile
 
             await self.manager.get_wallet_profile(
                 self.profile.context, wallet_record, provision=True
@@ -172,7 +152,7 @@ class TestAskarProfileMultitenantManager(AsyncTestCase):
                 )
 
     async def test_remove_wallet_profile(self):
-        test_profile = InMemoryProfile.test_profile()
+        test_profile = InMemoryProfile.test_profile({"wallet.id": "test"})
 
         with async_mock.patch.object(InMemoryProfile, "remove") as profile_remove:
             await self.manager.remove_wallet_profile(test_profile)

--- a/aries_cloudagent/multitenant/tests/test_base.py
+++ b/aries_cloudagent/multitenant/tests/test_base.py
@@ -23,6 +23,25 @@ from ..base import BaseMultitenantManager, MultitenantManagerError
 from ..error import WalletKeyMissingError
 
 
+class MockMultitenantManager(BaseMultitenantManager):
+    async def get_wallet_profile(
+        self,
+        base_context,
+        wallet_record: WalletRecord,
+        extra_settings: dict = ...,
+        *,
+        provision=False
+    ):
+        """Do nothing."""
+
+    async def remove_wallet_profile(self, profile):
+        """Do nothing."""
+
+    @property
+    def open_profiles(self):
+        """Do nothing."""
+
+
 class TestBaseMultitenantManager(AsyncTestCase):
     async def setUp(self):
         self.profile = InMemoryProfile.test_profile()
@@ -31,11 +50,11 @@ class TestBaseMultitenantManager(AsyncTestCase):
         self.responder = async_mock.CoroutineMock(send=async_mock.CoroutineMock())
         self.context.injector.bind_instance(BaseResponder, self.responder)
 
-        self.manager = BaseMultitenantManager(self.profile)
+        self.manager = MockMultitenantManager(self.profile)
 
     async def test_init_throws_no_profile(self):
         with self.assertRaises(MultitenantManagerError):
-            BaseMultitenantManager(None)
+            MockMultitenantManager(None)
 
     async def test_get_default_mediator(self):
         with async_mock.patch.object(
@@ -158,7 +177,7 @@ class TestBaseMultitenantManager(AsyncTestCase):
 
     async def test_create_wallet_removes_key_only_unmanaged_mode(self):
         with async_mock.patch.object(
-            BaseMultitenantManager, "get_wallet_profile"
+            self.manager, "get_wallet_profile"
         ) as get_wallet_profile:
             get_wallet_profile.return_value = InMemoryProfile.test_profile()
 
@@ -174,7 +193,7 @@ class TestBaseMultitenantManager(AsyncTestCase):
 
     async def test_create_wallet_fails_if_wallet_name_exists(self):
         with async_mock.patch.object(
-            BaseMultitenantManager, "_wallet_name_exists"
+            self.manager, "_wallet_name_exists"
         ) as _wallet_name_exists:
             _wallet_name_exists.return_value = True
 
@@ -191,9 +210,9 @@ class TestBaseMultitenantManager(AsyncTestCase):
         with async_mock.patch.object(
             WalletRecord, "save"
         ) as wallet_record_save, async_mock.patch.object(
-            BaseMultitenantManager, "get_wallet_profile"
+            self.manager, "get_wallet_profile"
         ) as get_wallet_profile, async_mock.patch.object(
-            BaseMultitenantManager, "add_key"
+            self.manager, "add_key"
         ) as add_key:
             get_wallet_profile.return_value = InMemoryProfile.test_profile()
 
@@ -227,9 +246,9 @@ class TestBaseMultitenantManager(AsyncTestCase):
         with async_mock.patch.object(
             WalletRecord, "save"
         ) as wallet_record_save, async_mock.patch.object(
-            BaseMultitenantManager, "get_wallet_profile"
+            self.manager, "get_wallet_profile"
         ) as get_wallet_profile, async_mock.patch.object(
-            BaseMultitenantManager, "add_key"
+            self.manager, "add_key"
         ) as add_key, async_mock.patch.object(
             InMemoryWallet, "get_public_did"
         ) as get_public_did:
@@ -257,15 +276,13 @@ class TestBaseMultitenantManager(AsyncTestCase):
             assert wallet_record.key_management_mode == WalletRecord.MODE_MANAGED
             assert wallet_record.wallet_key == "test_key"
 
-    async def test_update_wallet_update_wallet_profile(self):
+    async def test_update_wallet(self):
         with async_mock.patch.object(
             WalletRecord, "retrieve_by_id"
         ) as retrieve_by_id, async_mock.patch.object(
             WalletRecord, "save"
         ) as wallet_record_save:
             wallet_id = "test-wallet-id"
-            wallet_profile = InMemoryProfile.test_profile()
-            self.manager._instances["test-wallet-id"] = wallet_profile
             retrieve_by_id.return_value = WalletRecord(
                 wallet_id=wallet_id,
                 settings={
@@ -285,10 +302,6 @@ class TestBaseMultitenantManager(AsyncTestCase):
             assert isinstance(wallet_record, WalletRecord)
             assert wallet_record.wallet_webhook_urls == ["new-webhook-url"]
             assert wallet_record.wallet_dispatch_type == "default"
-            assert wallet_profile.settings.get("wallet.webhook_urls") == [
-                "new-webhook-url"
-            ]
-            assert wallet_profile.settings.get("wallet.dispatch_type") == "default"
 
     async def test_remove_wallet_fails_no_wallet_key_but_required(self):
         with async_mock.patch.object(WalletRecord, "retrieve_by_id") as retrieve_by_id:
@@ -305,9 +318,9 @@ class TestBaseMultitenantManager(AsyncTestCase):
         with async_mock.patch.object(
             WalletRecord, "retrieve_by_id"
         ) as retrieve_by_id, async_mock.patch.object(
-            BaseMultitenantManager, "get_wallet_profile"
+            self.manager, "get_wallet_profile"
         ) as get_wallet_profile, async_mock.patch.object(
-            BaseMultitenantManager, "remove_wallet_profile"
+            self.manager, "remove_wallet_profile"
         ) as remove_wallet_profile, async_mock.patch.object(
             WalletRecord, "delete_record"
         ) as wallet_delete_record, async_mock.patch.object(
@@ -483,7 +496,7 @@ class TestBaseMultitenantManager(AsyncTestCase):
         ).decode()
 
         with async_mock.patch.object(
-            BaseMultitenantManager, "get_wallet_profile"
+            self.manager, "get_wallet_profile"
         ) as get_wallet_profile:
             mock_profile = InMemoryProfile.test_profile()
             get_wallet_profile.return_value = mock_profile
@@ -517,7 +530,7 @@ class TestBaseMultitenantManager(AsyncTestCase):
         ).decode()
 
         with async_mock.patch.object(
-            BaseMultitenantManager, "get_wallet_profile"
+            self.manager, "get_wallet_profile"
         ) as get_wallet_profile:
             mock_profile = InMemoryProfile.test_profile()
             get_wallet_profile.return_value = mock_profile
@@ -557,7 +570,7 @@ class TestBaseMultitenantManager(AsyncTestCase):
         ]
 
         with async_mock.patch.object(
-            BaseMultitenantManager, "_get_wallet_by_key"
+            self.manager, "_get_wallet_by_key"
         ) as get_wallet_by_key:
             get_wallet_by_key.side_effect = return_wallets
 

--- a/aries_cloudagent/multitenant/tests/test_cache.py
+++ b/aries_cloudagent/multitenant/tests/test_cache.py
@@ -1,0 +1,100 @@
+import sys
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
+
+from ..cache import ProfileCache
+
+
+class TestProfileCache(AsyncTestCase):
+    async def setUp(self):
+        pass
+
+    async def test_cache_cleanup_capacity_reached(self):
+        with async_mock.patch.object(ProfileCache, "_cleanup") as _cleanup:
+            cache = ProfileCache(1)
+
+            await cache.put("1", async_mock.MagicMock())
+            _cleanup.assert_not_called()
+
+            await cache.put("2", async_mock.MagicMock())
+            _cleanup.assert_called_once()
+
+    async def test_get_not_in_cache(self):
+        cache = ProfileCache(1)
+
+        assert cache.get("1") is None
+
+    async def test_put_get_in_cache(self):
+        cache = ProfileCache(1)
+
+        profile = async_mock.MagicMock()
+        await cache.put("1", profile)
+
+        assert cache.get("1") is profile
+
+    async def test_remove(self):
+        cache = ProfileCache(1)
+
+        profile = async_mock.MagicMock()
+        await cache.put("1", profile)
+
+        assert cache.get("1") is profile
+
+        cache.remove("1")
+
+        assert cache.get("1") is None
+
+    async def test_has_true(self):
+        cache = ProfileCache(1)
+
+        profile = async_mock.MagicMock()
+
+        assert cache.has("1") is False
+        await cache.put("1", profile)
+        assert cache.has("1") is True
+
+    async def test_cleanup(self):
+        cache = ProfileCache(1)
+
+        with async_mock.patch.object(sys, "getrefcount") as getrefcount:
+            getrefcount.return_value = 4
+
+            profile1 = async_mock.MagicMock(close=async_mock.CoroutineMock())
+            profile2 = async_mock.MagicMock(close=async_mock.CoroutineMock())
+
+            await cache.put("1", profile1)
+
+            assert len(cache.profiles) == 1
+
+            await cache.put("2", profile2)
+
+            assert len(cache.profiles) == 1
+            assert cache.get("1") == None
+            profile1.close.assert_called_once()
+
+    async def test_cleanup_reference(self):
+        cache = ProfileCache(3)
+
+        with async_mock.patch.object(sys, "getrefcount") as getrefcount:
+            getrefcount.side_effect = [6, 4]
+
+            profile1 = async_mock.MagicMock(close=async_mock.CoroutineMock())
+            profile2 = async_mock.MagicMock(close=async_mock.CoroutineMock())
+            profile3 = async_mock.MagicMock(close=async_mock.CoroutineMock())
+            profile4 = async_mock.MagicMock(close=async_mock.CoroutineMock())
+
+            await cache.put("1", profile1)
+            await cache.put("2", profile2)
+            await cache.put("3", profile3)
+
+            assert len(cache.profiles) == 3
+
+            await cache.put("4", profile4)
+
+            assert len(cache.profiles) == 3
+            assert cache.get("1") == profile1
+            assert cache.get("2") == None
+            assert cache.get("3") == profile3
+            assert cache.get("4") == profile4
+
+            profile2.close.assert_called_once()

--- a/aries_cloudagent/multitenant/tests/test_cache.py
+++ b/aries_cloudagent/multitenant/tests/test_cache.py
@@ -1,82 +1,82 @@
-from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
 
 from ..cache import ProfileCache
 
 
-class TestProfileCache(AsyncTestCase):
-    async def setUp(self):
-        pass
+def test_get_not_in_cache():
+    cache = ProfileCache(1)
 
-    async def test_get_not_in_cache(self):
-        cache = ProfileCache(1)
+    assert cache.get("1") is None
 
-        assert cache.get("1") is None
 
-    async def test_put_get_in_cache(self):
-        cache = ProfileCache(1)
+def test_put_get_in_cache():
+    cache = ProfileCache(1)
 
-        profile = async_mock.MagicMock()
-        await cache.put("1", profile)
+    profile = async_mock.MagicMock()
+    cache.put("1", profile)
 
-        assert cache.get("1") is profile
+    assert cache.get("1") is profile
 
-    async def test_remove(self):
-        cache = ProfileCache(1)
 
-        profile = async_mock.MagicMock()
-        await cache.put("1", profile)
+def test_remove():
+    cache = ProfileCache(1)
 
-        assert cache.get("1") is profile
+    profile = async_mock.MagicMock()
+    cache.put("1", profile)
 
-        cache.remove("1")
+    assert cache.get("1") is profile
 
-        assert cache.get("1") is None
+    cache.remove("1")
 
-    async def test_has_true(self):
-        cache = ProfileCache(1)
+    assert cache.get("1") is None
 
-        profile = async_mock.MagicMock()
 
-        assert cache.has("1") is False
-        await cache.put("1", profile)
-        assert cache.has("1") is True
+def test_has_true():
+    cache = ProfileCache(1)
 
-    async def test_cleanup(self):
-        cache = ProfileCache(1)
+    profile = async_mock.MagicMock()
 
-        profile1 = async_mock.MagicMock()
-        profile2 = async_mock.MagicMock()
+    assert cache.has("1") is False
+    cache.put("1", profile)
+    assert cache.has("1") is True
 
-        await cache.put("1", profile1)
 
-        assert len(cache.profiles) == 1
+def test_cleanup():
+    cache = ProfileCache(1)
 
-        await cache.put("2", profile2)
+    profile1 = async_mock.MagicMock()
+    profile2 = async_mock.MagicMock()
 
-        assert len(cache.profiles) == 1
-        assert cache.get("1") == None
+    cache.put("1", profile1)
 
-    async def test_cleanup_lru(self):
-        cache = ProfileCache(3)
+    assert len(cache.profiles) == 1
 
-        profile1 = async_mock.MagicMock()
-        profile2 = async_mock.MagicMock()
-        profile3 = async_mock.MagicMock()
-        profile4 = async_mock.MagicMock()
+    cache.put("2", profile2)
 
-        await cache.put("1", profile1)
-        await cache.put("2", profile2)
-        await cache.put("3", profile3)
+    assert len(cache.profiles) == 1
+    assert cache.get("1") == None
 
-        assert len(cache.profiles) == 3
 
-        cache.get("1")
+def test_cleanup_lru():
+    cache = ProfileCache(3)
 
-        await cache.put("4", profile4)
+    profile1 = async_mock.MagicMock()
+    profile2 = async_mock.MagicMock()
+    profile3 = async_mock.MagicMock()
+    profile4 = async_mock.MagicMock()
 
-        assert len(cache.profiles) == 3
-        assert cache.get("1") == profile1
-        assert cache.get("2") == None
-        assert cache.get("3") == profile3
-        assert cache.get("4") == profile4
+    cache.put("1", profile1)
+    cache.put("2", profile2)
+    cache.put("3", profile3)
+
+    assert len(cache.profiles) == 3
+
+    cache.get("1")
+
+    cache.put("4", profile4)
+
+    assert len(cache.profiles) == 3
+    assert cache.get("1") == profile1
+    assert cache.get("2") == None
+    assert cache.get("3") == profile3
+    assert cache.get("4") == profile4


### PR DESCRIPTION
This PR is intended to supersede #928. Due to significant changes since the original PR was opened, I cherry-picked a commit but had to modify it. History has not been well preserved, unfortunately. Credit to @TimoGlastra for the original work on the `ProfileCache` especially and for assistance in finding the solution implemented here.

This PR adds a LRU cache for profiles opened by `MultitenantManager` (corresponding to wallet types `indy` and `askar`, but not `askar-profile`). `weakref.finalize` is used to ensure the profiles are closed when they fall out of scope. An ordered dictionary of profiles holds a (strong) reference to the profile until it is evicted. If that profile happens to still be in use at the time it is evicted, it will not be closed until other (strong) references to it expire, i.e. after processing of a message or admin request has finished. This exact scenario is unlikely but possible.

In addition to this profile caching mechanism, I also updated a few aspects of the `BaseMultitenantManager` and its subclasses to make them more consistent with conventions used in ACA-Py.

Also, after being very confused by handling of askar profiles (not to be confused with `AskarProfile`s) within the `AskarProfileMultitenantManager` and `AskarProfile`, I did some light updates to (I hope) improve clarity.

A brief listing of known limitations:
- As implemented, the capacity of the LRU cache is statically defined as 100.
- A temporally based system for evicting profiles from the cache is likely better than a max capacity based system.
- 