### PR TITLE
Fix: update IndyLedgerRequestsExecutor logic - multitenancy and basic base wallet type 

### DIFF
--- a/aries_cloudagent/indy/models/pres_preview.py
+++ b/aries_cloudagent/indy/models/pres_preview.py
@@ -14,6 +14,7 @@ from ...ledger.multiple_ledger.ledger_requests_executor import (
 from ...messaging.models.base import BaseModel, BaseModelSchema
 from ...messaging.util import canon
 from ...messaging.valid import INDY_CRED_DEF_ID, INDY_PREDICATE
+from ...multitenant.base import BaseMultitenantManager
 from ...protocols.didcomm_prefix import DIDCommPrefix
 from ...wallet.util import b64_to_str
 
@@ -351,7 +352,11 @@ class IndyPresPreview(BaseModel):
             revoc_support = False
             if cd_id:
                 if profile:
-                    ledger_exec_inst = profile.inject(IndyLedgerRequestsExecutor)
+                    multitenant_mgr = profile.inject_or(BaseMultitenantManager)
+                    if multitenant_mgr:
+                        ledger_exec_inst = IndyLedgerRequestsExecutor(profile)
+                    else:
+                        ledger_exec_inst = profile.inject(IndyLedgerRequestsExecutor)
                     ledger = (
                         await ledger_exec_inst.get_ledger_for_identifier(
                             cd_id,
@@ -410,7 +415,11 @@ class IndyPresPreview(BaseModel):
             revoc_support = False
             if cd_id:
                 if profile:
-                    ledger_exec_inst = profile.inject(IndyLedgerRequestsExecutor)
+                    multitenant_mgr = profile.inject_or(BaseMultitenantManager)
+                    if multitenant_mgr:
+                        ledger_exec_inst = IndyLedgerRequestsExecutor(profile)
+                    else:
+                        ledger_exec_inst = profile.inject(IndyLedgerRequestsExecutor)
                     ledger = (
                         await ledger_exec_inst.get_ledger_for_identifier(
                             cd_id,

--- a/aries_cloudagent/indy/models/tests/test_pres_preview.py
+++ b/aries_cloudagent/indy/models/tests/test_pres_preview.py
@@ -13,6 +13,8 @@ from ....ledger.multiple_ledger.ledger_requests_executor import (
     IndyLedgerRequestsExecutor,
 )
 from ....messaging.util import canon
+from ....multitenant.base import BaseMultitenantManager
+from ....multitenant.manager import MultitenantManager
 from ....protocols.didcomm_prefix import DIDCommPrefix
 
 
@@ -442,6 +444,10 @@ class TestIndyPresPreviewAsync(AsyncTestCase):
         context = mock_profile.context
         context.injector.bind_instance(
             IndyLedgerRequestsExecutor, IndyLedgerRequestsExecutor(mock_profile)
+        )
+        context.injector.bind_instance(
+            BaseMultitenantManager,
+            async_mock.MagicMock(MultitenantManager, autospec=True),
         )
         with async_mock.patch.object(
             IndyLedgerRequestsExecutor, "get_ledger_for_identifier"

--- a/aries_cloudagent/indy/verifier.py
+++ b/aries_cloudagent/indy/verifier.py
@@ -12,6 +12,7 @@ from ..ledger.multiple_ledger.ledger_requests_executor import (
     IndyLedgerRequestsExecutor,
 )
 from ..messaging.util import canon, encode
+from ..multitenant.base import BaseMultitenantManager
 
 from .models.xform import indy_proof_req2non_revoc_intervals
 
@@ -111,7 +112,11 @@ class IndyVerifier(ABC, metaclass=ABCMeta):
         for (index, ident) in enumerate(pres["identifiers"]):
             if ident.get("timestamp"):
                 cred_def_id = ident["cred_def_id"]
-                ledger_exec_inst = profile.inject(IndyLedgerRequestsExecutor)
+                multitenant_mgr = profile.inject_or(BaseMultitenantManager)
+                if multitenant_mgr:
+                    ledger_exec_inst = IndyLedgerRequestsExecutor(profile)
+                else:
+                    ledger_exec_inst = profile.inject(IndyLedgerRequestsExecutor)
                 ledger = (
                     await ledger_exec_inst.get_ledger_for_identifier(
                         cred_def_id,

--- a/aries_cloudagent/ledger/routes.py
+++ b/aries_cloudagent/ledger/routes.py
@@ -18,6 +18,7 @@ from ..messaging.valid import (
     INT_EPOCH,
     UUIDFour,
 )
+from ..multitenant.base import BaseMultitenantManager
 
 from ..protocols.endorse_transaction.v1_0.manager import (
     TransactionManager,
@@ -369,7 +370,11 @@ async def get_nym_role(request: web.BaseRequest):
         raise web.HTTPBadRequest(reason="Request query must include DID")
 
     async with context.profile.session() as session:
-        ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = session.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(context.profile)
+        else:
+            ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
         ledger_id, ledger = await ledger_exec_inst.get_ledger_for_identifier(
             did,
             txn_record_type=GET_NYM_ROLE,
@@ -442,7 +447,11 @@ async def get_did_verkey(request: web.BaseRequest):
         raise web.HTTPBadRequest(reason="Request query must include DID")
 
     async with context.profile.session() as session:
-        ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = session.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(context.profile)
+        else:
+            ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
         ledger_id, ledger = await ledger_exec_inst.get_ledger_for_identifier(
             did,
             txn_record_type=GET_KEY_FOR_DID,
@@ -487,7 +496,11 @@ async def get_did_endpoint(request: web.BaseRequest):
         raise web.HTTPBadRequest(reason="Request query must include DID")
 
     async with context.profile.session() as session:
-        ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = session.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(context.profile)
+        else:
+            ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
         ledger_id, ledger = await ledger_exec_inst.get_ledger_for_identifier(
             did,
             txn_record_type=GET_ENDPOINT_FOR_DID,

--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -28,6 +28,7 @@ from ...ledger.multiple_ledger.ledger_requests_executor import (
     GET_CRED_DEF,
     IndyLedgerRequestsExecutor,
 )
+from ...multitenant.base import BaseMultitenantManager
 from ...protocols.endorse_transaction.v1_0.manager import (
     TransactionManager,
     TransactionManagerError,
@@ -371,7 +372,11 @@ async def credential_definitions_get_credential_definition(request: web.BaseRequ
     cred_def_id = request.match_info["cred_def_id"]
 
     async with context.profile.session() as session:
-        ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = session.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(context.profile)
+        else:
+            ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
     ledger_id, ledger = await ledger_exec_inst.get_ledger_for_identifier(
         cred_def_id,
         txn_record_type=GET_CRED_DEF,
@@ -416,7 +421,11 @@ async def credential_definitions_fix_cred_def_wallet_record(request: web.BaseReq
 
     async with context.profile.session() as session:
         storage = session.inject(BaseStorage)
-        ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = session.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(context.profile)
+        else:
+            ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
     ledger_id, ledger = await ledger_exec_inst.get_ledger_for_identifier(
         cred_def_id,
         txn_record_type=GET_CRED_DEF,

--- a/aries_cloudagent/messaging/credential_definitions/tests/test_routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/tests/test_routes.py
@@ -8,6 +8,8 @@ from ....ledger.base import BaseLedger
 from ....ledger.multiple_ledger.ledger_requests_executor import (
     IndyLedgerRequestsExecutor,
 )
+from ....multitenant.base import BaseMultitenantManager
+from ....multitenant.manager import MultitenantManager
 from ....storage.base import BaseStorage
 from ....tails.base import BaseTailsServer
 
@@ -343,6 +345,28 @@ class TestCredentialDefinitionRoutes(AsyncTestCase):
         )
         self.request.match_info = {"cred_def_id": CRED_DEF_ID}
         with async_mock.patch.object(test_module.web, "json_response") as mock_response:
+            result = await test_module.credential_definitions_get_credential_definition(
+                self.request
+            )
+            assert result == mock_response.return_value
+            mock_response.assert_called_once_with(
+                {
+                    "ledger_id": "test_ledger_id",
+                    "credential_definition": {"cred": "def", "signed_txn": "..."},
+                }
+            )
+
+    async def test_get_credential_definition_multitenant(self):
+        self.profile_injector.bind_instance(
+            BaseMultitenantManager,
+            async_mock.MagicMock(MultitenantManager, autospec=True),
+        )
+        self.request.match_info = {"cred_def_id": CRED_DEF_ID}
+        with async_mock.patch.object(
+            IndyLedgerRequestsExecutor,
+            "get_ledger_for_identifier",
+            async_mock.CoroutineMock(return_value=("test_ledger_id", self.ledger)),
+        ), async_mock.patch.object(test_module.web, "json_response") as mock_response:
             result = await test_module.credential_definitions_get_credential_definition(
                 self.request
             )

--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -28,6 +28,7 @@ from ...ledger.multiple_ledger.ledger_requests_executor import (
     GET_SCHEMA,
     IndyLedgerRequestsExecutor,
 )
+from ...multitenant.base import BaseMultitenantManager
 from ...protocols.endorse_transaction.v1_0.manager import (
     TransactionManager,
     TransactionManagerError,
@@ -355,7 +356,11 @@ async def schemas_get_schema(request: web.BaseRequest):
     schema_id = request.match_info["schema_id"]
 
     async with context.profile.session() as session:
-        ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = session.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(context.profile)
+        else:
+            ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
     ledger_id, ledger = await ledger_exec_inst.get_ledger_for_identifier(
         schema_id,
         txn_record_type=GET_SCHEMA,
@@ -400,7 +405,11 @@ async def schemas_fix_schema_wallet_record(request: web.BaseRequest):
 
     async with profile.session() as session:
         storage = session.inject(BaseStorage)
-        ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = session.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(context.profile)
+        else:
+            ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
     ledger_id, ledger = await ledger_exec_inst.get_ledger_for_identifier(
         schema_id,
         txn_record_type=GET_SCHEMA,

--- a/aries_cloudagent/messaging/schemas/tests/test_routes.py
+++ b/aries_cloudagent/messaging/schemas/tests/test_routes.py
@@ -8,6 +8,8 @@ from ....ledger.base import BaseLedger
 from ....ledger.multiple_ledger.ledger_requests_executor import (
     IndyLedgerRequestsExecutor,
 )
+from ....multitenant.base import BaseMultitenantManager
+from ....multitenant.manager import MultitenantManager
 from ....storage.base import BaseStorage
 
 from .. import routes as test_module
@@ -315,6 +317,26 @@ class TestSchemaRoutes(AsyncTestCase):
         )
         self.request.match_info = {"schema_id": SCHEMA_ID}
         with async_mock.patch.object(test_module.web, "json_response") as mock_response:
+            result = await test_module.schemas_get_schema(self.request)
+            assert result == mock_response.return_value
+            mock_response.assert_called_once_with(
+                {
+                    "ledger_id": "test_ledger_id",
+                    "schema": {"schema": "def", "signed_txn": "..."},
+                }
+            )
+
+    async def test_get_schema_multitenant(self):
+        self.profile_injector.bind_instance(
+            BaseMultitenantManager,
+            async_mock.MagicMock(MultitenantManager, autospec=True),
+        )
+        self.request.match_info = {"schema_id": SCHEMA_ID}
+        with async_mock.patch.object(
+            IndyLedgerRequestsExecutor,
+            "get_ledger_for_identifier",
+            async_mock.CoroutineMock(return_value=("test_ledger_id", self.ledger)),
+        ), async_mock.patch.object(test_module.web, "json_response") as mock_response:
             result = await test_module.schemas_get_schema(self.request)
             assert result == mock_response.return_value
             mock_response.assert_called_once_with(

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -21,6 +21,7 @@ from ....messaging.credential_definitions.util import (
     CRED_DEF_SENT_RECORD_TYPE,
 )
 from ....messaging.responder import BaseResponder
+from ....multitenant.base import BaseMultitenantManager
 from ....revocation.indy import IndyRevocation
 from ....revocation.models.revocation_registry import RevocationRegistry
 from ....revocation.models.issuer_rev_reg_record import IssuerRevRegRecord
@@ -266,7 +267,11 @@ class CredentialManager:
         credential_preview = credential_proposal_message.credential_proposal
 
         # vet attributes
-        ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = self.profile.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(self.profile)
+        else:
+            ledger_exec_inst = self.profile.inject(IndyLedgerRequestsExecutor)
         ledger = (
             await ledger_exec_inst.get_ledger_for_identifier(
                 cred_def_id,
@@ -406,7 +411,11 @@ class CredentialManager:
         cred_req_meta = None
 
         async def _create():
-            ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
+            multitenant_mgr = self.profile.inject_or(BaseMultitenantManager)
+            if multitenant_mgr:
+                ledger_exec_inst = IndyLedgerRequestsExecutor(self.profile)
+            else:
+                ledger_exec_inst = self.profile.inject(IndyLedgerRequestsExecutor)
             ledger = (
                 await ledger_exec_inst.get_ledger_for_identifier(
                     credential_definition_id,
@@ -572,7 +581,11 @@ class CredentialManager:
             cred_offer_ser = cred_ex_record._credential_offer.ser
             cred_req_ser = cred_ex_record._credential_request.ser
             schema_id = cred_ex_record.schema_id
-            ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
+            multitenant_mgr = self.profile.inject_or(BaseMultitenantManager)
+            if multitenant_mgr:
+                ledger_exec_inst = IndyLedgerRequestsExecutor(self.profile)
+            else:
+                ledger_exec_inst = self.profile.inject(IndyLedgerRequestsExecutor)
             ledger = (
                 await ledger_exec_inst.get_ledger_for_identifier(
                     schema_id,
@@ -804,7 +817,11 @@ class CredentialManager:
 
         raw_cred_serde = cred_ex_record._raw_credential
         revoc_reg_def = None
-        ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = self.profile.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(self.profile)
+        else:
+            ledger_exec_inst = self.profile.inject(IndyLedgerRequestsExecutor)
         ledger = (
             await ledger_exec_inst.get_ledger_for_identifier(
                 raw_cred_serde.de.cred_def_id,

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
@@ -24,6 +24,7 @@ from ......messaging.credential_definitions.util import (
     CredDefQueryStringSchema,
 )
 from ......messaging.decorators.attach_decorator import AttachDecorator
+from ......multitenant.base import BaseMultitenantManager
 from ......revocation.models.issuer_rev_reg_record import IssuerRevRegRecord
 from ......revocation.models.revocation_registry import RevocationRegistry
 from ......revocation.indy import IndyRevocation
@@ -202,7 +203,11 @@ class IndyCredFormatHandler(V20CredFormatHandler):
             offer_json = await issuer.create_credential_offer(cred_def_id)
             return json.loads(offer_json)
 
-        ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = self.profile.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(self.profile)
+        else:
+            ledger_exec_inst = self.profile.inject(IndyLedgerRequestsExecutor)
         ledger = (
             await ledger_exec_inst.get_ledger_for_identifier(
                 cred_def_id,
@@ -263,7 +268,11 @@ class IndyCredFormatHandler(V20CredFormatHandler):
         cred_def_id = cred_offer["cred_def_id"]
 
         async def _create():
-            ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
+            multitenant_mgr = self.profile.inject_or(BaseMultitenantManager)
+            if multitenant_mgr:
+                ledger_exec_inst = IndyLedgerRequestsExecutor(self.profile)
+            else:
+                ledger_exec_inst = self.profile.inject(IndyLedgerRequestsExecutor)
             ledger = (
                 await ledger_exec_inst.get_ledger_for_identifier(
                     cred_def_id,
@@ -331,7 +340,11 @@ class IndyCredFormatHandler(V20CredFormatHandler):
 
         rev_reg_id = None
         rev_reg = None
-        ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = self.profile.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(self.profile)
+        else:
+            ledger_exec_inst = self.profile.inject(IndyLedgerRequestsExecutor)
         ledger = (
             await ledger_exec_inst.get_ledger_for_identifier(
                 schema_id,
@@ -475,7 +488,11 @@ class IndyCredFormatHandler(V20CredFormatHandler):
         cred = cred_ex_record.cred_issue.attachment(IndyCredFormatHandler.format)
 
         rev_reg_def = None
-        ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = self.profile.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(self.profile)
+        else:
+            ledger_exec_inst = self.profile.inject(IndyLedgerRequestsExecutor)
         ledger = (
             await ledger_exec_inst.get_ledger_for_identifier(
                 cred["cred_def_id"],

--- a/aries_cloudagent/protocols/present_proof/indy/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/indy/pres_exch_handler.py
@@ -14,6 +14,7 @@ from ....ledger.multiple_ledger.ledger_requests_executor import (
     GET_REVOC_REG_DELTA,
     IndyLedgerRequestsExecutor,
 )
+from ....multitenant.base import BaseMultitenantManager
 from ....revocation.models.revocation_registry import RevocationRegistry
 
 from ..v1_0.models.presentation_exchange import V10PresentationExchange
@@ -93,7 +94,11 @@ class IndyPresExchHandler:
 
         for credential in credentials.values():
             schema_id = credential["schema_id"]
-            ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
+            multitenant_mgr = self._profile.inject_or(BaseMultitenantManager)
+            if multitenant_mgr:
+                ledger_exec_inst = IndyLedgerRequestsExecutor(self._profile)
+            else:
+                ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
             ledger = (
                 await ledger_exec_inst.get_ledger_for_identifier(
                     schema_id,
@@ -127,7 +132,11 @@ class IndyPresExchHandler:
             if "timestamp" in precis:
                 continue
             rev_reg_id = credentials[credential_id]["rev_reg_id"]
-            ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
+            multitenant_mgr = self._profile.inject_or(BaseMultitenantManager)
+            if multitenant_mgr:
+                ledger_exec_inst = IndyLedgerRequestsExecutor(self._profile)
+            else:
+                ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
             ledger = (
                 await ledger_exec_inst.get_ledger_for_identifier(
                     rev_reg_id,
@@ -222,7 +231,11 @@ class IndyPresExchHandler:
         for identifier in identifiers:
             schema_ids.append(identifier["schema_id"])
             cred_def_ids.append(identifier["cred_def_id"])
-            ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
+            multitenant_mgr = self._profile.inject_or(BaseMultitenantManager)
+            if multitenant_mgr:
+                ledger_exec_inst = IndyLedgerRequestsExecutor(self._profile)
+            else:
+                ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
             ledger = (
                 await ledger_exec_inst.get_ledger_for_identifier(
                     identifier["schema_id"],

--- a/aries_cloudagent/protocols/present_proof/v2_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/tests/test_manager.py
@@ -20,6 +20,8 @@ from .....ledger.multiple_ledger.ledger_requests_executor import (
 )
 from .....messaging.decorators.attach_decorator import AttachDecorator
 from .....messaging.responder import BaseResponder, MockResponder
+from .....multitenant.base import BaseMultitenantManager
+from .....multitenant.manager import MultitenantManager
 from .....storage.error import StorageNotFoundError
 
 from ...indy import pres_exch_handler as test_indy_util_module
@@ -805,7 +807,15 @@ class TestV20PresManager(AsyncTestCase):
                 return_value="/tmp/sample/tails/path"
             )
         )
+        self.profile.context.injector.bind_instance(
+            BaseMultitenantManager,
+            async_mock.MagicMock(MultitenantManager, autospec=True),
+        )
         with async_mock.patch.object(
+            IndyLedgerRequestsExecutor,
+            "get_ledger_for_identifier",
+            async_mock.CoroutineMock(return_value=("test_ledger_id", self.ledger)),
+        ), async_mock.patch.object(
             V20PresExRecord, "save", autospec=True
         ) as save_ex, async_mock.patch.object(
             test_indy_handler, "AttachDecorator", autospec=True
@@ -1858,8 +1868,15 @@ class TestV20PresManager(AsyncTestCase):
             pres_request=pres_request,
             pres=pres,
         )
-
-        with async_mock.patch.object(V20PresExRecord, "save", autospec=True) as save_ex:
+        self.profile.context.injector.bind_instance(
+            BaseMultitenantManager,
+            async_mock.MagicMock(MultitenantManager, autospec=True),
+        )
+        with async_mock.patch.object(
+            IndyLedgerRequestsExecutor,
+            "get_ledger_for_identifier",
+            async_mock.CoroutineMock(return_value=("test_ledger_id", self.ledger)),
+        ), async_mock.patch.object(V20PresExRecord, "save", autospec=True) as save_ex:
             px_rec_out = await self.manager.verify_pres(px_rec_in)
             save_ex.assert_called_once()
 

--- a/aries_cloudagent/resolver/default/indy.py
+++ b/aries_cloudagent/resolver/default/indy.py
@@ -17,6 +17,7 @@ from ...ledger.multiple_ledger.ledger_requests_executor import (
     IndyLedgerRequestsExecutor,
 )
 from ...messaging.valid import IndyDID
+from ...multitenant.base import BaseMultitenantManager
 
 from ..base import BaseDIDResolver, DIDNotFound, ResolverError, ResolverType
 
@@ -44,7 +45,11 @@ class IndyDIDResolver(BaseDIDResolver):
 
     async def _resolve(self, profile: Profile, did: str) -> dict:
         """Resolve an indy DID."""
-        ledger_exec_inst = profile.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = profile.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(profile)
+        else:
+            ledger_exec_inst = profile.inject(IndyLedgerRequestsExecutor)
         ledger = (
             await ledger_exec_inst.get_ledger_for_identifier(
                 did,

--- a/aries_cloudagent/resolver/default/tests/test_indy.py
+++ b/aries_cloudagent/resolver/default/tests/test_indy.py
@@ -12,6 +12,8 @@ from ....ledger.multiple_ledger.ledger_requests_executor import (
     IndyLedgerRequestsExecutor,
 )
 from ....messaging.valid import IndyDID
+from ....multitenant.base import BaseMultitenantManager
+from ....multitenant.manager import MultitenantManager
 
 from ...base import DIDNotFound, ResolverError
 from .. import indy as test_module
@@ -64,6 +66,22 @@ class TestIndyResolver:
     async def test_resolve(self, profile: Profile, resolver: IndyDIDResolver):
         """Test resolve method."""
         assert await resolver.resolve(profile, TEST_DID0)
+
+    @pytest.mark.asyncio
+    async def test_resolve_multitenant(
+        self, profile: Profile, resolver: IndyDIDResolver, ledger: BaseLedger
+    ):
+        """Test resolve method."""
+        profile.context.injector.bind_instance(
+            BaseMultitenantManager,
+            async_mock.MagicMock(MultitenantManager, autospec=True),
+        )
+        with async_mock.patch.object(
+            IndyLedgerRequestsExecutor,
+            "get_ledger_for_identifier",
+            async_mock.CoroutineMock(return_value=("test_ledger_id", ledger)),
+        ):
+            assert await resolver.resolve(profile, TEST_DID0)
 
     @pytest.mark.asyncio
     async def test_resolve_x_no_ledger(

--- a/aries_cloudagent/revocation/indy.py
+++ b/aries_cloudagent/revocation/indy.py
@@ -8,6 +8,7 @@ from ..ledger.multiple_ledger.ledger_requests_executor import (
     GET_REVOC_REG_DEF,
     IndyLedgerRequestsExecutor,
 )
+from ..multitenant.base import BaseMultitenantManager
 from ..storage.base import StorageNotFoundError
 
 from .error import RevocationNotSupportedError, RevocationRegistryBadSizeError
@@ -32,7 +33,11 @@ class IndyRevocation:
         tag: str = None,
     ) -> "IssuerRevRegRecord":
         """Create a new revocation registry record for a credential definition."""
-        ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = self._profile.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(self._profile)
+        else:
+            ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
         ledger = (
             await ledger_exec_inst.get_ledger_for_identifier(
                 cred_def_id,
@@ -108,7 +113,11 @@ class IndyRevocation:
         if revoc_reg_id in IndyRevocation.REV_REG_CACHE:
             return IndyRevocation.REV_REG_CACHE[revoc_reg_id]
 
-        ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
+        multitenant_mgr = self._profile.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(self._profile)
+        else:
+            ledger_exec_inst = self._profile.inject(IndyLedgerRequestsExecutor)
         ledger = (
             await ledger_exec_inst.get_ledger_for_identifier(
                 revoc_reg_id,


### PR DESCRIPTION
- resolve #1691 
- Earlier `IndyLedgerRequestsExecutor` instance was retrieved by calling `profile.inject(IndyLedgerRequestsExecutor)` which would correspond to the `root_profile`. If the base `wallet_type` is basic then the `BaseLedger` instance will not be specified which caused the above issue. I have now updated the logic to create a new `IndyLedgerRequestsExecutor` instance for each sub wallet.