### PR TITLE
feat: Add filter param to connection list for invitations

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -205,6 +205,11 @@ class ConnectionsListQueryStringSchema(OpenAPISchema):
         ),
         example=ConnRecord.Protocol.RFC_0160.aries_protocol,
     )
+    invitation_msg_id = fields.UUID(
+        description="Identifier of the associated Invintation Mesage",
+        required=False,
+        example=UUIDFour.EXAMPLE,
+    )
 
 
 class CreateInvitationQueryStringSchema(OpenAPISchema):
@@ -336,6 +341,7 @@ async def connections_list(request: web.BaseRequest):
         "request_id",
         "invitation_key",
         "their_public_did",
+        "invitation_msg_id",
     ):
         if param_name in request.query and request.query[param_name] != "":
             tag_filter[param_name] = request.query[param_name]

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
@@ -33,6 +33,7 @@ class TestConnectionRoutes(AsyncTestCase):
             "connection_protocol": ConnRecord.Protocol.RFC_0160.aries_protocol,
             "invitation_key": "some-invitation-key",
             "their_public_did": "a_public_did",
+            "invitation_msg_id": "dummy_msg",
         }
 
         STATE_COMPLETED = ConnRecord.State.COMPLETED
@@ -94,6 +95,7 @@ class TestConnectionRoutes(AsyncTestCase):
                         "invitation_id": "dummy",
                         "invitation_key": "some-invitation-key",
                         "their_public_did": "a_public_did",
+                        "invitation_msg_id": "dummy_msg",
                     },
                     post_filter_positive={
                         "their_role": [v for v in ConnRecord.Role.REQUESTER.value],


### PR DESCRIPTION
As mentioned in #1789, there is no way to currently filter for connections/invited created via the OOB handler. This commit adds a filter query parameter to filter with the invitation message ID.
- resolve #1789 