### PR TITLE
Feat/public did endpoints for agents behind mediators

### DIFF
--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -7,7 +7,7 @@ import re
 from abc import ABC, abstractmethod, ABCMeta
 from enum import Enum
 from hashlib import sha256
-from typing import Sequence, Tuple, Union
+from typing import List, Sequence, Tuple, Union
 
 from ..indy.issuer import DEFAULT_CRED_DEF_TAG, IndyIssuer, IndyIssuerError
 from ..utils import sentinel
@@ -80,6 +80,23 @@ class BaseLedger(ABC, metaclass=ABCMeta):
         """
 
     @abstractmethod
+    async def construct_attr_json(
+        self,
+        endpoint: str,
+        endpoint_type: EndpointType = None,
+        all_exist_endpoints: dict = None,
+        routing_keys: List[str] = None,
+    ) -> str:
+        """Create attr_json string.
+
+        Args:
+            all_exist_endpoings: Dictionary of all existing endpoints
+            endpoint: The endpoint address
+            endpoint_type: The type of the endpoint
+            routing_keys: List of routing_keys if mediator is present
+        """
+
+    @abstractmethod
     async def update_endpoint_for_did(
         self,
         did: str,
@@ -87,6 +104,7 @@ class BaseLedger(ABC, metaclass=ABCMeta):
         endpoint_type: EndpointType = EndpointType.ENDPOINT,
         write_ledger: bool = True,
         endorser_did: str = None,
+        routing_keys: List[str] = None,
     ) -> bool:
         """Check and update the endpoint on the ledger.
 

--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -79,8 +79,7 @@ class BaseLedger(ABC, metaclass=ABCMeta):
             did: The DID to look up on the ledger or in the cache
         """
 
-    @abstractmethod
-    async def construct_attr_json(
+    async def _construct_attr_json(
         self,
         endpoint: str,
         endpoint_type: EndpointType = None,
@@ -95,6 +94,23 @@ class BaseLedger(ABC, metaclass=ABCMeta):
             endpoint_type: The type of the endpoint
             routing_keys: List of routing_keys if mediator is present
         """
