### PR TITLE
fix: schema class can set Meta.unknown

### DIFF
--- a/aries_cloudagent/messaging/models/base.py
+++ b/aries_cloudagent/messaging/models/base.py
@@ -5,7 +5,7 @@ import json
 
 from abc import ABC
 from collections import namedtuple
-from typing import Mapping, Union
+from typing import Literal, Mapping, Optional, Type, TypeVar, Union, cast, overload
 
 from marshmallow import Schema, post_dump, pre_load, post_load, ValidationError, EXCLUDE
 
@@ -17,7 +17,7 @@ LOGGER = logging.getLogger(__name__)
 SerDe = namedtuple("SerDe", "ser de")
 
 
-def resolve_class(the_cls, relative_cls: type = None):
+def resolve_class(the_cls, relative_cls: Optional[type] = None) -> type:
     """
     Resolve a class.
 
@@ -38,6 +38,10 @@ def resolve_class(the_cls, relative_cls: type = None):
     elif isinstance(the_cls, str):
         default_module = relative_cls and relative_cls.__module__
         resolved = ClassLoader.load_class(the_cls, default_module)
+    else:
+        raise TypeError(
+            f"Could not resolve class from {the_cls}; incorrect type {type(the_cls)}"
+        )
     return resolved
 
 
@@ -70,6 +74,9 @@ class BaseModelError(BaseError):
     """Base exception class for base model errors."""
 
 
+ModelType = TypeVar("ModelType", bound="BaseModel")
+
+
 class BaseModel(ABC):
     """Base model that provides convenience methods."""
 
@@ -94,7 +101,7 @@ class BaseModel(ABC):
             )
 
     @classmethod
-    def _get_schema_class(cls):
+    def _get_schema_class(cls) -> Type["BaseModelSchema"]:
         """
         Get the schema class.
 
@@ -102,10 +109,16 @@ class BaseModel(ABC):
             The resolved schema class
 
         """
-        return resolve_class(cls.Meta.schema_class, cls)
+        resolved = resolve_class(cls.Meta.schema_class, cls)
+        if issubclass(resolved, BaseModelSchema):
+            return resolved
+
+        raise TypeError(
+            f"Resolved class is not a subclass of BaseModelSchema: {resolved}"
+        )
 
     @property
-    def Schema(self) -> type:
+    def Schema(self) -> Type["BaseModelSchema"]:
         """
         Accessor for the model's schema class.
 
@@ -115,8 +128,46 @@ class BaseModel(ABC):
         """
         return self._get_schema_class()
 
+    @overload
     @classmethod
-    def deserialize(cls, obj, unknown: str = None, none2none: str = False):
+    def deserialize(
+        cls: Type[ModelType],
+        obj,
+        *,
+        unknown: Optional[str] = None,
+    ) -> ModelType:
+        ...
+
+    @overload
+    @classmethod
+    def deserialize(
+        cls: Type[ModelType],
+        obj,
+        *,
+        none2none: Literal[False],
+        unknown: Optional[str] = None,
+    ) -> ModelType:
+        ...
+
+    @overload
+    @classmethod
+    def deserialize(
+        cls: Type[ModelType],
+        obj,
+        *,
+        none2none: Literal[True],
+        unknown: Optional[str] = None,
+    ) -> Optional[ModelType]:
+        ...
+
+    @classmethod
+    def deserialize(
+        cls: Type[ModelType],
+        obj,
+        *,
+        unknown: Optional[str] = None,
+        none2none: bool = False,
+    ) -> Optional[ModelType]:
         """
         Convert from JSON representation to a model instance.
 
@@ -132,18 +183,41 @@ class BaseModel(ABC):
         if obj is None and none2none:
             return None
 
-        schema = cls._get_schema_class()(unknown=unknown or EXCLUDE)
+        schema_cls = cls._get_schema_class()
+        schema = schema_cls(unknown=unknown or schema_cls.Meta.unknown)
+
         try:
-            return schema.loads(obj) if isinstance(obj, str) else schema.load(obj)
+            return cast(
+                ModelType,
+                schema.loads(obj) if isinstance(obj, str) else schema.load(obj),
+            )
         except (AttributeError, ValidationError) as err:
             LOGGER.exception(f"{cls.__name__} message validation error:")
             raise BaseModelError(f"{cls.__name__} schema validation failed") from err
 
+    @overload
     def serialize(
         self,
-        as_string=False,
-        unknown: str = None,
+        *,
+        as_string: Literal[True],
+        unknown: Optional[str] = None,
+    ) -> str:
+        ...
+
+    @overload
+    def serialize(
+        self,
+        *,
+        unknown: Optional[str] = None,
     ) -> dict:
+        ...
+
+    def serialize(
+        self,
+        *,
+        as_string: bool = False,
+        unknown: Optional[str] = None,
+    ) -> Union[str, dict]:
         """
         Create a JSON-compatible dict representation of the model instance.
 
@@ -154,7 +228,8 @@ class BaseModel(ABC):
             A dict representation of this model, or a JSON string if as_string is True
 
         """
-        schema = self.Schema(unknown=unknown or EXCLUDE)
+        schema_cls = self._get_schema_class()
+        schema = schema_cls(unknown=unknown or schema_cls.Meta.unknown)
         try:
             return (
                 schema.dumps(self, separators=(",", ":"))
@@ -168,18 +243,17 @@ class BaseModel(ABC):
             ) from err
 
     @classmethod
-    def serde(cls, obj: Union["BaseModel", Mapping]) -> SerDe:
+    def serde(cls, obj: Union["BaseModel", Mapping]) -> Optional[SerDe]:
         """Return serialized, deserialized representations of input object."""
+        if obj is None:
+            return None
 
