### PR TITLE
Endorser support for updating DID endpoints on ledger

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         args: ["--config", ".commitlint.config.js"]
         additional_dependencies: ['@commitlint/config-conventional']
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         stages: [commit]

--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -75,6 +75,8 @@ class BaseLedger(ABC, metaclass=ABCMeta):
         did: str,
         endpoint: str,
         endpoint_type: EndpointType = EndpointType.ENDPOINT,
+        write_ledger: bool = True, 
+        endorser_did: str = None
     ) -> bool:
         """Check and update the endpoint on the ledger.
 

--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -75,8 +75,8 @@ class BaseLedger(ABC, metaclass=ABCMeta):
         did: str,
         endpoint: str,
         endpoint_type: EndpointType = EndpointType.ENDPOINT,
-        write_ledger: bool = True, 
-        endorser_did: str = None
+        write_ledger: bool = True,
+        endorser_did: str = None,
     ) -> bool:
         """Check and update the endpoint on the ledger.
 

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -888,7 +888,12 @@ class IndySdkLedger(BaseLedger):
         return address
 
     async def update_endpoint_for_did(
-        self, did: str, endpoint: str, endpoint_type: EndpointType = None, write_ledger: bool = True, endorser_did: str = None
+        self,
+        did: str,
+        endpoint: str,
+        endpoint_type: EndpointType = None,
+        write_ledger: bool = True,
+        endorser_did: str = None,
     ) -> bool:
         """Check and update the endpoint on the ledger.
 
@@ -899,8 +904,10 @@ class IndySdkLedger(BaseLedger):
         """
         public_info = await self.get_wallet_public_did()
         if not public_info:
-            raise BadLedgerRequestError("Cannot update endpoint at ledger without a public DID")        
-        
+            raise BadLedgerRequestError(
+                "Cannot update endpoint at ledger without a public DID"
+            )
+
         if not endpoint_type:
             endpoint_type = EndpointType.ENDPOINT
 
@@ -935,7 +942,10 @@ class IndySdkLedger(BaseLedger):
                         request_json, endorser_did
                     )
                     resp = await self._submit(
-                        request_json, True, sign_did=public_info, write_ledger=write_ledger
+                        request_json,
+                        True,
+                        sign_did=public_info,
+                        write_ledger=write_ledger,
                     )
                     if not write_ledger:
                         return {"signed_txn": resp}

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -888,7 +888,7 @@ class IndySdkLedger(BaseLedger):
         return address
 
     async def update_endpoint_for_did(
-        self, did: str, endpoint: str, endpoint_type: EndpointType = None
+        self, did: str, endpoint: str, endpoint_type: EndpointType = None, write_ledger: bool = True, endorser_did: str = None
     ) -> bool:
         """Check and update the endpoint on the ledger.
 
@@ -897,6 +897,10 @@ class IndySdkLedger(BaseLedger):
             endpoint: The endpoint address
             endpoint_type: The type of the endpoint
         """
+        public_info = await self.get_wallet_public_did()
+        if not public_info:
+            raise BadLedgerRequestError("Cannot update endpoint at ledger without a public DID")        
+        
         if not endpoint_type:
             endpoint_type = EndpointType.ENDPOINT
 
@@ -925,6 +929,17 @@ class IndySdkLedger(BaseLedger):
                 request_json = await indy.ledger.build_attrib_request(
                     nym, nym, None, attr_json, None
                 )
+
+                if endorser_did and not write_ledger:
+                    request_json = await indy.ledger.append_request_endorser(
+                        request_json, endorser_did
+                    )
+                    resp = await self._submit(
+                        request_json, True, sign_did=public_info, write_ledger=write_ledger
+                    )
+                    if not write_ledger:
+                        return {"signed_txn": resp}
+
             await self._submit(request_json, True, True)
             return True
         return False

--- a/aries_cloudagent/ledger/indy_vdr.py
+++ b/aries_cloudagent/ledger/indy_vdr.py
@@ -943,11 +943,11 @@ class IndyVdrLedger(BaseLedger):
                 )
 
                 if endorser_did and not write_ledger:
