### PR TITLE
fix: incorrect response schema for discover features

### DIFF
--- a/aries_cloudagent/protocols/discovery/v1_0/routes.py
+++ b/aries_cloudagent/protocols/discovery/v1_0/routes.py
@@ -18,15 +18,6 @@ from .models.discovery_record import (
 )
 
 
-class V10DiscoveryExchangeResultSchema(OpenAPISchema):
-    """Result schema for Discover Features v1.0 exchange record."""
-
-    results = fields.Nested(
-        V10DiscoveryRecordSchema,
-        description="Discover Features v1.0 exchange record",
-    )
-
-
 class V10DiscoveryExchangeListResultSchema(OpenAPISchema):
     """Result schema for Discover Features v1.0 exchange records."""
 

--- a/aries_cloudagent/protocols/discovery/v1_0/routes.py
+++ b/aries_cloudagent/protocols/discovery/v1_0/routes.py
@@ -70,7 +70,7 @@ class QueryDiscoveryExchRecordsSchema(OpenAPISchema):
     summary="Query supported features",
 )
 @querystring_schema(QueryFeaturesQueryStringSchema())
-@response_schema(V10DiscoveryExchangeResultSchema(), 200, description="")
+@response_schema(V10DiscoveryRecordSchema(), 200, description="")
 async def query_features(request: web.BaseRequest):
     """
     Request handler for creating and sending feature query.


### PR DESCRIPTION
Small change that won't really affect anything but OpenAPI json and client generators.

The query features endpoint returns the discovery record directly rather than nesting it in a `results` attribute.