### PR TITLE
feat: make base wallet route access configurable

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -4,7 +4,7 @@ import asyncio
 from hmac import compare_digest
 import logging
 import re
-from typing import Callable, Coroutine
+from typing import Callable, Coroutine, Optional, Pattern, Sequence, cast
 import uuid
 import warnings
 
@@ -249,8 +249,31 @@ class AdminServer(BaseAdminServer):
         self.websocket_queues = {}
         self.site = None
         self.multitenant_manager = context.inject_or(BaseMultitenantManager)
+        self._additional_route_pattern: Optional[Pattern] = None
 
         self.server_paths = []
+
+    @property
+    def additional_routes_pattern(self) -> Optional[Pattern]:
+        """Pattern for configured addtional routes to permit base wallet to access."""
+        if self._additional_route_pattern:
+            return self._additional_route_pattern
+
+        base_wallet_routes = self.context.settings.get("multitenant.base_wallet_routes")
+        base_wallet_routes = cast(Sequence[str], base_wallet_routes)
+        if base_wallet_routes:
+            self._additional_route_pattern = re.compile(
+                "^(?:" + "|".join(base_wallet_routes) + ")"
+            )
+        return None
+
+    def _matches_additional_routes(self, path: str) -> bool:
+        """Path matches additional_routes_pattern."""
+        pattern = self.additional_routes_pattern
+        if pattern:
+            return bool(pattern.match(path))
+
+        return False
 
     async def make_application(self) -> web.Application:
         """Get the aiohttp application instance."""
@@ -324,6 +347,7 @@ class AdminServer(BaseAdminServer):
                         path,
                     )
                     or path.startswith("/mediation/default-mediator")
+                    or self._matches_additional_routes(path)
                 )
 
                 # base wallet is not allowed to perform ssi related actions.

--- a/aries_cloudagent/admin/tests/test_admin_server.py
+++ b/aries_cloudagent/admin/tests/test_admin_server.py
@@ -195,7 +195,9 @@ class TestAdminServer(AsyncTestCase):
 
     async def test_import_routes_multitenant_middleware(self):
         # imports all default admin routes
-        context = InjectionContext()
+        context = InjectionContext(
+            settings={"multitenant.base_wallet_routes": ["/test"]}
+        )
         context.injector.bind_instance(ProtocolRegistry, ProtocolRegistry())
         context.injector.bind_instance(GoalCodeRegistry, GoalCodeRegistry())
         profile = InMemoryProfile.test_profile()
@@ -244,6 +246,16 @@ class TestAdminServer(AsyncTestCase):
             method="GET",
             headers={"Authorization": "Bearer ..."},
             path="/protected/non-multitenancy/non-server",
+            text=async_mock.CoroutineMock(return_value="abc123"),
+        )
+        mock_handler = async_mock.CoroutineMock()
+        await mt_authz_middle(mock_request, mock_handler)
+        assert mock_handler.called_once_with(mock_request)
+
+        mock_request = async_mock.MagicMock(
+            method="GET",
+            headers={"Authorization": "Non-bearer ..."},
+            path="/test",
             text=async_mock.CoroutineMock(return_value="abc123"),
         )
         mock_handler = async_mock.CoroutineMock()

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -1636,7 +1636,9 @@ class MultitenantGroup(ArgumentGroup):
             required=False,
             metavar="<REGEX>",
             help=(
-                "Patterns matching admin routes that should be permitted for base wallet."
+                "Patterns matching admin routes that should be permitted for "
+                "base wallet. The base wallet is preconfigured to have access to "
+                "essential endpoints. This argument should be used sparingly."
             ),
         )
 

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -1629,6 +1629,16 @@ class MultitenantGroup(ArgumentGroup):
                 '"wallet_name" is only used when "wallet_type" is "askar-profile"'
             ),
         )
+        parser.add_argument(
+            "--base-wallet-routes",
+            type=str,
+            nargs="+",
+            required=False,
+            metavar="<REGEX>",
+            help=(
+                "Patterns matching admin routes that should be permitted for base wallet."
+            ),
+        )
 
     def get_settings(self, args: Namespace):
         """Extract multitenant settings."""
@@ -1663,6 +1673,9 @@ class MultitenantGroup(ArgumentGroup):
                     settings[
                         "multitenant.key_derivation_method"
                     ] = multitenancyConfig.get("key_derivation_method")
+
+            if args.base_wallet_routes:
+                settings["multitenant.base_wallet_routes"] = args.base_wallet_routes
 
         return settings
 

--- a/aries_cloudagent/config/tests/test_argparse.py
+++ b/aries_cloudagent/config/tests/test_argparse.py
@@ -231,7 +231,6 @@ class TestArgParse(AsyncTestCase):
                 "--jwt-secret",
                 "secret",
                 "--multitenancy-config",
-                '{"wallet_type":"askar","wallet_name":"test"}',
                 '{"wallet_type":"askar","wallet_name":"test", "cache_size": 10}',
                 "--base-wallet-routes",
                 "/my_route",

--- a/aries_cloudagent/config/tests/test_argparse.py
+++ b/aries_cloudagent/config/tests/test_argparse.py
@@ -232,6 +232,8 @@ class TestArgParse(AsyncTestCase):
                 "secret",
                 "--multitenancy-config",
                 '{"wallet_type":"askar","wallet_name":"test"}',
+                "--base-wallet-routes",
+                "/my_route",
             ]
         )
 
@@ -241,6 +243,7 @@ class TestArgParse(AsyncTestCase):
         assert settings.get("multitenant.jwt_secret") == "secret"
         assert settings.get("multitenant.wallet_type") == "askar"
         assert settings.get("multitenant.wallet_name") == "test"
+        assert settings.get("multitenant.base_wallet_routes") == ["/my_route"]
 
     async def test_endorser_settings(self):
         """Test required argument parsing."""


### PR DESCRIPTION
When adding admin routes through plugins, it makes sense for the plugin to be able to specify that those routes should be accessible to the base wallet when appropriate.