### PR TITLE
platform target in run tests.

### DIFF
--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -8,7 +8,7 @@ FAST=${FAST:-0}
 cd "$(dirname "$0")" || exit
 
 if [[ $FAST -eq 0 ]]; then
-  $CONTAINER_RUNTIME build -t aries-cloudagent-test -f ../docker/Dockerfile.test .. || exit 1
+  $CONTAINER_RUNTIME build --platform linux/amd64 -t aries-cloudagent-test -f ../docker/Dockerfile.test .. || exit 1
 fi
 
 DOCKER_ARGS=""
@@ -40,5 +40,6 @@ if [ ! -z "$TEST_REDIS_CONFIG" ]; then
 fi
 
 $CONTAINER_RUNTIME run --rm -ti --name aries-cloudagent-runner \
+  --platform linux/amd64 \
 	-v "$(pwd)/../test-reports:/usr/src/app/test-reports:z" \
 	$DOCKER_ARGS aries-cloudagent-test "$@"


### PR DESCRIPTION
@dbluhm suggested seeing if adding a platform target would allow docker to run the test scripts, which worked. I expect more changes for complete mac m1 development support but this seems to be a good starting point.

Signed-off-by: Adam Burdett <burdettadam@gmail.com>