+
+        if not routing_keys:
+            routing_keys = []
+
+        endpoint_dict = {"endpoint": endpoint}
+
+        if all_exist_endpoints:
+            all_exist_endpoints[endpoint_type.indy] = endpoint_dict
+            endpoint_dict["routingKeys"] = routing_keys
+            attr_json = json.dumps({"endpoint": all_exist_endpoints})
+
+        else:
+            endpoint_val = {endpoint_type.indy: endpoint_dict}
+            endpoint_dict["routingKeys"] = routing_keys
+            attr_json = json.dumps({"endpoint": endpoint_val})
+
+        return attr_json
 
     @abstractmethod
     async def update_endpoint_for_did(

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -8,7 +8,7 @@ from datetime import date, datetime
 from io import StringIO
 from os import path
 from time import time
-from typing import TYPE_CHECKING, Tuple, Optional
+from typing import TYPE_CHECKING, List, Tuple, Optional
 
 import indy.ledger
 import indy.pool
@@ -738,6 +738,40 @@ class IndySdkLedger(BaseLedger):
 
         return address
 
+    async def construct_attr_json(
+        self,
+        endpoint: str,
+        endpoint_type: EndpointType = None,
+        all_exist_endpoints: dict = None,
+        routing_keys: List[str] = None,
+    ) -> str:
+        """Create attr_json string.
+
+        Args:
+            all_exist_endpoings: Dictionary of all existing endpoints
+            endpoint: The endpoint address
+            endpoint_type: The type of the endpoint
+            routing_keys: List of routing_keys if mediator is present
+        """
+
+        if not routing_keys:
+            routing_keys = []
+
+        endpoint_dict = {"endpoint": endpoint}
+
+        if all_exist_endpoints:
+            all_exist_endpoints[endpoint_type.indy] = endpoint_dict
+            endpoint_dict["routingKeys"] = routing_keys
+            attr_json = json.dumps({"endpoint": all_exist_endpoints})
+
+        else:
+            endpoint_val = {endpoint_type.indy: endpoint_dict}
+            endpoint_dict["routingKeys"] = routing_keys
+            attr_json = json.dumps({"endpoint": endpoint_val})
+
+        return attr_json
+
+
     async def update_endpoint_for_did(
         self,
         did: str,
@@ -745,6 +779,7 @@ class IndySdkLedger(BaseLedger):
         endpoint_type: EndpointType = None,
         write_ledger: bool = True,
         endorser_did: str = None,
+        routing_keys: List[str] = None,
     ) -> bool:
         """Check and update the endpoint on the ledger.
 
@@ -777,11 +812,12 @@ class IndySdkLedger(BaseLedger):
 
             nym = self.did_to_nym(did)
 
-            if all_exist_endpoints:
-                all_exist_endpoints[endpoint_type.indy] = endpoint
-                attr_json = json.dumps({"endpoint": all_exist_endpoints})
-            else:
-                attr_json = json.dumps({"endpoint": {endpoint_type.indy: endpoint}})
+            attr_json = await self.construct_attr_json(
+                endpoint,
+                endpoint_type,
+                all_exist_endpoints,
+                routing_keys,
+            )
 
             with IndyErrorHandler("Exception building attribute request", LedgerError):
                 request_json = await indy.ledger.build_attrib_request(

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -771,7 +771,6 @@ class IndySdkLedger(BaseLedger):
 
         return attr_json
 
-
     async def update_endpoint_for_did(
         self,
         did: str,
@@ -813,10 +812,7 @@ class IndySdkLedger(BaseLedger):
             nym = self.did_to_nym(did)
 
             attr_json = await self.construct_attr_json(
-                endpoint,
-                endpoint_type,
-                all_exist_endpoints,
-                routing_keys,
+                endpoint, endpoint_type, all_exist_endpoints, routing_keys
             )
 
             with IndyErrorHandler("Exception building attribute request", LedgerError):

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -738,39 +738,6 @@ class IndySdkLedger(BaseLedger):
 
         return address
 
-    async def construct_attr_json(
-        self,
-        endpoint: str,
-        endpoint_type: EndpointType = None,
-        all_exist_endpoints: dict = None,
-        routing_keys: List[str] = None,
-    ) -> str:
-        """Create attr_json string.
-
-        Args:
-            all_exist_endpoings: Dictionary of all existing endpoints
-            endpoint: The endpoint address
-            endpoint_type: The type of the endpoint
-            routing_keys: List of routing_keys if mediator is present
-        """
-
-        if not routing_keys:
-            routing_keys = []
-
-        endpoint_dict = {"endpoint": endpoint}
-
-        if all_exist_endpoints:
-            all_exist_endpoints[endpoint_type.indy] = endpoint_dict
-            endpoint_dict["routingKeys"] = routing_keys
-            attr_json = json.dumps({"endpoint": all_exist_endpoints})
-
-        else:
-            endpoint_val = {endpoint_type.indy: endpoint_dict}
-            endpoint_dict["routingKeys"] = routing_keys
-            attr_json = json.dumps({"endpoint": endpoint_val})
-
-        return attr_json
-
     async def update_endpoint_for_did(
         self,
         did: str,
@@ -811,7 +778,7 @@ class IndySdkLedger(BaseLedger):
 
             nym = self.did_to_nym(did)
 
-            attr_json = await self.construct_attr_json(
+            attr_json = await self._construct_attr_json(
                 endpoint, endpoint_type, all_exist_endpoints, routing_keys
             )
 

--- a/aries_cloudagent/ledger/indy_vdr.py
+++ b/aries_cloudagent/ledger/indy_vdr.py
@@ -672,39 +672,6 @@ class IndyVdrLedger(BaseLedger):
 
         return address
 
-    async def construct_attr_json(
-        self,
-        endpoint: str,
-        endpoint_type: EndpointType = None,
-        all_exist_endpoints: dict = None,
-        routing_keys: List[str] = None,
-    ) -> str:
-        """Create attr_json string.
-
-        Args:
-            all_exist_endpoings: Dictionary of all existing endpoints
-            endpoint: The endpoint address
-            endpoint_type: The type of the endpoint
-            routing_keys: List of routing_keys if mediator is present
-        """
-
-        if not routing_keys:
-            routing_keys = []
-
-        endpoint_dict = {"endpoint": endpoint}
-
-        if all_exist_endpoints:
-            all_exist_endpoints[endpoint_type.indy] = endpoint_dict
-            endpoint_dict["routingKeys"] = routing_keys
-            attr_json = json.dumps({"endpoint": all_exist_endpoints})
-
-        else:
-            endpoint_val = {endpoint_type.indy: endpoint_dict}
-            endpoint_dict["routingKeys"] = routing_keys
-            attr_json = json.dumps({"endpoint": endpoint_val})
-
-        return attr_json
-
     async def update_endpoint_for_did(
         self,
         did: str,
@@ -745,11 +712,8 @@ class IndyVdrLedger(BaseLedger):
 
             nym = self.did_to_nym(did)
 
-            attr_json = await self.construct_attr_json(
-                endpoint,
-                endpoint_type,
-                all_exist_endpoints,
-                routing_keys,
+            attr_json = await self._construct_attr_json(
+                endpoint, endpoint_type, all_exist_endpoints, routing_keys
             )
 
             try:

--- a/aries_cloudagent/ledger/tests/test_indy.py
+++ b/aries_cloudagent/ledger/tests/test_indy.py
@@ -2301,6 +2301,94 @@ class TestIndySdkLedger(AsyncTestCase):
 
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_open")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_close")
+    @pytest.mark.asyncio
+    async def test_construct_attr_json_with_routing_keys(
+        self,
+        mock_close,
+        mock_open,
+    ):
+        ledger = IndySdkLedger(IndySdkLedgerPool("name", checked=True), self.profile)
+        async with ledger:
+            attr_json = await ledger.construct_attr_json(
+                "https://url",
+                EndpointType.ENDPOINT,
+                all_exist_endpoints={"Endpoint": "https://endpoint"},
+                routing_keys=['3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn'],
+            )
+        assert attr_json == json.dumps(
+            {
+                "endpoint": {
+                        "Endpoint": "https://endpoint",
+                        "endpoint": {
+                            "endpoint": "https://url",
+                            "routingKeys": ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"]
+                        }
+                    }
+            }
+        )
+
+    @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_open")
+    @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_close")
+    @async_mock.patch("indy.ledger.build_get_attrib_request")
+    @async_mock.patch("indy.ledger.build_attrib_request")
+    @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedger._submit")
+    @pytest.mark.asyncio
+    async def test_update_endpoint_for_did_calls_attr_json(
+        self,
+        mock_submit,
+        mock_build_attrib_req,
+        mock_build_get_attrib_req,
+        mock_close,
+        mock_open,
+    ):
+        routing_keys = ['3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn']
+        mock_wallet = async_mock.MagicMock()
+        self.session.context.injector.bind_provider(BaseWallet, mock_wallet)
+        ledger = IndySdkLedger(IndySdkLedgerPool("name", checked=True), self.profile)
+        async with ledger:
+            with async_mock.patch.object(
+                IndySdkWallet, "get_public_did"
+            ) as mock_wallet_get_public_did, async_mock.patch.object(
+                ledger,
+                "construct_attr_json",
+                async_mock.CoroutineMock(
+                    return_value=json.dumps(
+                        {
+                            "endpoint": {
+                                "endpoint": {
+                                    "endpoint": "https://url",
+                                    "routingKeys": []
+                                }
+                            }
+                        }
+                    )
+                ),
+            ) as mock_construct_attr_json, async_mock.patch.object(
+                ledger,
+                "get_all_endpoints_for_did",
+                async_mock.CoroutineMock(
+                    return_value={}
+                )
+            ), async_mock.patch.object(
+                ledger,
+                "did_to_nym",
+            ):
+                mock_wallet_get_public_did.return_value = self.test_did_info
+                await ledger.update_endpoint_for_did(
+                    mock_wallet_get_public_did,
+                    "https://url",
+                    EndpointType.ENDPOINT,
+                    routing_keys=routing_keys,
+                )
+                mock_construct_attr_json.assert_called_once_with(
+                    "https://url",
+                    EndpointType.ENDPOINT,
+                    {},
+                    routing_keys,
+                )
+
+    @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_open")
+    @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_close")
     @async_mock.patch("indy.ledger.build_get_attrib_request")
     @async_mock.patch("indy.ledger.build_attrib_request")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedger._submit")

--- a/aries_cloudagent/ledger/tests/test_indy.py
+++ b/aries_cloudagent/ledger/tests/test_indy.py
@@ -2305,7 +2305,7 @@ class TestIndySdkLedger(AsyncTestCase):
     async def test_construct_attr_json_with_routing_keys(self, mock_close, mock_open):
         ledger = IndySdkLedger(IndySdkLedgerPool("name", checked=True), self.profile)
         async with ledger:
-            attr_json = await ledger.construct_attr_json(
+            attr_json = await ledger._construct_attr_json(
                 "https://url",
                 EndpointType.ENDPOINT,
                 all_exist_endpoints={"Endpoint": "https://endpoint"},
@@ -2346,7 +2346,7 @@ class TestIndySdkLedger(AsyncTestCase):
                 IndySdkWallet, "get_public_did"
             ) as mock_wallet_get_public_did, async_mock.patch.object(
                 ledger,
-                "construct_attr_json",
+                "_construct_attr_json",
                 async_mock.CoroutineMock(
                     return_value=json.dumps(
                         {

--- a/aries_cloudagent/ledger/tests/test_indy.py
+++ b/aries_cloudagent/ledger/tests/test_indy.py
@@ -2302,28 +2302,24 @@ class TestIndySdkLedger(AsyncTestCase):
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_open")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_close")
     @pytest.mark.asyncio
-    async def test_construct_attr_json_with_routing_keys(
-        self,
-        mock_close,
-        mock_open,
-    ):
+    async def test_construct_attr_json_with_routing_keys(self, mock_close, mock_open):
         ledger = IndySdkLedger(IndySdkLedgerPool("name", checked=True), self.profile)
         async with ledger:
             attr_json = await ledger.construct_attr_json(
                 "https://url",
                 EndpointType.ENDPOINT,
                 all_exist_endpoints={"Endpoint": "https://endpoint"},
-                routing_keys=['3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn'],
+                routing_keys=["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
             )
         assert attr_json == json.dumps(
             {
                 "endpoint": {
-                        "Endpoint": "https://endpoint",
-                        "endpoint": {
-                            "endpoint": "https://url",
-                            "routingKeys": ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"]
-                        }
-                    }
+                    "Endpoint": "https://endpoint",
+                    "endpoint": {
+                        "endpoint": "https://url",
+                        "routingKeys": ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
+                    },
+                }
             }
         )
 
@@ -2341,7 +2337,7 @@ class TestIndySdkLedger(AsyncTestCase):
         mock_close,
         mock_open,
     ):
-        routing_keys = ['3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn']
+        routing_keys = ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"]
         mock_wallet = async_mock.MagicMock()
         self.session.context.injector.bind_provider(BaseWallet, mock_wallet)
         ledger = IndySdkLedger(IndySdkLedgerPool("name", checked=True), self.profile)
@@ -2357,7 +2353,7 @@ class TestIndySdkLedger(AsyncTestCase):
                             "endpoint": {
                                 "endpoint": {
                                     "endpoint": "https://url",
-                                    "routingKeys": []
+                                    "routingKeys": [],
                                 }
                             }
                         }
@@ -2366,12 +2362,9 @@ class TestIndySdkLedger(AsyncTestCase):
             ) as mock_construct_attr_json, async_mock.patch.object(
                 ledger,
                 "get_all_endpoints_for_did",
-                async_mock.CoroutineMock(
-                    return_value={}
-                )
+                async_mock.CoroutineMock(return_value={}),
             ), async_mock.patch.object(
-                ledger,
-                "did_to_nym",
+                ledger, "did_to_nym"
             ):
                 mock_wallet_get_public_did.return_value = self.test_did_info
                 await ledger.update_endpoint_for_did(
@@ -2381,10 +2374,7 @@ class TestIndySdkLedger(AsyncTestCase):
                     routing_keys=routing_keys,
                 )
                 mock_construct_attr_json.assert_called_once_with(
-                    "https://url",
-                    EndpointType.ENDPOINT,
-                    {},
-                    routing_keys,
+                    "https://url", EndpointType.ENDPOINT, {}, routing_keys
                 )
 
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedgerPool.context_open")

--- a/aries_cloudagent/ledger/tests/test_indy.py
+++ b/aries_cloudagent/ledger/tests/test_indy.py
@@ -2328,9 +2328,11 @@ class TestIndySdkLedger(AsyncTestCase):
     @async_mock.patch("indy.ledger.build_get_attrib_request")
     @async_mock.patch("indy.ledger.build_attrib_request")
     @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedger._submit")
+    @async_mock.patch("aries_cloudagent.ledger.indy.IndySdkLedger.is_ledger_read_only")
     @pytest.mark.asyncio
     async def test_update_endpoint_for_did_calls_attr_json(
         self,
+        mock_is_ledger_read_only,
         mock_submit,
         mock_build_attrib_req,
         mock_build_get_attrib_req,
@@ -2341,6 +2343,7 @@ class TestIndySdkLedger(AsyncTestCase):
         mock_wallet = async_mock.MagicMock()
         self.session.context.injector.bind_provider(BaseWallet, mock_wallet)
         ledger = IndySdkLedger(IndySdkLedgerPool("name", checked=True), self.profile)
+        mock_is_ledger_read_only.return_value = False
         async with ledger:
             with async_mock.patch.object(
                 IndySdkWallet, "get_public_did"

--- a/aries_cloudagent/ledger/tests/test_indy_vdr.py
+++ b/aries_cloudagent/ledger/tests/test_indy_vdr.py
@@ -666,7 +666,7 @@ class TestIndyVdrLedger:
         self, ledger: IndyVdrLedger, all_exist_endpoints, routing_keys, result
     ):
         async with ledger:
-            attr_json = await ledger.construct_attr_json(
+            attr_json = await ledger._construct_attr_json(
                 "https://url", EndpointType.ENDPOINT, all_exist_endpoints, routing_keys
             )
         assert attr_json == json.dumps(result)
@@ -680,7 +680,7 @@ class TestIndyVdrLedger:
         async with ledger:
             with async_mock.patch.object(
                 ledger,
-                "construct_attr_json",
+                "_construct_attr_json",
                 async_mock.CoroutineMock(
                     return_value=json.dumps(
                         {

--- a/aries_cloudagent/ledger/tests/test_indy_vdr.py
+++ b/aries_cloudagent/ledger/tests/test_indy_vdr.py
@@ -1,4 +1,5 @@
 import json
+from aries_cloudagent.messaging.valid import ENDPOINT_TYPE
 import pytest
 
 from asynctest import mock as async_mock
@@ -606,6 +607,123 @@ class TestIndyVdrLedger:
             result = await ledger.update_endpoint_for_did(
                 "55GkHamhTU1ZbTbV2ab9DE", "https://url", EndpointType.ENDPOINT
             )
+
+    @pytest.mark.parametrize(
+        "all_exist_endpoints, routing_keys, result",
+        [
+            (
+                {"Endpoint": "https://endpoint"},
+                ['3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn'],
+                {
+                    "endpoint": {
+                            "Endpoint": "https://endpoint",
+                            "endpoint": {
+                                "endpoint": "https://url",
+                                "routingKeys": ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"]
+                            }
+                        }
+                },
+            ),
+            (
+                {"Endpoint": "https://endpoint"},
+                None,
+                {
+                    "endpoint": {
+                        "Endpoint": "https://endpoint",
+                        "endpoint": {
+                            "endpoint": "https://url",
+                            "routingKeys": []
+                        }
+                    }
+                },
+            ),
+            (
+                None,
+                ['3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn'],
+                {
+                    "endpoint": {
+                        "endpoint": {
+                            "endpoint": "https://url",
+                            "routingKeys": ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"]
+                        }
+                    }
+                },
+            ),
+            (
+                None,
+                None,
+                {
+                    "endpoint": {
+                        "endpoint": {
+                            "endpoint": "https://url",
+                            "routingKeys": []
+                        }
+                    }
+                },
+            )
+        ]
+    )
+    @pytest.mark.asyncio
+    async def test_construct_attr_json(
+        self,
+        ledger: IndyVdrLedger,
+        all_exist_endpoints,
+        routing_keys,
+        result,
+    ):
+        async with ledger:
+            attr_json = await ledger.construct_attr_json(
+                "https://url",
+                EndpointType.ENDPOINT,
+                all_exist_endpoints,
+                routing_keys,
+            )
+        assert attr_json == json.dumps(result)
+
+    @pytest.mark.asyncio
+    async def test_update_endpoint_for_did_calls_attr_json(
+        self,
+        ledger: IndyVdrLedger,
+    ):
+        routing_keys = ['3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn']
+        wallet = (await ledger.profile.session()).wallet
+        test_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+
+        async with ledger:
+            with async_mock.patch.object(
+                ledger,
+                "construct_attr_json",
+                async_mock.CoroutineMock(
+                    return_value=json.dumps(
+                        {
+                            "endpoint": {
+                                "endpoint": {
+                                    "endpoint": "https://url",
+                                    "routingKeys": []
+                                }
+                            }
+                        }
+                    )
+                ),
+            ) as mock_construct_attr_json, async_mock.patch.object(
+                ledger,
+                "get_all_endpoints_for_did",
+                async_mock.CoroutineMock(
+                    return_value={}
+                )
+            ):
+                await ledger.update_endpoint_for_did(
+                    test_did.did,
+                    "https://url",
+                    EndpointType.ENDPOINT,
+                    routing_keys=routing_keys,
+                )
+                mock_construct_attr_json.assert_called_once_with(
+                    "https://url",
+                    EndpointType.ENDPOINT,
+                    {},
+                    routing_keys,
+                )
 
     @pytest.mark.asyncio
     async def test_update_endpoint_for_did_no_public(

--- a/aries_cloudagent/ledger/tests/test_indy_vdr.py
+++ b/aries_cloudagent/ledger/tests/test_indy_vdr.py
@@ -613,15 +613,17 @@ class TestIndyVdrLedger:
         [
             (
                 {"Endpoint": "https://endpoint"},
-                ['3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn'],
+                ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
                 {
                     "endpoint": {
-                            "Endpoint": "https://endpoint",
-                            "endpoint": {
-                                "endpoint": "https://url",
-                                "routingKeys": ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"]
-                            }
-                        }
+                        "Endpoint": "https://endpoint",
+                        "endpoint": {
+                            "endpoint": "https://url",
+                            "routingKeys": [
+                                "3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"
+                            ],
+                        },
+                    }
                 },
             ),
             (
@@ -630,62 +632,48 @@ class TestIndyVdrLedger:
                 {
                     "endpoint": {
                         "Endpoint": "https://endpoint",
+                        "endpoint": {"endpoint": "https://url", "routingKeys": []},
+                    }
+                },
+            ),
+            (
+                None,
+                ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"],
+                {
+                    "endpoint": {
                         "endpoint": {
                             "endpoint": "https://url",
-                            "routingKeys": []
+                            "routingKeys": [
+                                "3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"
+                            ],
                         }
                     }
                 },
             ),
             (
                 None,
-                ['3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn'],
+                None,
                 {
                     "endpoint": {
-                        "endpoint": {
-                            "endpoint": "https://url",
-                            "routingKeys": ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"]
-                        }
+                        "endpoint": {"endpoint": "https://url", "routingKeys": []}
                     }
                 },
             ),
-            (
-                None,
-                None,
-                {
-                    "endpoint": {
-                        "endpoint": {
-                            "endpoint": "https://url",
-                            "routingKeys": []
-                        }
-                    }
-                },
-            )
-        ]
+        ],
     )
     @pytest.mark.asyncio
     async def test_construct_attr_json(
-        self,
-        ledger: IndyVdrLedger,
-        all_exist_endpoints,
-        routing_keys,
-        result,
+        self, ledger: IndyVdrLedger, all_exist_endpoints, routing_keys, result
     ):
         async with ledger:
             attr_json = await ledger.construct_attr_json(
-                "https://url",
-                EndpointType.ENDPOINT,
-                all_exist_endpoints,
-                routing_keys,
+                "https://url", EndpointType.ENDPOINT, all_exist_endpoints, routing_keys
             )
         assert attr_json == json.dumps(result)
 
     @pytest.mark.asyncio
-    async def test_update_endpoint_for_did_calls_attr_json(
-        self,
-        ledger: IndyVdrLedger,
-    ):
-        routing_keys = ['3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn']
+    async def test_update_endpoint_for_did_calls_attr_json(self, ledger: IndyVdrLedger):
+        routing_keys = ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"]
         wallet = (await ledger.profile.session()).wallet
         test_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
 
@@ -699,7 +687,7 @@ class TestIndyVdrLedger:
                             "endpoint": {
                                 "endpoint": {
                                     "endpoint": "https://url",
-                                    "routingKeys": []
+                                    "routingKeys": [],
                                 }
                             }
                         }
@@ -708,9 +696,7 @@ class TestIndyVdrLedger:
             ) as mock_construct_attr_json, async_mock.patch.object(
                 ledger,
                 "get_all_endpoints_for_did",
-                async_mock.CoroutineMock(
-                    return_value={}
-                )
+                async_mock.CoroutineMock(return_value={}),
             ):
                 await ledger.update_endpoint_for_did(
                     test_did.did,

--- a/aries_cloudagent/wallet/askar.py
+++ b/aries_cloudagent/wallet/askar.py
@@ -448,6 +448,7 @@ class AskarWallet(BaseWallet):
         endpoint_type: EndpointType = None,
         write_ledger: bool = True,
         endorser_did: str = None,
+        routing_keys: List[str] = None,
     ):
         """
         Update the endpoint for a DID in the wallet, send to ledger if public or posted.
@@ -486,6 +487,7 @@ class AskarWallet(BaseWallet):
                         endpoint_type,
                         write_ledger=write_ledger,
                         endorser_did=endorser_did,
+                        routing_keys=routing_keys,
                     )
                     if not write_ledger:
                         return attrib_def

