### PR TITLE
fix: didx request cannot be accepted

### DIFF
--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -477,7 +477,10 @@ class DIDXManager(BaseConnectionManager):
             conn_rec.their_did = request.did
             conn_rec.state = ConnRecord.State.REQUEST.rfc23
             conn_rec.request_id = request._id
-
+            async with self.profile.session() as session:
+                await conn_rec.save(
+                    session, reason="Received connection request from invitation"
+                )
         else:
             # request is against implicit invitation on public DID
             async with self.profile.session() as session:

--- a/aries_cloudagent/protocols/out_of_band/v1_0/routes.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/routes.py
@@ -9,7 +9,6 @@ from marshmallow import fields, validate
 from marshmallow.exceptions import ValidationError
 
 from ....admin.request_context import AdminRequestContext
-from ....connections.models.conn_record import ConnRecordSchema
 from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
 from ....messaging.valid import UUID4
@@ -22,6 +21,7 @@ from .manager import OutOfBandManager, OutOfBandManagerError
 from .messages.invitation import HSProto, InvitationMessage, InvitationMessageSchema
 from .message_types import SPEC_URI
 from .models.invitation import InvitationRecordSchema
+from .models.oob_record import OobRecordSchema
 
 LOGGER = logging.getLogger(__name__)
 
@@ -188,7 +188,7 @@ async def invitation_create(request: web.BaseRequest):
 )
 @querystring_schema(InvitationReceiveQueryStringSchema())
 @request_schema(InvitationMessageSchema())
-@response_schema(ConnRecordSchema(), 200, description="")
+@response_schema(OobRecordSchema(), 200, description="")
 async def invitation_receive(request: web.BaseRequest):
     """
     Request handler for receiving a new connection invitation.


### PR DESCRIPTION
Hi everyone,

this PR fixes a few problems which were apparently introduced by #1710:

- A didx request which is received in response to an explicit oob invitation cannot be accepted because the state of the corresponding connection record is not updated to `'request-received'`

- The admin api incorrectly indicates that the `/out-of-band/receive-invitation` endpoint returns a `ConnRecord` instead of the new `OobRecord` (which is also why the `OobRecord` is not included in the `swagger.json`)

@TimoGlastra: maybe you want to take a look to make sure I didn't break the connectionless exchange feature by saving the updated connection record?