### PR TITLE
Fix: OOB - Handling of minor versions

### DIFF
--- a/aries_cloudagent/core/protocol_registry.py
+++ b/aries_cloudagent/core/protocol_registry.py
@@ -108,7 +108,7 @@ class ProtocolRegistry:
                 updated_typeset[updated_msg_type_string] = module_path
         return updated_typeset
 
-    def _template_message_type_check(self, typeset, idx: int = 0) -> bool:
+    def _template_message_type_check(self, typeset) -> bool:
         for msg_type_string, _ in typeset.items():
             if "$version" in msg_type_string:
                 return True

--- a/aries_cloudagent/core/protocol_registry.py
+++ b/aries_cloudagent/core/protocol_registry.py
@@ -77,7 +77,7 @@ class ProtocolRegistry:
 
     def create_msg_types_for_minor_version(self, typesets, version_definition):
         """
-        Return a mapping of message type string [missing] with minor versions to module path.
+        Return mapping of message type to module path for minor versions.
 
         Args:
             typesets: Mappings of message types to register
@@ -98,7 +98,7 @@ class ProtocolRegistry:
                     for msg_type_string, module_path in typeset.items():
                         if to_check not in msg_type_string:
                             updated_msg_type_string = re.sub(
-                                "(\/\d+\.)?(\*|\d+\/)", to_check, msg_type_string
+                                r"(\/\d+\.)?(\*|\d+\/)", to_check, msg_type_string
                             )
                             if not updated_typeset:
                                 updated_typeset = {}

--- a/aries_cloudagent/core/tests/test_dispatcher.py
+++ b/aries_cloudagent/core/tests/test_dispatcher.py
@@ -1,7 +1,7 @@
 import json
 
 from async_case import IsolatedAsyncioTestCase
-import mock as async_mock
+from asynctest import mock as async_mock
 import pytest
 
 from marshmallow import EXCLUDE
@@ -111,9 +111,17 @@ class TestDispatcher(IsolatedAsyncioTestCase):
             StubAgentMessageHandler, "handle", autospec=True
         ) as handler_mock, async_mock.patch.object(
             test_module, "ConnectionManager", autospec=True
-        ) as conn_mgr_mock:
+        ) as conn_mgr_mock, async_mock.patch.object(
+            test_module,
+            "get_version_from_message_type",
+            async_mock.CoroutineMock(return_value="1.1"),
+        ), async_mock.patch.object(
+            test_module,
+            "validate_get_response_version",
+            async_mock.CoroutineMock(return_value=("1.1", None)),
+        ):
             conn_mgr_mock.return_value = async_mock.MagicMock(
-                find_inbound_connection=async_mock.AsyncMock(
+                find_inbound_connection=async_mock.CoroutineMock(
                     return_value=async_mock.MagicMock(connection_id="dummy")
                 )
             )
@@ -152,7 +160,15 @@ class TestDispatcher(IsolatedAsyncioTestCase):
 
         with async_mock.patch.object(
             StubAgentMessageHandler, "handle", autospec=True
-        ) as handler_mock:
+        ) as handler_mock, async_mock.patch.object(
+            test_module,
+            "get_version_from_message_type",
+            async_mock.CoroutineMock(return_value="1.1"),
+        ), async_mock.patch.object(
+            test_module,
+            "validate_get_response_version",
+            async_mock.CoroutineMock(return_value=("1.1", None)),
+        ):
             await dispatcher.queue_message(
                 dispatcher.profile, make_inbound(message), rcv.send
             )
@@ -265,7 +281,15 @@ class TestDispatcher(IsolatedAsyncioTestCase):
 
         with async_mock.patch.object(
             StubAgentMessageHandler, "handle", autospec=True
-        ) as handler_mock:
+        ) as handler_mock, async_mock.patch.object(
+            test_module,
+            "get_version_from_message_type",
+            async_mock.CoroutineMock(return_value="1.1"),
+        ), async_mock.patch.object(
+            test_module,
+            "validate_get_response_version",
+            async_mock.CoroutineMock(return_value=("1.1", None)),
+        ):
             await dispatcher.queue_message(
                 dispatcher.profile, make_inbound(message), rcv.send
             )
@@ -317,17 +341,22 @@ class TestDispatcher(IsolatedAsyncioTestCase):
         await dispatcher.setup()
         rcv = Receiver()
         bad_messages = ["not even a dict", {"bad": "message"}]
-        for bad in bad_messages:
-            await dispatcher.queue_message(
-                dispatcher.profile, make_inbound(bad), rcv.send
-            )
-            await dispatcher.task_queue
-            assert rcv.messages and isinstance(rcv.messages[0][1], OutboundMessage)
-            payload = json.loads(rcv.messages[0][1].payload)
-            assert payload["@type"] == DIDCommPrefix.qualify_current(
-                ProblemReport.Meta.message_type
-            )
-            rcv.messages.clear()
+        with async_mock.patch.object(
+            test_module, "get_version_from_message_type", async_mock.CoroutineMock()
+        ), async_mock.patch.object(
+            test_module, "validate_get_response_version", async_mock.CoroutineMock()
+        ):
+            for bad in bad_messages:
+                await dispatcher.queue_message(
+                    dispatcher.profile, make_inbound(bad), rcv.send
+                )
+                await dispatcher.task_queue
+                assert rcv.messages and isinstance(rcv.messages[0][1], OutboundMessage)
+                payload = json.loads(rcv.messages[0][1].payload)
+                assert payload["@type"] == DIDCommPrefix.qualify_current(
+                    ProblemReport.Meta.message_type
+                )
+                rcv.messages.clear()
 
     async def test_bad_message_dispatch_problem_report_x(self):
         profile = make_profile()
@@ -387,7 +416,7 @@ class TestDispatcher(IsolatedAsyncioTestCase):
         message = StubAgentMessage()
         responder = test_module.DispatcherResponder(context, message, None)
         outbound_message = await responder.create_outbound(message)
-        with async_mock.patch.object(responder, "_send", async_mock.AsyncMock()):
+        with async_mock.patch.object(responder, "_send", async_mock.CoroutineMock()):
             await responder.send_outbound(outbound_message)
 
     async def test_create_send_webhook(self):
@@ -404,7 +433,7 @@ class TestDispatcher(IsolatedAsyncioTestCase):
         message = b"abc123xyz7890000"
         responder = test_module.DispatcherResponder(context, message, None)
         with async_mock.patch.object(
-            responder, "send_outbound", async_mock.AsyncMock()
+            responder, "send_outbound", async_mock.CoroutineMock()
         ) as mock_send_outbound:
             await responder.send(message)
             assert mock_send_outbound.called_once()
@@ -425,3 +454,91 @@ class TestDispatcher(IsolatedAsyncioTestCase):
 
         with self.assertRaises(RuntimeError):
             await responder.send_webhook("test", {})
+
+    # async def test_dispatch_version_with_degraded_features(self):
+    #     profile = make_profile()
+    #     registry = profile.inject(ProtocolRegistry)
+    #     registry.register_message_types(
+    #         {
+    #             pfx.qualify(StubAgentMessage.Meta.message_type): StubAgentMessage
+    #             for pfx in DIDCommPrefix
+    #         }
+    #     )
+    #     dispatcher = test_module.Dispatcher(profile)
+    #     await dispatcher.setup()
+    #     rcv = Receiver()
+    #     message = {
+    #         "@type": DIDCommPrefix.qualify_current(StubAgentMessage.Meta.message_type)
+    #     }
+
+    #     with async_mock.patch.object(
+    #         test_module,
+    #         "get_version_from_message_type",
+    #         async_mock.CoroutineMock(return_value="1.1"),
+    #     ), async_mock.patch.object(
+    #         test_module,
+    #         "validate_get_response_version",
+    #         async_mock.CoroutineMock(return_value=("1.1", "fields-ignored-due-to-version-mismatch")),
+    #     ):
+    #         await dispatcher.queue_message(
+    #             dispatcher.profile, make_inbound(message), rcv.send
+    #         )
+
+    # async def test_dispatch_fields_ignored_due_to_version_mismatch(self):
+    #     profile = make_profile()
+    #     registry = profile.inject(ProtocolRegistry)
+    #     registry.register_message_types(
+    #         {
+    #             pfx.qualify(StubAgentMessage.Meta.message_type): StubAgentMessage
+    #             for pfx in DIDCommPrefix
+    #         }
+    #     )
+    #     dispatcher = test_module.Dispatcher(profile)
+    #     await dispatcher.setup()
+    #     rcv = Receiver()
+    #     message = {
+    #         "@type": DIDCommPrefix.qualify_current(StubAgentMessage.Meta.message_type)
+    #     }
+
+    #     with async_mock.patch.object(
+    #         test_module,
+    #         "get_version_from_message_type",
+    #         async_mock.CoroutineMock(return_value="1.1"),
+    #     ), async_mock.patch.object(
+    #         test_module,
+    #         "validate_get_response_version",
+    #         async_mock.CoroutineMock(return_value=("1.1", "version-with-degraded-features")),
+    #     ):
+    #         await dispatcher.queue_message(
+    #             dispatcher.profile, make_inbound(message), rcv.send
+    #         )
+
+    # async def test_dispatch_version_not_supported(self):
+    #     profile = make_profile()
+    #     registry = profile.inject(ProtocolRegistry)
+    #     registry.register_message_types(
+    #         {
+    #             pfx.qualify(StubAgentMessage.Meta.message_type): StubAgentMessage
+    #             for pfx in DIDCommPrefix
+    #         }
+    #     )
+    #     dispatcher = test_module.Dispatcher(profile)
+    #     await dispatcher.setup()
+    #     rcv = Receiver()
+    #     message = {
+    #         "@type": DIDCommPrefix.qualify_current(StubAgentMessage.Meta.message_type)
+    #     }
+
+    #     with async_mock.patch.object(
+    #         test_module,
+    #         "get_version_from_message_type",
+    #         async_mock.CoroutineMock(return_value="1.1"),
+    #     ), async_mock.patch.object(
+    #         test_module,
+    #         "validate_get_response_version",
+    #         async_mock.CoroutineMock(return_value=("1.1", "version-not-supported")),
+    #     ):
+    #         with self.assertRaises(test_module.MessageParseError):
+    #             await dispatcher.queue_message(
+    #                 dispatcher.profile, make_inbound(message), rcv.send
+    #             )

--- a/aries_cloudagent/core/tests/test_dispatcher.py
+++ b/aries_cloudagent/core/tests/test_dispatcher.py
@@ -1,7 +1,7 @@
 import json
 
 from async_case import IsolatedAsyncioTestCase
-from asynctest import mock as async_mock
+import mock as async_mock
 import pytest
 
 from marshmallow import EXCLUDE
@@ -114,14 +114,14 @@ class TestDispatcher(IsolatedAsyncioTestCase):
         ) as conn_mgr_mock, async_mock.patch.object(
             test_module,
             "get_version_from_message_type",
-            async_mock.CoroutineMock(return_value="1.1"),
+            async_mock.AsyncMock(return_value="1.1"),
         ), async_mock.patch.object(
             test_module,
             "validate_get_response_version",
-            async_mock.CoroutineMock(return_value=("1.1", None)),
+            async_mock.AsyncMock(return_value=("1.1", None)),
         ):
             conn_mgr_mock.return_value = async_mock.MagicMock(
-                find_inbound_connection=async_mock.CoroutineMock(
+                find_inbound_connection=async_mock.AsyncMock(
                     return_value=async_mock.MagicMock(connection_id="dummy")
                 )
             )
@@ -163,11 +163,11 @@ class TestDispatcher(IsolatedAsyncioTestCase):
         ) as handler_mock, async_mock.patch.object(
             test_module,
             "get_version_from_message_type",
-            async_mock.CoroutineMock(return_value="1.1"),
+            async_mock.AsyncMock(return_value="1.1"),
         ), async_mock.patch.object(
             test_module,
             "validate_get_response_version",
-            async_mock.CoroutineMock(return_value=("1.1", None)),
+            async_mock.AsyncMock(return_value=("1.1", None)),
         ):
             await dispatcher.queue_message(
                 dispatcher.profile, make_inbound(message), rcv.send
@@ -284,11 +284,11 @@ class TestDispatcher(IsolatedAsyncioTestCase):
         ) as handler_mock, async_mock.patch.object(
             test_module,
             "get_version_from_message_type",
-            async_mock.CoroutineMock(return_value="1.1"),
+            async_mock.AsyncMock(return_value="1.1"),
         ), async_mock.patch.object(
             test_module,
             "validate_get_response_version",
-            async_mock.CoroutineMock(return_value=("1.1", None)),
+            async_mock.AsyncMock(return_value=("1.1", None)),
         ):
             await dispatcher.queue_message(
                 dispatcher.profile, make_inbound(message), rcv.send
@@ -342,9 +342,9 @@ class TestDispatcher(IsolatedAsyncioTestCase):
         rcv = Receiver()
         bad_messages = ["not even a dict", {"bad": "message"}]
         with async_mock.patch.object(
-            test_module, "get_version_from_message_type", async_mock.CoroutineMock()
+            test_module, "get_version_from_message_type", async_mock.AsyncMock()
         ), async_mock.patch.object(
-            test_module, "validate_get_response_version", async_mock.CoroutineMock()
+            test_module, "validate_get_response_version", async_mock.AsyncMock()
         ):
             for bad in bad_messages:
                 await dispatcher.queue_message(
@@ -416,7 +416,7 @@ class TestDispatcher(IsolatedAsyncioTestCase):
         message = StubAgentMessage()
         responder = test_module.DispatcherResponder(context, message, None)
         outbound_message = await responder.create_outbound(message)
-        with async_mock.patch.object(responder, "_send", async_mock.CoroutineMock()):
+        with async_mock.patch.object(responder, "_send", async_mock.AsyncMock()):
             await responder.send_outbound(outbound_message)
 
     async def test_create_send_webhook(self):
@@ -433,7 +433,7 @@ class TestDispatcher(IsolatedAsyncioTestCase):
         message = b"abc123xyz7890000"
         responder = test_module.DispatcherResponder(context, message, None)
         with async_mock.patch.object(
-            responder, "send_outbound", async_mock.CoroutineMock()
+            responder, "send_outbound", async_mock.AsyncMock()
         ) as mock_send_outbound:
             await responder.send(message)
             assert mock_send_outbound.called_once()
@@ -474,11 +474,11 @@ class TestDispatcher(IsolatedAsyncioTestCase):
     #     with async_mock.patch.object(
     #         test_module,
     #         "get_version_from_message_type",
-    #         async_mock.CoroutineMock(return_value="1.1"),
+    #         async_mock.AsyncMock(return_value="1.1"),
     #     ), async_mock.patch.object(
     #         test_module,
     #         "validate_get_response_version",
-    #         async_mock.CoroutineMock(return_value=("1.1", "fields-ignored-due-to-version-mismatch")),
+    #         async_mock.AsyncMock(return_value=("1.1", "fields-ignored-due-to-version-mismatch")),
     #     ):
     #         await dispatcher.queue_message(
     #             dispatcher.profile, make_inbound(message), rcv.send
@@ -503,11 +503,11 @@ class TestDispatcher(IsolatedAsyncioTestCase):
     #     with async_mock.patch.object(
     #         test_module,
     #         "get_version_from_message_type",
-    #         async_mock.CoroutineMock(return_value="1.1"),
+    #         async_mock.AsyncMock(return_value="1.1"),
     #     ), async_mock.patch.object(
     #         test_module,
     #         "validate_get_response_version",
-    #         async_mock.CoroutineMock(return_value=("1.1", "version-with-degraded-features")),
+    #         async_mock.AsyncMock(return_value=("1.1", "version-with-degraded-features")),
     #     ):
     #         await dispatcher.queue_message(
     #             dispatcher.profile, make_inbound(message), rcv.send
@@ -532,11 +532,11 @@ class TestDispatcher(IsolatedAsyncioTestCase):
     #     with async_mock.patch.object(
     #         test_module,
     #         "get_version_from_message_type",
-    #         async_mock.CoroutineMock(return_value="1.1"),
+    #         async_mock.AsyncMock(return_value="1.1"),
     #     ), async_mock.patch.object(
     #         test_module,
     #         "validate_get_response_version",
-    #         async_mock.CoroutineMock(return_value=("1.1", "version-not-supported")),
+    #         async_mock.AsyncMock(return_value=("1.1", "version-not-supported")),
     #     ):
     #         with self.assertRaises(test_module.MessageParseError):
     #             await dispatcher.queue_message(

--- a/aries_cloudagent/core/tests/test_protocol_registry.py
+++ b/aries_cloudagent/core/tests/test_protocol_registry.py
@@ -45,14 +45,16 @@ class TestProtocolRegistry(AsyncTestCase):
             assert matches == ()
 
     def test_create_msg_types_for_minor_version(self):
-        test_typesets = {
-            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/0.1/forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
-            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/0.1/invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
-            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/0.1/invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
-            "https://didcom.org/introduction-service/0.1/forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
-            "https://didcom.org/introduction-service/0.1/invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
-            "https://didcom.org/introduction-service/0.1/invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
-        }
+        test_typesets = (
+            {
+                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/0.1/forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
+                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/0.1/invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
+                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/0.1/invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
+                "https://didcom.org/introduction-service/0.1/forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
+                "https://didcom.org/introduction-service/0.1/invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
+                "https://didcom.org/introduction-service/0.1/invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
+            },
+        )
         test_version_def = {
             "current_minor_version": 1,
             "major_version": 0,
@@ -63,14 +65,16 @@ class TestProtocolRegistry(AsyncTestCase):
             test_typesets, test_version_def
         )
         assert not updated_typeset
-        test_typesets = {
-            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.0/fake-forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
-            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.0/fake-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
-            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.0/fake-invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
-            "https://didcom.org/introduction-service/1.0/fake-forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
-            "https://didcom.org/introduction-service/1.0/fake-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
-            "https://didcom.org/introduction-service/1.0/fake-invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
-        }
+        test_typesets = (
+            {
+                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.0/fake-forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
+                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.0/fake-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
+                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.0/fake-invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
+                "https://didcom.org/introduction-service/1.0/fake-forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
+                "https://didcom.org/introduction-service/1.0/fake-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
+                "https://didcom.org/introduction-service/1.0/fake-invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
+            },
+        )
         test_version_def = {
             "current_minor_version": 1,
             "major_version": 1,

--- a/aries_cloudagent/core/tests/test_protocol_registry.py
+++ b/aries_cloudagent/core/tests/test_protocol_registry.py
@@ -47,32 +47,12 @@ class TestProtocolRegistry(AsyncTestCase):
     def test_create_msg_types_for_minor_version(self):
         test_typesets = (
             {
-                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/0.1/forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
-                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/0.1/invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
-                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/0.1/invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
-                "https://didcom.org/introduction-service/0.1/forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
-                "https://didcom.org/introduction-service/0.1/invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
-                "https://didcom.org/introduction-service/0.1/invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
-            },
-        )
-        test_version_def = {
-            "current_minor_version": 1,
-            "major_version": 0,
-            "minimum_minor_version": 1,
-            "path": "v0_1",
-        }
-        updated_typeset = self.registry.create_msg_types_for_minor_version(
-            test_typesets, test_version_def
-        )
-        assert not updated_typeset
-        test_typesets = (
-            {
-                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.0/fake-forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
-                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.0/fake-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
-                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.0/fake-invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
-                "https://didcom.org/introduction-service/1.0/fake-forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
-                "https://didcom.org/introduction-service/1.0/fake-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
-                "https://didcom.org/introduction-service/1.0/fake-invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
+                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/$version/fake-forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
+                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/$version/fake-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
+                "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/$version/fake-invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
+                "https://didcom.org/introduction-service/$version/fake-forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
+                "https://didcom.org/introduction-service/$version/fake-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
+                "https://didcom.org/introduction-service/$version/fake-invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
             },
         )
         test_version_def = {
@@ -81,19 +61,20 @@ class TestProtocolRegistry(AsyncTestCase):
             "minimum_minor_version": 0,
             "path": "v0_1",
         }
-        updated_typeset = self.registry.create_msg_types_for_minor_version(
+        updated_typesets = self.registry.create_msg_types_for_minor_version(
             test_typesets, test_version_def
         )
+        updated_typeset = updated_typesets[0]
         assert (
-            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.1/fake-forward-invitation"
+            "https://didcom.org/introduction-service/1.0/fake-forward-invitation"
             in updated_typeset
         )
         assert (
-            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.1/fake-invitation"
+            "https://didcom.org/introduction-service/1.0/fake-invitation"
             in updated_typeset
         )
         assert (
-            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.1/fake-invitation-request"
+            "https://didcom.org/introduction-service/1.0/fake-invitation-request"
             in updated_typeset
         )
         assert (
@@ -110,7 +91,11 @@ class TestProtocolRegistry(AsyncTestCase):
         )
         assert (
             "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.0/fake-forward-invitation"
-            not in updated_typeset
+            in updated_typeset
+        )
+        assert (
+            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.1/fake-invitation-request"
+            in updated_typeset
         )
 
     async def test_disclosed(self):

--- a/aries_cloudagent/core/tests/test_protocol_registry.py
+++ b/aries_cloudagent/core/tests/test_protocol_registry.py
@@ -44,6 +44,71 @@ class TestProtocolRegistry(AsyncTestCase):
             matches = self.registry.protocols_matching_query(q)
             assert matches == ()
 
+    def test_create_msg_types_for_minor_version(self):
+        test_typesets = {
+            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/0.1/forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
+            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/0.1/invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
+            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/0.1/invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
+            "https://didcom.org/introduction-service/0.1/forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
+            "https://didcom.org/introduction-service/0.1/invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
+            "https://didcom.org/introduction-service/0.1/invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
+        }
+        test_version_def = {
+            "current_minor_version": 1,
+            "major_version": 0,
+            "minimum_minor_version": 1,
+            "path": "v0_1",
+        }
+        updated_typeset = self.registry.create_msg_types_for_minor_version(
+            test_typesets, test_version_def
+        )
+        assert not updated_typeset
+        test_typesets = {
+            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.0/fake-forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
+            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.0/fake-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
+            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.0/fake-invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
+            "https://didcom.org/introduction-service/1.0/fake-forward-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.forward_invitation.ForwardInvitation",
+            "https://didcom.org/introduction-service/1.0/fake-invitation": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation.Invitation",
+            "https://didcom.org/introduction-service/1.0/fake-invitation-request": "aries_cloudagent.protocols.introduction.v0_1.messages.invitation_request.InvitationRequest",
+        }
+        test_version_def = {
+            "current_minor_version": 1,
+            "major_version": 1,
+            "minimum_minor_version": 0,
+            "path": "v0_1",
+        }
+        updated_typeset = self.registry.create_msg_types_for_minor_version(
+            test_typesets, test_version_def
+        )
+        assert (
+            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.1/fake-forward-invitation"
+            in updated_typeset
+        )
+        assert (
+            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.1/fake-invitation"
+            in updated_typeset
+        )
+        assert (
+            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.1/fake-invitation-request"
+            in updated_typeset
+        )
+        assert (
+            "https://didcom.org/introduction-service/1.1/fake-forward-invitation"
+            in updated_typeset
+        )
+        assert (
+            "https://didcom.org/introduction-service/1.1/fake-invitation"
+            in updated_typeset
+        )
+        assert (
+            "https://didcom.org/introduction-service/1.1/fake-invitation-request"
+            in updated_typeset
+        )
+        assert (
+            "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/introduction-service/1.0/fake-forward-invitation"
+            not in updated_typeset
+        )
+
     async def test_disclosed(self):
         self.registry.register_message_types(
             {self.test_message_type: self.test_message_handler}

--- a/aries_cloudagent/core/tests/test_util.py
+++ b/aries_cloudagent/core/tests/test_util.py
@@ -1,0 +1,73 @@
+from async_case import IsolatedAsyncioTestCase
+
+from ...cache.base import BaseCache
+from ...cache.in_memory import InMemoryCache
+from ...core.in_memory import InMemoryProfile
+from ...core.profile import Profile
+from ...protocols.didcomm_prefix import DIDCommPrefix
+from ...protocols.introduction.v0_1.messages.invitation import Invitation
+from ...protocols.out_of_band.v1_0.messages.reuse import HandshakeReuse
+
+from .. import util as test_module
+
+
+def make_profile() -> Profile:
+    profile = InMemoryProfile.test_profile()
+    profile.context.injector.bind_instance(BaseCache, InMemoryCache())
+    return profile
+
+
+class TestUtils(IsolatedAsyncioTestCase):
+    async def test_validate_get_response_version(self):
+        profile = make_profile()
+        (resp_version, warning) = await test_module.validate_get_response_version(
+            profile, "1.1", HandshakeReuse
+        )
+        assert resp_version == "1.1"
+        assert not warning
+
+        # cached
+        (resp_version, warning) = await test_module.validate_get_response_version(
+            profile, "1.1", HandshakeReuse
+        )
+        assert resp_version == "1.1"
+        assert not warning
+
+        (resp_version, warning) = await test_module.validate_get_response_version(
+            profile, "1.0", HandshakeReuse
+        )
+        assert resp_version == "1.0"
+        assert warning == test_module.WARNING_DEGRADED_FEATURES
+
+        (resp_version, warning) = await test_module.validate_get_response_version(
+            profile, "1.2", HandshakeReuse
+        )
+        assert resp_version == "1.1"
+        assert warning == test_module.WARNING_VERSION_MISMATCH
+
+        with self.assertRaises(test_module.ProtocolMinorVersionNotSupported):
+            (resp_version, warning) = await test_module.validate_get_response_version(
+                profile, "0.0", Invitation
+            )
+
+        with self.assertRaises(Exception):
+            (resp_version, warning) = await test_module.validate_get_response_version(
+                profile, "1.0", Invitation
+            )
+
+    def test_get_version_from_message_type(self):
+        assert (
+            test_module.get_version_from_message_type(
+                DIDCommPrefix.qualify_current("out-of-band/1.1/handshake-reuse")
+            )
+            == "1.1"
+        )
+
+    def test_get_version_from_message(self):
+        assert test_module.get_version_from_message(HandshakeReuse()) == "1.0"
+
+    async def test_get_proto_default_version(self):
+        profile = make_profile()
+        assert (
+            await test_module.get_proto_default_version(profile, HandshakeReuse)
+        ) == "1.1"

--- a/aries_cloudagent/core/util.py
+++ b/aries_cloudagent/core/util.py
@@ -1,10 +1,145 @@
 """Core utilities and constants."""
 
+import inspect
+import os
 import re
 
+from typing import Optional, Tuple
+
+from ..cache.base import BaseCache
+from ..core.profile import Profile
+from ..messaging.agent_message import AgentMessage
+from ..utils.classloader import ClassLoader
+
+from .error import ProtocolMinorVersionNotSupported
 
 CORE_EVENT_PREFIX = "acapy::core::"
 STARTUP_EVENT_TOPIC = CORE_EVENT_PREFIX + "startup"
 STARTUP_EVENT_PATTERN = re.compile(f"^{STARTUP_EVENT_TOPIC}?$")
 SHUTDOWN_EVENT_TOPIC = CORE_EVENT_PREFIX + "shutdown"
 SHUTDOWN_EVENT_PATTERN = re.compile(f"^{SHUTDOWN_EVENT_TOPIC}?$")
+WARNING_DEGRADED_FEATURES = "version-with-degraded-features"
+WARNING_VERSION_MISMATCH = "fields-ignored-due-to-version-mismatch"
+WARNING_VERSION_NOT_SUPPORTED = "version-not-supported"
+
+
+async def validate_get_response_version(
+    profile: Profile, rec_version: str, msg_class: type
+) -> Tuple[str, Optional[str]]:
+    """
+    Return a tuple with version to respond with and warnings.
+
+    Process received version and protocol version definition,
+    returns the tuple.
+
+    Args:
+        profile: Profile
+        rec_version: received version from message
+        msg_class: type
+
+    Returns:
+        Tuple with response version and any warnings
+
+    """
+    resp_version = rec_version
+    warning = None
+    version_string_tokens = rec_version.split(".")
+    rec_major_version = int(version_string_tokens[0])
+    rec_minor_version = int(version_string_tokens[1])
+    version_definition = await get_version_def_from_msg_class(
+        profile, msg_class, rec_major_version
+    )
+    proto_major_version = int(version_definition["major_version"])
+    proto_curr_minor_version = int(version_definition["current_minor_version"])
+    proto_min_minor_version = int(version_definition["minimum_minor_version"])
+    if rec_minor_version < proto_min_minor_version:
+        warning = WARNING_VERSION_NOT_SUPPORTED
+    elif (
+        rec_minor_version >= proto_min_minor_version
+        and rec_minor_version < proto_curr_minor_version
+    ):
+        warning = WARNING_DEGRADED_FEATURES
+    elif rec_minor_version > proto_curr_minor_version:
+        warning = WARNING_VERSION_MISMATCH
+    if proto_major_version == rec_major_version:
+        if (
+            proto_min_minor_version <= rec_minor_version
+            and proto_curr_minor_version >= rec_minor_version
+        ):
+            resp_version = f"{str(proto_major_version)}.{str(rec_minor_version)}"
+        elif rec_minor_version > proto_curr_minor_version:
+            resp_version = f"{str(proto_major_version)}.{str(proto_curr_minor_version)}"
+        elif rec_minor_version < proto_min_minor_version:
+            raise ProtocolMinorVersionNotSupported(
+                "Minimum supported minor version is "
+                + f"{proto_min_minor_version}."
+                + f" Received {rec_minor_version}."
+            )
+    else:
+        raise Exception(
+            f"Supported major version {proto_major_version}"
+            " is not same as received major version"
+            f" {rec_major_version}."
+        )
+    return (resp_version, warning)
+
+
+def get_version_from_message_type(msg_type: str) -> str:
+    """Return version from provided message_type."""
+    return (re.search(r"(\d+\.)?(\*|\d+)", msg_type)).group()
+
+
+def get_version_from_message(msg: AgentMessage) -> str:
+    """Return version from provided AgentMessage."""
+    msg_type = msg._type
+    return get_version_from_message_type(msg_type)
+
+
+async def get_proto_default_version(
+    profile: Profile, msg_class: type, major_version: int = 1
+):
+    """Return default protocol version from version_definition."""
+    version_definition = await get_version_def_from_msg_class(
+        profile, msg_class, major_version
+    )
+    default_major_version = version_definition["major_version"]
+    default_minor_version = version_definition["current_minor_version"]
+    return f"{default_major_version}.{default_minor_version}"
+
+
+def _get_path_from_msg_class(msg_class: type) -> str:
+    path = os.path.normpath(inspect.getfile(msg_class))
+    split_str = os.getenv("ACAPY_HOME") or "aries_cloudagent"
+    path = split_str + path.rsplit(split_str, 1)[1]
+    version = (re.search(r"v(\d+\_)?(\*|\d+)", path)).group()
+    path = path.split(version, 1)[0]
+    return (path.replace("/", ".")) + "definition"
+
+
+async def get_version_def_from_msg_class(
+    profile: Profile, msg_class: type, major_version: int = 1
+):
+    """Return version_definition of a protocol."""
+    cache = profile.inject_or(BaseCache)
+    version_definition = None
+    if cache:
+        version_definition = await cache.get(
+            f"version_definition::{str(msg_class).lower()}"
+        )
+        if version_definition:
+            return version_definition
+    definition_path = _get_path_from_msg_class(msg_class)
+    definition = ClassLoader.load_module(definition_path)
+    for protocol_version in definition.versions:
+        if major_version == protocol_version["major_version"]:
+            version_definition = protocol_version
+            break
+    if not version_definition:
+        raise Exception(
+            f"Unable to load protocol version_definition for {str(msg_class)}"
+        )
+    if cache:
+        await cache.set(
+            f"version_definition::{str(msg_class).lower()}", version_definition
+        )
+    return version_definition

--- a/aries_cloudagent/core/util.py
+++ b/aries_cloudagent/core/util.py
@@ -11,7 +11,7 @@ from ..core.profile import Profile
 from ..messaging.agent_message import AgentMessage
 from ..utils.classloader import ClassLoader
 
-from .error import ProtocolMinorVersionNotSupported
+from .error import ProtocolMinorVersionNotSupported, ProtocolDefinitionValidationError
 
 CORE_EVENT_PREFIX = "acapy::core::"
 STARTUP_EVENT_TOPIC = CORE_EVENT_PREFIX + "startup"
@@ -76,7 +76,7 @@ async def validate_get_response_version(
                 + f" Received {rec_minor_version}."
             )
     else:
-        raise Exception(
+        raise ProtocolMinorVersionNotSupported(
             f"Supported major version {proto_major_version}"
             " is not same as received major version"
             f" {rec_major_version}."
@@ -135,7 +135,7 @@ async def get_version_def_from_msg_class(
             version_definition = protocol_version
             break
     if not version_definition:
-        raise Exception(
+        raise ProtocolDefinitionValidationError(
             f"Unable to load protocol version_definition for {str(msg_class)}"
         )
     if cache:

--- a/aries_cloudagent/core/util.py
+++ b/aries_cloudagent/core/util.py
@@ -97,7 +97,7 @@ def get_version_from_message(msg: AgentMessage) -> str:
 
 async def get_proto_default_version(
     profile: Profile, msg_class: type, major_version: int = 1
-):
+) -> str:
     """Return default protocol version from version_definition."""
     version_definition = await get_version_def_from_msg_class(
         profile, msg_class, major_version

--- a/aries_cloudagent/protocols/out_of_band/definition.py
+++ b/aries_cloudagent/protocols/out_of_band/definition.py
@@ -3,7 +3,7 @@
 versions = [
     {
         "major_version": 1,
-        "minimum_minor_version": 1,
+        "minimum_minor_version": 0,
         "current_minor_version": 1,
         "path": "v1_0",
     }

--- a/aries_cloudagent/protocols/out_of_band/definition.py
+++ b/aries_cloudagent/protocols/out_of_band/definition.py
@@ -3,8 +3,8 @@
 versions = [
     {
         "major_version": 1,
-        "minimum_minor_version": 0,
-        "current_minor_version": 0,
+        "minimum_minor_version": 1,
+        "current_minor_version": 1,
         "path": "v1_0",
     }
 ]

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -9,6 +9,7 @@ import uuid
 
 from ....messaging.decorators.service_decorator import ServiceDecorator
 from ....core.event_bus import EventBus
+from ....core.util import get_version_from_message
 from ....connections.base_manager import BaseConnectionManager
 from ....connections.models.conn_record import ConnRecord
 from ....core.error import BaseError
@@ -906,7 +907,9 @@ class OutOfBandManager(BaseConnectionManager):
         invi_msg_id = reuse_msg._thread.pthid
         reuse_msg_id = reuse_msg._thread_id
 
-        reuse_accept_msg = HandshakeReuseAccept()
+        reuse_accept_msg = HandshakeReuseAccept(
+            version=get_version_from_message(reuse_msg)
+        )
         reuse_accept_msg.assign_thread_id(thid=reuse_msg_id, pthid=invi_msg_id)
         connection_targets = await self.fetch_connection_targets(connection=conn_rec)
 

--- a/aries_cloudagent/protocols/out_of_band/v1_0/message_types.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/message_types.py
@@ -8,10 +8,10 @@ SPEC_URI = (
 )
 
 # Message types
-INVITATION = "out-of-band/1.0/invitation"
-MESSAGE_REUSE = "out-of-band/1.0/handshake-reuse"
-MESSAGE_REUSE_ACCEPT = "out-of-band/1.0/handshake-reuse-accepted"
-PROBLEM_REPORT = "out-of-band/1.0/problem_report"
+INVITATION = "out-of-band/$version/invitation"
+MESSAGE_REUSE = "out-of-band/$version/handshake-reuse"
+MESSAGE_REUSE_ACCEPT = "out-of-band/$version/handshake-reuse-accepted"
+PROBLEM_REPORT = "out-of-band/$version/problem_report"
 
 PROTOCOL_PACKAGE = "aries_cloudagent.protocols.out_of_band.v1_0"
 

--- a/aries_cloudagent/protocols/out_of_band/v1_0/messages/problem_report.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/messages/problem_report.py
@@ -10,6 +10,7 @@ from marshmallow import (
     validates_schema,
     ValidationError,
 )
+from string import Template
 
 from ....problem_report.v1_0.message import ProblemReport, ProblemReportSchema
 
@@ -21,6 +22,7 @@ HANDLER_CLASS = (
 )
 
 LOGGER = logging.getLogger(__name__)
+BASE_PROTO_VERSION = "1.0"
 
 
 class ProblemReportReason(Enum):
@@ -40,9 +42,17 @@ class OOBProblemReport(ProblemReport):
         message_type = PROBLEM_REPORT
         schema_class = "OOBProblemReportSchema"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, version: str = BASE_PROTO_VERSION, *args, **kwargs):
         """Initialize a ProblemReport message instance."""
         super().__init__(*args, **kwargs)
+        self.assign_version_to_message_type(version=version)
+
+    @classmethod
+    def assign_version_to_message_type(cls, version: str):
+        """Assign version to Meta.message_type."""
+        cls.Meta.message_type = Template(cls.Meta.message_type).substitute(
+            version=version
+        )
 
 
 class OOBProblemReportSchema(ProblemReportSchema):

--- a/aries_cloudagent/protocols/out_of_band/v1_0/messages/reuse.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/messages/reuse.py
@@ -1,6 +1,7 @@
 """Represents a Handshake Reuse message under RFC 0434."""
 
 from marshmallow import EXCLUDE, pre_dump, ValidationError
+from string import Template
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -9,6 +10,7 @@ from ..message_types import MESSAGE_REUSE, PROTOCOL_PACKAGE
 HANDLER_CLASS = (
     f"{PROTOCOL_PACKAGE}.handlers.reuse_handler.HandshakeReuseMessageHandler"
 )
+BASE_PROTO_VERSION = "1.0"
 
 
 class HandshakeReuse(AgentMessage):
@@ -23,10 +25,19 @@ class HandshakeReuse(AgentMessage):
 
     def __init__(
         self,
+        version: str = BASE_PROTO_VERSION,
         **kwargs,
     ):
         """Initialize Handshake Reuse message object."""
         super().__init__(**kwargs)
+        self.assign_version_to_message_type(version=version)
+
+    @classmethod
+    def assign_version_to_message_type(cls, version: str):
+        """Assign version to Meta.message_type."""
+        cls.Meta.message_type = Template(cls.Meta.message_type).substitute(
+            version=version
+        )
 
 
 class HandshakeReuseSchema(AgentMessageSchema):

--- a/aries_cloudagent/protocols/out_of_band/v1_0/messages/reuse_accept.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/messages/reuse_accept.py
@@ -1,6 +1,7 @@
 """Represents a Handshake Reuse Accept message under RFC 0434."""
 
 from marshmallow import EXCLUDE, pre_dump, ValidationError
+from string import Template
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 
@@ -10,6 +11,7 @@ HANDLER_CLASS = (
     f"{PROTOCOL_PACKAGE}.handlers"
     ".reuse_accept_handler.HandshakeReuseAcceptMessageHandler"
 )
+BASE_PROTO_VERSION = "1.0"
 
 
 class HandshakeReuseAccept(AgentMessage):
@@ -24,10 +26,19 @@ class HandshakeReuseAccept(AgentMessage):
 
     def __init__(
         self,
+        version: str = BASE_PROTO_VERSION,
         **kwargs,
     ):
         """Initialize Handshake Reuse Accept object."""
         super().__init__(**kwargs)
+        self.assign_version_to_message_type(version=version)
+
+    @classmethod
+    def assign_version_to_message_type(cls, version: str):
+        """Assign version to Meta.message_type."""
+        cls.Meta.message_type = Template(cls.Meta.message_type).substitute(
+            version=version
+        )
 
 
 class HandshakeReuseAcceptSchema(AgentMessageSchema):

--- a/aries_cloudagent/protocols/out_of_band/v1_0/messages/tests/test_invitation.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/messages/tests/test_invitation.py
@@ -1,5 +1,6 @@
 import pytest
 
+from string import Template
 from unittest import TestCase
 
 from ......messaging.models.base import BaseModelError
@@ -51,7 +52,9 @@ class TestInvitationMessage(TestCase):
             services=[TEST_DID],
         )
         assert invi.services == [TEST_DID]
-        assert invi._type == DIDCommPrefix.qualify_current(INVITATION)
+        assert invi._type == DIDCommPrefix.qualify_current(
+            Template(INVITATION).substitute(version="1.0")
+        )
 
         service = Service(_id="#inline", _type=DID_COMM, did=TEST_DID)
         invi_msg = InvitationMessage(
@@ -61,7 +64,9 @@ class TestInvitationMessage(TestCase):
             services=[service],
         )
         assert invi_msg.services == [service]
-        assert invi_msg._type == DIDCommPrefix.qualify_current(INVITATION)
+        assert invi_msg._type == DIDCommPrefix.qualify_current(
+            Template(INVITATION).substitute(version="1.0")
+        )
 
     def test_wrap_serde(self):
         """Test conversion of aries message to attachment decorator."""

--- a/aries_cloudagent/protocols/out_of_band/v1_0/routes.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/routes.py
@@ -75,6 +75,15 @@ class InvitationCreateRequestSchema(OpenAPISchema):
         ),
         required=False,
     )
+    # accept = fields.List(
+    #     fields.Str(),
+    #     description=(
+    #         "List of mime type in order of preference that should be"
+    #         " use in responding to the message"
+    #     ),
+    #     example="['didcomm/aip1', 'didcomm/aip2;env=rfc19']",
+    #     required=False,
+    # )
     use_public_did = fields.Boolean(
         default=False,
         description="Whether to use public DID in invitation",

--- a/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
@@ -3,6 +3,7 @@
 import json
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
+from string import Template
 from typing import List
 from unittest.mock import ANY
 
@@ -388,7 +389,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             )
 
             assert invi_rec.invitation._type == DIDCommPrefix.qualify_current(
-                INVITATION
+                Template(INVITATION).substitute(version="1.0")
             )
             assert not invi_rec.invitation.requests_attach
             assert (
@@ -475,7 +476,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 )
                 assert isinstance(invite, InvitationRecord)
                 assert invite.invitation._type == DIDCommPrefix.qualify_current(
-                    INVITATION
+                    Template(INVITATION).substitute(version="1.0")
                 )
                 assert invite.invitation.label == "test123"
                 assert (
@@ -793,7 +794,9 @@ class TestOOBManager(AsyncTestCase, TestConfig):
 
                 assert invi_rec._invitation.ser[
                     "@type"
-                ] == DIDCommPrefix.qualify_current(INVITATION)
+                ] == DIDCommPrefix.qualify_current(
+                    Template(INVITATION).substitute(version="1.0")
+                )
                 assert not invi_rec._invitation.ser.get("requests~attach")
                 assert invi_rec.invitation.label == "That guy"
                 assert (
@@ -900,7 +903,9 @@ class TestOOBManager(AsyncTestCase, TestConfig):
             assert oob_record.state == OobRecord.STATE_AWAIT_RESPONSE
 
             # Assert responder has been called with the reuse message
-            assert reuse_message._type == DIDCommPrefix.qualify_current(MESSAGE_REUSE)
+            assert reuse_message._type == DIDCommPrefix.qualify_current(
+                Template(MESSAGE_REUSE).substitute(version="1.0")
+            )
             assert oob_record.reuse_msg_id == reuse_message._id
 
     async def test_create_handshake_reuse_msg_catch_exception(self):


### PR DESCRIPTION
Signed-off-by: Shaanjot Gill [gill.shaanjots@gmail.com](mailto:gill.shaanjots@gmail.com)

- resolve #1917
- Fixes the following error:
```
File "/home/indy/.venv/lib/python3.6/site-packages/aries_cloudagent/utils/classloader.py", line 97, in load_class
   |     if "." in class_name:
   | TypeError: argument of type 'NoneType' is not iterable
```
- Working on adding minor changes for adding OOB 1.1 and a mechanism for ACA-Py to respond with the same supported version, basically, `handshake-reuse-accepted 1.1` for `handshake-reuse 1.1` and `handshake-reuse-accepted 1.0` for `handshake-reuse 1.0`. 