--- a/aries_cloudagent/wallet/base.py
+++ b/aries_cloudagent/wallet/base.py
@@ -226,6 +226,7 @@ class BaseWallet(ABC):
         endpoint_type: EndpointType = None,
         write_ledger: bool = True,
         endorser_did: str = None,
+        routing_keys: List[str] = None,
     ):
         """
         Update the endpoint for a DID in the wallet, send to ledger if public or posted.

--- a/aries_cloudagent/wallet/indy.py
+++ b/aries_cloudagent/wallet/indy.py
@@ -707,6 +707,7 @@ class IndySdkWallet(BaseWallet):
         endpoint_type: EndpointType = None,
         write_ledger: bool = True,
         endorser_did: str = None,
+        routing_keys: List[str] = None,
     ):
         """
         Update the endpoint for a DID in the wallet, send to ledger if public or posted.
@@ -746,6 +747,7 @@ class IndySdkWallet(BaseWallet):
                         endpoint_type,
                         write_ledger=write_ledger,
                         endorser_did=endorser_did,
+                        routing_keys=routing_keys,
                     )
                     if not write_ledger:
                         return attrib_def

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -455,11 +455,9 @@ async def wallet_set_public_did(request: web.BaseRequest):
     profile = context.profile
     route_manager = profile.inject(RouteManager)
     mediation_record = await route_manager.mediation_record_if_id(
-        profile=profile,
-        mediation_id=mediation_id,
-        or_default=True,
+        profile=profile, mediation_id=mediation_id, or_default=True
     )
