### PR TITLE
RFC 0593 Compliance: Allow issuing JSON LD Credentials with credentialStatus

### DIFF
--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -850,7 +850,7 @@ CREDENTIAL_SUBJECT = {
 }
 CREDENTIAL_STATUS = {
     "validate": CredentialStatus(),
-    "example": CredentialStatus.EXAMPLE
+    "example": CredentialStatus.EXAMPLE,
 }
 INDY_OR_KEY_DID = {
     "validate": IndyOrKeyDID(),

--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -769,9 +769,9 @@ class CredentialStatus(Validator):
 
     def __call__(self, value):
         """Validate input value."""
-        if "type" not in value or value["type"] != CredentialStatus.CREDENTIAL_TYPE:
+        if "type" not in value or type(value["type"]) != str:
             raise ValidationError(
-                f"type must include {CredentialStatus.CREDENTIAL_TYPE}"
+                f"type is a required string for CredentialStatus"
             )
 
         return value

--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -757,6 +757,24 @@ class CredentialSubject(Validator):
         return value
 
 
+class CredentialStatus(Validator):
+    """Credential Type."""
+
+    CREDENTIAL_TYPE = "CredentialStatusList2017"
+    EXAMPLE = [CREDENTIAL_TYPE]
+
+    def __init__(self) -> None:
+        """Initializer."""
+        super().__init__()
+
+    def __call__(self, value):
+        """Validate input value."""
+        if "type" not in value or value["type"] != CredentialStatus.CREDENTIAL_TYPE:
+            raise ValidationError(f"type must include {CredentialStatus.CREDENTIAL_TYPE}")
+
+        return value
+
+
 class IndyOrKeyDID(Regexp):
     """Indy or Key DID class."""
 
@@ -828,6 +846,7 @@ CREDENTIAL_SUBJECT = {
     "validate": CredentialSubject(),
     "example": CredentialSubject.EXAMPLE,
 }
+CREDENTIAL_STATUS = {"validate": CredentialStatus(), "example": CredentialStatus.EXAMPLE}
 INDY_OR_KEY_DID = {
     "validate": IndyOrKeyDID(),
     "example": IndyOrKeyDID.EXAMPLE,

--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -770,7 +770,9 @@ class CredentialStatus(Validator):
     def __call__(self, value):
         """Validate input value."""
         if "type" not in value or value["type"] != CredentialStatus.CREDENTIAL_TYPE:
-            raise ValidationError(f"type must include {CredentialStatus.CREDENTIAL_TYPE}")
+            raise ValidationError(
+                f"type must include {CredentialStatus.CREDENTIAL_TYPE}"
+            )
 
         return value
 
@@ -846,7 +848,10 @@ CREDENTIAL_SUBJECT = {
     "validate": CredentialSubject(),
     "example": CredentialSubject.EXAMPLE,
 }
-CREDENTIAL_STATUS = {"validate": CredentialStatus(), "example": CredentialStatus.EXAMPLE}
+CREDENTIAL_STATUS = {
+    "validate": CredentialStatus(),
+    "example": CredentialStatus.EXAMPLE
+}
 INDY_OR_KEY_DID = {
     "validate": IndyOrKeyDID(),
     "example": IndyOrKeyDID.EXAMPLE,

--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -770,9 +770,7 @@ class CredentialStatus(Validator):
     def __call__(self, value):
         """Validate input value."""
         if "type" not in value or type(value["type"]) != str:
-            raise ValidationError(
-                f"type is a required string for CredentialStatus"
-            )
+            raise ValidationError(f"type is a required string for CredentialStatus")
 
         return value
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
@@ -469,6 +469,7 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
         )
         detail = LDProofVCDetail.deserialize(detail_dict)
         detail = await self._prepare_detail(detail)
+        detail.credential.credential_status = detail.options.credential_status
 
         # Get signature suite, proof purpose and document loader
         suite = await self._get_suite_for_detail(detail)

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
@@ -776,7 +776,7 @@ class TestV20LDProofCredFormatHandler(AsyncTestCase):
         detail["options"]["credentialStatus"] = {"type": "CredentialStatusType"}
 
         vc = deepcopy(LD_PROOF_VC)
-        vc["credentialStatus"] = {"type": "SomeRandomType"}
+        vc["credentialStatus"] = {"type": "CredentialStatusList2017"}
 
         cred_issue = V20CredIssue(
             formats=[

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
@@ -776,7 +776,7 @@ class TestV20LDProofCredFormatHandler(AsyncTestCase):
         detail["options"]["credentialStatus"] = {"type": "CredentialStatusType"}
 
         vc = deepcopy(LD_PROOF_VC)
-        vc["credentialStatus"] = {"type": "CredentialStatusList2017"}
+        vc["credentialStatus"] = {"type": "SomeRandomType"}
 
         cred_issue = V20CredIssue(
             formats=[

--- a/aries_cloudagent/vc/vc_ld/models/credential.py
+++ b/aries_cloudagent/vc/vc_ld/models/credential.py
@@ -11,6 +11,7 @@ from ....messaging.valid import (
     CREDENTIAL_CONTEXT,
     CREDENTIAL_TYPE,
     CREDENTIAL_SUBJECT,
+    CREDENTIAL_STATUS,
     DIDKey,
     DictOrDictListField,
     RFC3339_DATETIME,
@@ -45,6 +46,7 @@ class VerifiableCredential(BaseModel):
         issuance_date: Optional[str] = None,
         expiration_date: Optional[str] = None,
         credential_subject: Optional[Union[dict, List[dict]]] = None,
+        credential_status: Optional[Union[dict, List[dict]]] = None,
         proof: Optional[Union[dict, LDProof]] = None,
         **kwargs,
     ) -> None:
@@ -54,6 +56,7 @@ class VerifiableCredential(BaseModel):
         self._type = type or [VERIFIABLE_CREDENTIAL_TYPE]
         self._issuer = issuer
         self._credential_subject = credential_subject
+        self._credential_status = credential_status
 
         # TODO: proper date parsing
         self._issuance_date = issuance_date
@@ -231,6 +234,30 @@ class VerifiableCredential(BaseModel):
         self._credential_subject = credential_subject
 
     @property
+    def credential_status(self):
+        """Getter for credential subject."""
+        return self._credential_status
+
+    @credential_status.setter
+    def credential_status(self, credential_status: Union[dict, List[dict]]):
+        """Setter for credential subject."""
+
+        # uri_validator = Uri()
+
+        # subjects = (
+        #     [credential_subject]
+        #     if isinstance(credential_subject, dict)
+        #     else credential_subject
+        # )
+
+        # # loop trough all credential subjects and check for valid id uri
+        # for subject in subjects:
+        #     if subject.get("id"):
+        #         uri_validator(subject.get("id"))
+
+        self._credential_status = credential_status
+
+    @property
     def proof(self):
         """Getter for proof."""
         return self._proof
@@ -322,6 +349,12 @@ class CredentialSchema(BaseModelSchema):
         required=True,
         data_key="credentialSubject",
         **CREDENTIAL_SUBJECT,
+    )
+
+    credential_status = DictOrDictListField(
+        required=False,
+        data_key="credentialStatus",
+        **CREDENTIAL_STATUS,
     )
 
     proof = fields.Nested(

--- a/aries_cloudagent/vc/vc_ld/models/credential.py
+++ b/aries_cloudagent/vc/vc_ld/models/credential.py
@@ -242,19 +242,6 @@ class VerifiableCredential(BaseModel):
     def credential_status(self, credential_status: Union[dict, List[dict]]):
         """Setter for credential subject."""
 
-        # uri_validator = Uri()
-
-        # subjects = (
-        #     [credential_subject]
-        #     if isinstance(credential_subject, dict)
-        #     else credential_subject
-        # )
-
-        # # loop trough all credential subjects and check for valid id uri
-        # for subject in subjects:
-        #     if subject.get("id"):
-        #         uri_validator(subject.get("id"))
-
         self._credential_status = credential_status
 
     @property


### PR DESCRIPTION
Following the documentation for JSONLD Credentials, there is a parameter
for adding `credentialStatus` to a credential:
https://github.com/hyperledger/aries-rfcs/blob/main/features/0593-json-ld-cred-attach/README.md

However, adding the parameter causes all flows to fail due to the
credentialStatus never making it into the credential. I don't know the
history of this parameter, but in order to follow RFC 0593 a bit more
closely, I have fixed up the flow so that it doesn't fail issuance.

Signed-off-by: Colton Wolkins (Indicio work address) <colton@indicio.tech>