### PR TITLE
Pre-populate revoc_reg_id on IssuerRevRegRecord

### DIFF
--- a/aries_cloudagent/revocation/indy.py
+++ b/aries_cloudagent/revocation/indy.py
@@ -75,8 +75,6 @@ class IndyRevocation:
 
         record_id = str(uuid4())
         issuer_did = cred_def_id.split(":")[0]
-        tag = tag or record_id
-        revoc_reg_id = f"{issuer_did}:4:{cred_def_id}:{revoc_def_type}:{tag}"
         record = IssuerRevRegRecord(
             new_with_id=True,
             record_id=record_id,
@@ -84,9 +82,11 @@ class IndyRevocation:
             issuer_did=issuer_did,
             max_cred_num=max_cred_num,
             revoc_def_type=revoc_def_type,
-            revoc_reg_id=revoc_reg_id,
             tag=tag,
         )
+        revoc_def_type = record.revoc_def_type
+        rtag = record.tag or record_id
+        record.revoc_reg_id = f"{issuer_did}:4:{cred_def_id}:{revoc_def_type}:{rtag}"
         async with self._profile.session() as session:
             await record.save(session, reason="Init revocation registry")
 

--- a/aries_cloudagent/revocation/indy.py
+++ b/aries_cloudagent/revocation/indy.py
@@ -1,6 +1,7 @@
 """Indy revocation registry management."""
 
 from typing import Optional, Sequence, Tuple
+from uuid import uuid4
 
 from ..core.profile import Profile
 from ..ledger.base import BaseLedger
@@ -44,7 +45,7 @@ class IndyRevocation:
         create_pending_rev_reg: bool = False,
         endorser_connection_id: str = None,
         notify: bool = True,
-    ) -> "IssuerRevRegRecord":
+    ) -> IssuerRevRegRecord:
         """Create a new revocation registry record for a credential definition."""
         multitenant_mgr = self._profile.inject_or(BaseMultitenantManager)
         if multitenant_mgr:
@@ -72,11 +73,18 @@ class IndyRevocation:
                 f"Bad revocation registry size: {max_cred_num}"
             )
 
+        record_id = str(uuid4())
+        issuer_did = cred_def_id.split(":")[0]
+        tag = tag or record_id
+        revoc_reg_id = f"{issuer_did}:4:{cred_def_id}:{revoc_def_type}:{tag}"
         record = IssuerRevRegRecord(
+            new_with_id=True,
+            record_id=record_id,
             cred_def_id=cred_def_id,
-            issuer_did=cred_def_id.split(":")[0],
+            issuer_did=issuer_did,
             max_cred_num=max_cred_num,
             revoc_def_type=revoc_def_type,
+            revoc_reg_id=revoc_reg_id,
             tag=tag,
         )
         async with self._profile.session() as session:

--- a/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
+++ b/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
@@ -202,6 +202,8 @@ class IssuerRevRegRecord(BaseRecord):
         except IndyIssuerError as err:
             raise RevocationError() from err
 
+        if self.revoc_reg_id and revoc_reg_id != self.revoc_reg_id:
+            raise RevocationError("Generated registry ID does not match assigned value")
         self.revoc_reg_id = revoc_reg_id
         self.revoc_reg_def = json.loads(revoc_reg_def_json)
         self.revoc_reg_entry = json.loads(revoc_reg_entry_json)

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -585,9 +585,19 @@ async def rev_regs_created(request: web.BaseRequest):
         tag: request.query[tag] for tag in search_tags if tag in request.query
     }
     async with context.profile.session() as session:
-        found = await IssuerRevRegRecord.query(session, tag_filter)
+        found = await IssuerRevRegRecord.query(
+            session,
+            tag_filter,
+            post_filter_negative={"state": IssuerRevRegRecord.STATE_INIT},
+        )
 
-    return web.json_response({"rev_reg_ids": [record.revoc_reg_id for record in found]})
+    return web.json_response(
+        {
+            "rev_reg_ids": [
+                record.revoc_reg_id for record in found if record.revoc_reg_id
+            ]
+        }
+    )
 
 
 @docs(

--- a/aries_cloudagent/revocation/tests/test_indy.py
+++ b/aries_cloudagent/revocation/tests/test_indy.py
@@ -20,7 +20,6 @@ from ..models.issuer_rev_reg_record import DEFAULT_REGISTRY_SIZE, IssuerRevRegRe
 from ..models.revocation_registry import RevocationRegistry
 
 
-@pytest.mark.indy
 class TestIndyRevocation(AsyncTestCase):
     def setUp(self):
         self.profile = InMemoryProfile.test_profile()

--- a/aries_cloudagent/revocation/tests/test_routes.py
+++ b/aries_cloudagent/revocation/tests/test_routes.py
@@ -282,7 +282,6 @@ class TestRevocationRoutes(AsyncTestCase):
 
     async def test_rev_regs_created(self):
         CRED_DEF_ID = f"{self.test_did}:3:CL:1234:default"
-        STATE = "active"
         self.request.query = {
             "cred_def_id": CRED_DEF_ID,
             "state": test_module.IssuerRevRegRecord.STATE_ACTIVE,


### PR DESCRIPTION
This avoids having a confusingly blank `revoc_reg_id` on the record in the `init` state.

Registries in the `init` state are also filtered from the `/revocation/registries/created` endpoint.