### PR TITLE
fix: update RouteManager methods use to pass profile as parameter

### DIFF
--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/routes.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/routes.py
@@ -532,13 +532,13 @@ async def update_keylist_for_connection(request: web.BaseRequest):
         async with context.session() as session:
             connection_record = await ConnRecord.retrieve_by_id(session, connection_id)
             mediation_record = await route_manager.mediation_record_for_connection(
-                connection_record, mediation_id, or_default=True
+                context.profile, connection_record, mediation_id, or_default=True
             )
 
         # MediationRecord is permitted to be None; route manager will
         # ensure the correct mediator is notified.
         keylist_update = await route_manager.route_connection(
-            connection_record, mediation_record
+            context.profile, connection_record, mediation_record
         )
 
         results = keylist_update.serialize() if keylist_update else {}


### PR DESCRIPTION
Adapt uses of `RouteManager` to pass the profile as argument.
This is following a refactoring in #1851

Signed-off-by: Clément Humbert <clement.humbert@sicpa.com>