### PR TITLE
Feature/undelivered events

### DIFF
--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -677,7 +677,7 @@ class Conductor:
         if self.outbound_queue:
             return await self._queue_external(profile, outbound)
         else:
-            return await self._queue_internal(profile, outbound)
+            return self._queue_internal(profile, outbound)
 
     async def _queue_external(
         self,
@@ -701,7 +701,7 @@ class Conductor:
 
             return OutboundSendStatus.SENT_TO_EXTERNAL_QUEUE
 
-    async def _queue_internal(
+    def _queue_internal(
         self, profile: Profile, outbound: OutboundMessage
     ) -> OutboundSendStatus:
         """Save the message to an internal outbound queue."""
@@ -710,19 +710,18 @@ class Conductor:
             return OutboundSendStatus.QUEUED_FOR_DELIVERY
         except OutboundDeliveryError:
             LOGGER.warning("Cannot queue message for delivery, no supported transport")
-            return await self.handle_not_delivered(profile, outbound)
+            return self.handle_not_delivered(profile, outbound)
 
     async def handle_not_delivered(
         self, profile: Profile, outbound: OutboundMessage
     ) -> OutboundSendStatus:
         """Handle a message that failed delivery via outbound transports."""
         queued_for_inbound = self.inbound_transport_manager.return_undelivered(outbound)
-        status = (
+        return (
             OutboundSendStatus.WAITING_FOR_PICKUP
             if queued_for_inbound
             else OutboundSendStatus.UNDELIVERABLE
         )
-        return status
 
     def webhook_router(
         self,

--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -70,7 +70,7 @@ from .dispatcher import Dispatcher
 from .util import STARTUP_EVENT_TOPIC, SHUTDOWN_EVENT_TOPIC
 
 LOGGER = logging.getLogger(__name__)
-UNDELIVERABLE_EVENT_TOPIC = "acapy::outbound-message::undeliverable"
+OUTBOUND_STATUS_PREFIX = "acapy::outbound-message::"
 
 
 class Conductor:
@@ -603,6 +603,10 @@ class Conductor:
                 outbound.reply_from_verkey = inbound.receipt.recipient_verkey
             # return message to an inbound session
             if self.inbound_transport_manager.return_to_session(outbound):
+                await profile.notify(
+                    f"{OUTBOUND_STATUS_PREFIX}{OutboundSendStatus.SENT_TO_SESSION}",
+                    outbound,
+                )
                 return OutboundSendStatus.SENT_TO_SESSION
 
         if not outbound.to_session_only:
@@ -680,6 +684,10 @@ class Conductor:
                     encoded_outbound_message.payload, target.endpoint
                 )
 
+            await profile.notify(
+                f"{OUTBOUND_STATUS_PREFIX}{OutboundSendStatus.SENT_TO_EXTERNAL_QUEUE}",
+                outbound,
+            )
             return OutboundSendStatus.SENT_TO_EXTERNAL_QUEUE
 
     async def _queue_internal(
@@ -688,6 +696,10 @@ class Conductor:
         """Save the message to an internal outbound queue."""
         try:
             self.outbound_transport_manager.enqueue_message(profile, outbound)
+            await profile.notify(
+                f"{OUTBOUND_STATUS_PREFIX}{OutboundSendStatus.QUEUED_FOR_DELIVERY}",
+                outbound,
+            )
             return OutboundSendStatus.QUEUED_FOR_DELIVERY
         except OutboundDeliveryError:
             LOGGER.warning("Cannot queue message for delivery, no supported transport")
@@ -698,12 +710,13 @@ class Conductor:
     ) -> OutboundSendStatus:
         """Handle a message that failed delivery via outbound transports."""
         queued_for_inbound = self.inbound_transport_manager.return_undelivered(outbound)
-        await profile.notify(UNDELIVERABLE_EVENT_TOPIC, outbound)
-        return (
+        status = (
             OutboundSendStatus.WAITING_FOR_PICKUP
             if queued_for_inbound
             else OutboundSendStatus.UNDELIVERABLE
         )
+        await profile.notify(f"{OUTBOUND_STATUS_PREFIX}{status}", outbound)
+        return status
 
     def webhook_router(
         self,

--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -712,7 +712,7 @@ class Conductor:
             LOGGER.warning("Cannot queue message for delivery, no supported transport")
             return self.handle_not_delivered(profile, outbound)
 
-    async def handle_not_delivered(
+    def handle_not_delivered(
         self, profile: Profile, outbound: OutboundMessage
     ) -> OutboundSendStatus:
         """Handle a message that failed delivery via outbound transports."""

--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -70,6 +70,7 @@ from .dispatcher import Dispatcher
 from .util import STARTUP_EVENT_TOPIC, SHUTDOWN_EVENT_TOPIC
 
 LOGGER = logging.getLogger(__name__)
+UNDELIVERABLE_EVENT_TOPIC = "acapy::outbound-message::undeliverable"
 
 
 class Conductor:
@@ -697,7 +698,7 @@ class Conductor:
     ) -> OutboundSendStatus:
         """Handle a message that failed delivery via outbound transports."""
         queued_for_inbound = self.inbound_transport_manager.return_undelivered(outbound)
-
+        profile.notify(UNDELIVERABLE_EVENT_TOPIC, outbound)
         return (
             OutboundSendStatus.WAITING_FOR_PICKUP
             if queued_for_inbound

--- a/aries_cloudagent/core/tests/test_conductor.py
+++ b/aries_cloudagent/core/tests/test_conductor.py
@@ -46,8 +46,6 @@ from ...wallet.did_method import DIDMethod
 
 from .. import conductor as test_module
 
-EVENT_PREFIX = test_module.OUTBOUND_STATUS_PREFIX
-
 
 class Config:
     test_settings = {"admin.webhook_urls": ["http://sample.webhook.ca"]}

--- a/aries_cloudagent/core/tests/test_conductor.py
+++ b/aries_cloudagent/core/tests/test_conductor.py
@@ -323,10 +323,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             )
             assert status == OutboundSendStatus.SENT_TO_SESSION
             assert bus.events
-            assert (
-                bus.events[0][1].topic
-                == f"{EVENT_PREFIX}{OutboundSendStatus.SENT_TO_SESSION}"
-            )
+            assert bus.events[0][1].topic == status.topic
             assert bus.events[0][1].payload == message
             mock_return.assert_called_once_with(message)
             mock_queue.assert_not_awaited()
@@ -355,10 +352,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             assert status == OutboundSendStatus.QUEUED_FOR_DELIVERY
             assert bus.events
             print(bus.events)
-            assert (
-                bus.events[0][1].topic
-                == f"{EVENT_PREFIX}{OutboundSendStatus.QUEUED_FOR_DELIVERY}"
-            )
+            assert bus.events[0][1].topic == status.topic
             assert bus.events[0][1].payload == message
             mock_outbound_mgr.return_value.enqueue_message.assert_called_once_with(
                 conductor.root_profile, message
@@ -389,10 +383,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             assert status == OutboundSendStatus.QUEUED_FOR_DELIVERY
             assert bus.events
             print(bus.events)
-            assert (
-                bus.events[0][1].topic
-                == f"{EVENT_PREFIX}{OutboundSendStatus.QUEUED_FOR_DELIVERY}"
-            )
+            assert bus.events[0][1].topic == status.topic
             assert bus.events[0][1].payload == message
 
             conn_mgr.return_value.get_connection_targets.assert_awaited_once_with(
@@ -435,10 +426,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             assert status == OutboundSendStatus.QUEUED_FOR_DELIVERY
             assert bus.events
             print(bus.events)
-            assert (
-                bus.events[0][1].topic
-                == f"{EVENT_PREFIX}{OutboundSendStatus.QUEUED_FOR_DELIVERY}"
-            )
+            assert bus.events[0][1].topic == status.topic
             assert bus.events[0][1].payload == message
 
             mock_outbound_mgr.return_value.enqueue_message.assert_called_once_with(

--- a/aries_cloudagent/core/tests/test_conductor.py
+++ b/aries_cloudagent/core/tests/test_conductor.py
@@ -15,6 +15,7 @@ from ...connections.models.diddoc import (
     PublicKeyType,
     Service,
 )
+from ...core.event_bus import EventBus, MockEventBus
 from ...core.in_memory import InMemoryProfileManager
 from ...core.profile import ProfileManager
 from ...core.protocol_registry import ProtocolRegistry
@@ -34,6 +35,7 @@ from ...transport.inbound.receipt import MessageReceipt
 from ...transport.outbound.base import OutboundDeliveryError
 from ...transport.outbound.manager import QueuedOutboundMessage
 from ...transport.outbound.message import OutboundMessage
+from ...transport.outbound.status import OutboundSendStatus
 from ...transport.wire_format import BaseWireFormat
 from ...transport.pack_format import PackWireFormat
 from ...utils.stats import Collector
@@ -43,6 +45,8 @@ from ...wallet.key_type import KeyType
 from ...wallet.did_method import DIDMethod
 
 from .. import conductor as test_module
+
+EVENT_PREFIX = test_module.OUTBOUND_STATUS_PREFIX
 
 
 class Config:
@@ -92,6 +96,7 @@ class StubContextBuilder(ContextBuilder):
         context.injector.bind_instance(ProtocolRegistry, ProtocolRegistry())
         context.injector.bind_instance(BaseWireFormat, self.wire_format)
         context.injector.bind_instance(DIDResolver, DIDResolver(DIDResolverRegistry()))
+        context.injector.bind_instance(EventBus, MockEventBus())
         return context
 
 
@@ -297,6 +302,8 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
 
         await conductor.setup()
 
+        bus = conductor.root_profile.inject(EventBus)
+
         payload = "{}"
         message = OutboundMessage(payload=payload)
         message.reply_to_verkey = test_to_verkey
@@ -310,7 +317,17 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             conductor, "queue_outbound", async_mock.CoroutineMock()
         ) as mock_queue:
             mock_return.return_value = True
-            await conductor.outbound_message_router(conductor.context, message)
+
+            status = await conductor.outbound_message_router(
+                conductor.root_profile, message
+            )
+            assert status == OutboundSendStatus.SENT_TO_SESSION
+            assert bus.events
+            assert (
+                bus.events[0][1].topic
+                == f"{EVENT_PREFIX}{OutboundSendStatus.SENT_TO_SESSION}"
+            )
+            assert bus.events[0][1].payload == message
             mock_return.assert_called_once_with(message)
             mock_queue.assert_not_awaited()
 
@@ -324,16 +341,27 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
 
             await conductor.setup()
 
+            bus = conductor.root_profile.inject(EventBus)
+
             payload = "{}"
             target = ConnectionTarget(
                 endpoint="endpoint", recipient_keys=(), routing_keys=(), sender_key=""
             )
             message = OutboundMessage(payload=payload, target=target)
 
-            await conductor.outbound_message_router(conductor.context, message)
-
+            status = await conductor.outbound_message_router(
+                conductor.root_profile, message
+            )
+            assert status == OutboundSendStatus.QUEUED_FOR_DELIVERY
+            assert bus.events
+            print(bus.events)
+            assert (
+                bus.events[0][1].topic
+                == f"{EVENT_PREFIX}{OutboundSendStatus.QUEUED_FOR_DELIVERY}"
+            )
+            assert bus.events[0][1].payload == message
             mock_outbound_mgr.return_value.enqueue_message.assert_called_once_with(
-                conductor.context, message
+                conductor.root_profile, message
             )
 
     async def test_outbound_message_handler_with_connection(self):
@@ -348,11 +376,24 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
 
             await conductor.setup()
 
+            bus = conductor.root_profile.inject(EventBus)
+
             payload = "{}"
             connection_id = "connection_id"
             message = OutboundMessage(payload=payload, connection_id=connection_id)
 
-            await conductor.outbound_message_router(conductor.root_profile, message)
+            status = await conductor.outbound_message_router(
+                conductor.root_profile, message
+            )
+
+            assert status == OutboundSendStatus.QUEUED_FOR_DELIVERY
+            assert bus.events
+            print(bus.events)
+            assert (
+                bus.events[0][1].topic
+                == f"{EVENT_PREFIX}{OutboundSendStatus.QUEUED_FOR_DELIVERY}"
+            )
+            assert bus.events[0][1].payload == message
 
             conn_mgr.return_value.get_connection_targets.assert_awaited_once_with(
                 connection_id=connection_id
@@ -376,21 +417,32 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
 
             await conductor.setup()
 
+            bus = conductor.root_profile.inject(EventBus)
+
             payload = "{}"
             message = OutboundMessage(
                 payload=payload, reply_to_verkey=TestDIDs.test_verkey
             )
 
-            await conductor.outbound_message_router(
-                conductor.context,
+            status = await conductor.outbound_message_router(
+                conductor.root_profile,
                 message,
                 inbound=async_mock.MagicMock(
                     receipt=async_mock.MagicMock(recipient_verkey=TestDIDs.test_verkey)
                 ),
             )
 
+            assert status == OutboundSendStatus.QUEUED_FOR_DELIVERY
+            assert bus.events
+            print(bus.events)
+            assert (
+                bus.events[0][1].topic
+                == f"{EVENT_PREFIX}{OutboundSendStatus.QUEUED_FOR_DELIVERY}"
+            )
+            assert bus.events[0][1].payload == message
+
             mock_outbound_mgr.return_value.enqueue_message.assert_called_once_with(
-                conductor.context, message
+                conductor.root_profile, message
             )
 
     async def test_handle_nots(self):

--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -363,7 +363,9 @@ class OutboundTransportManager:
                             exc_info=queued.error,
                         )
                         if self.handle_not_delivered and queued.message:
-                            self.handle_not_delivered(queued.profile, queued.message)
+                            await self.handle_not_delivered(
+                                queued.profile, queued.message
+                            )
                     continue  # remove from buffer
 
                 deliver = False

--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -363,9 +363,7 @@ class OutboundTransportManager:
                             exc_info=queued.error,
                         )
                         if self.handle_not_delivered and queued.message:
-                            await self.handle_not_delivered(
-                                queued.profile, queued.message
-                            )
+                            self.handle_not_delivered(queued.profile, queued.message)
                     continue  # remove from buffer
 
                 deliver = False

--- a/aries_cloudagent/transport/outbound/status.py
+++ b/aries_cloudagent/transport/outbound/status.py
@@ -26,4 +26,5 @@ class OutboundSendStatus(Enum):
 
     @property
     def topic(self):
+        """Return an event topic associated with a given status."""
         return f"{OUTBOUND_STATUS_PREFIX}{self.value}"

--- a/aries_cloudagent/transport/outbound/status.py
+++ b/aries_cloudagent/transport/outbound/status.py
@@ -2,6 +2,8 @@
 
 from enum import Enum
 
+OUTBOUND_STATUS_PREFIX = "acapy::outbound-message::"
+
 
 class OutboundSendStatus(Enum):
     """Send status of outbound messages."""
@@ -21,3 +23,7 @@ class OutboundSendStatus(Enum):
 
     # No endpoint available, and no internal queue for messages.
     UNDELIVERABLE = "undeliverable"
+
+    @property
+    def topic(self):
+        return f"{OUTBOUND_STATUS_PREFIX}{self.value}"


### PR DESCRIPTION
This PR adds in a number of events which are emitted when a message is undelivered.

These events can be leveraged by plugins to take certain actions when messages are undelivered, such as writing the message to a persistent queue, sending a push notification to a mobile device that attempted to send the message, or some other action.

The events leverage the existing `OutboundSendStatus` states and don’t supersede the current return value. The `OutboundSendStatus` is still returned within ACA-Py as it has been, so this shouldn’t impact any existing functionality, but I’d be happy to hear any concerns I’ve not thought of. Thanks to @dbluhm for his feedback prior to this PR being opened. 