### PR TITLE
fix: add a close statement to ensure session is closed on error

### DIFF
--- a/aries_cloudagent/askar/profile.py
+++ b/aries_cloudagent/askar/profile.py
@@ -213,6 +213,7 @@ class AskarProfileSession(ProfileSession):
                 await self._handle.commit()
             except AskarError as err:
                 raise ProfileError("Error committing transaction") from err
+        await self._handle.close()
         self._handle = None
         self._check_duration()
 

--- a/aries_cloudagent/askar/profile.py
+++ b/aries_cloudagent/askar/profile.py
@@ -213,7 +213,8 @@ class AskarProfileSession(ProfileSession):
                 await self._handle.commit()
             except AskarError as err:
                 raise ProfileError("Error committing transaction") from err
-        await self._handle.close()
+        if self._handle:
+            await self._handle.close()
         self._handle = None
         self._check_duration()
 


### PR DESCRIPTION
Askar, on error, would end up not returning connections to the connection pool because aca-py left the connections open.