### PR TITLE
Allow setting a baseurl for the swagger urls

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -269,6 +269,7 @@ class AdminServer(BaseAdminServer):
         # This should be enforced during parameter parsing but to be sure,
         # we check here.
         assert self.admin_insecure_mode ^ bool(self.admin_api_key)
+
         def is_unprotected_path(path: str):
             return path in [
                 "/api/doc",

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -269,7 +269,6 @@ class AdminServer(BaseAdminServer):
         # This should be enforced during parameter parsing but to be sure,
         # we check here.
         assert self.admin_insecure_mode ^ bool(self.admin_api_key)
-        
         def is_unprotected_path(path: str):
             return path in [
                 "/api/doc",

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -269,6 +269,7 @@ class AdminServer(BaseAdminServer):
         # This should be enforced during parameter parsing but to be sure,
         # we check here.
         assert self.admin_insecure_mode ^ bool(self.admin_api_key)
+        
         def is_unprotected_path(path: str):
             return path in [
                 "/api/doc",


### PR DESCRIPTION
When deploying different agents on same gateway url in service mesh there occures some problem cause static swagger path und swagger.json has no unique uri. This PR enables a baseurl to be set for the swagger urls mentioned via the environment variable ACA_PY_BASE_URL:
Until now, the static swagger path and swagger.json path is always the default value set in setup_aiohttp_apispec (static/swagger for 'static_path' and /api/docs/swagger.json for 'url'). By setting the ACA_PY_BASE_URL, the path can now be adjusted so that the urls can be set to ${ACA_PY_BASE_URL }/static/swagger or ${ACA_PY_BASE_URL }/api/docs/swagger.json. The urls can then be easily resolved in the virtual service via unique urls.