### PR TITLE
Unit test fixes for python 3.9

### DIFF
--- a/aries_cloudagent/core/plugin_registry.py
+++ b/aries_cloudagent/core/plugin_registry.py
@@ -218,7 +218,7 @@ class PluginRegistry:
     ):
         """Load a particular protocol version."""
         protocol_registry = context.inject(ProtocolRegistry)
-        goal_code_resgistry = context.inject(GoalCodeRegistry)
+        goal_code_registry = context.inject(GoalCodeRegistry)
         if hasattr(mod, "MESSAGE_TYPES"):
             protocol_registry.register_message_types(
                 mod.MESSAGE_TYPES, version_definition=version_definition
@@ -227,7 +227,7 @@ class PluginRegistry:
             protocol_registry.register_controllers(
                 mod.CONTROLLERS, version_definition=version_definition
             )
-            goal_code_resgistry.register_controllers(mod.CONTROLLERS)
+            goal_code_registry.register_controllers(mod.CONTROLLERS)
 
     async def load_protocols(self, context: InjectionContext, plugin: ModuleType):
         """For modules that don't implement setup, register protocols manually."""

--- a/aries_cloudagent/core/tests/test_conductor.py
+++ b/aries_cloudagent/core/tests/test_conductor.py
@@ -1,8 +1,7 @@
 from io import StringIO
 
-import asynctest
-from asynctest import TestCase as AsyncTestCase
-from asynctest import mock as async_mock
+import mock as async_mock
+from async_case import IsolatedAsyncioTestCase
 
 from ...admin.base_server import BaseAdminServer
 from ...config.base_context import ContextBuilder
@@ -21,7 +20,6 @@ from ...core.profile import ProfileManager
 from ...core.protocol_registry import ProtocolRegistry
 from ...protocols.coordinate_mediation.mediation_invite_store import (
     MediationInviteRecord,
-    MediationInviteStore,
 )
 from ...protocols.coordinate_mediation.v1_0.models.mediation_record import (
     MediationRecord,
@@ -106,7 +104,7 @@ class StubCollectorContextBuilder(StubContextBuilder):
         return context
 
 
-class TestConductor(AsyncTestCase, Config, TestDIDs):
+class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
     async def test_startup(self):
         builder: ContextBuilder = StubContextBuilder(self.test_settings)
         conductor = test_module.Conductor(builder)
@@ -120,7 +118,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
         ) as mock_logger, async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
+            async_mock.AsyncMock(
                 return_value=async_mock.MagicMock(value=f"v{__version__}")
             ),
         ):
@@ -188,14 +186,14 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
         ) as mock_logger, async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
+            async_mock.AsyncMock(
                 return_value=async_mock.MagicMock(value=f"v{__version__}")
             ),
         ):
             mock_outbound_mgr.return_value.registered_transports = {}
-            mock_outbound_mgr.return_value.enqueue_message = async_mock.CoroutineMock()
-            mock_outbound_mgr.return_value.start = async_mock.CoroutineMock()
-            mock_outbound_mgr.return_value.stop = async_mock.CoroutineMock()
+            mock_outbound_mgr.return_value.enqueue_message = async_mock.AsyncMock()
+            mock_outbound_mgr.return_value.start = async_mock.AsyncMock()
+            mock_outbound_mgr.return_value.stop = async_mock.AsyncMock()
             await conductor.setup()
 
             mock_inbound_mgr.return_value.setup.assert_awaited_once()
@@ -464,8 +462,8 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             test_module, "OutboundTransportManager", async_mock.MagicMock()
         ) as mock_outbound_mgr:
             mock_outbound_mgr.return_value = async_mock.MagicMock(
-                setup=async_mock.CoroutineMock(),
-                enqueue_message=async_mock.CoroutineMock(),
+                setup=async_mock.AsyncMock(),
+                enqueue_message=async_mock.AsyncMock(),
             )
 
             payload = "{}"
@@ -485,7 +483,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
                 conductor.dispatcher, "run_task", async_mock.MagicMock()
             ) as mock_run_task:
                 mock_conn_mgr.return_value.get_connection_targets = (
-                    async_mock.CoroutineMock()
+                    async_mock.AsyncMock()
                 )
                 mock_run_task.side_effect = test_module.ConnectionManagerError()
                 await conductor.queue_outbound(conductor.root_profile, message)
@@ -527,7 +525,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
         with async_mock.patch.object(
             conductor.dispatcher, "run_task", async_mock.MagicMock()
         ) as mock_dispatch_run, async_mock.patch.object(
-            conductor, "queue_outbound", async_mock.CoroutineMock()
+            conductor, "queue_outbound", async_mock.AsyncMock()
         ) as mock_queue, async_mock.patch.object(
             conductor.admin_server, "notify_fatal_error", async_mock.MagicMock()
         ) as mock_notify:
@@ -567,7 +565,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
         ) as mock_dispatch_run, async_mock.patch.object(
             conductor.admin_server, "notify_fatal_error", async_mock.MagicMock()
         ) as mock_notify:
-            conn_mgr.return_value.get_connection_targets = async_mock.CoroutineMock()
+            conn_mgr.return_value.get_connection_targets = async_mock.AsyncMock()
             mock_dispatch_run.side_effect = test_module.LedgerConfigError(
                 "No such ledger"
             )
@@ -613,7 +611,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
         ) as admin_stop, async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
+            async_mock.AsyncMock(
                 return_value=async_mock.MagicMock(value=f"v{__version__}")
             ),
         ):
@@ -661,15 +659,15 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
         ) as conn_mgr, async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
+            async_mock.AsyncMock(
                 return_value=async_mock.MagicMock(value=f"v{__version__}")
             ),
         ):
             admin_start.side_effect = KeyError("trouble")
-            oob_mgr.return_value.create_invitation = async_mock.CoroutineMock(
+            oob_mgr.return_value.create_invitation = async_mock.AsyncMock(
                 side_effect=KeyError("double trouble")
             )
-            conn_mgr.return_value.create_invitation = async_mock.CoroutineMock(
+            conn_mgr.return_value.create_invitation = async_mock.AsyncMock(
                 side_effect=KeyError("triple trouble")
             )
             await conductor.start()
@@ -704,7 +702,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
         ) as mock_mgr, async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
+            async_mock.AsyncMock(
                 return_value=async_mock.MagicMock(value=f"v{__version__}")
             ),
         ), async_mock.patch.object(
@@ -722,7 +720,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
                 KeyType.ED25519,
             )
 
-            mock_mgr.return_value.create_static_connection = async_mock.CoroutineMock()
+            mock_mgr.return_value.create_static_connection = async_mock.AsyncMock()
             await conductor.start()
             mock_mgr.return_value.create_static_connection.assert_awaited_once()
 
