### PR TITLE
chore: update pydid

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pyld~=2.0.3
 pyyaml~=5.4.0
 ConfigArgParse~=1.5.3
 pyjwt~=2.4.0
-pydid~=0.3.3
+pydid~=0.3.6
 jsonpath_ng==1.5.2
 pytz~=2021.1
 python-dateutil~=2.8.1


### PR DESCRIPTION
Recent changes to the resolution of sov/indy DIDs caused PyDID to parse
service endpoints that should have been recognized as DIDComm services
as plain services. This broke some logic in accepting invitations from
public DIDs. Pulling in these updates from PyDID resolves the issue.

Signed-off-by: Daniel Bluhm <dbluhm@pm.me>