### PR TITLE
Leave credentialStatus element in the LD credential

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
@@ -503,7 +503,7 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
 
         # Remove values from cred that are not part of detail
         cred_dict.pop("proof")
-        credential_status = cred_dict.pop("credentialStatus", None)
+        credential_status = cred_dict.get("credentialStatus", None)
         detail_status = detail.options.credential_status
 
         if cred_dict != detail_dict["credential"]:

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
@@ -770,14 +770,14 @@ class TestV20LDProofCredFormatHandler(AsyncTestCase):
 
     async def test_receive_credential_x_credential_status_ne_both_set(self):
         detail = deepcopy(LD_PROOF_VC_DETAIL)
-        statusEntry = {"type": "SomeRandomType"}
+        status_entry = {"type": "SomeRandomType"}
 
         # Set credential status in both request and reference credential
         detail["options"]["credentialStatus"] = {"type": "CredentialStatusType"}
-        detail["credential"]["credentialStatus"] = deepcopy(statusEntry)
+        detail["credential"]["credentialStatus"] = deepcopy(status_entry)
 
         vc = deepcopy(LD_PROOF_VC)
-        vc["credentialStatus"] = deepcopy(statusEntry)
+        vc["credentialStatus"] = deepcopy(status_entry)
 
         cred_issue = V20CredIssue(
             formats=[

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
@@ -770,13 +770,14 @@ class TestV20LDProofCredFormatHandler(AsyncTestCase):
 
     async def test_receive_credential_x_credential_status_ne_both_set(self):
         detail = deepcopy(LD_PROOF_VC_DETAIL)
+        statusEntry = {"type": "SomeRandomType"}
 
-        # Set credential status so it's only set on the detail
-        # not the issued credential
+        # Set credential status in both request and reference credential
         detail["options"]["credentialStatus"] = {"type": "CredentialStatusType"}
+        detail["credential"]["credentialStatus"] = deepcopy(statusEntry)
 
         vc = deepcopy(LD_PROOF_VC)
-        vc["credentialStatus"] = {"type": "SomeRandomType"}
+        vc["credentialStatus"] = deepcopy(statusEntry)
 
         cred_issue = V20CredIssue(
             formats=[


### PR DESCRIPTION
During the implementation we stumbled upon inability of a recipient to validate a credential offer. That happens because the `credentialStatus` fields is popped from the credential offer (see [here](https://github.com/sake/aries-cloudagent-python/blob/main/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py#L506)). Later, the two entities (one from credential request, and another from the offer) are being compared, and naturally the comparison fails, which leads to inability to receive the credential offer.
This change makes sure that the comparison of the provided reference data is comparable with the credential content, by replacing the `pop` method with `get` to leave the `credentialStatus` intact in the offer object.