### PR TITLE
[#1895] Stopping the aca-py shell process keeps python process running

### DIFF
--- a/bin/aca-py
+++ b/bin/aca-py
@@ -7,4 +7,4 @@ if [ -z "$PYTHON" ]; then
     fi
 fi
 
-$PYTHON -m aries_cloudagent "$@"
+exec $PYTHON -m aries_cloudagent "$@"


### PR DESCRIPTION
Signed-off-by: Thomas Diesler <tdiesler@redhat.com>