### PR TITLE
Fix Issue-1682

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -1424,6 +1424,15 @@ class WalletGroup(ArgumentGroup):
             ),
         )
         parser.add_argument(
+            "--wallet-allow-insecure-seed",
+            action="store_true",
+            env_var="ACAPY_WALLET_ALLOW_INSECURE_SEED",
+            help=(
+                "If this parameter is set, allows to use a custom seed "
+                "to create a local DID"
+            ),
+        )
+        parser.add_argument(
             "--wallet-key",
             type=str,
             metavar="<wallet-key>",
@@ -1543,6 +1552,8 @@ class WalletGroup(ArgumentGroup):
             settings["wallet.seed"] = args.seed
         if args.wallet_local_did:
             settings["wallet.local_did"] = True
+        if args.wallet_allow_insecure_seed:
+            settings["wallet.allow_insecure_seed"] = True
         if args.wallet_key:
             settings["wallet.key"] = args.wallet_key
         if args.wallet_rekey:

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -355,13 +355,20 @@ async def wallet_create_did(request: web.BaseRequest):
                 f" support key type {key_type.key_type}"
             )
         )
+    seed = None
+    if context.settings.get("wallet.allow_insecure_seed"):
+        seed = body.get("seed") or None
     info = None
     async with context.session() as session:
         wallet = session.inject_or(BaseWallet)
         if not wallet:
             raise web.HTTPForbidden(reason="No wallet available")
         try:
-            info = await wallet.create_local_did(method=method, key_type=key_type)
+            info = await wallet.create_local_did(
+                method=method,
+                key_type=key_type,
+                seed=seed,
+            )
 
         except WalletError as err:
             raise web.HTTPBadRequest(reason=err.roll_up) from err


### PR DESCRIPTION
- Added wallet startup parameter: --wallet-allow-insecure-seed
- support seed in wallet/did/create route

Some questions around
1. How do we support importing a key pair into the wallet as mentioned in the Issue
2. Should I add seed in the schema of wallet/did/create ? . I don't think we can add conditional schemas according to startup parameter.  I can have it as an optional field.