@@ -739,14 +737,14 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             test_module, "OutboundTransportManager", autospec=True
         ) as mock_outbound_mgr:
             mock_intx_mgr.return_value = async_mock.MagicMock(
-                setup=async_mock.CoroutineMock(),
-                start=async_mock.CoroutineMock(side_effect=KeyError("trouble")),
+                setup=async_mock.AsyncMock(),
+                start=async_mock.AsyncMock(side_effect=KeyError("trouble")),
             )
             mock_outbound_mgr.return_value.registered_transports = {
                 "test": async_mock.MagicMock(schemes=["http"])
             }
             await conductor.setup()
-            mock_mgr.return_value.create_static_connection = async_mock.CoroutineMock()
+            mock_mgr.return_value.create_static_connection = async_mock.AsyncMock()
             with self.assertRaises(KeyError):
                 await conductor.start()
 
@@ -761,12 +759,12 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             test_module, "OutboundTransportManager"
         ) as mock_outx_mgr:
             mock_outx_mgr.return_value = async_mock.MagicMock(
-                setup=async_mock.CoroutineMock(),
-                start=async_mock.CoroutineMock(side_effect=KeyError("trouble")),
+                setup=async_mock.AsyncMock(),
+                start=async_mock.AsyncMock(side_effect=KeyError("trouble")),
                 registered_transports={"test": async_mock.MagicMock(schemes=["http"])},
             )
             await conductor.setup()
-            mock_mgr.return_value.create_static_connection = async_mock.CoroutineMock()
+            mock_mgr.return_value.create_static_connection = async_mock.AsyncMock()
             with self.assertRaises(KeyError):
                 await conductor.start()
 
@@ -781,14 +779,14 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             test_module, "OutboundTransportManager"
         ) as mock_outx_mgr:
             mock_outx_mgr.return_value = async_mock.MagicMock(
-                setup=async_mock.CoroutineMock(),
-                start=async_mock.CoroutineMock(side_effect=KeyError("trouble")),
-                stop=async_mock.CoroutineMock(),
+                setup=async_mock.AsyncMock(),
+                start=async_mock.AsyncMock(side_effect=KeyError("trouble")),
+                stop=async_mock.AsyncMock(),
                 registered_transports={},
-                enqueue_message=async_mock.CoroutineMock(),
+                enqueue_message=async_mock.AsyncMock(),
             )
             await conductor.setup()
-            mock_mgr.return_value.create_static_connection = async_mock.CoroutineMock()
+            mock_mgr.return_value.create_static_connection = async_mock.AsyncMock()
             with self.assertRaises(KeyError):
                 await conductor.start()
 
@@ -799,8 +797,9 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
         message_body = "{}"
         receipt = MessageReceipt(direct_response_mode="snail mail")
         message = InboundMessage(message_body, receipt)
+        exc = KeyError("sample exception")
         mock_task = async_mock.MagicMock(
-            exc_info=(KeyError, KeyError("sample exception"), "..."),
+            exc_info=(type(exc), exc, exc.__traceback__),
             ident="abc",
             timing={
                 "queued": 1234567890,
@@ -831,12 +830,9 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
         message_body = "{}"
         receipt = MessageReceipt(direct_response_mode="snail mail")
         message = InboundMessage(message_body, receipt)
+        exc = test_module.LedgerTransactionError("Ledger is wobbly")
         mock_task = async_mock.MagicMock(
-            exc_info=(
-                test_module.LedgerTransactionError,
-                test_module.LedgerTransactionError("Ledger is wobbly"),
-                "...",
-            ),
+            exc_info=(type(exc), exc, exc.__traceback__),
             ident="abc",
             timing={
                 "queued": 1234567890,
@@ -876,7 +872,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
         ) as captured, async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
+            async_mock.AsyncMock(
                 return_value=async_mock.MagicMock(value=f"v{__version__}")
             ),
         ), async_mock.patch.object(
@@ -917,12 +913,12 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             test_module,
             "MediationManager",
             return_value=async_mock.MagicMock(
-                clear_default_mediator=async_mock.CoroutineMock()
+                clear_default_mediator=async_mock.AsyncMock()
             ),
         ) as mock_mgr, async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
+            async_mock.AsyncMock(
                 return_value=async_mock.MagicMock(value=f"v{__version__}")
             ),
         ):
@@ -947,10 +943,10 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
             test_module,
             "MediationManager",
             return_value=async_mock.MagicMock(
-                set_default_mediator_by_id=async_mock.CoroutineMock()
+                set_default_mediator_by_id=async_mock.AsyncMock()
             ),
         ) as mock_mgr, async_mock.patch.object(
-            MediationRecord, "retrieve_by_id", async_mock.CoroutineMock()
+            MediationRecord, "retrieve_by_id", async_mock.AsyncMock()
         ), async_mock.patch.object(
             test_module,
             "LOGGER",
@@ -962,7 +958,7 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
         ), async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
+            async_mock.AsyncMock(
                 return_value=async_mock.MagicMock(value=f"v{__version__}")
             ),
         ):
@@ -986,13 +982,13 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
         with async_mock.patch.object(
             MediationRecord,
             "retrieve_by_id",
-            async_mock.CoroutineMock(side_effect=Exception()),
+            async_mock.AsyncMock(side_effect=Exception()),
         ), async_mock.patch.object(
             test_module, "LOGGER"
         ) as mock_logger, async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
+            async_mock.AsyncMock(
                 return_value=async_mock.MagicMock(value=f"v{__version__}")
             ),
         ):
@@ -1064,11 +1060,11 @@ class TestConductor(AsyncTestCase, Config, TestDIDs):
 
             multitenant_mgr._profiles.put(
                 "test1",
-                async_mock.MagicMock(close=async_mock.CoroutineMock()),
+                async_mock.MagicMock(close=async_mock.AsyncMock()),
             )
             multitenant_mgr._profiles.put(
                 "test2",
-                async_mock.MagicMock(close=async_mock.CoroutineMock()),
+                async_mock.MagicMock(close=async_mock.AsyncMock()),
             )
 
             await conductor.stop()
