### PR TITLE
Fix: SchemasInputDescriptorFilter: broken deserialization renders generated clients unusable

### DIFF
--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch.py
@@ -237,7 +237,9 @@ class SchemasInputDescriptorFilterSchema(BaseModelSchema):
         """deserialize."""
         new_data = {}
         if isinstance(data, dict):
-            if "oneof_filter" in data:
+            if "uri_groups" in data:
+                return data
+            elif "oneof_filter" in data and isinstance(data["oneof_filter"], list):
                 new_data["oneof_filter"] = True
                 uri_group_list_of_list = []
                 uri_group_list = data.get("oneof_filter")

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch.py
@@ -395,6 +395,10 @@ class TestPresExchSchemas(TestCase):
         deser_schema_filter = SchemasInputDescriptorFilter.deserialize(
             test_schemas_filter
         )
+        ser_schema_filter = deser_schema_filter.serialize()
+        deser_schema_filter = SchemasInputDescriptorFilter.deserialize(
+            ser_schema_filter
+        )
         assert deser_schema_filter.oneof_filter
         assert deser_schema_filter.uri_groups[0][0].uri == test_schema_list[0][0].get(
             "uri"
@@ -418,6 +422,10 @@ class TestPresExchSchemas(TestCase):
         deser_schema_filter = SchemasInputDescriptorFilter.deserialize(
             test_schemas_filter
         )
+        ser_schema_filter = deser_schema_filter.serialize()
+        deser_schema_filter = SchemasInputDescriptorFilter.deserialize(
+            ser_schema_filter
+        )
         assert deser_schema_filter.oneof_filter
         assert deser_schema_filter.uri_groups[0][0].uri == test_schema_list[0].get(
             "uri"
@@ -428,6 +436,10 @@ class TestPresExchSchemas(TestCase):
         assert isinstance(deser_schema_filter, SchemasInputDescriptorFilter)
 
         deser_schema_filter = SchemasInputDescriptorFilter.deserialize(test_schema_list)
+        ser_schema_filter = deser_schema_filter.serialize()
+        deser_schema_filter = SchemasInputDescriptorFilter.deserialize(
+            ser_schema_filter
+        )
         assert not deser_schema_filter.oneof_filter
         assert deser_schema_filter.uri_groups[0][0].uri == test_schema_list[0].get(
             "uri"


### PR DESCRIPTION
**What’s wrong?**
The OpenAPI spec requires an Input Descriptor’s `schema` property to contain a `SchemasInputDescriptorFilter` object.
However, on deserialization, there is a [preprocessing step](https://github.com/hyperledger/aries-cloudagent-python/blob/d407c48cc9f041c5b27ee8f589fc0e2eaef2220d/aries_cloudagent/protocols/present_proof/dif/pres_exch.py#L235-L254) which ensures that lists of URIs or a dict containing a `oneof_filter` property are accepted as well by transforming them into said object. (These alternative input formats are also [included as examples](https://github.com/hyperledger/aries-cloudagent-python/blob/d407c48cc9f041c5b27ee8f589fc0e2eaef2220d/aries_cloudagent/protocols/present_proof/dif/pres_exch.py#L640-L663) in the `InputDescriptors` model.) Yet, input that already IS a `SchemasInputDescriptorFilter` object is not handled correctly during preprocessing and deserialization fails. This results in any client adhering to the spec being unable to create valid input descriptors and, ultimately, a presentation definition to use in a DIF proof request.

**What has been changed?**
I adjusted the preprocessing step such that input is forwarded as-is if it looks like a `SchemasInputDescriptorFilter`. I also extended the tests to cover deserializing the actual object.