### PR TITLE
run_docker start - specify argument from environment variables

### DIFF
--- a/scripts/run_docker
+++ b/scripts/run_docker
@@ -14,9 +14,8 @@ for PORT in $PORTS; do
   ARGS="${ARGS} -p $PORT"
 done
 
-ENV_VAR_ARGS=""
 for ENV_VAR in $ENV_VARS; do
-  ENV_VAR_ARGS="${ENV_VAR_ARGS} -e $ENV_VAR"
+  ARGS="${ARGS} -e $ENV_VAR"
 done
 PTVSD_PORT="${PTVSD_PORT-5678}"
 
@@ -49,5 +48,5 @@ if [ "$OSTYPE" == "msys" ]; then
 fi
 
 RAND_NAME=$(env LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 16 | head -n 1)
-$CONTAINER_RUNTIME run --rm -ti --name "aries-cloudagent-runner_${RAND_NAME}" $ENV_VAR_ARGS \
+$CONTAINER_RUNTIME run --rm -ti --name "aries-cloudagent-runner_${RAND_NAME}" \
     $ARGS aries-cloudagent-run "$@"

--- a/scripts/run_docker
+++ b/scripts/run_docker
@@ -14,6 +14,10 @@ for PORT in $PORTS; do
   ARGS="${ARGS} -p $PORT"
 done
 
+ENV_VAR_ARGS=""
+for ENV_VAR in $ENV_VARS; do
+  ENV_VAR_ARGS="${ENV_VAR_ARGS} -e $ENV_VAR"
+done
 PTVSD_PORT="${PTVSD_PORT-5678}"
 
 for arg in "$@"; do
@@ -45,5 +49,5 @@ if [ "$OSTYPE" == "msys" ]; then
 fi
 
 RAND_NAME=$(env LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 16 | head -n 1)
-$CONTAINER_RUNTIME run --rm -ti --name "aries-cloudagent-runner_${RAND_NAME}" \
+$CONTAINER_RUNTIME run --rm -ti --name "aries-cloudagent-runner_${RAND_NAME}" $ENV_VAR_ARGS \
     $ARGS aries-cloudagent-run "$@"


### PR DESCRIPTION
Signed-off-by: Shaanjot Gill <shaangill025@users.noreply.github.com>
- resolve #1330 
- @MonolithicMonk I think you are starting ACA-Py agent from `./scripts/run_docker start ...`. You can either specify the environment variables in `./scripts/run_docker` by adding each one of them as something like:
```
$CONTAINER_RUNTIME run --rm -ti --name "aries-cloudagent-runner_${RAND_NAME}" \
-e ACAPY_OUTBOUND_TRANSPORT=http -e ACAPY_INBOUND_TRANSPORT=[[\"http\",\"0.0.0.0\",\"8021\"],[\"ws\",\"0.0.0.0\",\"8023\"]] \
    $ARGS aries-cloudagent-run "$@"
```
- Another option [if this PR is approved and merged], is just to export the `environment variable` as usual. Updated script will go through all the `environment variables`, extract all with `*ACAPY_*` and `*=*` pattern match and add them to `docker run ... -e env_var -e env_var .....`.