@@ -1084,14 +1080,12 @@ def get_invite_store_mock(
     used_invite = MediationInviteRecord(invite_string, used=True)
 
     return async_mock.MagicMock(
-        get_mediation_invite_record=async_mock.CoroutineMock(
-            return_value=unused_invite
-        ),
-        mark_default_invite_as_used=async_mock.CoroutineMock(return_value=used_invite),
+        get_mediation_invite_record=async_mock.AsyncMock(return_value=unused_invite),
+        mark_default_invite_as_used=async_mock.AsyncMock(return_value=used_invite),
     )
 
 
-class TestConductorMediationSetup(AsyncTestCase, Config):
+class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
     """
     Test related with setting up mediation from given arguments or stored invitation.
     """
@@ -1106,12 +1100,12 @@ class TestConductorMediationSetup(AsyncTestCase, Config):
 
         return builder
 
-    @asynctest.patch.object(
+    @async_mock.patch.object(
         test_module,
         "MediationInviteStore",
         return_value=get_invite_store_mock("test-invite"),
     )
-    @asynctest.patch.object(test_module.ConnectionInvitation, "from_url")
+    @async_mock.patch.object(test_module.ConnectionInvitation, "from_url")
     async def test_mediator_invitation_0160(self, mock_from_url, _):
         conductor = test_module.Conductor(
             self.__get_mediator_config("test-invite", True)
@@ -1131,17 +1125,17 @@ class TestConductorMediationSetup(AsyncTestCase, Config):
             "ConnectionManager",
             async_mock.MagicMock(
                 return_value=async_mock.MagicMock(
-                    receive_invitation=async_mock.CoroutineMock(
+                    receive_invitation=async_mock.AsyncMock(
                         return_value=mock_conn_record
                     )
                 )
             ),
         ) as mock_mgr, async_mock.patch.object(
-            mock_conn_record, "metadata_set", async_mock.CoroutineMock()
+            mock_conn_record, "metadata_set", async_mock.AsyncMock()
         ), async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
+            async_mock.AsyncMock(
                 return_value=async_mock.MagicMock(value=f"v{__version__}")
             ),
         ):
@@ -1150,12 +1144,12 @@ class TestConductorMediationSetup(AsyncTestCase, Config):
             mock_from_url.assert_called_once_with("test-invite")
             mock_mgr.return_value.receive_invitation.assert_called_once()
 
-    @asynctest.patch.object(
+    @async_mock.patch.object(
         test_module,
         "MediationInviteStore",
         return_value=get_invite_store_mock("test-invite"),
     )
-    @asynctest.patch.object(test_module.InvitationMessage, "from_url")
+    @async_mock.patch.object(test_module.InvitationMessage, "from_url")
     async def test_mediator_invitation_0434(self, mock_from_url, _):
         conductor = test_module.Conductor(
             self.__get_mediator_config("test-invite", False)
@@ -1181,15 +1175,13 @@ class TestConductorMediationSetup(AsyncTestCase, Config):
             "OutOfBandManager",
             async_mock.MagicMock(
                 return_value=async_mock.MagicMock(
-                    receive_invitation=async_mock.CoroutineMock(
-                        return_value=conn_record
-                    )
+                    receive_invitation=async_mock.AsyncMock(return_value=conn_record)
                 )
             ),
         ) as mock_mgr, async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
+            async_mock.AsyncMock(
                 return_value=async_mock.MagicMock(value=f"v{__version__}")
             ),
         ):
@@ -1198,8 +1190,8 @@ class TestConductorMediationSetup(AsyncTestCase, Config):
             mock_from_url.assert_called_once_with("test-invite")
             mock_mgr.return_value.receive_invitation.assert_called_once()
 
-    @asynctest.patch.object(test_module, "MediationInviteStore")
-    @asynctest.patch.object(test_module.ConnectionInvitation, "from_url")
+    @async_mock.patch.object(test_module, "MediationInviteStore")
+    @async_mock.patch.object(test_module.ConnectionInvitation, "from_url")
     async def test_mediation_invitation_should_use_stored_invitation(
         self, patched_from_url, patched_invite_store
     ):
@@ -1227,23 +1219,23 @@ class TestConductorMediationSetup(AsyncTestCase, Config):
         patched_invite_store.return_value = mocked_store
 
         connection_manager_mock = async_mock.MagicMock(
-            receive_invitation=async_mock.CoroutineMock(return_value=mock_conn_record)
+            receive_invitation=async_mock.AsyncMock(return_value=mock_conn_record)
         )
         mock_mediation_manager = async_mock.MagicMock(
-            clear_default_mediator=async_mock.CoroutineMock()
+            clear_default_mediator=async_mock.AsyncMock()
         )
 
         # when
         with async_mock.patch.object(
             test_module, "ConnectionManager", return_value=connection_manager_mock
         ), async_mock.patch.object(
-            mock_conn_record, "metadata_set", async_mock.CoroutineMock()
+            mock_conn_record, "metadata_set", async_mock.AsyncMock()
         ), async_mock.patch.object(
             test_module, "MediationManager", return_value=mock_mediation_manager
         ), async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
+            async_mock.AsyncMock(
                 return_value=async_mock.MagicMock(value=f"v{__version__}")
             ),
         ):
@@ -1257,8 +1249,8 @@ class TestConductorMediationSetup(AsyncTestCase, Config):
             patched_from_url.assert_called_with(invite_string)
             mock_mediation_manager.clear_default_mediator.assert_called_once()
 
-    @asynctest.patch.object(test_module, "MediationInviteStore")
-    @asynctest.patch.object(test_module, "ConnectionManager")
+    @async_mock.patch.object(test_module, "MediationInviteStore")
+    @async_mock.patch.object(test_module, "ConnectionManager")
     async def test_mediation_invitation_should_not_create_connection_for_old_invitation(
         self, patched_connection_manager, patched_invite_store
     ):
@@ -1280,13 +1272,13 @@ class TestConductorMediationSetup(AsyncTestCase, Config):
         patched_invite_store.return_value = invite_store_mock
 
         connection_manager_mock = async_mock.MagicMock(
-            receive_invitation=async_mock.CoroutineMock()
+            receive_invitation=async_mock.AsyncMock()
         )
         patched_connection_manager.return_value = connection_manager_mock
         with async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
+            async_mock.AsyncMock(
                 return_value=async_mock.MagicMock(value=f"v{__version__}")
             ),
         ):
@@ -1300,7 +1292,7 @@ class TestConductorMediationSetup(AsyncTestCase, Config):
             )
             connection_manager_mock.receive_invitation.assert_not_called()
 
-    @asynctest.patch.object(
+    @async_mock.patch.object(
         test_module,
         "MediationInviteStore",
         return_value=get_invite_store_mock("test-invite"),
@@ -1326,7 +1318,7 @@ class TestConductorMediationSetup(AsyncTestCase, Config):
         ) as mock_logger, async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
+            async_mock.AsyncMock(
                 return_value=async_mock.MagicMock(value=f"v{__version__}")
             ),
         ):