-                    request_json = await indy.ledger.append_request_endorser(
-                        request_json, endorser_did
+                    attrib_req = await ledger.append_request_endorser(
+                        attrib_req, endorser_did
                     )
                     resp = await self._submit(
-                        request_json,
+                        attrib_req,
                         True,
                         sign_did=public_info,
                         write_ledger=write_ledger,

--- a/aries_cloudagent/ledger/indy_vdr.py
+++ b/aries_cloudagent/ledger/indy_vdr.py
@@ -943,9 +943,7 @@ class IndyVdrLedger(BaseLedger):
                 )
 
                 if endorser_did and not write_ledger:
-                    attrib_req = await ledger.append_request_endorser(
-                        attrib_req, endorser_did
-                    )
+                    attrib_req.set_endorser(endorser_did)
                     resp = await self._submit(
                         attrib_req,
                         True,

--- a/aries_cloudagent/ledger/indy_vdr.py
+++ b/aries_cloudagent/ledger/indy_vdr.py
@@ -893,7 +893,12 @@ class IndyVdrLedger(BaseLedger):
         return address
 
     async def update_endpoint_for_did(
-        self, did: str, endpoint: str, endpoint_type: EndpointType = None
+        self,
+        did: str,
+        endpoint: str,
+        endpoint_type: EndpointType = None,
+        write_ledger: bool = True,
+        endorser_did: str = None,
     ) -> bool:
         """Check and update the endpoint on the ledger.
 
@@ -902,6 +907,12 @@ class IndyVdrLedger(BaseLedger):
             endpoint: The endpoint address
             endpoint_type: The type of the endpoint
         """
+        public_info = await self.get_wallet_public_did()
+        if not public_info:
+            raise BadLedgerRequestError(
+                "Cannot update endpoint at ledger without a public DID"
+            )
+
         if not endpoint_type:
             endpoint_type = EndpointType.ENDPOINT
 
@@ -930,6 +941,20 @@ class IndyVdrLedger(BaseLedger):
                 attrib_req = ledger.build_attrib_request(
                     nym, nym, None, attr_json, None
                 )
+
+                if endorser_did and not write_ledger:
+                    request_json = await indy.ledger.append_request_endorser(
+                        request_json, endorser_did
+                    )
+                    resp = await self._submit(
+                        request_json,
+                        True,
+                        sign_did=public_info,
+                        write_ledger=write_ledger,
+                    )
+                    if not write_ledger:
+                        return {"signed_txn": resp}
+
             except VdrError as err:
                 raise LedgerError("Exception when building attribute request") from err
 

--- a/aries_cloudagent/wallet/askar.py
+++ b/aries_cloudagent/wallet/askar.py
@@ -446,6 +446,8 @@ class AskarWallet(BaseWallet):
         endpoint: str,
         ledger: BaseLedger,
         endpoint_type: EndpointType = None,
+        write_ledger: bool = True,
+        endorser_did: str = None,
     ):
         """
         Update the endpoint for a DID in the wallet, send to ledger if public or posted.
@@ -478,7 +480,15 @@ class AskarWallet(BaseWallet):
                 )
             if not ledger.read_only:
                 async with ledger:
-                    await ledger.update_endpoint_for_did(did, endpoint, endpoint_type)
+                    attrib_def = await ledger.update_endpoint_for_did(
+                        did,
+                        endpoint,
+                        endpoint_type,
+                        write_ledger=write_ledger,
+                        endorser_did=endorser_did,
+                    )
+                    if not write_ledger:
+                        return attrib_def
 
         await self.replace_local_did_metadata(did, metadata)
 

--- a/aries_cloudagent/wallet/base.py
+++ b/aries_cloudagent/wallet/base.py
@@ -224,6 +224,8 @@ class BaseWallet(ABC):
         endpoint: str,
         _ledger: BaseLedger,
         endpoint_type: EndpointType = None,
+        write_ledger: bool = True,
+        endorser_did: str = None,
     ):
         """
         Update the endpoint for a DID in the wallet, send to ledger if public or posted.

--- a/aries_cloudagent/wallet/indy.py
+++ b/aries_cloudagent/wallet/indy.py
@@ -740,7 +740,13 @@ class IndySdkWallet(BaseWallet):
                 )
             if not ledger.read_only:
                 async with ledger:
-                    attrib_def = await ledger.update_endpoint_for_did(did, endpoint, endpoint_type, write_ledger=write_ledger, endorser_did=endorser_did)
+                    attrib_def = await ledger.update_endpoint_for_did(
+                        did,
+                        endpoint,
+                        endpoint_type,
+                        write_ledger=write_ledger,
+                        endorser_did=endorser_did,
+                    )
                     if not write_ledger:
                         return attrib_def
 

--- a/aries_cloudagent/wallet/indy.py
+++ b/aries_cloudagent/wallet/indy.py
@@ -705,6 +705,8 @@ class IndySdkWallet(BaseWallet):
         endpoint: str,
         ledger: BaseLedger,
         endpoint_type: EndpointType = None,
+        write_ledger: bool = True,
+        endorser_did: str = None,
     ):
         """
         Update the endpoint for a DID in the wallet, send to ledger if public or posted.
@@ -738,7 +740,9 @@ class IndySdkWallet(BaseWallet):
                 )
             if not ledger.read_only:
                 async with ledger:
-                    await ledger.update_endpoint_for_did(did, endpoint, endpoint_type)
+                    attrib_def = await ledger.update_endpoint_for_did(did, endpoint, endpoint_type, write_ledger=write_ledger, endorser_did=endorser_did)
+                    if not write_ledger:
+                        return attrib_def
 
         await self.replace_local_did_metadata(did, metadata)
 

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -36,9 +36,9 @@ from ..protocols.endorse_transaction.v1_0.manager import (
 )
 from ..protocols.endorse_transaction.v1_0.util import (
     is_author_role,
-    get_endorser_connection_id
+    get_endorser_connection_id,
 )
-from ..storage.error import (StorageNotFoundError, StorageError)
+from ..storage.error import StorageNotFoundError, StorageError
 
 from .base import BaseWallet
 from .did_info import DIDInfo
@@ -201,9 +201,7 @@ class CreateAttribTxnForEndorserOptionSchema(OpenAPISchema):
 class AttribConnIdMatchInfoSchema(OpenAPISchema):
     """Path parameters and validators for request taking connection id."""
 
-    conn_id = fields.Str(
-        description="Connection identifier", required=False
-    )
+    conn_id = fields.Str(description="Connection identifier", required=False)
 
 
 def format_did_info(info: DIDInfo):
@@ -454,8 +452,7 @@ async def wallet_set_public_did(request: web.BaseRequest):
         transaction_mgr = TransactionManager(context.profile)
         try:
             transaction = await transaction_mgr.create_record(
-                messages_attach=attrib_def["signed_txn"],
-                connection_id=connection_id
+                messages_attach=attrib_def["signed_txn"], connection_id=connection_id
             )
         except StorageError as err:
             raise web.HTTPBadRequest(reason=err.roll_up) from err
@@ -674,8 +671,7 @@ async def wallet_set_did_endpoint(request: web.BaseRequest):
         transaction_mgr = TransactionManager(context.profile)
         try:
             transaction = await transaction_mgr.create_record(
-                messages_attach=attrib_def["signed_txn"],
-                connection_id=connection_id
+                messages_attach=attrib_def["signed_txn"], connection_id=connection_id
             )
         except StorageError as err:
             raise web.HTTPBadRequest(reason=err.roll_up) from err

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -1,5 +1,7 @@
 """Wallet admin routes."""
 
+import json
+
 from aiohttp import web
 from aiohttp_apispec import (
     docs,
@@ -13,9 +15,11 @@ from marshmallow import fields, validate
 from ..admin.request_context import AdminRequestContext
 from ..core.event_bus import Event, EventBus
 from ..core.profile import Profile
+from ..connections.models.conn_record import ConnRecord
 from ..ledger.base import BaseLedger
 from ..ledger.endpoint_type import EndpointType
 from ..ledger.error import LedgerConfigError, LedgerError
+from ..messaging.models.base import BaseModelError
 from ..messaging.models.openapi import OpenAPISchema
 from ..messaging.valid import (
     DID_POSTURE,
@@ -26,9 +30,12 @@ from ..messaging.valid import (
     INDY_RAW_PUBLIC_KEY,
 )
 from ..multitenant.base import BaseMultitenantManager
+from ..protocols.endorse_transaction.v1_0.manager import (TransactionManager, TransactionManagerError)
 from ..protocols.endorse_transaction.v1_0.util import (
     is_author_role,
+    get_endorser_connection_id
 )
+from ..storage.error import ( StorageNotFoundError, StorageError)
 
 from .base import BaseWallet
 from .did_info import DIDInfo
@@ -178,6 +185,18 @@ class DIDCreateSchema(OpenAPISchema):
         description="To define a key type for a did:key",
     )
 
+class CreateAttribTxnForEndorserOptionSchema(OpenAPISchema):
+    """Class for user to input whether to create a transaction for endorser or not."""
+    create_transaction_for_endorser = fields.Boolean(
+        description="Create Transaction For Endorser's signature",
+        required=False,
+    )
+
+class AttribConnIdMatchInfoSchema(OpenAPISchema):
+    """Path parameters and validators for request taking connection id."""
+    conn_id = fields.Str(
+        description="Connection identifier", required=False
+    )
 
 def format_did_info(info: DIDInfo):
     """Serialize a DIDInfo object."""
@@ -373,6 +392,8 @@ async def wallet_get_public_did(request: web.BaseRequest):
 
 @docs(tags=["wallet"], summary="Assign the current public DID")
 @querystring_schema(DIDQueryStringSchema())
+@querystring_schema(CreateAttribTxnForEndorserOptionSchema())
+@querystring_schema(AttribConnIdMatchInfoSchema())
 @response_schema(DIDResultSchema, 200, description="")
 async def wallet_set_public_did(request: web.BaseRequest):
     """
