### PR TITLE
Fix put_file when the server returns a redirect

### DIFF
--- a/aries_cloudagent/utils/tests/test_http.py
+++ b/aries_cloudagent/utils/tests/test_http.py
@@ -1,14 +1,33 @@
+import os
+import tempfile
+
 from aiohttp import web
-from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
-from asynctest import mock as async_mock, mock_open
+from aiohttp.test_utils import AioHTTPTestCase
 
 from ..http import fetch, fetch_stream, FetchError, put_file, PutError
+
+
+class TempFile:
+    def __init__(self):
+        self.name = None
+
+    def __enter__(self):
+        file = tempfile.NamedTemporaryFile(delete=False)
+        file.write(b"test")
+        file.close()
+        self.name = file.name
+        return self.name
+
+    def __exit__(self, *args):
+        if self.name:
+            os.unlink(self.name)
 
 
 class TestTransportUtils(AioHTTPTestCase):
     async def setUpAsync(self):
         self.fail_calls = 0
         self.succeed_calls = 0
+        self.redirects = 0
         await super().setUpAsync()
 
     async def get_application(self):
@@ -19,18 +38,29 @@ class TestTransportUtils(AioHTTPTestCase):
                 web.get("/succeed", self.succeed_route),
                 web.put("/fail", self.fail_route),
                 web.put("/succeed", self.succeed_route),
+                web.put("/redirect", self.redirect_route),
             ]
         )
         return app
 
     async def fail_route(self, request):
         self.fail_calls += 1
+        # avoid aiohttp test server issue: https://github.com/aio-libs/aiohttp/issues/3968
+        await request.read()
         raise web.HTTPForbidden()
 
     async def succeed_route(self, request):
         self.succeed_calls += 1
         ret = web.json_response([True])
         return ret
+
+    async def redirect_route(self, request):
+        if self.redirects > 0:
+            self.redirects -= 1
+            # avoid aiohttp test server issue: https://github.com/aio-libs/aiohttp/issues/3968
+            await request.read()
+            raise web.HTTPRedirection(f"http://localhost:{self.server.port}/success")
+        return await self.succeed_route(request)
 
     async def test_fetch_stream(self):
         server_addr = f"http://localhost:{self.server.port}"
@@ -84,40 +114,55 @@ class TestTransportUtils(AioHTTPTestCase):
             )
         assert self.fail_calls == 2
 
-    async def test_put_file(self):
+    async def test_put_file_with_session(self):
         server_addr = f"http://localhost:{self.server.port}"
-        with async_mock.patch("builtins.open", mock_open(read_data="data")):
+        with TempFile() as tails:
             result = await put_file(
                 f"{server_addr}/succeed",
-                {"tails": "/tmp/dummy/path"},
+                {"tails": tails},
                 {"genesis": "..."},
                 session=self.client.session,
                 json=True,
             )
-        assert result == [1]
+        assert result == [True]
         assert self.succeed_calls == 1
 
     async def test_put_file_default_client(self):
         server_addr = f"http://localhost:{self.server.port}"
-        with async_mock.patch("builtins.open", mock_open(read_data="data")):
+        with TempFile() as tails:
             result = await put_file(
                 f"{server_addr}/succeed",
-                {"tails": "/tmp/dummy/path"},
+                {"tails": tails},
                 {"genesis": "..."},
                 json=True,
             )
-        assert result == [1]
+        assert result == [True]
         assert self.succeed_calls == 1
 
     async def test_put_file_fail(self):
         server_addr = f"http://localhost:{self.server.port}"
-        with async_mock.patch("builtins.open", mock_open(read_data="data")):
+        with TempFile() as tails:
             with self.assertRaises(PutError):
-                result = await put_file(
+                _ = await put_file(
                     f"{server_addr}/fail",
-                    {"tails": "/tmp/dummy/path"},
+                    {"tails": tails},
                     {"genesis": "..."},
                     max_attempts=2,
                     json=True,
                 )
         assert self.fail_calls == 2
+
+    async def test_put_file_redirect(self):
+        server_addr = f"http://localhost:{self.server.port}"
+        self.redirects = 1
+        with TempFile() as tails:
+            result = await put_file(
+                f"{server_addr}/redirect",
+                {"tails": tails},
+                {"genesis": "..."},
+                max_attempts=2,
+                json=True,
+            )
+        assert result == [True]
+        assert self.succeed_calls == 1
+        assert self.redirects == 0


### PR DESCRIPTION
I believe this fix only applies to tails file uploads at the moment. Previously, aiohttp would encounter an error because it closed the tails file after the first attempt.