@@ -1344,9 +1336,9 @@ class TestConductorMediationSetup(AsyncTestCase, Config):
         with async_mock.patch.object(
             test_module,
             "load_multiple_genesis_transactions_from_config",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_multiple_genesis_load, async_mock.patch.object(
-            test_module, "get_genesis_transactions", async_mock.CoroutineMock()
+            test_module, "get_genesis_transactions", async_mock.AsyncMock()
         ) as mock_genesis_load, async_mock.patch.object(
             test_module, "OutboundTransportManager", autospec=True
         ) as mock_outbound_mgr:
@@ -1363,7 +1355,7 @@ class TestConductorMediationSetup(AsyncTestCase, Config):
         conductor = test_module.Conductor(builder)
 
         with async_mock.patch.object(
-            test_module, "get_genesis_transactions", async_mock.CoroutineMock()
+            test_module, "get_genesis_transactions", async_mock.AsyncMock()
         ) as mock_genesis_load, async_mock.patch.object(
             test_module, "OutboundTransportManager", autospec=True
         ) as mock_outbound_mgr:
@@ -1386,9 +1378,7 @@ class TestConductorMediationSetup(AsyncTestCase, Config):
         ) as mock_logger, async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(
-                return_value=async_mock.MagicMock(value=f"v0.6.0")
-            ),
+            async_mock.AsyncMock(return_value=async_mock.MagicMock(value=f"v0.6.0")),
         ):
             mock_outbound_mgr.return_value.registered_transports = {
                 "test": async_mock.MagicMock(schemes=["http"])
@@ -1425,7 +1415,7 @@ class TestConductorMediationSetup(AsyncTestCase, Config):
         ) as mock_logger, async_mock.patch.object(
             BaseStorage,
             "find_record",
-            async_mock.CoroutineMock(side_effect=StorageNotFoundError()),
+            async_mock.AsyncMock(side_effect=StorageNotFoundError()),
         ):
             mock_outbound_mgr.return_value.registered_transports = {
                 "test": async_mock.MagicMock(schemes=["http"])

--- a/aries_cloudagent/ledger/tests/test_routes.py
+++ b/aries_cloudagent/ledger/tests/test_routes.py
@@ -1,5 +1,7 @@
-from asynctest import mock as async_mock, TestCase as AsyncTestCase
 from typing import Tuple
+
+from async_case import IsolatedAsyncioTestCase
+import mock as async_mock
 
 from ...core.in_memory import InMemoryProfile
 from ...ledger.base import BaseLedger
@@ -18,7 +20,7 @@ from ..indy import Role
 from ...connections.models.conn_record import ConnRecord
 
 
-class TestLedgerRoutes(AsyncTestCase):
+class TestLedgerRoutes(IsolatedAsyncioTestCase):
     def setUp(self):
         self.ledger = async_mock.create_autospec(BaseLedger)
         self.ledger.pool_name = "pool.0"
@@ -28,7 +30,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(BaseLedger, self.ledger)
         self.request_dict = {
             "context": self.context,
-            "outbound_message_router": async_mock.CoroutineMock(),
+            "outbound_message_router": async_mock.AsyncMock(),
         }
         self.request = async_mock.MagicMock(
             app={},
@@ -47,7 +49,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             IndyLedgerRequestsExecutor,
             async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
+                get_ledger_for_identifier=async_mock.AsyncMock(
                     return_value=(None, None)
                 )
             ),
@@ -82,7 +84,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             IndyLedgerRequestsExecutor,
             async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
+                get_ledger_for_identifier=async_mock.AsyncMock(
                     return_value=(None, self.ledger)
                 )
             ),
@@ -102,7 +104,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             IndyLedgerRequestsExecutor,
             async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
+                get_ledger_for_identifier=async_mock.AsyncMock(
                     return_value=("test_ledger_id", self.ledger)
                 )
             ),
@@ -130,7 +132,7 @@ class TestLedgerRoutes(AsyncTestCase):
         with async_mock.patch.object(
             IndyLedgerRequestsExecutor,
             "get_ledger_for_identifier",
-            async_mock.CoroutineMock(return_value=("test_ledger_id", self.ledger)),
+            async_mock.AsyncMock(return_value=("test_ledger_id", self.ledger)),
         ), async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as json_response:
@@ -153,7 +155,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             IndyLedgerRequestsExecutor,
             async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
+                get_ledger_for_identifier=async_mock.AsyncMock(
                     return_value=("test_ledger_id", self.ledger)
                 )
             ),
@@ -167,7 +169,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             IndyLedgerRequestsExecutor,
             async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
+                get_ledger_for_identifier=async_mock.AsyncMock(
                     return_value=(None, self.ledger)
                 )
             ),
@@ -181,7 +183,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             IndyLedgerRequestsExecutor,
             async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
+                get_ledger_for_identifier=async_mock.AsyncMock(
                     return_value=(None, self.ledger)
                 )
             ),
@@ -206,7 +208,7 @@ class TestLedgerRoutes(AsyncTestCase):
         with async_mock.patch.object(
             IndyLedgerRequestsExecutor,
             "get_ledger_for_identifier",
-            async_mock.CoroutineMock(return_value=("test_ledger_id", self.ledger)),
+            async_mock.AsyncMock(return_value=("test_ledger_id", self.ledger)),
         ), async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as json_response:
@@ -224,7 +226,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             IndyLedgerRequestsExecutor,
             async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
+                get_ledger_for_identifier=async_mock.AsyncMock(
                     return_value=("test_ledger_id", self.ledger)
                 )
             ),
@@ -257,7 +259,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             IndyLedgerRequestsExecutor,
             async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
+                get_ledger_for_identifier=async_mock.AsyncMock(
                     return_value=("test_ledger_id", self.ledger)
                 )
             ),