-        return (
-            SerDe(obj.serialize(), obj)
-            if isinstance(obj, BaseModel)
-            else None
-            if obj is None
-            else SerDe(obj, cls.deserialize(obj))
-        )
+        if isinstance(obj, BaseModel):
+            return SerDe(obj.serialize(), obj)
 
-    def validate(self, unknown: str = None):
+        return SerDe(obj, cls.deserialize(obj))
+
+    def validate(self, unknown: Optional[str] = None):
         """Validate a constructed model."""
         schema = self.Schema(unknown=unknown)
         errors = schema.validate(self.serialize())
@@ -191,7 +265,7 @@ class BaseModel(ABC):
     def from_json(
         cls,
         json_repr: Union[str, bytes],
-        unknown: str = None,
+        unknown: Optional[str] = None,
     ):
         """
         Parse a JSON string into a model instance.
@@ -218,7 +292,7 @@ class BaseModel(ABC):
             A JSON representation of this message
 
         """
-        return json.dumps(self.serialize(unknown=unknown or EXCLUDE))
+        return json.dumps(self.serialize(unknown=unknown))
 
     def __repr__(self) -> str:
         """
@@ -246,6 +320,7 @@ class BaseModelSchema(Schema):
         model_class = None
         skip_values = [None]
         ordered = True
+        unknown = EXCLUDE
 
     def __init__(self, *args, **kwargs):
         """

--- a/aries_cloudagent/messaging/models/tests/test_base.py
+++ b/aries_cloudagent/messaging/models/tests/test_base.py
@@ -1,15 +1,6 @@
-import json
-
 from asynctest import TestCase as AsyncTestCase, mock as async_mock
 
-from marshmallow import EXCLUDE, fields, validates_schema, ValidationError
-
-from ....cache.base import BaseCache
-from ....config.injection_context import InjectionContext
-from ....storage.base import BaseStorage, StorageRecord
-
-from ...responder import BaseResponder, MockResponder
-from ...util import time_now
+from marshmallow import EXCLUDE, INCLUDE, fields, validates_schema, ValidationError
 
 from ..base import BaseModel, BaseModelError, BaseModelSchema
 
@@ -26,6 +17,48 @@ class SchemaImpl(BaseModelSchema):
     class Meta:
         model_class = ModelImpl
         unknown = EXCLUDE
+
+    attr = fields.String(required=True)
+
+    @validates_schema
+    def validate_fields(self, data, **kwargs):
+        if data["attr"] != "succeeds":
+            raise ValidationError("")
+
+
+class ModelImplWithUnknown(BaseModel):
+    class Meta:
+        schema_class = "SchemaImplWithUnknown"
+
+    def __init__(self, *, attr=None, **kwargs):
+        self.attr = attr
+        self.extra = kwargs
+
+
+class SchemaImplWithUnknown(BaseModelSchema):
+    class Meta:
+        model_class = ModelImplWithUnknown
+        unknown = INCLUDE
+
+    attr = fields.String(required=True)
+
+    @validates_schema
+    def validate_fields(self, data, **kwargs):
+        if data["attr"] != "succeeds":
+            raise ValidationError("")
+
+
+class ModelImplWithoutUnknown(BaseModel):
+    class Meta:
+        schema_class = "SchemaImplWithoutUnknown"
+
+    def __init__(self, *, attr=None):
+        self.attr = attr
+
+
+class SchemaImplWithoutUnknown(BaseModelSchema):
+    class Meta:
+        model_class = ModelImplWithoutUnknown
 
     attr = fields.String(required=True)
 
@@ -63,3 +96,24 @@ class TestBase(AsyncTestCase):
         data = "{}{}"
         with self.assertRaises(BaseModelError):
             ModelImpl.from_json(data)
+
+    def test_model_with_unknown(self):
+        model = ModelImplWithUnknown(attr="succeeds")
+        model = model.validate()
+        assert model.attr == "succeeds"
+
+        model = ModelImplWithUnknown.deserialize(
+            {"attr": "succeeds", "another": "value"}
+        )
+        assert model.extra
+        assert model.extra["another"] == "value"
+        assert model.attr == "succeeds"
+
+    def test_model_without_unknown_default_exclude(self):
+        model = ModelImplWithoutUnknown(attr="succeeds")
+        model = model.validate()
+        assert model.attr == "succeeds"
+
+        assert ModelImplWithoutUnknown.deserialize(
+            {"attr": "succeeds", "another": "value"}
+        )

--- a/aries_cloudagent/utils/classloader.py
+++ b/aries_cloudagent/utils/classloader.py
@@ -7,7 +7,7 @@ import sys
 from importlib import import_module
 from importlib.util import find_spec, resolve_name
 from types import ModuleType
-from typing import Sequence, Type
+from typing import Optional, Sequence, Type
 
 from ..core.error import BaseError
 
@@ -75,7 +75,10 @@ class ClassLoader:
 
     @classmethod
     def load_class(
-        cls, class_name: str, default_module: str = None, package: str = None
+        cls,
+        class_name: str,
+        default_module: Optional[str] = None,
+        package: Optional[str] = None,
     ):
         """
         Resolve a complete class path (ie. typing.Dict) to the class itself.


### PR DESCRIPTION
This PR enables the Schema class of a model to determine the default `unknown` behavior. Without this, if you have a schema where you expect extra values to be present, every time `deserialize` or `serialize` is called, you must set `unknown=INCLUDE`. Now, in the `Meta` class of the Schema, `unknown` can be set to some value that will be respected as the default if not overrided by method parameter.

While I was at it, I also touched up some of the typing. I'm not fond of using `@overload` but I think it's the best way to address typing a method where a bool flag impacts the return type.