### PR TITLE
Replace async workaround within document loader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ aiohttp-apispec~=2.2.1
 aiohttp-cors~=0.7.0
 apispec~=3.3.0
 async-timeout~=4.0.2
+nest_asyncio~=1.5.5
 aioredis~=2.0.0
 base58~=2.1.0
 deepmerge~=0.3.0


### PR DESCRIPTION
After talking with Timo, the document loader uses a separate thread due to the fact that PyLD is synchronous code and calls 
into the document loader (which requires asynchronous code). When swapping out the cache with (for example) a Redis based cache, the exception `got Future attached to a different loop` may arise due to the current separate thread/event loop based implementation.

Switching to `nest_asyncio` over using a separate thread/event loop resolves the issues that were observed.