### PR TITLE
Fix external Outbound Transport loading code

### DIFF
--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -124,7 +124,7 @@ class OutboundTransportManager:
                 module = module_name
 
             imported_class = ClassLoader.load_subclass_of(
-                BaseInboundTransport, module, package
+                BaseOutboundTransport, module, package
             )
         except (ModuleLoadError, ClassNotFoundError) as e:
             raise InboundTransportRegistrationError(

--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -127,7 +127,7 @@ class OutboundTransportManager:
                 BaseOutboundTransport, module, package
             )
         except (ModuleLoadError, ClassNotFoundError) as e:
-            raise InboundTransportRegistrationError(
+            raise OutboundTransportRegistrationError(
                 f"Outbound transport module {module} could not be resolved."
             ) from e
 

--- a/aries_cloudagent/transport/outbound/manager.py
+++ b/aries_cloudagent/transport/outbound/manager.py
@@ -100,12 +100,12 @@ class OutboundTransportManager:
         for outbound_transport in outbound_transports:
             self.register(outbound_transport)
 
-    def register(self, module: str) -> str:
+    def register(self, module_name: str) -> str:
         """
         Register a new outbound transport by module path.
 
         Args:
-            module: Module name to register
+            module_name: Module name to register
 
         Raises:
             OutboundTransportRegistrationError: If the imported class cannot
@@ -117,13 +117,19 @@ class OutboundTransportManager:
 
         """
         try:
+            if "." in module_name:
+                package, module = module_name.split(".", 1)
+            else:
+                package = MODULE_BASE_PATH
+                module = module_name
+
             imported_class = ClassLoader.load_subclass_of(
-                BaseOutboundTransport, module, MODULE_BASE_PATH
+                BaseInboundTransport, module, package
             )
-        except (ModuleLoadError, ClassNotFoundError):
-            raise OutboundTransportRegistrationError(
+        except (ModuleLoadError, ClassNotFoundError) as e:
+            raise InboundTransportRegistrationError(
                 f"Outbound transport module {module} could not be resolved."
-            )
+            ) from e
 
         return self.register_class(imported_class)
 


### PR DESCRIPTION
As the code currently stands, only internal outbound transports are able to be loaded. With these changes, it should be possible to load a new outbound transport via a plugin.