### PR TITLE
Fix a typo in DevReadMe.md

### DIFF
--- a/DevReadMe.md
+++ b/DevReadMe.md
@@ -149,7 +149,7 @@ To enable the [ptvsd](https://github.com/Microsoft/ptvsd) Python debugger for Vi
 Any ports you will be using from the docker container should be published using the `PORTS` environment variable. For example:
 
 ```bash
-PORTS="5000:5000 8000:8000 1000:1000" ./scripts/run_docker start --inbound-transport http 0.0.0.0 10000 --outbound-transport http --debug --log-level DEBUG
+PORTS="5000:5000 8000:8000 10000:10000" ./scripts/run_docker start --inbound-transport http 0.0.0.0 10000 --outbound-transport http --debug --log-level DEBUG
 ```
 
 Refer to [the previous section](#Running) for instructions on how to run the software.


### PR DESCRIPTION
There is a typo in the example command to run the project using the docker container.

```
PORTS="5000:5000 8000:8000 1000:1000" ./scripts/run_docker start --inbound-transport http 0.0.0.0 10000 --outbound-transport http --debug --log-level DEBUG
```

It opens the port 1,000 for access instead of 10,000 which is specified as "inbound-transport". As a result, the agent wouldn't be accessible. 