-    routing_keys=None
+    routing_keys = None
     if mediation_record:
         routing_keys = mediation_record.routing_keys
 

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from typing import List
 
 from aiohttp import web
 from aiohttp_apispec import docs, querystring_schema, request_schema, response_schema
@@ -207,6 +208,12 @@ class AttribConnIdMatchInfoSchema(OpenAPISchema):
     conn_id = fields.Str(description="Connection identifier", required=False)
 
 
+class MediationIDSchema(OpenAPISchema):
+    """Class for user to optionally input a mediation_id."""
+
+    mediation_id = fields.Str(description="Mediation identifier", required=False)
+
+
 def format_did_info(info: DIDInfo):
     """Serialize a DIDInfo object."""
     if info:
@@ -410,6 +417,7 @@ async def wallet_get_public_did(request: web.BaseRequest):
 @querystring_schema(DIDQueryStringSchema())
 @querystring_schema(CreateAttribTxnForEndorserOptionSchema())
 @querystring_schema(AttribConnIdMatchInfoSchema())
+@querystring_schema(MediationIDSchema())
 @response_schema(DIDResultSchema, 200, description="")
 async def wallet_set_public_did(request: web.BaseRequest):
     """
@@ -442,6 +450,19 @@ async def wallet_set_public_did(request: web.BaseRequest):
         raise web.HTTPBadRequest(reason="Request query must include DID")
 
     info: DIDInfo = None
+
+    mediation_id = request.query.get("mediation_id")
+    profile = context.profile
+    route_manager = profile.inject(RouteManager)
+    mediation_record = await route_manager.mediation_record_if_id(
+        profile=profile,
+        mediation_id=mediation_id,
+        or_default=True,
+    )
+    routing_keys=None
+    if mediation_record:
+        routing_keys = mediation_record.routing_keys
+
     try:
         info, attrib_def = await promote_wallet_public_did(
             context.profile,
@@ -450,6 +471,7 @@ async def wallet_set_public_did(request: web.BaseRequest):
             did,
             write_ledger=write_ledger,
             connection_id=connection_id,
+            routing_keys=routing_keys,
         )
     except LookupError as err:
         raise web.HTTPNotFound(reason=str(err)) from err
@@ -496,6 +518,7 @@ async def promote_wallet_public_did(
     did: str,
     write_ledger: bool = False,
     connection_id: str = None,
+    routing_keys: List[str] = None,
 ) -> DIDInfo:
     """Promote supplied DID to the wallet public DID."""
     info: DIDInfo = None
@@ -570,6 +593,7 @@ async def promote_wallet_public_did(
                     ledger,
                     write_ledger=write_ledger,
                     endorser_did=endorser_did,
+                    routing_keys=routing_keys,
                 )
 
         # Commented the below lines as the function set_did_endpoint

--- a/aries_cloudagent/wallet/tests/test_indy_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_indy_wallet.py
@@ -130,6 +130,7 @@ class TestIndySdkWallet(test_in_memory_wallet.TestInMemoryWallet):
             EndpointType.ENDPOINT,
             endorser_did=None,
             write_ledger=True,
+            routing_keys=None,
         )
         info_pub2 = await wallet.get_public_did()
         assert info_pub2.metadata["endpoint"] == "http://1.2.3.4:8021"
@@ -137,6 +138,27 @@ class TestIndySdkWallet(test_in_memory_wallet.TestInMemoryWallet):
         with pytest.raises(test_module.LedgerConfigError) as excinfo:
             await wallet.set_did_endpoint(info_pub.did, "http://1.2.3.4:8021", None)
         assert "No ledger available" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_set_did_endpoint_ledger_with_routing_keys(self, wallet: IndySdkWallet):
+        routing_keys = ['3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn']
+        mock_ledger = async_mock.MagicMock(
+            read_only=False, update_endpoint_for_did=async_mock.CoroutineMock()
+        )
+        info_pub = await wallet.create_public_did(
+            DIDMethod.SOV,
+            KeyType.ED25519,
+        )
+        await wallet.set_did_endpoint(info_pub.did, "http://1.2.3.4:8021", mock_ledger, routing_keys=routing_keys)
+
+        mock_ledger.update_endpoint_for_did.assert_called_once_with(
+            info_pub.did,
+            "http://1.2.3.4:8021",
+            EndpointType.ENDPOINT,
+            endorser_did=None,
+            write_ledger=True,
+            routing_keys=routing_keys,
+        )
 
     @pytest.mark.asyncio
     async def test_set_did_endpoint_readonly_ledger(self, wallet: IndySdkWallet):

--- a/aries_cloudagent/wallet/tests/test_indy_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_indy_wallet.py
@@ -140,16 +140,17 @@ class TestIndySdkWallet(test_in_memory_wallet.TestInMemoryWallet):
         assert "No ledger available" in str(excinfo.value)
 
     @pytest.mark.asyncio
-    async def test_set_did_endpoint_ledger_with_routing_keys(self, wallet: IndySdkWallet):
-        routing_keys = ['3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn']
+    async def test_set_did_endpoint_ledger_with_routing_keys(
+        self, wallet: IndySdkWallet
+    ):
+        routing_keys = ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"]
         mock_ledger = async_mock.MagicMock(
             read_only=False, update_endpoint_for_did=async_mock.CoroutineMock()
         )
-        info_pub = await wallet.create_public_did(
-            DIDMethod.SOV,
-            KeyType.ED25519,
+        info_pub = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        await wallet.set_did_endpoint(
+            info_pub.did, "http://1.2.3.4:8021", mock_ledger, routing_keys=routing_keys
         )
-        await wallet.set_did_endpoint(info_pub.did, "http://1.2.3.4:8021", mock_ledger, routing_keys=routing_keys)
 
         mock_ledger.update_endpoint_for_did.assert_called_once_with(
             info_pub.did,

--- a/aries_cloudagent/wallet/tests/test_indy_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_indy_wallet.py
@@ -123,20 +123,20 @@ class TestIndySdkWallet(test_in_memory_wallet.TestInMemoryWallet):
             DIDMethod.SOV,
             KeyType.ED25519,
         )
-        await wallet.set_did_endpoint(info_pub.did, "http://1.2.3.4:8021", mock_ledger)
+        await wallet.set_did_endpoint(info_pub.did, "https://example.com", mock_ledger)
         mock_ledger.update_endpoint_for_did.assert_called_once_with(
             info_pub.did,
-            "http://1.2.3.4:8021",
+            "https://example.com",
             EndpointType.ENDPOINT,
             endorser_did=None,
             write_ledger=True,
             routing_keys=None,
         )
         info_pub2 = await wallet.get_public_did()
-        assert info_pub2.metadata["endpoint"] == "http://1.2.3.4:8021"
+        assert info_pub2.metadata["endpoint"] == "https://example.com"
 
         with pytest.raises(test_module.LedgerConfigError) as excinfo:
-            await wallet.set_did_endpoint(info_pub.did, "http://1.2.3.4:8021", None)
+            await wallet.set_did_endpoint(info_pub.did, "https://example.com", None)
         assert "No ledger available" in str(excinfo.value)
 
     @pytest.mark.asyncio
@@ -149,12 +149,12 @@ class TestIndySdkWallet(test_in_memory_wallet.TestInMemoryWallet):
         )
         info_pub = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
         await wallet.set_did_endpoint(
-            info_pub.did, "http://1.2.3.4:8021", mock_ledger, routing_keys=routing_keys
+            info_pub.did, "https://example.com", mock_ledger, routing_keys=routing_keys
         )
 
         mock_ledger.update_endpoint_for_did.assert_called_once_with(
             info_pub.did,
-            "http://1.2.3.4:8021",
+            "https://example.com",
             EndpointType.ENDPOINT,
             endorser_did=None,
             write_ledger=True,
@@ -170,13 +170,13 @@ class TestIndySdkWallet(test_in_memory_wallet.TestInMemoryWallet):
             DIDMethod.SOV,
             KeyType.ED25519,
         )
-        await wallet.set_did_endpoint(info_pub.did, "http://1.2.3.4:8021", mock_ledger)
+        await wallet.set_did_endpoint(info_pub.did, "https://example.com", mock_ledger)
         mock_ledger.update_endpoint_for_did.assert_not_called()
         info_pub2 = await wallet.get_public_did()
-        assert info_pub2.metadata["endpoint"] == "http://1.2.3.4:8021"
+        assert info_pub2.metadata["endpoint"] == "https://example.com"
 
         with pytest.raises(test_module.LedgerConfigError) as excinfo:
-            await wallet.set_did_endpoint(info_pub.did, "http://1.2.3.4:8021", None)
+            await wallet.set_did_endpoint(info_pub.did, "https://example.com", None)
         assert "No ledger available" in str(excinfo.value)
 
     @pytest.mark.asyncio

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -380,8 +380,13 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         ledger.update_endpoint_for_did = async_mock.AsyncMock()
         ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
+
         mock_route_manager = async_mock.MagicMock()
         mock_route_manager.route_public_did = async_mock.AsyncMock()
+        mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.__aenter__ = async_mock.AsyncMock(
+            return_value=mock_route_manager
+        )
         self.profile.context.injector.bind_instance(RouteManager, mock_route_manager)
 
         with async_mock.patch.object(
@@ -414,6 +419,13 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             await test_module.wallet_set_public_did(self.request)
 
     async def test_set_public_did_no_ledger(self):
+
+        mock_route_manager = async_mock.MagicMock()
+        mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.__aenter__ = async_mock.AsyncMock(
+            return_value=mock_route_manager
+        )
+        self.profile.context.injector.bind_instance(RouteManager, mock_route_manager)
         self.request.query = {"did": self.test_did}
 
         with self.assertRaises(test_module.web.HTTPForbidden):
@@ -428,6 +440,13 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
 
+        mock_route_manager = async_mock.MagicMock()
+        mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.__aenter__ = async_mock.AsyncMock(
+            return_value=mock_route_manager
+        )
+        self.profile.context.injector.bind_instance(RouteManager, mock_route_manager)
+
         with self.assertRaises(test_module.web.HTTPNotFound):
             await test_module.wallet_set_public_did(self.request)
 
@@ -439,6 +458,13 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         ledger.get_key_for_did = async_mock.AsyncMock(return_value=None)
         ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
+
+        mock_route_manager = async_mock.MagicMock()
+        mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.__aenter__ = async_mock.AsyncMock(
+            return_value=mock_route_manager
+        )
+        self.profile.context.injector.bind_instance(RouteManager, mock_route_manager)
 
         self.wallet.get_local_did.side_effect = test_module.WalletNotFoundError()
         with self.assertRaises(test_module.web.HTTPNotFound):
@@ -453,6 +479,14 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         ledger.get_key_for_did = async_mock.AsyncMock()
         ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
+
+        mock_route_manager = async_mock.MagicMock()
+        mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.__aenter__ = async_mock.AsyncMock(
+            return_value=mock_route_manager
+        )
+        self.profile.context.injector.bind_instance(RouteManager, mock_route_manager)
+
         with async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as json_response:
@@ -477,6 +511,13 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
 
+        mock_route_manager = async_mock.MagicMock()
+        mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.__aenter__ = async_mock.AsyncMock(
+            return_value=mock_route_manager
+        )
+        self.profile.context.injector.bind_instance(RouteManager, mock_route_manager)
+
         with async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as json_response:
@@ -500,8 +541,13 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         ledger.get_key_for_did = async_mock.AsyncMock()
         ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
+
         mock_route_manager = async_mock.MagicMock()
         mock_route_manager.route_public_did = async_mock.AsyncMock()
+        mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.__aenter__ = async_mock.AsyncMock(
+            return_value=mock_route_manager
+        )
         self.profile.context.injector.bind_instance(RouteManager, mock_route_manager)
 
         with async_mock.patch.object(
@@ -541,8 +587,15 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         ledger.get_key_for_did = async_mock.AsyncMock()
         ledger.__aenter__ = async_mock.AsyncMock(return_value=ledger)
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
+
         mock_route_manager = async_mock.MagicMock()
         mock_route_manager.route_public_did = async_mock.AsyncMock()
+        mock_route_manager.mediation_record_if_id = async_mock.AsyncMock(
+            return_value=None
+        )
+        mock_route_manager.__aenter__ = async_mock.AsyncMock(
+            return_value=mock_route_manager
+        )
         self.profile.context.injector.bind_instance(RouteManager, mock_route_manager)
 
         with async_mock.patch.object(
@@ -565,6 +618,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 ledger,
                 write_ledger=True,
                 endorser_did=None,
+                routing_keys=None,
             )
             json_response.assert_called_once_with(
                 {


### PR DESCRIPTION
This PR supports publishing endpoint information with routing keys in accordance with the did:sov specification. Routing keys are retrieved from `mediation_id` if specified, or else a default mediator. If no mediated connection is present, `routingKeys` defaults to an empty array. 

This PR allows for publishing DIDs with routing keys; PR #1863 allows for resolving DIDs with routing keys.