@@ -325,21 +327,21 @@ class TestLedgerRoutes(AsyncTestCase):
         }
 
         with async_mock.patch.object(
-            ConnRecord, "retrieve_by_id", async_mock.CoroutineMock()
+            ConnRecord, "retrieve_by_id", async_mock.AsyncMock()
         ) as mock_conn_rec_retrieve, async_mock.patch.object(
             test_module, "TransactionManager", async_mock.MagicMock()
         ) as mock_txn_mgr, async_mock.patch.object(
             test_module.web, "json_response", async_mock.MagicMock()
         ) as mock_response:
             mock_txn_mgr.return_value = async_mock.MagicMock(
-                create_record=async_mock.CoroutineMock(
+                create_record=async_mock.AsyncMock(
                     return_value=async_mock.MagicMock(
                         serialize=async_mock.MagicMock(return_value={"...": "..."})
                     )
                 )
             )
             mock_conn_rec_retrieve.return_value = async_mock.MagicMock(
-                metadata_get=async_mock.CoroutineMock(
+                metadata_get=async_mock.AsyncMock(
                     return_value={
                         "endorser_did": ("did"),
                         "endorser_name": ("name"),
@@ -368,18 +370,18 @@ class TestLedgerRoutes(AsyncTestCase):
         }
 
         with async_mock.patch.object(
-            ConnRecord, "retrieve_by_id", async_mock.CoroutineMock()
+            ConnRecord, "retrieve_by_id", async_mock.AsyncMock()
         ) as mock_conn_rec_retrieve, async_mock.patch.object(
             test_module, "TransactionManager", async_mock.MagicMock()
         ) as mock_txn_mgr:
 
             mock_txn_mgr.return_value = async_mock.MagicMock(
-                create_record=async_mock.CoroutineMock(
+                create_record=async_mock.AsyncMock(
                     side_effect=test_module.StorageError()
                 )
             )
             mock_conn_rec_retrieve.return_value = async_mock.MagicMock(
-                metadata_get=async_mock.CoroutineMock(
+                metadata_get=async_mock.AsyncMock(
                     return_value={
                         "endorser_did": ("did"),
                         "endorser_name": ("name"),
@@ -405,7 +407,7 @@ class TestLedgerRoutes(AsyncTestCase):
         }
 
         with async_mock.patch.object(
-            ConnRecord, "retrieve_by_id", async_mock.CoroutineMock()
+            ConnRecord, "retrieve_by_id", async_mock.AsyncMock()
         ) as mock_conn_rec_retrieve:
             mock_conn_rec_retrieve.side_effect = test_module.StorageNotFoundError()
             self.ledger.register_nym.return_value: Tuple[bool, dict] = (
@@ -427,7 +429,7 @@ class TestLedgerRoutes(AsyncTestCase):
         }
 
         with async_mock.patch.object(
-            ConnRecord, "retrieve_by_id", async_mock.CoroutineMock()
+            ConnRecord, "retrieve_by_id", async_mock.AsyncMock()
         ) as mock_conn_rec_retrieve:
             mock_conn_rec_retrieve.side_effect = test_module.BaseModelError()
             self.ledger.register_nym.return_value: Tuple[bool, dict] = (
@@ -451,10 +453,10 @@ class TestLedgerRoutes(AsyncTestCase):
         }
 
         with async_mock.patch.object(
-            ConnRecord, "retrieve_by_id", async_mock.CoroutineMock()
+            ConnRecord, "retrieve_by_id", async_mock.AsyncMock()
         ) as mock_conn_rec_retrieve:
             mock_conn_rec_retrieve.return_value = async_mock.MagicMock(
-                metadata_get=async_mock.CoroutineMock(return_value=None)
+                metadata_get=async_mock.AsyncMock(return_value=None)
             )
             self.ledger.register_nym.return_value: Tuple[bool, dict] = (
                 True,
@@ -475,10 +477,10 @@ class TestLedgerRoutes(AsyncTestCase):
         }
 
         with async_mock.patch.object(
-            ConnRecord, "retrieve_by_id", async_mock.CoroutineMock()
+            ConnRecord, "retrieve_by_id", async_mock.AsyncMock()
         ) as mock_conn_rec_retrieve:
             mock_conn_rec_retrieve.return_value = async_mock.MagicMock(
-                metadata_get=async_mock.CoroutineMock(
+                metadata_get=async_mock.AsyncMock(
                     return_value={
                         "endorser_name": ("name"),
                     }
@@ -496,7 +498,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             IndyLedgerRequestsExecutor,
             async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
+                get_ledger_for_identifier=async_mock.AsyncMock(
                     return_value=(None, self.ledger)
                 )
             ),
@@ -515,7 +517,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             IndyLedgerRequestsExecutor,
             async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
+                get_ledger_for_identifier=async_mock.AsyncMock(
                     return_value=("test_ledger_id", self.ledger)
                 )
             ),
@@ -542,7 +544,7 @@ class TestLedgerRoutes(AsyncTestCase):
         with async_mock.patch.object(
             IndyLedgerRequestsExecutor,
             "get_ledger_for_identifier",
-            async_mock.CoroutineMock(return_value=("test_ledger_id", self.ledger)),
+            async_mock.AsyncMock(return_value=("test_ledger_id", self.ledger)),
         ), async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as json_response:
@@ -562,7 +564,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             IndyLedgerRequestsExecutor,
             async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
+                get_ledger_for_identifier=async_mock.AsyncMock(
                     return_value=("test_ledger_id", self.ledger)
                 )
             ),
@@ -578,7 +580,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             IndyLedgerRequestsExecutor,
             async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
+                get_ledger_for_identifier=async_mock.AsyncMock(
                     return_value=("test_ledger_id", self.ledger)
                 )
             ),
@@ -594,7 +596,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             IndyLedgerRequestsExecutor,
             async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
+                get_ledger_for_identifier=async_mock.AsyncMock(
                     return_value=(None, self.ledger)
                 )
             ),
@@ -608,7 +610,7 @@ class TestLedgerRoutes(AsyncTestCase):
         with async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as json_response:
-            self.ledger.rotate_public_did_keypair = async_mock.CoroutineMock()
+            self.ledger.rotate_public_did_keypair = async_mock.AsyncMock()
 
             await test_module.rotate_public_did_keypair(self.request)
             json_response.assert_called_once_with({})
@@ -617,7 +619,7 @@ class TestLedgerRoutes(AsyncTestCase):
         with async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as json_response:
-            self.ledger.rotate_public_did_keypair = async_mock.CoroutineMock(
+            self.ledger.rotate_public_did_keypair = async_mock.AsyncMock(
                 side_effect=test_module.WalletError("Exception")
             )
 
@@ -660,7 +662,7 @@ class TestLedgerRoutes(AsyncTestCase):
             await test_module.ledger_get_taa(self.request)
 
     async def test_taa_accept_not_required(self):
-        self.request.json = async_mock.CoroutineMock(
+        self.request.json = async_mock.AsyncMock(
             return_value={
                 "version": "version",
                 "text": "text",
@@ -673,7 +675,7 @@ class TestLedgerRoutes(AsyncTestCase):
             await test_module.ledger_accept_taa(self.request)
 
     async def test_accept_taa(self):
-        self.request.json = async_mock.CoroutineMock(
+        self.request.json = async_mock.AsyncMock(
             return_value={
                 "version": "version",
                 "text": "text",
@@ -701,7 +703,7 @@ class TestLedgerRoutes(AsyncTestCase):
             assert result is json_response.return_value
 
     async def test_accept_taa_x(self):
-        self.request.json = async_mock.CoroutineMock(
+        self.request.json = async_mock.AsyncMock(
             return_value={
                 "version": "version",
                 "text": "text",
@@ -732,7 +734,7 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             BaseMultipleLedgerManager,
             async_mock.MagicMock(
-                get_write_ledger=async_mock.CoroutineMock(
+                get_write_ledger=async_mock.AsyncMock(
                     return_value=("test_ledger_id", self.ledger)
                 )
             ),
@@ -757,14 +759,14 @@ class TestLedgerRoutes(AsyncTestCase):
         self.profile.context.injector.bind_instance(
             BaseMultipleLedgerManager,
             async_mock.MagicMock(
-                get_prod_ledgers=async_mock.CoroutineMock(
+                get_prod_ledgers=async_mock.AsyncMock(
                     return_value={
                         "test_1": async_mock.MagicMock(),
                         "test_2": async_mock.MagicMock(),
                         "test_5": async_mock.MagicMock(),
                     }
                 ),
-                get_nonprod_ledgers=async_mock.CoroutineMock(
+                get_nonprod_ledgers=async_mock.AsyncMock(
                     return_value={
                         "test_3": async_mock.MagicMock(),
                         "test_4": async_mock.MagicMock(),

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
@@ -1,10 +1,10 @@
 import asyncio
-from datetime import datetime
-import pytest
-
-from asynctest import mock as async_mock
 from copy import deepcopy
+from datetime import datetime
 from uuid import uuid4
+
+import mock as async_mock
+import pytest
 
 from .....core.in_memory import InMemoryProfile
 from .....did.did_key import DIDKey
@@ -16,7 +16,6 @@ from .....wallet.crypto import KeyType
 from .....wallet.did_method import DIDMethod
 from .....wallet.error import WalletNotFoundError
 from .....vc.ld_proofs import (
-    BbsBlsSignatureProof2020,
     BbsBlsSignature2020,
 )
 from .....vc.ld_proofs.document_loader import DocumentLoader
@@ -25,7 +24,6 @@ from .....vc.ld_proofs.constants import SECURITY_CONTEXT_BBS_URL
 from .....vc.tests.document_loader import custom_document_loader
 from .....vc.tests.data import (
     BBS_SIGNED_VC_MATTR,
-    BBS_NESTED_VC_REVEAL_DOCUMENT_MATTR,
 )
 
 from .. import pres_exch_handler as test_module
@@ -60,7 +58,7 @@ from .test_data import (
 )
 
 
-@pytest.yield_fixture(scope="class")
+@pytest.fixture(scope="class")
 def event_loop(request):
     loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop
@@ -1670,7 +1668,6 @@ class TestPresExchHandler:
         tmp_cred.issuer_id = "19b823fb-55ef-49f4-8caf-2a26b8b9286f"
         assert dif_pres_exch_handler.subject_is_issuer(tmp_cred) is False
 
-    @pytest.mark.asyncio
     def test_is_numeric(self, profile):
         dif_pres_exch_handler = DIFPresExchHandler(profile)
         with pytest.raises(DIFPresExchError):
@@ -1682,7 +1679,6 @@ class TestPresExchHandler:
         with pytest.raises(DIFPresExchError):
             dif_pres_exch_handler.is_numeric(2 + 3j)
 
-    @pytest.mark.asyncio
     def test_filter_no_match(self, profile):
         dif_pres_exch_handler = DIFPresExchHandler(profile)
         tmp_filter_excl_min = Filter(exclusive_min=7)
@@ -1700,7 +1696,6 @@ class TestPresExchHandler:
         tmp_filter_max = Filter(maximum=10)
         assert dif_pres_exch_handler.maximum_check("test", tmp_filter_max) is False
 
-    @pytest.mark.asyncio
     def test_filter_valueerror(self, profile):
         dif_pres_exch_handler = DIFPresExchHandler(profile)
         tmp_filter_excl_min = Filter(exclusive_min=7, fmt="date")
@@ -1718,7 +1713,6 @@ class TestPresExchHandler:
         tmp_filter_max = Filter(maximum=10, fmt="date")
         assert dif_pres_exch_handler.maximum_check("test", tmp_filter_max) is False
 
-    @pytest.mark.asyncio
     def test_filter_length_check(self, profile):
         dif_pres_exch_handler = DIFPresExchHandler(profile)
         tmp_filter_both = Filter(min_length=7, max_length=10)
@@ -1729,7 +1723,6 @@ class TestPresExchHandler:
         assert dif_pres_exch_handler.length_check("test", tmp_filter_max) is True
         assert dif_pres_exch_handler.length_check("test12", tmp_filter_min) is False
 
-    @pytest.mark.asyncio
     def test_filter_pattern_check(self, profile):
         dif_pres_exch_handler = DIFPresExchHandler(profile)
         tmp_filter = Filter(pattern="test1|test2")
@@ -1737,7 +1730,6 @@ class TestPresExchHandler:
         tmp_filter = Filter(const="test3")
         assert dif_pres_exch_handler.pattern_check("test3", tmp_filter) is False
 
-    @pytest.mark.asyncio
     def test_is_len_applicable(self, profile):
         dif_pres_exch_handler = DIFPresExchHandler(profile)
         tmp_req_a = Requirement(count=1)
@@ -1748,7 +1740,6 @@ class TestPresExchHandler:
         assert dif_pres_exch_handler.is_len_applicable(tmp_req_b, 2) is False
         assert dif_pres_exch_handler.is_len_applicable(tmp_req_c, 6) is False
 
-    @pytest.mark.asyncio
     def test_create_vcrecord(self, profile):
         dif_pres_exch_handler = DIFPresExchHandler(profile)
         test_cred_dict = {
@@ -2037,7 +2028,7 @@ class TestPresExchHandler:
         with async_mock.patch.object(
             DIFPresExchHandler,
             "_did_info_for_did",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_did_info:
             did_info = DIDInfo(
                 did="did:sov:LjgpST2rjsoxYegQDRm7EL",
@@ -2102,7 +2093,7 @@ class TestPresExchHandler:
         with async_mock.patch.object(
             DIFPresExchHandler,
             "_did_info_for_did",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_did_info:
             did_info = DIDInfo(
                 did="did:sov:LjgpST2rjsoxYegQDRm7EL",
@@ -2170,7 +2161,7 @@ class TestPresExchHandler:
         with async_mock.patch.object(
             DIFPresExchHandler,
             "_did_info_for_did",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_did_info:
             did_info = DIDInfo(
                 did="did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL",
@@ -2240,23 +2231,23 @@ class TestPresExchHandler:
         with async_mock.patch.object(
             DIFPresExchHandler,
             "_did_info_for_did",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_did_info, async_mock.patch.object(
             DIFPresExchHandler,
             "make_requirement",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_make_req, async_mock.patch.object(
             DIFPresExchHandler,
             "apply_requirements",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_apply_req, async_mock.patch.object(
             DIFPresExchHandler,
             "merge",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_merge, async_mock.patch.object(
             test_module,
             "create_presentation",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_create_vp:
             mock_make_req.return_value = async_mock.MagicMock()
             mock_apply_req.return_value = async_mock.MagicMock()
@@ -2292,27 +2283,27 @@ class TestPresExchHandler:
         with async_mock.patch.object(
             DIFPresExchHandler,
             "_did_info_for_did",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_did_info, async_mock.patch.object(
             DIFPresExchHandler,
             "make_requirement",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_make_req, async_mock.patch.object(
             DIFPresExchHandler,
             "apply_requirements",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_apply_req, async_mock.patch.object(
             DIFPresExchHandler,
             "merge",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_merge, async_mock.patch.object(
             test_module,
             "create_presentation",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_create_vp, async_mock.patch.object(
             test_module,
             "sign_presentation",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_sign_vp:
             mock_make_req.return_value = async_mock.MagicMock()
             mock_apply_req.return_value = async_mock.MagicMock()
@@ -2349,27 +2340,27 @@ class TestPresExchHandler:
         with async_mock.patch.object(
             DIFPresExchHandler,
             "_did_info_for_did",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_did_info, async_mock.patch.object(
             DIFPresExchHandler,
             "make_requirement",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_make_req, async_mock.patch.object(
             DIFPresExchHandler,
             "apply_requirements",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_apply_req, async_mock.patch.object(
             DIFPresExchHandler,
             "merge",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_merge, async_mock.patch.object(
             test_module,
             "create_presentation",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_create_vp, async_mock.patch.object(
             DIFPresExchHandler,
             "get_sign_key_credential_subject_id",
-            async_mock.CoroutineMock(),
+            async_mock.AsyncMock(),
         ) as mock_sign_key_cred_subject:
             mock_make_req.return_value = async_mock.MagicMock()
             mock_apply_req.return_value = async_mock.MagicMock()
@@ -2993,6 +2984,7 @@ class TestPresExchHandler:
         assert filtered_cred_list[1].record_id in record_id_list
 
     @pytest.mark.asyncio
+    @pytest.mark.ursa_bbs_signatures
     async def test_create_vp_record_ids(self, profile):
         dif_pres_exch_handler = DIFPresExchHandler(profile)
         test_pd_filter_with_only_num_type = """

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -1,5 +1,7 @@
+import mock as async_mock
+from async_case import IsolatedAsyncioTestCase
+
 from aiohttp.web import HTTPForbidden
-from asynctest import TestCase as AsyncTestCase, mock as async_mock
 
 from .. import routes as test_module
 from ...admin.request_context import AdminRequestContext
@@ -13,7 +15,7 @@ from ..did_info import DIDInfo
 from ..did_posture import DIDPosture
 
 
-class TestWalletRoutes(AsyncTestCase):
+class TestWalletRoutes(IsolatedAsyncioTestCase):
     def setUp(self):
         self.wallet = async_mock.create_autospec(BaseWallet)
         self.session_inject = {BaseWallet: self.wallet}
@@ -23,7 +25,7 @@ class TestWalletRoutes(AsyncTestCase):
         )
         self.request_dict = {
             "context": self.context,
-            "outbound_message_router": async_mock.CoroutineMock(),
+            "outbound_message_router": async_mock.AsyncMock(),
         }
         self.request = async_mock.MagicMock(
             app={},
@@ -53,7 +55,7 @@ class TestWalletRoutes(AsyncTestCase):
             await test_module.wallet_set_public_did(self.request)
 
         with self.assertRaises(HTTPForbidden):
-            self.request.json = async_mock.CoroutineMock(
+            self.request.json = async_mock.AsyncMock(
                 return_value={
                     "did": self.test_did,
                     "endpoint": "https://my-endpoint.ca:8020",
@@ -125,7 +127,7 @@ class TestWalletRoutes(AsyncTestCase):
             assert result is json_response.return_value
 
     async def test_create_did_unsupported_key_type(self):
-        self.request.json = async_mock.CoroutineMock(
+        self.request.json = async_mock.AsyncMock(
             return_value={"method": "sov", "options": {"key_type": "bls12381g2"}}
         )
         with self.assertRaises(test_module.web.HTTPForbidden):
@@ -374,12 +376,12 @@ class TestWalletRoutes(AsyncTestCase):
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
-        ledger.get_key_for_did = async_mock.CoroutineMock()
-        ledger.update_endpoint_for_did = async_mock.CoroutineMock()
-        ledger.__aenter__ = async_mock.CoroutineMock(return_value=ledger)
+        ledger.get_key_for_did = async_mock.AsyncMock()
+        ledger.update_endpoint_for_did = async_mock.AsyncMock()
+        ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
         mock_route_manager = async_mock.MagicMock()
-        mock_route_manager.route_public_did = async_mock.CoroutineMock()
+        mock_route_manager.route_public_did = async_mock.AsyncMock()
         self.profile.context.injector.bind_instance(RouteManager, mock_route_manager)
 
         with async_mock.patch.object(
@@ -422,8 +424,8 @@ class TestWalletRoutes(AsyncTestCase):
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
-        ledger.get_key_for_did = async_mock.CoroutineMock(return_value=None)
-        ledger.__aenter__ = async_mock.CoroutineMock(return_value=ledger)
+        ledger.get_key_for_did = async_mock.AsyncMock(return_value=None)
+        ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
 
         with self.assertRaises(test_module.web.HTTPNotFound):
@@ -434,8 +436,8 @@ class TestWalletRoutes(AsyncTestCase):
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
-        ledger.get_key_for_did = async_mock.CoroutineMock(return_value=None)
-        ledger.__aenter__ = async_mock.CoroutineMock(return_value=ledger)
+        ledger.get_key_for_did = async_mock.AsyncMock(return_value=None)
+        ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
 
         self.wallet.get_local_did.side_effect = test_module.WalletNotFoundError()
@@ -447,9 +449,9 @@ class TestWalletRoutes(AsyncTestCase):
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
-        ledger.update_endpoint_for_did = async_mock.CoroutineMock()
-        ledger.get_key_for_did = async_mock.CoroutineMock()
-        ledger.__aenter__ = async_mock.CoroutineMock(return_value=ledger)
+        ledger.update_endpoint_for_did = async_mock.AsyncMock()
+        ledger.get_key_for_did = async_mock.AsyncMock()
+        ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
         with async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
@@ -470,9 +472,9 @@ class TestWalletRoutes(AsyncTestCase):
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
-        ledger.update_endpoint_for_did = async_mock.CoroutineMock()
-        ledger.get_key_for_did = async_mock.CoroutineMock()
-        ledger.__aenter__ = async_mock.CoroutineMock(return_value=ledger)
+        ledger.update_endpoint_for_did = async_mock.AsyncMock()
+        ledger.get_key_for_did = async_mock.AsyncMock()
+        ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
 
         with async_mock.patch.object(
@@ -494,12 +496,12 @@ class TestWalletRoutes(AsyncTestCase):
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
-        ledger.update_endpoint_for_did = async_mock.CoroutineMock()
-        ledger.get_key_for_did = async_mock.CoroutineMock()
-        ledger.__aenter__ = async_mock.CoroutineMock(return_value=ledger)
+        ledger.update_endpoint_for_did = async_mock.AsyncMock()
+        ledger.get_key_for_did = async_mock.AsyncMock()
+        ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
         mock_route_manager = async_mock.MagicMock()
-        mock_route_manager.route_public_did = async_mock.CoroutineMock()
+        mock_route_manager.route_public_did = async_mock.AsyncMock()
         self.profile.context.injector.bind_instance(RouteManager, mock_route_manager)
 
         with async_mock.patch.object(
@@ -535,12 +537,12 @@ class TestWalletRoutes(AsyncTestCase):
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
-        ledger.update_endpoint_for_did = async_mock.CoroutineMock()
-        ledger.get_key_for_did = async_mock.CoroutineMock()
-        ledger.__aenter__ = async_mock.CoroutineMock(return_value=ledger)
+        ledger.update_endpoint_for_did = async_mock.AsyncMock()
+        ledger.get_key_for_did = async_mock.AsyncMock()
+        ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
         mock_route_manager = async_mock.MagicMock()
-        mock_route_manager.route_public_did = async_mock.CoroutineMock()
+        mock_route_manager.route_public_did = async_mock.AsyncMock()
         self.profile.context.injector.bind_instance(RouteManager, mock_route_manager)
 
         with async_mock.patch.object(
@@ -578,7 +580,7 @@ class TestWalletRoutes(AsyncTestCase):
             assert result is json_response.return_value
 
     async def test_set_did_endpoint(self):
-        self.request.json = async_mock.CoroutineMock(
+        self.request.json = async_mock.AsyncMock(
             return_value={
                 "did": self.test_did,
                 "endpoint": "https://my-endpoint.ca:8020",
@@ -587,8 +589,8 @@ class TestWalletRoutes(AsyncTestCase):
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
-        ledger.update_endpoint_for_did = async_mock.CoroutineMock()
-        ledger.__aenter__ = async_mock.CoroutineMock(return_value=ledger)
+        ledger.update_endpoint_for_did = async_mock.AsyncMock()
+        ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
 
         self.wallet.get_local_did.return_value = DIDInfo(
@@ -613,7 +615,7 @@ class TestWalletRoutes(AsyncTestCase):
             json_response.assert_called_once_with({})
 
     async def test_set_did_endpoint_public_did_no_ledger(self):
-        self.request.json = async_mock.CoroutineMock(
+        self.request.json = async_mock.AsyncMock(
             return_value={
                 "did": self.test_did,
                 "endpoint": "https://my-endpoint.ca:8020",
@@ -640,7 +642,7 @@ class TestWalletRoutes(AsyncTestCase):
             await test_module.wallet_set_did_endpoint(self.request)
 
     async def test_set_did_endpoint_x(self):
-        self.request.json = async_mock.CoroutineMock(
+        self.request.json = async_mock.AsyncMock(
             return_value={
                 "did": self.test_did,
                 "endpoint": "https://my-endpoint.ca:8020",
@@ -649,8 +651,8 @@ class TestWalletRoutes(AsyncTestCase):
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
-        ledger.update_endpoint_for_did = async_mock.CoroutineMock()
-        ledger.__aenter__ = async_mock.CoroutineMock(return_value=ledger)
+        ledger.update_endpoint_for_did = async_mock.AsyncMock()
+        ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
 
         self.wallet.set_did_endpoint.side_effect = test_module.WalletError()
@@ -659,7 +661,7 @@ class TestWalletRoutes(AsyncTestCase):
             await test_module.wallet_set_did_endpoint(self.request)
 
     async def test_set_did_endpoint_no_wallet_did(self):
-        self.request.json = async_mock.CoroutineMock(
+        self.request.json = async_mock.AsyncMock(
             return_value={
                 "did": self.test_did,
                 "endpoint": "https://my-endpoint.ca:8020",
@@ -668,8 +670,8 @@ class TestWalletRoutes(AsyncTestCase):
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
-        ledger.update_endpoint_for_did = async_mock.CoroutineMock()
-        ledger.__aenter__ = async_mock.CoroutineMock(return_value=ledger)
+        ledger.update_endpoint_for_did = async_mock.AsyncMock()
+        ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
 
         self.wallet.set_did_endpoint.side_effect = test_module.WalletNotFoundError()
@@ -727,7 +729,7 @@ class TestWalletRoutes(AsyncTestCase):
         with async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as json_response:
-            self.wallet.get_local_did = async_mock.CoroutineMock(
+            self.wallet.get_local_did = async_mock.AsyncMock(
                 return_value=DIDInfo(
                     "did",
                     "verkey",
@@ -736,8 +738,8 @@ class TestWalletRoutes(AsyncTestCase):
                     KeyType.ED25519,
                 )
             )
-            self.wallet.rotate_did_keypair_start = async_mock.CoroutineMock()
-            self.wallet.rotate_did_keypair_apply = async_mock.CoroutineMock()
+            self.wallet.rotate_did_keypair_start = async_mock.AsyncMock()
+            self.wallet.rotate_did_keypair_apply = async_mock.AsyncMock()
 
             await test_module.wallet_rotate_did_keypair(self.request)
             json_response.assert_called_once_with({})
@@ -756,13 +758,13 @@ class TestWalletRoutes(AsyncTestCase):
     async def test_rotate_did_keypair_did_not_local(self):
         self.request.query = {"did": "did"}
 
-        self.wallet.get_local_did = async_mock.CoroutineMock(
+        self.wallet.get_local_did = async_mock.AsyncMock(
             side_effect=test_module.WalletNotFoundError("Unknown DID")
         )
         with self.assertRaises(test_module.web.HTTPNotFound):
             await test_module.wallet_rotate_did_keypair(self.request)
 
-        self.wallet.get_local_did = async_mock.CoroutineMock(
+        self.wallet.get_local_did = async_mock.AsyncMock(
             return_value=DIDInfo(
                 "did",
                 "verkey",
@@ -777,7 +779,7 @@ class TestWalletRoutes(AsyncTestCase):
     async def test_rotate_did_keypair_x(self):
         self.request.query = {"did": "did"}
 
-        self.wallet.get_local_did = async_mock.CoroutineMock(
+        self.wallet.get_local_did = async_mock.AsyncMock(
             return_value=DIDInfo(
                 "did",
                 "verkey",
@@ -786,7 +788,7 @@ class TestWalletRoutes(AsyncTestCase):
                 KeyType.ED25519,
             )
         )
-        self.wallet.rotate_did_keypair_start = async_mock.CoroutineMock(
+        self.wallet.rotate_did_keypair_start = async_mock.AsyncMock(
             side_effect=test_module.WalletError()
         )
         with self.assertRaises(test_module.web.HTTPBadRequest):

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,8 +1,10 @@
 asynctest==0.13.0
+async-case~=10.1
 pytest~=5.4.0
 pytest-asyncio==0.14.0
 pytest-cov==2.10.1
 pytest-flake8==1.0.6
+mock~=4.0
 
 flake8==3.9.0
 # flake8-rst-docstrings==0.0.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ markers =
     ursa_bbs_signatures: Tests specificaly relating to BBS Signatures support
     postgres: Tests relating to the postgres storage plugin for Indy
 junit_family = xunit1
+asyncio_mode = auto
 
 [flake8]
 # https://github.com/ambv/black#line-length


### PR DESCRIPTION
This partially implements the updates in #1717, for the specific tests that were failing under 3.9. There is some overlap with #1854.