@@ -386,19 +407,30 @@ async def wallet_set_public_did(request: web.BaseRequest):
 
     """
     context: AdminRequestContext = request["context"]
-    async with context.session() as session:
-        wallet = session.inject_or(BaseWallet)
-        if not wallet:
-            raise web.HTTPForbidden(reason="No wallet available")
+    profile = context.profile
+    session = await context.session()
 
+    outbound_handler = request["outbound_message_router"]
+
+    create_transaction_for_endorser = json.loads(
+        request.query.get("create_transaction_for_endorser", "false")
+    )
+    write_ledger = not create_transaction_for_endorser
+    endorser_did = None
+    connection_id = request.query.get("conn_id")
+    attrib_def = None
+
+    wallet = session.inject_or(BaseWallet)
+    if not wallet:
+        raise web.HTTPForbidden(reason="No wallet available")
     did = request.query.get("did")
     if not did:
         raise web.HTTPBadRequest(reason="Request query must include DID")
 
     info: DIDInfo = None
     try:
-        info = await promote_wallet_public_did(
-            context.profile, context, context.session, did
+        info, attrib_def = await promote_wallet_public_did(
+            context.profile, context, context.session, did, write_ledger=write_ledger
         )
     except LookupError as err:
         raise web.HTTPNotFound(reason=str(err)) from err
@@ -409,11 +441,39 @@ async def wallet_set_public_did(request: web.BaseRequest):
     except (LedgerError, WalletError) as err:
         raise web.HTTPBadRequest(reason=err.roll_up) from err
 
-    return web.json_response({"result": format_did_info(info)})
+    if not create_transaction_for_endorser:
+        return web.json_response({"result": format_did_info(info)})
+    
+    else:
+        transaction_mgr = TransactionManager(context.profile)
+        try:
+            transaction = await transaction_mgr.create_record(
+                messages_attach=attrib_def["signed_txn"],
+                connection_id=connection_id
+            )
+        except StorageError as err:
+            raise web.HTTPBadRequest(reason=err.roll_up) from err
+
+        # if auto-request, send the request to the endorser
+        if context.settings.get_value("endorser.auto_request"):
+            try:
+                transaction, transaction_request = await transaction_mgr.create_request(
+                    transaction=transaction,
+                    # TODO see if we need to parameterize these params
+                    # expires_time=expires_time,
+                    # endorser_write_txn=endorser_write_txn,
+                )
+            except (StorageError, TransactionManagerError) as err:
+                raise web.HTTPBadRequest(reason=err.roll_up) from err
+
+            await outbound_handler(transaction_request, connection_id=connection_id)
+
+        return web.json_response({"txn": transaction.serialize()})
+
 
 
 async def promote_wallet_public_did(
-    profile: Profile, context: AdminRequestContext, session_fn, did: str
+    profile: Profile, context: AdminRequestContext, session_fn, did: str, write_ledger: bool = False
 ) -> DIDInfo:
     """Promote supplied DID to the wallet public DID."""
 
@@ -421,6 +481,7 @@ async def promote_wallet_public_did(
     wallet_id = context.settings.get("wallet.id")
 
     info: DIDInfo = None
+    endorser_did = None
     ledger = profile.inject_or(BaseLedger)
     if not ledger:
         reason = "No ledger available"
@@ -431,7 +492,48 @@ async def promote_wallet_public_did(
     async with ledger:
         if not await ledger.get_key_for_did(did):
             raise LookupError(f"DID {did} is not posted to the ledger")
+
+
+    # check if we need to endorse
+    if is_author_role(context.profile):
+        # authors cannot write to the ledger
+        write_ledger = False
+        create_transaction_for_endorser = True
+        if not connection_id:
+            # author has not provided a connection id, so determine which to use
+            connection_id = await get_endorser_connection_id(context.profile)
+            if not connection_id:
+                raise web.HTTPBadRequest(reason="No endorser connection found")
+
+    if not write_ledger:
+        try:
+            async with profile.session() as session:
+                connection_record = await ConnRecord.retrieve_by_id(
+                    session, connection_id
+                )
+        except StorageNotFoundError as err:
+            raise web.HTTPNotFound(reason=err.roll_up) from err
+        except BaseModelError as err:
+            raise web.HTTPBadRequest(reason=err.roll_up) from err
+
+        async with profile.session() as session:
+            endorser_info = await connection_record.metadata_get(
+                session, "endorser_info"
+            )
+        if not endorser_info:
+            raise web.HTTPForbidden(
+                reason="Endorser Info is not set up in "
+                "connection metadata for this connection record"
+            )
+        if "endorser_did" not in endorser_info.keys():
+            raise web.HTTPForbidden(
+                reason=' "endorser_did" is not set in "endorser_info"'
+                " in connection metadata for this connection record"
+            )
+        endorser_did = endorser_info["endorser_did"]
+
     did_info: DIDInfo = None
+    attrib_def = None
     async with session_fn() as session:
         wallet = session.inject_or(BaseWallet)
         did_info = await wallet.get_local_did(did)
@@ -444,10 +546,14 @@ async def promote_wallet_public_did(
             async with session_fn() as session:
                 wallet = session.inject_or(BaseWallet)
                 endpoint = context.settings.get("default_endpoint")
-                await wallet.set_did_endpoint(info.did, endpoint, ledger)
+                attrib_def = await wallet.set_did_endpoint(info.did, endpoint, ledger,
+                                              write_ledger=write_ledger,
+                                              endorser_did=endorser_did)
 
-        async with ledger:
-            await ledger.update_endpoint_for_did(info.did, endpoint)
+        # Commented the below lines as the function set_did_endpoint
+        # was calling update_endpoint_for_did of ledger
+        # async with ledger:
+        #     await ledger.update_endpoint_for_did(info.did, endpoint)
 
         # Multitenancy setup
         multitenant_mgr = profile.inject_or(BaseMultitenantManager)
@@ -455,13 +561,15 @@ async def promote_wallet_public_did(
         if multitenant_mgr and wallet_id:
             await multitenant_mgr.add_key(wallet_id, info.verkey, skip_if_exists=True)
 
-    return info
+    return info, attrib_def
 
 
 @docs(
     tags=["wallet"], summary="Update endpoint in wallet and on ledger if posted to it"
 )
 @request_schema(DIDEndpointWithTypeSchema)
+@querystring_schema(CreateAttribTxnForEndorserOptionSchema())
+@querystring_schema(AttribConnIdMatchInfoSchema())
 @response_schema(WalletModuleResponseSchema(), description="")
 async def wallet_set_did_endpoint(request: web.BaseRequest):
     """
