### PR TITLE
Adds support to faber demo for returning json response in connectionless proof-requests

### DIFF
--- a/demo/runners/faber.py
+++ b/demo/runners/faber.py
@@ -607,14 +607,17 @@ async def main(args):
                         "/present-proof/create-request", proof_request_web_request
                     )
                     pres_req_id = proof_request["presentation_exchange_id"]
-                    url = os.getenv("WEBHOOK_TARGET") or (
-                        "http://"
-                        + os.getenv("DOCKERHOST").replace(
-                            "{PORT}", str(faber_agent.agent.admin_port + 1)
+                    url = (
+                        os.getenv("WEBHOOK_TARGET")
+                        or (
+                            "http://"
+                            + os.getenv("DOCKERHOST").replace(
+                                "{PORT}", str(faber_agent.agent.admin_port + 1)
+                            )
+                            + "/webhooks"
                         )
-                        + "/webhooks"
+                        + f"/pres_req/{pres_req_id}/"
                     )
-                    +f"/pres_req/{pres_req_id}/"
                     log_msg(f"Proof request url: {url}")
                     qr = QRCode(border=1)
                     qr.add_data(url)

--- a/demo/runners/faber.py
+++ b/demo/runners/faber.py
@@ -607,11 +607,14 @@ async def main(args):
                         "/present-proof/create-request", proof_request_web_request
                     )
                     pres_req_id = proof_request["presentation_exchange_id"]
-                    url = (
-                        os.getenv("WEBHOOK_TARGET")
-                        or ("http://" + os.getenv("DOCKERHOST").replace("{PORT}", str(faber_agent.agent.admin_port + 1)) + "/webhooks")
+                    url = os.getenv("WEBHOOK_TARGET") or (
+                        "http://"
+                        + os.getenv("DOCKERHOST").replace(
+                            "{PORT}", str(faber_agent.agent.admin_port + 1)
+                        )
+                        + "/webhooks"
                     )
-                    + f"/pres_req/{pres_req_id}/"
+                    +f"/pres_req/{pres_req_id}/"
                     log_msg(f"Proof request url: {url}")
                     qr = QRCode(border=1)
                     qr.add_data(url)

--- a/demo/runners/faber.py
+++ b/demo/runners/faber.py
@@ -608,14 +608,10 @@ async def main(args):
                     )
                     pres_req_id = proof_request["presentation_exchange_id"]
                     url = (
-                        "http://"
-                        + os.getenv("DOCKERHOST").replace(
-                            "{PORT}", str(faber_agent.agent.admin_port + 1)
-                        )
-                        + "/webhooks/pres_req/"
-                        + pres_req_id
-                        + "/"
+                        os.getenv("WEBHOOK_TARGET")
+                        or ("http://" + os.getenv("DOCKERHOST").replace("{PORT}", str(faber_agent.agent.admin_port + 1)) + "/webhooks")
                     )
+                    + f"/pres_req/{pres_req_id}/"
                     log_msg(f"Proof request url: {url}")
                     qr = QRCode(border=1)
                     qr.add_data(url)

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -769,7 +769,7 @@ class DemoAgent:
             return web.Response(status=404)
         proof_reg_txn = proof_exch["presentation_request_dict"]
         proof_reg_txn["~service"] = await self.service_decorator()
-        if request.headers['Accept'] == 'application/json':
+        if request.headers["Accept"] == "application/json":
             return web.json_response(proof_reg_txn)
         objJsonStr = json.dumps(proof_reg_txn)
         objJsonB64 = base64.b64encode(objJsonStr.encode("ascii"))

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -715,7 +715,7 @@ class DemoAgent:
         if RUN_MODE == "pwd":
             self.webhook_url = f"http://localhost:{str(webhook_port)}/webhooks"
         else:
-            self.webhook_url = (
+            self.webhook_url = self.external_webhook_target or (
                 f"http://{self.external_host}:{str(webhook_port)}/webhooks"
             )
         app = web.Application()
@@ -764,6 +764,8 @@ class DemoAgent:
             return web.Response(status=404)
         proof_reg_txn = proof_exch["presentation_request_dict"]
         proof_reg_txn["~service"] = await self.service_decorator()
+        if request.headers['Accept'] == 'application/json':
+            return web.json_response(proof_reg_txn)
         objJsonStr = json.dumps(proof_reg_txn)
         objJsonB64 = base64.b64encode(objJsonStr.encode("ascii"))
         service_url = self.webhook_url


### PR DESCRIPTION
Also updates demo to use `WEBHOOK_TARGET`, when supplied, to construct presentation request exchange urls 