### PR TITLE
fix: warnings in tests from IndySdkProfile

### DIFF
--- a/aries_cloudagent/indy/sdk/profile.py
+++ b/aries_cloudagent/indy/sdk/profile.py
@@ -128,9 +128,15 @@ class IndySdkProfile(Profile):
         See docs for weakref.finalize for more details on behavior of finalizers.
         """
 
+        async def _closer(opened: IndyOpenWallet):
+            try:
+                await opened.close()
+            except Exception:
+                LOGGER.exception("Failed to close wallet from finalizer")
+
         def _finalize(opened: IndyOpenWallet):
             LOGGER.debug("Profile finalizer called; closing wallet")
-            asyncio.get_event_loop().create_task(opened.close())
+            asyncio.get_event_loop().create_task(_closer(opened))
 
         return finalize(self, _finalize, opened)
 

--- a/aries_cloudagent/indy/sdk/tests/test_issuer.py
+++ b/aries_cloudagent/indy/sdk/tests/test_issuer.py
@@ -51,7 +51,8 @@ class TestIndySdkIssuer(AsyncTestCase):
                 "name": "test-wallet",
             }
         ).create_wallet()
-        self.profile = IndySdkProfile(self.wallet, self.context)
+        with async_mock.patch.object(IndySdkProfile, "_make_finalizer"):
+            self.profile = IndySdkProfile(self.wallet, self.context)
         self.issuer = test_module.IndySdkIssuer(self.profile)
 
     async def tearDown(self):

--- a/aries_cloudagent/ledger/multiple_ledger/tests/test_manager_provider.py
+++ b/aries_cloudagent/ledger/multiple_ledger/tests/test_manager_provider.py
@@ -66,15 +66,16 @@ class TestMultiIndyLedgerManagerProvider(AsyncTestCase):
     @pytest.mark.indy
     async def test_provide_indy_manager(self):
         context = InjectionContext()
-        profile = IndySdkProfile(
-            IndyOpenWallet(
-                config=IndyWalletConfig({"name": "test-profile"}),
-                created=True,
-                handle=1,
-                master_secret_id="master-secret",
-            ),
-            context,
-        )
+        with async_mock.patch.object(IndySdkProfile, "_make_finalizer"):
+            profile = IndySdkProfile(
+                IndyOpenWallet(
+                    config=IndyWalletConfig({"name": "test-profile"}),
+                    created=True,
+                    handle=1,
+                    master_secret_id="master-secret",
+                ),
+                context,
+            )
         context.injector.bind_instance(
             BaseLedger, IndySdkLedger(IndySdkLedgerPool("name"), profile)
         )

--- a/aries_cloudagent/ledger/tests/test_indy.py
+++ b/aries_cloudagent/ledger/tests/test_indy.py
@@ -76,10 +76,11 @@ class TestIndySdkLedger(AsyncTestCase):
         self.test_verkey = "3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"
         context = InjectionContext()
         context.injector.bind_instance(IndySdkLedgerPool, IndySdkLedgerPool("name"))
-        self.profile = IndySdkProfile(
-            async_mock.CoroutineMock(),
-            context,
-        )
+        with async_mock.patch.object(IndySdkProfile, "_make_finalizer"):
+            self.profile = IndySdkProfile(
+                async_mock.CoroutineMock(),
+                context,
+            )
         self.session = await self.profile.session()
 
     @async_mock.patch("indy.pool.create_pool_ledger_config")

--- a/aries_cloudagent/ledger/tests/test_routes.py
+++ b/aries_cloudagent/ledger/tests/test_routes.py
@@ -1,7 +1,6 @@
 from asynctest import mock as async_mock, TestCase as AsyncTestCase
 from typing import Tuple
 
-from ...admin.request_context import AdminRequestContext
 from ...core.in_memory import InMemoryProfile
 from ...ledger.base import BaseLedger
 from ...ledger.endpoint_type import EndpointType
@@ -10,7 +9,6 @@ from ...ledger.multiple_ledger.ledger_requests_executor import (
 )
 from ...ledger.multiple_ledger.base_manager import (
     BaseMultipleLedgerManager,
-    MultipleLedgerManagerError,
 )
 from ...multitenant.base import BaseMultitenantManager
 from ...multitenant.manager import MultitenantManager

--- a/aries_cloudagent/storage/vc_holder/tests/test_indy_vc_holder.py
+++ b/aries_cloudagent/storage/vc_holder/tests/test_indy_vc_holder.py
@@ -1,8 +1,9 @@
 import pytest
+from asynctest import mock as async_mock
 
 
 from ....config.injection_context import InjectionContext
-from ....indy.sdk.profile import IndySdkProfileManager
+from ....indy.sdk.profile import IndySdkProfileManager, IndySdkProfile
 from ....ledger.indy import IndySdkLedgerPool
 from ....wallet.indy import IndySdkWallet
 
@@ -25,16 +26,18 @@ async def make_profile():
     key = await IndySdkWallet.generate_wallet_key()
     context = InjectionContext()
     context.injector.bind_instance(IndySdkLedgerPool, IndySdkLedgerPool("name"))
-    return await IndySdkProfileManager().provision(
-        context,
-        {
-            "auto_recreate": True,
-            "auto_remove": True,
-            "name": "test-wallet",
-            "key": key,
-            "key_derivation_method": "RAW",  # much slower tests with argon-hashed keys
-        },
-    )
+
+    with async_mock.patch.object(IndySdkProfile, "_make_finalizer"):
+        return await IndySdkProfileManager().provision(
+            context,
+            {
+                "auto_recreate": True,
+                "auto_remove": True,
+                "name": "test-wallet",
+                "key": key,
+                "key_derivation_method": "RAW",  # much slower tests with argon-hashed keys
+            },
+        )
 
 
 @pytest.fixture()

--- a/aries_cloudagent/wallet/tests/test_indy_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_indy_wallet.py
@@ -41,22 +41,22 @@ async def wallet():
     key = await IndySdkWallet.generate_wallet_key()
     context = InjectionContext()
     context.injector.bind_instance(IndySdkLedgerPool, IndySdkLedgerPool("name"))
-    profile = cast(
-        IndySdkProfile,
-        await IndySdkProfileManager().provision(
-            context,
-            {
-                "auto_recreate": True,
-                "auto_remove": True,
-                "name": "test-wallet",
-                "key": key,
-                "key_derivation_method": "RAW",  # much slower tests with argon-hashed keys
-            },
-        ),
-    )
+    with async_mock.patch.object(IndySdkProfile, "_make_finalizer"):
+        profile = cast(
+            IndySdkProfile,
+            await IndySdkProfileManager().provision(
+                context,
+                {
+                    "auto_recreate": True,
+                    "auto_remove": True,
+                    "name": "test-wallet",
+                    "key": key,
+                    "key_derivation_method": "RAW",  # much slower tests with argon-hashed keys
+                },
+            ),
+        )
     async with profile.session() as session:
         yield session.inject(BaseWallet)
-    profile._finalizer()
     await profile.close()
 
 

--- a/aries_cloudagent/wallet/tests/test_indy_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_indy_wallet.py
@@ -1,5 +1,6 @@
 import json
 import os
+from typing import cast
 
 import indy.anoncreds
 import indy.crypto
@@ -13,7 +14,7 @@ from ...core.in_memory import InMemoryProfile
 from ...config.injection_context import InjectionContext
 from ...core.error import ProfileError, ProfileDuplicateError, ProfileNotFoundError
 from ...indy.sdk import wallet_setup as test_setup_module
-from ...indy.sdk.profile import IndySdkProfileManager
+from ...indy.sdk.profile import IndySdkProfile, IndySdkProfileManager
 from ...indy.sdk.wallet_setup import IndyWalletConfig
 from ...ledger.endpoint_type import EndpointType
 from ...wallet.key_type import KeyType
@@ -40,18 +41,22 @@ async def wallet():
     key = await IndySdkWallet.generate_wallet_key()
     context = InjectionContext()
     context.injector.bind_instance(IndySdkLedgerPool, IndySdkLedgerPool("name"))
-    profile = await IndySdkProfileManager().provision(
-        context,
-        {
-            "auto_recreate": True,
-            "auto_remove": True,
-            "name": "test-wallet",
-            "key": key,
-            "key_derivation_method": "RAW",  # much slower tests with argon-hashed keys
-        },
+    profile = cast(
+        IndySdkProfile,
+        await IndySdkProfileManager().provision(
+            context,
+            {
+                "auto_recreate": True,
+                "auto_remove": True,
+                "name": "test-wallet",
+                "key": key,
+                "key_derivation_method": "RAW",  # much slower tests with argon-hashed keys
+            },
+        ),
     )
     async with profile.session() as session:
         yield session.inject(BaseWallet)
+    profile._finalizer()
     await profile.close()
 
 


### PR DESCRIPTION
This PR includes some minor tweaks to tests involving `IndySdkProfile`s to prevent them from emitting warnings. Based on my analysis, the warnings are a result of how the event loop is managed in asynchronous testing with pytest. The profile reference falls out of scope at the same time as the event loop is closed for a test and what results are `Coroutine never awaited` errors.

This may not be the best solution (open to thoughts) but in most cases, I simply monkeypatched the `_make_finalizer` call where the behavior of the finalizer was not what was under test. Where it was under test, I opted to manually call the finalizer before the end of the test (or as a part of fixture clean up) and, therefore, before the event loop starts to close.