### PR TITLE
run_docker start - pass environment variables

### DIFF
--- a/scripts/run_docker
+++ b/scripts/run_docker
@@ -14,6 +14,9 @@ for PORT in $PORTS; do
   ARGS="${ARGS} -p $PORT"
 done
 
+for ENV_VAR in $ENV_VARS; do
+  ARGS="${ARGS} -e $ENV_VAR"
+done
 PTVSD_PORT="${PTVSD_PORT-5678}"
 
 for arg in "$@"; do


### PR DESCRIPTION
Signed-off-by: Shaanjot Gill <shaangill025@users.noreply.github.com>
- resolve #1330 
- Closed PR #1709, there were issues applying `fixup` during rebase to cleanup commit history. I thought it is safer to recreate the PR as it has minor changes.

@MonolithicMonk ACAPY_INBOUND_TRANSPORT should be specified as `ACAPY_INBOUND_TRANSPORT=[[\"http\",\"0.0.0.0\",\"8021\"]]` and not as `ACAPY_INBOUND_TRANSPORT=[["http","0.0.0.0","8021"]]`

You can pass environment variables using `ENV_VARS` variable [similar to `PORTS`]. For your reference:
```
PORTS="5002 8002" ENV_VARS="ACAPY_INBOUND_TRANSPORT=[[\"http\",\"0.0.0.0\",\"8021\"]]" \ 
./scripts/run_docker start ......
``` 