@@ -471,20 +579,76 @@ async def wallet_set_did_endpoint(request: web.BaseRequest):
         request: aiohttp request object
     """
     context: AdminRequestContext = request["context"]
+    
+    profile = context.profile
+    session = await context.session()
+
+    outbound_handler = request["outbound_message_router"]
+
     body = await request.json()
     did = body["did"]
     endpoint = body.get("endpoint")
     endpoint_type = EndpointType.get(
         body.get("endpoint_type", EndpointType.ENDPOINT.w3c)
     )
+
+
+    create_transaction_for_endorser = json.loads(
+        request.query.get("create_transaction_for_endorser", "false")
+    )
+    write_ledger = not create_transaction_for_endorser
+    endorser_did = None
+    connection_id = request.query.get("conn_id")
+    attrib_def = None
+
     async with context.session() as session:
         wallet = session.inject_or(BaseWallet)
         if not wallet:
             raise web.HTTPForbidden(reason="No wallet available")
+    
+            # check if we need to endorse
+    if is_author_role(context.profile):
+        # authors cannot write to the ledger
+        write_ledger = False
+        create_transaction_for_endorser = True
+        if not connection_id:
+            # author has not provided a connection id, so determine which to use
+            connection_id = await get_endorser_connection_id(context.profile)
+            if not connection_id:
+                raise web.HTTPBadRequest(reason="No endorser connection found")
+        
+    if not write_ledger:
+        try:
+            async with profile.session() as session:
+                connection_record = await ConnRecord.retrieve_by_id(
+                    session, connection_id
+                )
+        except StorageNotFoundError as err:
+            raise web.HTTPNotFound(reason=err.roll_up) from err
+        except BaseModelError as err:
+            raise web.HTTPBadRequest(reason=err.roll_up) from err
+
+        async with profile.session() as session:
+            endorser_info = await connection_record.metadata_get(
+                session, "endorser_info"
+            )
+        if not endorser_info:
+            raise web.HTTPForbidden(
+                reason="Endorser Info is not set up in "
+                "connection metadata for this connection record"
+            )
+        if "endorser_did" not in endorser_info.keys():
+            raise web.HTTPForbidden(
+                reason=' "endorser_did" is not set in "endorser_info"'
+                " in connection metadata for this connection record"
+            )
+        endorser_did = endorser_info["endorser_did"]
 
         try:
             ledger = context.profile.inject_or(BaseLedger)
-            await wallet.set_did_endpoint(did, endpoint, ledger, endpoint_type)
+            attrib_def = await wallet.set_did_endpoint(did, endpoint, ledger, endpoint_type, 
+                                            write_ledger=write_ledger,
+                                            endorser_did=endorser_did)
         except WalletNotFoundError as err:
             raise web.HTTPNotFound(reason=err.roll_up) from err
         except LedgerConfigError as err:
@@ -492,7 +656,33 @@ async def wallet_set_did_endpoint(request: web.BaseRequest):
         except (LedgerError, WalletError) as err:
             raise web.HTTPBadRequest(reason=err.roll_up) from err
 
-    return web.json_response({})
+    if not create_transaction_for_endorser:
+        return web.json_response({})
+    else:
+        transaction_mgr = TransactionManager(context.profile)
+        try:
+            transaction = await transaction_mgr.create_record(
+                messages_attach=attrib_def["signed_txn"],
+                connection_id=connection_id
+            )
+        except StorageError as err:
+            raise web.HTTPBadRequest(reason=err.roll_up) from err
+
+        # if auto-request, send the request to the endorser
+        if context.settings.get_value("endorser.auto_request"):
+            try:
+                transaction, transaction_request = await transaction_mgr.create_request(
+                    transaction=transaction,
+                    # TODO see if we need to parameterize these params
+                    # expires_time=expires_time,
+                    # endorser_write_txn=endorser_write_txn,
+                )
+            except (StorageError, TransactionManagerError) as err:
+                raise web.HTTPBadRequest(reason=err.roll_up) from err
+
+            await outbound_handler(transaction_request, connection_id=connection_id)
+
+        return web.json_response({"txn": transaction.serialize()})
 
 
 @docs(tags=["wallet"], summary="Query DID endpoint in wallet")

--- a/aries_cloudagent/wallet/tests/test_askar_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_askar_wallet.py
@@ -120,7 +120,11 @@ class TestAskarWallet(test_in_memory_wallet.TestInMemoryWallet):
         )
         await wallet.set_did_endpoint(info_pub.did, "http://1.2.3.4:8021", mock_ledger)
         mock_ledger.update_endpoint_for_did.assert_called_once_with(
-            info_pub.did, "http://1.2.3.4:8021", EndpointType.ENDPOINT
+            info_pub.did,
+            "http://1.2.3.4:8021",
+            EndpointType.ENDPOINT,
+            endorser_did=None,
+            write_ledger=True,
         )
         info_pub2 = await wallet.get_public_did()
         assert info_pub2.metadata["endpoint"] == "http://1.2.3.4:8021"

--- a/aries_cloudagent/wallet/tests/test_indy_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_indy_wallet.py
@@ -120,7 +120,11 @@ class TestIndySdkWallet(test_in_memory_wallet.TestInMemoryWallet):
         )
         await wallet.set_did_endpoint(info_pub.did, "http://1.2.3.4:8021", mock_ledger)
         mock_ledger.update_endpoint_for_did.assert_called_once_with(
-            info_pub.did, "http://1.2.3.4:8021", EndpointType.ENDPOINT
+            info_pub.did,
+            "http://1.2.3.4:8021",
+            EndpointType.ENDPOINT,
+            endorser_did=None,
+            write_ledger=True,
         )
         info_pub2 = await wallet.get_public_did()
         assert info_pub2.metadata["endpoint"] == "http://1.2.3.4:8021"

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -585,7 +585,11 @@ class TestWalletRoutes(AsyncTestCase):
             result = await test_module.wallet_set_public_did(self.request)
             self.wallet.set_public_did.assert_awaited_once()
             self.wallet.set_did_endpoint.assert_awaited_once_with(
-                did_info.did, "https://default_endpoint.com", ledger
+                did_info.did,
+                "https://default_endpoint.com",
+                ledger,
+                write_ledger=True,
+                endorser_did=None,
             )
             json_response.assert_called_once_with(
                 {

--- a/demo/features/0586-sign-transaction.feature
+++ b/demo/features/0586-sign-transaction.feature
@@ -8,10 +8,10 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | Bob   | author   | <Bob_capabilities>  |
       And "Acme" and "Bob" have an existing connection
       When "Acme" has a DID with role "ENDORSER"
-      And "Bob" has a DID with role "AUTHOR"
       And "Acme" connection has job role "TRANSACTION_ENDORSER"
       And "Bob" connection has job role "TRANSACTION_AUTHOR"
       And "Bob" connection sets endorser info
+      And "Bob" has a DID with role "AUTHOR"
       And "Bob" authors a schema transaction with <Schema_name>
       And "Bob" requests endorsement for the transaction
       And "Acme" endorses the transaction
@@ -34,10 +34,10 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | Bob   | author   | <Bob_capabilities>  |
       And "Acme" and "Bob" have an existing connection
       When "Acme" has a DID with role "ENDORSER"
-      And "Bob" has a DID with role "AUTHOR"
       And "Acme" connection has job role "TRANSACTION_ENDORSER"
       And "Bob" connection has job role "TRANSACTION_AUTHOR"
       And "Bob" connection sets endorser info
+      And "Bob" has a DID with role "AUTHOR"
       And "Bob" authors a schema transaction with <Schema_name>
       And "Bob" requests endorsement for the transaction
       And "Acme" endorses the transaction
@@ -57,10 +57,10 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | Bob   | author   | <Bob_capabilities>  |
       And "Acme" and "Bob" have an existing connection
       When "Acme" has a DID with role "ENDORSER"
-      And "Bob" has a DID with role "AUTHOR"
       And "Acme" connection has job role "TRANSACTION_ENDORSER"
       And "Bob" connection has job role "TRANSACTION_AUTHOR"
       And "Bob" connection sets endorser info
+      And "Bob" has a DID with role "AUTHOR"
       And "Bob" authors a schema transaction with <Schema_name>
       And "Bob" requests endorsement for the transaction
       And "Acme" endorses the transaction
@@ -101,10 +101,10 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | Bob   | author   | <Bob_capabilities>  |
       And "Acme" and "Bob" have an existing connection
       When "Acme" has a DID with role "ENDORSER"
-      And "Bob" has a DID with role "AUTHOR"
       And "Acme" connection has job role "TRANSACTION_ENDORSER"
       And "Bob" connection has job role "TRANSACTION_AUTHOR"
       And "Bob" connection sets endorser info
+      And "Bob" has a DID with role "AUTHOR"
       And "Bob" authors a schema transaction with <Schema_name>
       And "Bob" requests endorsement for the transaction
       And "Acme" endorses the transaction
@@ -142,10 +142,10 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | Bob   | author   | <Bob_capabilities>  |
       And "Acme" and "Bob" have an existing connection
       When "Acme" has a DID with role "ENDORSER"
-      And "Bob" has a DID with role "AUTHOR"
       And "Acme" connection has job role "TRANSACTION_ENDORSER"
       And "Bob" connection has job role "TRANSACTION_AUTHOR"
       And "Bob" connection sets endorser info
+      And "Bob" has a DID with role "AUTHOR"
       And "Bob" authors a schema transaction with <Schema_name>
       And "Bob" has written the schema <Schema_name> to the ledger
       And "Bob" authors a credential definition transaction with <Schema_name>
@@ -172,10 +172,10 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | Bob   | author   | <Bob_capabilities>  |
       And "Acme" and "Bob" have an existing connection
       When "Acme" has a DID with role "ENDORSER"
-      And "Bob" has a DID with role "AUTHOR"
       And "Acme" connection has job role "TRANSACTION_ENDORSER"
       And "Bob" connection has job role "TRANSACTION_AUTHOR"
       And "Bob" connection sets endorser info
+      And "Bob" has a DID with role "AUTHOR"
       And "Bob" authors a schema transaction with <Schema_name>
       And "Bob" has written the schema <Schema_name> to the ledger
       And "Bob" authors a credential definition transaction with <Schema_name>


### PR DESCRIPTION
As stated in #1447, the changes by Harsh fix an issue where ACA-Py could not publish ATTRIB records because they were not signed by the endorser. We need those changes in for 0.7.4 if possible, but PR #1616 has not seen any updates and has merge conflicts with the latest changes in main. I have attempted to fix those merge conflicts and make the requested changes from @ianco in that PR, as well as fix all the unit test failures. 

This closes #1616. I am not sure if more work is needed for #1447.