### PR TITLE
Githubaction publish docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,42 @@
+name: Create and publish a Docker image for each tagged commit
+
+on:
+  push:
+    tags: ['*', '**']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          file: docker/Dockerfile.run
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-name: Create and publish a Docker image for each tagged commit
+name: Build and publish a Docker image for each tagged commit
 
 on:
   push:


### PR DESCRIPTION
Hi, @swcurran mentioned in today's AcaPug call that you would be interested in a pipeline for building and publishing AcaPy Docker images automatically for every tagged commit.

The GitHub Action below should do this. It is triggered for every tagged commit and will build the docker image using the `docker/Dockerfile.run` file. The images are being published in the GitHub package registry of this repo.

Example: If a commit is tagged with `0.7.4-rc6` an image will automatically be built and published with the following two tags:
1. aries-cloudagent-python:latest
2. aries-cloudagent-python:0.7.4-rc6

You can also see the build image in my forked version of this repo: https://github.com/PaulWen/aries-cloudagent-python/pkgs/container/aries-cloudagent-python


Let me know if this is of any help or if I misunderstood the requirements. I am happy to iterate over it and appreciate any feedback!