### PR TITLE
Allow deleting a pres exchange item without reading it first

### DIFF
--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -19,7 +19,7 @@ from ...storage.record import StorageRecord
 from ..util import datetime_to_str, time_now
 from ..valid import INDY_ISO8601_DATETIME
 
-from .base import BaseModel, BaseModelSchema
+from .base import BaseModel, BaseModelSchema, BaseModelError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -329,7 +329,10 @@ class BaseRecord(BaseModel):
                 positive=False,
                 alt=alt,
             ):
-                result.append(cls.from_storage(record.id, vals))
+                try:
+                    result.append(cls.from_storage(record.id, vals))
+                except BaseModelError as err:
+                    raise BaseModelError(f"{err}, for record id {record.id}")
         return result
 
     async def save(

--- a/aries_cloudagent/protocols/present_proof/v2_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/routes.py
@@ -32,6 +32,7 @@ from ....messaging.valid import (
     UUID4,
 )
 from ....storage.error import StorageError, StorageNotFoundError
+from ....storage.base import BaseStorage
 from ....storage.vc_holder.base import VCHolder
 from ....storage.vc_holder.vc_record import VCRecord
 from ....utils.tracing import trace_event, get_timer, AdminAPIMessageTracingSchema
@@ -1265,8 +1266,17 @@ async def present_proof_remove(request: web.BaseRequest):
     pres_ex_record = None
     try:
         async with context.profile.session() as session:
-            pres_ex_record = await V20PresExRecord.retrieve_by_id(session, pres_ex_id)
-            await pres_ex_record.delete_record(session)
+            try:
+                pres_ex_record = await V20PresExRecord.retrieve_by_id(
+                    session, pres_ex_id
+                )
+                await pres_ex_record.delete_record(session)
+            except (BaseModelError, ValidationError):
+                storage = session.inject(BaseStorage)
+                storage_record = await storage.get_record(
+                    record_type=V20PresExRecord.RECORD_TYPE, record_id=pres_ex_id
+                )
+                await storage.delete_record(storage_record)
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
     except StorageError as err:


### PR DESCRIPTION
Related to #1687 this allows deleting a presentation exchange
record without reading it from storage.

@shaangill025 Does it make sense to have something like this in addition to your change in #1690 to make sure we always have an option to delete an item without reading it?