### PR TITLE
Fix: the type of tails file path to string.

### DIFF
--- a/aries_cloudagent/revocation/models/revocation_registry.py
+++ b/aries_cloudagent/revocation/models/revocation_registry.py
@@ -198,7 +198,7 @@ class RevocationRegistry:
                 "The hash of the downloaded tails file does not match."
             )
 
-        self.tails_local_path = tails_file_path
+        self.tails_local_path = str(tails_file_path)
         return self.tails_local_path
 
     async def get_or_fetch_local_tails_path(self):


### PR DESCRIPTION
Hi.

This PR corrects the type of tails file path.

`self.tails_local_path` must be a string. However, it was assigned a PosixPath value.

So I got the below error.
`TypeError: bytes or integer address expected instead of PosixPath instance`

At here.
https://github.com/hyperledger/indy-shared-rs/blob/main/wrappers/python/indy_credx/bindings.py#L797

Thanks!

Signed-off-by: Ethan Sung <baegjae@gmail.com>