### PR TITLE
did method registry

### DIFF
--- a/aries_cloudagent/config/default_context.py
+++ b/aries_cloudagent/config/default_context.py
@@ -1,27 +1,26 @@
 """Classes for configuring the default injection context."""
 
-from .base_context import ContextBuilder
-from .injection_context import InjectionContext
-from .provider import CachedProvider, ClassProvider
-
 from ..cache.base import BaseCache
 from ..cache.in_memory import InMemoryCache
 from ..core.event_bus import EventBus
+from ..core.goal_code_registry import GoalCodeRegistry
 from ..core.plugin_registry import PluginRegistry
 from ..core.profile import ProfileManager, ProfileManagerProvider
 from ..core.protocol_registry import ProtocolRegistry
-from ..core.goal_code_registry import GoalCodeRegistry
-from ..resolver.did_resolver import DIDResolver
-from ..tails.base import BaseTailsServer
-
 from ..protocols.actionmenu.v1_0.base_service import BaseMenuService
 from ..protocols.actionmenu.v1_0.driver_service import DriverMenuService
 from ..protocols.didcomm_prefix import DIDCommPrefix
 from ..protocols.introduction.v0_1.base_service import BaseIntroductionService
 from ..protocols.introduction.v0_1.demo_service import DemoIntroductionService
+from ..resolver.did_resolver import DIDResolver
+from ..tails.base import BaseTailsServer
 from ..transport.wire_format import BaseWireFormat
-from ..utils.stats import Collector
 from ..utils.dependencies import is_indy_sdk_module_installed
+from ..utils.stats import Collector
+from ..wallet.did_method import DIDMethods
+from .base_context import ContextBuilder
+from .injection_context import InjectionContext
+from .provider import CachedProvider, ClassProvider
 
 
 class DefaultContextBuilder(ContextBuilder):
@@ -51,6 +50,7 @@ class DefaultContextBuilder(ContextBuilder):
 
         # Global did resolver
         context.injector.bind_instance(DIDResolver, DIDResolver([]))
+        context.injector.bind_instance(DIDMethods, DIDMethods())
 
         await self.bind_providers(context)
         await self.load_plugins(context)

--- a/aries_cloudagent/config/wallet.py
+++ b/aries_cloudagent/config/wallet.py
@@ -11,7 +11,7 @@ from ..version import RECORD_TYPE_ACAPY_VERSION, __version__
 from ..wallet.base import BaseWallet
 from ..wallet.crypto import seed_to_did
 from ..wallet.did_info import DIDInfo
-from ..wallet.did_method import DIDMethod
+from ..wallet.did_method import SOV
 from ..wallet.key_type import KeyType
 from .base import ConfigError
 from .injection_context import InjectionContext
@@ -79,7 +79,7 @@ async def wallet_config(
         if wallet_seed and seed_to_did(wallet_seed) != public_did:
             if context.settings.get("wallet.replace_public_did"):
                 replace_did_info = await wallet.create_local_did(
-                    method=DIDMethod.SOV, key_type=KeyType.ED25519, seed=wallet_seed
+                    method=SOV, key_type=KeyType.ED25519, seed=wallet_seed
                 )
                 public_did = replace_did_info.did
                 await wallet.set_public_did(public_did)
@@ -99,7 +99,7 @@ async def wallet_config(
             metadata = {"endpoint": endpoint} if endpoint else None
 
             local_did_info = await wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=wallet_seed,
                 metadata=metadata,
@@ -110,7 +110,7 @@ async def wallet_config(
                 print(f"Verkey: {local_did_info.verkey}")
         else:
             public_did_info = await wallet.create_public_did(
-                method=DIDMethod.SOV, key_type=KeyType.ED25519, seed=wallet_seed
+                method=SOV, key_type=KeyType.ED25519, seed=wallet_seed
             )
             public_did = public_did_info.did
             if provision:
@@ -128,7 +128,7 @@ async def wallet_config(
             test_seed = "testseed000000000000000000000001"
     if test_seed:
         await wallet.create_local_did(
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
             seed=test_seed,
             metadata={"endpoint": "1.2.3.4:8021"},

--- a/aries_cloudagent/core/tests/test_conductor.py
+++ b/aries_cloudagent/core/tests/test_conductor.py
@@ -41,7 +41,7 @@ from ...utils.stats import Collector
 from ...version import __version__
 from ...wallet.base import BaseWallet
 from ...wallet.key_type import KeyType
-from ...wallet.did_method import DIDMethod
+from ...wallet.did_method import SOV
 
 from .. import conductor as test_module
 
@@ -131,7 +131,7 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
 
             wallet = session.inject(BaseWallet)
             await wallet.create_public_did(
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
 
@@ -600,7 +600,7 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
         session = await conductor.root_profile.session()
         wallet = session.inject(BaseWallet)
         await wallet.create_public_did(
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
         )
 
@@ -644,7 +644,7 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
         session = await conductor.root_profile.session()
         wallet = session.inject(BaseWallet)
         await wallet.create_public_did(
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
         )
 
@@ -716,7 +716,7 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
             session = await conductor.root_profile.session()
             wallet = session.inject(BaseWallet)
             await wallet.create_public_did(
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
 
@@ -886,7 +886,7 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
             session = await conductor.root_profile.session()
             wallet = session.inject(BaseWallet)
             await wallet.create_public_did(
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
 
@@ -1389,7 +1389,7 @@ class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
 
             wallet = session.inject(BaseWallet)
             await wallet.create_public_did(
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
 
@@ -1426,7 +1426,7 @@ class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
 
             wallet = session.inject(BaseWallet)
             await wallet.create_public_did(
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
 

--- a/aries_cloudagent/ledger/tests/test_indy.py
+++ b/aries_cloudagent/ledger/tests/test_indy.py
@@ -20,7 +20,7 @@ from ...wallet.did_posture import DIDPosture
 from ...wallet.error import WalletNotFoundError
 from ...wallet.indy import IndyOpenWallet, IndySdkWallet
 from ...wallet.key_type import KeyType
-from ...wallet.did_method import DIDMethod
+from ...wallet.did_method import SOV
 
 from ..endpoint_type import EndpointType
 from ..indy import (
@@ -70,7 +70,7 @@ class TestIndySdkLedger(AsyncTestCase):
             did=self.test_did,
             verkey="3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx",
             metadata={"test": "test"},
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
         self.test_verkey = "3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"
@@ -1219,7 +1219,7 @@ class TestIndySdkLedger(AsyncTestCase):
                     did=self.test_did,
                     verkey=self.test_verkey,
                     metadata=None,
-                    method=DIDMethod.SOV,
+                    method=SOV,
                     key_type=KeyType.ED25519,
                 )
                 mock_did = mock_wallet_get_public_did.return_value
@@ -1299,7 +1299,7 @@ class TestIndySdkLedger(AsyncTestCase):
                 self.test_did,
                 self.test_verkey,
                 None,
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             async with ledger:
@@ -1382,7 +1382,7 @@ class TestIndySdkLedger(AsyncTestCase):
                 did=self.test_did,
                 verkey=self.test_verkey,
                 metadata=None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
 
@@ -1794,7 +1794,7 @@ class TestIndySdkLedger(AsyncTestCase):
                     did=self.test_did,
                     verkey=self.test_verkey,
                     metadata=None,
-                    method=DIDMethod.SOV,
+                    method=SOV,
                     key_type=KeyType.ED25519,
                 )
                 mock_did = mock_wallet_get_public_did.return_value
@@ -1868,7 +1868,7 @@ class TestIndySdkLedger(AsyncTestCase):
                 did=self.test_did,
                 verkey=self.test_verkey,
                 metadata=None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             async with ledger:

--- a/aries_cloudagent/ledger/tests/test_indy_vdr.py
+++ b/aries_cloudagent/ledger/tests/test_indy_vdr.py
@@ -10,7 +10,7 @@ from ...core.in_memory import InMemoryProfile
 from ...indy.issuer import IndyIssuer
 from ...wallet.base import BaseWallet
 from ...wallet.key_type import KeyType
-from ...wallet.did_method import DIDMethod
+from ...wallet.did_method import SOV
 from ...wallet.did_info import DIDInfo
 
 from ..endpoint_type import EndpointType
@@ -67,7 +67,7 @@ class TestIndyVdrLedger:
         ledger: IndyVdrLedger,
     ):
         wallet = (await ledger.profile.session()).wallet
-        test_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        test_did = await wallet.create_public_did(SOV, KeyType.ED25519)
         test_msg = indy_vdr.ledger.build_get_txn_request(test_did.did, 1, 1)
 
         async with ledger:
@@ -120,7 +120,7 @@ class TestIndyVdrLedger:
         ledger: IndyVdrLedger,
     ):
         wallet = (await ledger.profile.session()).wallet
-        test_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        test_did = await wallet.create_public_did(SOV, KeyType.ED25519)
 
         async with ledger:
             test_msg = indy_vdr.ledger.build_get_txn_request(test_did.did, 1, 1)
@@ -188,7 +188,7 @@ class TestIndyVdrLedger:
             with pytest.raises(BadLedgerRequestError):
                 await ledger.txn_endorse(request_json=test_msg.body)
 
-            test_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+            test_did = await wallet.create_public_did(SOV, KeyType.ED25519)
             test_msg.set_endorser(test_did.did)
 
             endorsed_json = await ledger.txn_endorse(request_json=test_msg.body)
@@ -201,7 +201,7 @@ class TestIndyVdrLedger:
         ledger: IndyVdrLedger,
     ):
         wallet = (await ledger.profile.session()).wallet
-        test_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        test_did = await wallet.create_public_did(SOV, KeyType.ED25519)
         issuer = async_mock.MagicMock(IndyIssuer)
         issuer.create_schema.return_value = (
             "schema_issuer_did:schema_name:9.1",
@@ -262,7 +262,7 @@ class TestIndyVdrLedger:
         ledger: IndyVdrLedger,
     ):
         wallet = (await ledger.profile.session()).wallet
-        test_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        test_did = await wallet.create_public_did(SOV, KeyType.ED25519)
         issuer = async_mock.MagicMock(IndyIssuer)
         issuer.create_schema.return_value = (
             "schema_issuer_did:schema_name:9.1",
@@ -292,7 +292,7 @@ class TestIndyVdrLedger:
         ledger: IndyVdrLedger,
     ):
         wallet = (await ledger.profile.session()).wallet
-        test_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        test_did = await wallet.create_public_did(SOV, KeyType.ED25519)
         issuer = async_mock.MagicMock(IndyIssuer)
         issuer.create_schema.return_value = (
             "schema_issuer_did:schema_name:9.1",
@@ -321,7 +321,7 @@ class TestIndyVdrLedger:
         ledger: IndyVdrLedger,
     ):
         wallet = (await ledger.profile.session()).wallet
-        test_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        test_did = await wallet.create_public_did(SOV, KeyType.ED25519)
         issuer = async_mock.MagicMock(IndyIssuer)
         issuer.create_schema.return_value = (
             "schema_issuer_did:schema_name:9.1",
@@ -383,7 +383,7 @@ class TestIndyVdrLedger:
         ledger: IndyVdrLedger,
     ):
         wallet = (await ledger.profile.session()).wallet
-        test_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        test_did = await wallet.create_public_did(SOV, KeyType.ED25519)
         schema_id = "55GkHamhTU1ZbTbV2ab9DE:2:schema_name:9.1"
         cred_def_id = "55GkHamhTU1ZbTbV2ab9DE:3:CL:99:tag"
         cred_def = {
@@ -598,7 +598,7 @@ class TestIndyVdrLedger:
         ledger: IndyVdrLedger,
     ):
         wallet = (await ledger.profile.session()).wallet
-        test_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        test_did = await wallet.create_public_did(SOV, KeyType.ED25519)
         async with ledger:
             ledger.pool_handle.submit_request.side_effect = (
                 {"data": None},
@@ -675,7 +675,7 @@ class TestIndyVdrLedger:
     async def test_update_endpoint_for_did_calls_attr_json(self, ledger: IndyVdrLedger):
         routing_keys = ["3YJCx3TqotDWFGv7JMR5erEvrmgu5y4FDqjR7sKWxgXn"]
         wallet = (await ledger.profile.session()).wallet
-        test_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        test_did = await wallet.create_public_did(SOV, KeyType.ED25519)
 
         async with ledger:
             with async_mock.patch.object(
@@ -742,8 +742,8 @@ class TestIndyVdrLedger:
         ledger: IndyVdrLedger,
     ):
         wallet: BaseWallet = (await ledger.profile.session()).wallet
-        public_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
-        post_did = await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519)
+        public_did = await wallet.create_public_did(SOV, KeyType.ED25519)
+        post_did = await wallet.create_local_did(SOV, KeyType.ED25519)
         async with ledger:
             await ledger.register_nym(post_did.did, post_did.verkey)
         did = await wallet.get_local_did(post_did.did)
@@ -755,7 +755,7 @@ class TestIndyVdrLedger:
         ledger: IndyVdrLedger,
     ):
         wallet: BaseWallet = (await ledger.profile.session()).wallet
-        public_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        public_did = await wallet.create_public_did(SOV, KeyType.ED25519)
         async with ledger:
             await ledger.register_nym("55GkHamhTU1ZbTbV2ab9DE", "verkey")
 
@@ -898,7 +898,7 @@ class TestIndyVdrLedger:
         ledger: IndyVdrLedger,
     ):
         wallet: BaseWallet = (await ledger.profile.session()).wallet
-        public_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        public_did = await wallet.create_public_did(SOV, KeyType.ED25519)
         async with ledger:
             reg_id = (
                 "55GkHamhTU1ZbTbV2ab9DE:4:55GkHamhTU1ZbTbV2ab9DE:3:CL:99:tag:CL_ACCUM:0"
@@ -927,7 +927,7 @@ class TestIndyVdrLedger:
         ledger: IndyVdrLedger,
     ):
         wallet: BaseWallet = (await ledger.profile.session()).wallet
-        public_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        public_did = await wallet.create_public_did(SOV, KeyType.ED25519)
         async with ledger:
             reg_id = (
                 "55GkHamhTU1ZbTbV2ab9DE:4:55GkHamhTU1ZbTbV2ab9DE:3:CL:99:tag:CL_ACCUM:0"
@@ -966,7 +966,7 @@ class TestIndyVdrLedger:
     @pytest.mark.asyncio
     async def test_rotate_did_keypair(self, ledger: IndyVdrLedger):
         wallet = (await ledger.profile.session()).wallet
-        public_did = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        public_did = await wallet.create_public_did(SOV, KeyType.ED25519)
 
         async with ledger:
             with async_mock.patch.object(

--- a/aries_cloudagent/ledger/tests/test_indy_vdr.py
+++ b/aries_cloudagent/ledger/tests/test_indy_vdr.py
@@ -980,5 +980,5 @@ class TestIndyVdrLedger:
                     ]
                 ),
             ):
-                ledger.profile.context.injector.bind_instance(DIDMethods,DIDMethods())
+                ledger.profile.context.injector.bind_instance(DIDMethods, DIDMethods())
                 await ledger.rotate_public_did_keypair()

--- a/aries_cloudagent/ledger/tests/test_indy_vdr.py
+++ b/aries_cloudagent/ledger/tests/test_indy_vdr.py
@@ -10,7 +10,7 @@ from ...core.in_memory import InMemoryProfile
 from ...indy.issuer import IndyIssuer
 from ...wallet.base import BaseWallet
 from ...wallet.key_type import KeyType
-from ...wallet.did_method import SOV
+from ...wallet.did_method import SOV, DIDMethods
 from ...wallet.did_info import DIDInfo
 
 from ..endpoint_type import EndpointType
@@ -980,4 +980,5 @@ class TestIndyVdrLedger:
                     ]
                 ),
             ):
+                ledger.profile.context.injector.bind_instance(DIDMethods,DIDMethods())
                 await ledger.rotate_public_did_keypair()

--- a/aries_cloudagent/messaging/decorators/tests/test_attach_decorator.py
+++ b/aries_cloudagent/messaging/decorators/tests/test_attach_decorator.py
@@ -11,7 +11,7 @@ from ....messaging.models.base import BaseModelError
 from ....wallet.indy import IndySdkWallet
 from ....wallet.util import b64_to_bytes, bytes_to_b64
 from ....wallet.key_type import KeyType
-from ....wallet.did_method import DIDMethod
+from ....wallet.did_method import SOV
 
 from ..attach_decorator import (
     AttachDecorator,
@@ -434,7 +434,7 @@ class TestAttachDecoratorSignature:
     @pytest.mark.asyncio
     async def test_did_raw_key(self, wallet, seed):
         did_info = await wallet.create_local_did(
-            DIDMethod.SOV, KeyType.ED25519, seed[0]
+            SOV, KeyType.ED25519, seed[0]
         )
         did_key0 = did_key(did_info.verkey)
         raw_key0 = raw_key(did_key0)
@@ -457,7 +457,7 @@ class TestAttachDecoratorSignature:
         )
         deco_indy_master = deepcopy(deco_indy)
         did_info = [
-            await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519, seed[i])
+            await wallet.create_local_did(SOV, KeyType.ED25519, seed[i])
             for i in [0, 1]
         ]
         assert deco_indy.data.signatures == 0

--- a/aries_cloudagent/messaging/decorators/tests/test_attach_decorator.py
+++ b/aries_cloudagent/messaging/decorators/tests/test_attach_decorator.py
@@ -433,9 +433,7 @@ class TestAttachDecorator(TestCase):
 class TestAttachDecoratorSignature:
     @pytest.mark.asyncio
     async def test_did_raw_key(self, wallet, seed):
-        did_info = await wallet.create_local_did(
-            SOV, KeyType.ED25519, seed[0]
-        )
+        did_info = await wallet.create_local_did(SOV, KeyType.ED25519, seed[0])
         did_key0 = did_key(did_info.verkey)
         raw_key0 = raw_key(did_key0)
         assert raw_key0 != did_key0
@@ -457,8 +455,7 @@ class TestAttachDecoratorSignature:
         )
         deco_indy_master = deepcopy(deco_indy)
         did_info = [
-            await wallet.create_local_did(SOV, KeyType.ED25519, seed[i])
-            for i in [0, 1]
+            await wallet.create_local_did(SOV, KeyType.ED25519, seed[i]) for i in [0, 1]
         ]
         assert deco_indy.data.signatures == 0
         assert deco_indy.data.header_map() is None

--- a/aries_cloudagent/messaging/jsonld/tests/test_routes.py
+++ b/aries_cloudagent/messaging/jsonld/tests/test_routes.py
@@ -14,7 +14,7 @@ from ....resolver.base import DIDMethodNotSupported, DIDNotFound, ResolverError
 from ....resolver.did_resolver import DIDResolver
 from ....vc.ld_proofs.document_loader import DocumentLoader
 from ....wallet.base import BaseWallet
-from ....wallet.did_method import DIDMethod
+from ....wallet.did_method import SOV
 from ....wallet.error import WalletError
 from ....wallet.key_type import KeyType
 from ..error import (
@@ -275,7 +275,7 @@ class TestJSONLDRoutes(AsyncTestCase):
             DocumentLoader, custom_document_loader
         )
         self.did_info = await (await self.context.session()).wallet.create_local_did(
-            DIDMethod.SOV, KeyType.ED25519
+            SOV, KeyType.ED25519
         )
         self.request_dict = {
             "context": self.context,

--- a/aries_cloudagent/multitenant/tests/test_base.py
+++ b/aries_cloudagent/multitenant/tests/test_base.py
@@ -18,7 +18,7 @@ from ...protocols.routing.v1_0.models.route_record import RouteRecord
 from ...storage.error import StorageNotFoundError
 from ...storage.in_memory import InMemoryStorage
 from ...wallet.did_info import DIDInfo
-from ...wallet.did_method import DIDMethod
+from ...wallet.did_method import SOV
 from ...wallet.in_memory import InMemoryWallet
 from ...wallet.key_type import KeyType
 from ...wallet.models.wallet_record import WalletRecord
@@ -244,7 +244,7 @@ class TestBaseMultitenantManager(AsyncTestCase):
             did="public-did",
             verkey="test_verkey",
             metadata={"meta": "data"},
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -467,9 +467,7 @@ class ConnectionManager(BaseConnectionManager):
             if connection.is_multiuse_invitation:
                 async with self.profile.session() as session:
                     wallet = session.inject(BaseWallet)
-                    my_info = await wallet.create_local_did(
-                        SOV, KeyType.ED25519
-                    )
+                    my_info = await wallet.create_local_did(SOV, KeyType.ED25519)
 
                 new_connection = ConnRecord(
                     invitation_key=connection_key,

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -19,7 +19,7 @@ from ....transport.inbound.receipt import MessageReceipt
 from ....wallet.base import BaseWallet
 from ....wallet.crypto import create_keypair, seed_to_did
 from ....wallet.did_info import DIDInfo
-from ....wallet.did_method import DIDMethod
+from ....wallet.did_method import SOV
 from ....wallet.error import WalletNotFoundError
 from ....wallet.key_type import KeyType
 from ....wallet.util import bytes_to_b58
@@ -360,7 +360,7 @@ class ConnectionManager(BaseConnectionManager):
             async with self.profile.session() as session:
                 wallet = session.inject(BaseWallet)
                 # Create new DID for connection
-                my_info = await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519)
+                my_info = await wallet.create_local_did(SOV, KeyType.ED25519)
             connection.my_did = my_info.did
 
         # Idempotent; if routing has already been set up, no action taken
@@ -468,7 +468,7 @@ class ConnectionManager(BaseConnectionManager):
                 async with self.profile.session() as session:
                     wallet = session.inject(BaseWallet)
                     my_info = await wallet.create_local_did(
-                        DIDMethod.SOV, KeyType.ED25519
+                        SOV, KeyType.ED25519
                     )
 
                 new_connection = ConnRecord(
@@ -522,7 +522,7 @@ class ConnectionManager(BaseConnectionManager):
         else:  # request from public did
             async with self.profile.session() as session:
                 wallet = session.inject(BaseWallet)
-                my_info = await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519)
+                my_info = await wallet.create_local_did(SOV, KeyType.ED25519)
 
             async with self.profile.session() as session:
                 connection = await ConnRecord.retrieve_by_invitation_msg_id(
@@ -613,7 +613,7 @@ class ConnectionManager(BaseConnectionManager):
         else:
             async with self.profile.session() as session:
                 wallet = session.inject(BaseWallet)
-                my_info = await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519)
+                my_info = await wallet.create_local_did(SOV, KeyType.ED25519)
             connection.my_did = my_info.did
 
         # Idempotent; if routing has already been set up, no action taken
@@ -831,7 +831,7 @@ class ConnectionManager(BaseConnectionManager):
             wallet = session.inject(BaseWallet)
             # seed and DID optional
             my_info = await wallet.create_local_did(
-                DIDMethod.SOV, KeyType.ED25519, my_seed, my_did
+                SOV, KeyType.ED25519, my_seed, my_did
             )
 
         # must provide their DID and verkey if the seed is not known
@@ -845,7 +845,7 @@ class ConnectionManager(BaseConnectionManager):
             their_verkey_bin, _ = create_keypair(KeyType.ED25519, their_seed.encode())
             their_verkey = bytes_to_b58(their_verkey_bin)
         their_info = DIDInfo(
-            their_did, their_verkey, {}, method=DIDMethod.SOV, key_type=KeyType.ED25519
+            their_did, their_verkey, {}, method=SOV, key_type=KeyType.ED25519
         )
 
         # Create connection record
@@ -1106,7 +1106,7 @@ class ConnectionManager(BaseConnectionManager):
                 my_info = await wallet.get_local_did(connection.my_did)
             else:
                 # Create new DID for connection
-                my_info = await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519)
+                my_info = await wallet.create_local_did(SOV, KeyType.ED25519)
                 connection.my_did = my_info.did
 
         try:

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
@@ -23,7 +23,7 @@ from .....resolver.did_resolver import DIDResolver
 from .....storage.error import StorageNotFoundError
 from .....transport.inbound.receipt import MessageReceipt
 from .....wallet.base import DIDInfo
-from .....wallet.did_method import DIDMethod
+from .....wallet.did_method import SOV
 from .....wallet.error import WalletNotFoundError
 from .....wallet.in_memory import InMemoryWallet
 from .....wallet.key_type import KeyType
@@ -120,7 +120,7 @@ class TestConnectionManager(AsyncTestCase):
                 self.test_did,
                 self.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             with self.assertRaises(ConnectionManagerError):
@@ -166,7 +166,7 @@ class TestConnectionManager(AsyncTestCase):
                 self.test_did,
                 self.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             connect_record, connect_invite = await self.manager.create_invitation(
@@ -231,7 +231,7 @@ class TestConnectionManager(AsyncTestCase):
     async def test_create_invitation_recipient_routing_endpoint(self):
         async with self.profile.session() as session:
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -274,7 +274,7 @@ class TestConnectionManager(AsyncTestCase):
                 self.test_did,
                 self.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             with self.assertRaises(ConnectionManagerError):
@@ -435,7 +435,7 @@ class TestConnectionManager(AsyncTestCase):
     async def test_create_request_my_did(self):
         async with self.profile.session() as session:
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=self.test_did,
@@ -480,7 +480,7 @@ class TestConnectionManager(AsyncTestCase):
                 self.test_did,
                 self.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             await self.manager.create_request(
@@ -533,7 +533,7 @@ class TestConnectionManager(AsyncTestCase):
                 did=self.test_did,
                 verkey=self.test_verkey,
                 metadata={},
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             create_local_did.return_value = did_info
@@ -542,7 +542,7 @@ class TestConnectionManager(AsyncTestCase):
                 mediation_id=mediation_record.mediation_id,
                 my_endpoint=self.test_endpoint,
             )
-            create_local_did.assert_called_once_with(DIDMethod.SOV, KeyType.ED25519)
+            create_local_did.assert_called_once_with(SOV, KeyType.ED25519)
             create_did_document.assert_called_once_with(
                 self.manager,
                 did_info,
@@ -585,7 +585,7 @@ class TestConnectionManager(AsyncTestCase):
                     did=self.test_did,
                     verkey=self.test_verkey,
                     metadata={},
-                    method=DIDMethod.SOV,
+                    method=SOV,
                     key_type=KeyType.ED25519,
                 )
                 create_local_did.return_value = did_info
@@ -593,7 +593,7 @@ class TestConnectionManager(AsyncTestCase):
                     record,
                     my_endpoint=self.test_endpoint,
                 )
-                create_local_did.assert_called_once_with(DIDMethod.SOV, KeyType.ED25519)
+                create_local_did.assert_called_once_with(SOV, KeyType.ED25519)
                 create_did_document.assert_called_once_with(
                     self.manager,
                     did_info,
@@ -614,7 +614,7 @@ class TestConnectionManager(AsyncTestCase):
                 recipient_did=self.test_did, recipient_did_public=True
             )
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=self.test_did,
@@ -654,7 +654,7 @@ class TestConnectionManager(AsyncTestCase):
                 recipient_did=self.test_did, recipient_did_public=True
             )
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=self.test_did,
@@ -689,7 +689,7 @@ class TestConnectionManager(AsyncTestCase):
                 recipient_did=self.test_did, recipient_did_public=True
             )
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=self.test_did,
@@ -720,7 +720,7 @@ class TestConnectionManager(AsyncTestCase):
                 recipient_did=self.test_did, recipient_did_public=True
             )
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=self.test_did,
@@ -749,7 +749,7 @@ class TestConnectionManager(AsyncTestCase):
         receipt = MessageReceipt(recipient_did=self.test_did, recipient_did_public=True)
         async with self.profile.session() as session:
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=self.test_did,
@@ -780,7 +780,7 @@ class TestConnectionManager(AsyncTestCase):
                 recipient_did=self.test_did, recipient_did_public=True
             )
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=self.test_did,
@@ -867,7 +867,7 @@ class TestConnectionManager(AsyncTestCase):
                 self.test_did,
                 self.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             await self.manager.create_response(
@@ -941,7 +941,7 @@ class TestConnectionManager(AsyncTestCase):
                 did=self.test_did,
                 verkey=self.test_verkey,
                 metadata={},
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             create_local_did.return_value = did_info
@@ -950,7 +950,7 @@ class TestConnectionManager(AsyncTestCase):
                 mediation_id=mediation_record.mediation_id,
                 my_endpoint=self.test_endpoint,
             )
-            create_local_did.assert_called_once_with(DIDMethod.SOV, KeyType.ED25519)
+            create_local_did.assert_called_once_with(SOV, KeyType.ED25519)
             create_did_document.assert_called_once_with(
                 self.manager,
                 did_info,
@@ -1266,7 +1266,7 @@ class TestConnectionManager(AsyncTestCase):
                 self.test_did,
                 self.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
 
@@ -1299,7 +1299,7 @@ class TestConnectionManager(AsyncTestCase):
                 self.test_did,
                 self.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             await self.manager.create_static_connection(
@@ -1331,7 +1331,7 @@ class TestConnectionManager(AsyncTestCase):
                 self.test_did,
                 self.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
 
@@ -1359,7 +1359,7 @@ class TestConnectionManager(AsyncTestCase):
                 self.test_target_did,
                 self.test_target_verkey,
                 {},
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             create_did_document.assert_has_calls(
@@ -1537,7 +1537,7 @@ class TestConnectionManager(AsyncTestCase):
                 self.test_did,
                 self.test_verkey,
                 {"posted": True},
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             mock_mgr_find_conn.return_value = mock_conn
@@ -1589,7 +1589,7 @@ class TestConnectionManager(AsyncTestCase):
             self.test_did,
             self.test_verkey,
             None,
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 
@@ -1622,7 +1622,7 @@ class TestConnectionManager(AsyncTestCase):
             self.test_did,
             self.test_verkey,
             None,
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 
@@ -1650,7 +1650,7 @@ class TestConnectionManager(AsyncTestCase):
             self.test_did,
             self.test_verkey,
             None,
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 
@@ -1685,7 +1685,7 @@ class TestConnectionManager(AsyncTestCase):
             self.test_did,
             self.test_verkey,
             None,
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 
@@ -1723,7 +1723,7 @@ class TestConnectionManager(AsyncTestCase):
             self.test_did,
             self.test_verkey,
             None,
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 
@@ -1769,7 +1769,7 @@ class TestConnectionManager(AsyncTestCase):
             self.test_did,
             self.test_verkey,
             None,
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
         mediation_record = MediationRecord(
@@ -1795,7 +1795,7 @@ class TestConnectionManager(AsyncTestCase):
             self.test_did,
             self.test_verkey,
             None,
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
         mediation_record1 = MediationRecord(
@@ -1828,7 +1828,7 @@ class TestConnectionManager(AsyncTestCase):
             self.test_did,
             self.test_verkey,
             None,
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
         mediation_record = MediationRecord(
@@ -1863,7 +1863,7 @@ class TestConnectionManager(AsyncTestCase):
     async def test_get_connection_targets_conn_invitation_no_did(self):
         async with self.profile.session() as session:
             local_did = await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -1922,7 +1922,7 @@ class TestConnectionManager(AsyncTestCase):
     async def test_get_connection_targets_retrieve_connection(self):
         async with self.profile.session() as session:
             local_did = await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -1975,7 +1975,7 @@ class TestConnectionManager(AsyncTestCase):
         async with self.profile.session() as session:
             self.context.injector.clear_binding(BaseCache)
             local_did = await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -2025,7 +2025,7 @@ class TestConnectionManager(AsyncTestCase):
         async with self.profile.session() as session:
             self.context.injector.bind_instance(DIDResolver, DIDResolver([]))
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -2071,7 +2071,7 @@ class TestConnectionManager(AsyncTestCase):
             self.context.injector.bind_instance(DIDResolver, self.resolver)
 
             local_did = await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -2139,7 +2139,7 @@ class TestConnectionManager(AsyncTestCase):
             self.resolver.resolve = async_mock.CoroutineMock(return_value=did_doc)
             self.context.injector.bind_instance(DIDResolver, self.resolver)
             local_did = await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=did_doc.id,
@@ -2204,7 +2204,7 @@ class TestConnectionManager(AsyncTestCase):
             self.context.injector.bind_instance(DIDResolver, self.resolver)
 
             local_did = await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=did_doc.id,
@@ -2244,7 +2244,7 @@ class TestConnectionManager(AsyncTestCase):
             self.resolver.resolve = async_mock.CoroutineMock(return_value=did_doc)
             self.context.injector.bind_instance(DIDResolver, self.resolver)
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=did_doc.id,
@@ -2290,7 +2290,7 @@ class TestConnectionManager(AsyncTestCase):
             self.resolver.resolve = async_mock.CoroutineMock(return_value=did_doc)
             self.context.injector.bind_instance(DIDResolver, self.resolver)
             local_did = await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=did_doc.id,
@@ -2319,7 +2319,7 @@ class TestConnectionManager(AsyncTestCase):
         async with self.profile.session() as session:
             self.context.injector.bind_instance(DIDResolver, DIDResolver([]))
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -2360,7 +2360,7 @@ class TestConnectionManager(AsyncTestCase):
             self.context.injector.bind_instance(DIDResolver, self.resolver)
 
             local_did = await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -2405,7 +2405,7 @@ class TestConnectionManager(AsyncTestCase):
             self.context.injector.bind_instance(DIDResolver, self.resolver)
 
             local_did = await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -2451,7 +2451,7 @@ class TestConnectionManager(AsyncTestCase):
     async def test_fetch_connection_targets_conn_initiator_completed_no_their_did(self):
         async with self.profile.session() as session:
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -2468,7 +2468,7 @@ class TestConnectionManager(AsyncTestCase):
     async def test_fetch_connection_targets_conn_completed_their_did(self):
         async with self.profile.session() as session:
             local_did = await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -2499,7 +2499,7 @@ class TestConnectionManager(AsyncTestCase):
     async def test_fetch_connection_targets_conn_no_invi_with_their_did(self):
         async with self.profile.session() as session:
             local_did = await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -2554,7 +2554,7 @@ class TestConnectionManager(AsyncTestCase):
     async def test_establish_inbound(self):
         async with self.profile.session() as session:
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -2584,7 +2584,7 @@ class TestConnectionManager(AsyncTestCase):
     async def test_establish_inbound_conn_rec_no_my_did(self):
         async with self.profile.session() as session:
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -2613,7 +2613,7 @@ class TestConnectionManager(AsyncTestCase):
     async def test_establish_inbound_no_conn_record(self):
         async with self.profile.session() as session:
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,
@@ -2642,7 +2642,7 @@ class TestConnectionManager(AsyncTestCase):
     async def test_establish_inbound_router_not_ready(self):
         async with self.profile.session() as session:
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=self.test_seed,
                 did=self.test_did,

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/manager.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/manager.py
@@ -11,7 +11,7 @@ from ....storage.error import StorageNotFoundError
 from ....storage.record import StorageRecord
 from ....wallet.base import BaseWallet
 from ....wallet.did_info import DIDInfo
-from ....wallet.did_method import DIDMethod
+from ....wallet.did_method import SOV
 from ....wallet.key_type import KeyType
 from ...routing.v1_0.manager import RoutingManager
 from ...routing.v1_0.models.route_record import RouteRecord
@@ -111,7 +111,7 @@ class MediationManager:
         wallet = session.inject(BaseWallet)
         storage = session.inject(BaseStorage)
         info = await wallet.create_local_did(
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
             metadata={"type": "routing_did"},
         )

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/route_manager.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/route_manager.py
@@ -14,7 +14,7 @@ from ....messaging.responder import BaseResponder
 from ....storage.error import StorageNotFoundError
 from ....wallet.base import BaseWallet
 from ....wallet.did_info import DIDInfo
-from ....wallet.did_method import DIDMethod
+from ....wallet.did_method import SOV
 from ....wallet.key_type import KeyType
 from ...routing.v1_0.models.route_record import RouteRecord
 from .manager import MediationManager
@@ -40,7 +40,7 @@ class RouteManager(ABC):
             async with profile.session() as session:
                 wallet = session.inject(BaseWallet)
                 # Create new DID for connection
-                my_info = await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519)
+                my_info = await wallet.create_local_did(SOV, KeyType.ED25519)
                 conn_record.my_did = my_info.did
                 await conn_record.save(session, reason="Connection my did created")
         else:

--- a/aries_cloudagent/protocols/didexchange/v1_0/handlers/tests/test_request_handler.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/handlers/tests/test_request_handler.py
@@ -10,7 +10,7 @@ from ......connections.models.diddoc import (
 )
 from ......core.in_memory import InMemoryProfile
 from ......wallet.key_type import KeyType
-from ......wallet.did_method import DIDMethod
+from ......wallet.did_method import SOV
 from ......messaging.decorators.attach_decorator import AttachDecorator
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
@@ -88,7 +88,7 @@ class TestDIDXRequestHandler(AsyncTestCase):
 
         wallet = self.session.wallet
         self.did_info = await wallet.create_local_did(
-            method=DIDMethod.SOV, key_type=KeyType.ED25519
+            method=SOV, key_type=KeyType.ED25519
         )
 
         self.did_doc_attach = AttachDecorator.data_base64(self.did_doc().serialize())

--- a/aries_cloudagent/protocols/didexchange/v1_0/handlers/tests/test_response_handler.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/handlers/tests/test_response_handler.py
@@ -14,7 +14,7 @@ from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
 from ......transport.inbound.receipt import MessageReceipt
 from ......wallet.key_type import KeyType
-from ......wallet.did_method import DIDMethod
+from ......wallet.did_method import SOV
 
 from .....problem_report.v1_0.message import ProblemReport
 from .....trustping.v1_0.messages.ping import Ping
@@ -65,7 +65,7 @@ class TestDIDXResponseHandler(AsyncTestCase):
 
         wallet = (await self.ctx.session()).wallet
         self.did_info = await wallet.create_local_did(
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -23,7 +23,7 @@ from ....resolver.did_resolver import DIDResolver
 from ....storage.error import StorageNotFoundError
 from ....transport.inbound.receipt import MessageReceipt
 from ....wallet.base import BaseWallet
-from ....wallet.did_method import DIDMethod
+from ....wallet.did_method import SOV
 from ....wallet.did_posture import DIDPosture
 from ....wallet.error import WalletError
 from ....wallet.key_type import KeyType
@@ -284,7 +284,7 @@ class DIDXManager(BaseConnectionManager):
             async with self.profile.session() as session:
                 wallet = session.inject(BaseWallet)
                 my_info = await wallet.create_local_did(
-                    method=DIDMethod.SOV,
+                    method=SOV,
                     key_type=KeyType.ED25519,
                 )
             conn_rec.my_did = my_info.did
@@ -417,7 +417,7 @@ class DIDXManager(BaseConnectionManager):
                 async with self.profile.session() as session:
                     wallet = session.inject(BaseWallet)
                     my_info = await wallet.create_local_did(
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
 
@@ -486,7 +486,7 @@ class DIDXManager(BaseConnectionManager):
             async with self.profile.session() as session:
                 wallet = session.inject(BaseWallet)
                 my_info = await wallet.create_local_did(
-                    method=DIDMethod.SOV,
+                    method=SOV,
                     key_type=KeyType.ED25519,
                 )
 
@@ -580,7 +580,7 @@ class DIDXManager(BaseConnectionManager):
             async with self.profile.session() as session:
                 wallet = session.inject(BaseWallet)
                 my_info = await wallet.create_local_did(
-                    method=DIDMethod.SOV,
+                    method=SOV,
                     key_type=KeyType.ED25519,
                 )
             conn_rec.my_did = my_info.did

--- a/aries_cloudagent/protocols/didexchange/v1_0/messages/tests/test_request.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/messages/tests/test_request.py
@@ -8,7 +8,7 @@ from ......connections.models.diddoc import (
     PublicKeyType,
     Service,
 )
-from ......wallet.did_method import DIDMethod
+from ......wallet.did_method import SOV
 from ......wallet.key_type import KeyType
 from ......core.in_memory import InMemoryProfile
 from ......messaging.decorators.attach_decorator import AttachDecorator
@@ -59,7 +59,7 @@ class TestDIDXRequest(AsyncTestCase, TestConfig):
     async def setUp(self):
         self.wallet = InMemoryProfile.test_session().wallet
         self.did_info = await self.wallet.create_local_did(
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 
@@ -116,7 +116,7 @@ class TestDIDXRequestSchema(AsyncTestCase, TestConfig):
     async def setUp(self):
         self.wallet = InMemoryProfile.test_session().wallet
         self.did_info = await self.wallet.create_local_did(
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 

--- a/aries_cloudagent/protocols/didexchange/v1_0/messages/tests/test_response.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/messages/tests/test_response.py
@@ -8,7 +8,7 @@ from ......connections.models.diddoc import (
     PublicKeyType,
     Service,
 )
-from ......wallet.did_method import DIDMethod
+from ......wallet.did_method import SOV
 from ......wallet.key_type import KeyType
 from ......core.in_memory import InMemoryProfile
 from ......messaging.decorators.attach_decorator import AttachDecorator
@@ -58,7 +58,7 @@ class TestDIDXResponse(AsyncTestCase, TestConfig):
     async def setUp(self):
         self.wallet = InMemoryProfile.test_session().wallet
         self.did_info = await self.wallet.create_local_did(
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 
@@ -112,7 +112,7 @@ class TestDIDXResponseSchema(AsyncTestCase, TestConfig):
     async def setUp(self):
         self.wallet = InMemoryProfile.test_session().wallet
         self.did_info = await self.wallet.create_local_did(
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -28,7 +28,7 @@ from .....transport.inbound.receipt import MessageReceipt
 from .....wallet.did_info import DIDInfo
 from .....wallet.error import WalletError
 from .....wallet.in_memory import InMemoryWallet
-from .....wallet.did_method import DIDMethod
+from .....wallet.did_method import SOV
 from .....wallet.key_type import KeyType
 from .....did.did_key import DIDKey
 
@@ -114,7 +114,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
         self.context = self.profile.context
         async with self.profile.session() as session:
             self.did_info = await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
 
@@ -202,7 +202,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             self.profile.context.update_settings({"public_invites": True})
             public_did_info = None
             await session.wallet.create_public_did(
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             public_did_info = await session.wallet.get_public_did()
@@ -303,7 +303,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
     async def test_create_request_implicit_use_public_did(self):
         async with self.profile.session() as session:
             info_public = await session.wallet.create_public_did(
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             conn_rec = await self.manager.create_request_implicit(
@@ -374,7 +374,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
                 TestConfig.test_did,
                 TestConfig.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             mock_attach_deco.data_base64 = async_mock.MagicMock(
@@ -502,7 +502,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             await mediation_record.save(session)
 
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=TestConfig.test_did,
@@ -601,7 +601,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             )
 
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=TestConfig.test_did,
@@ -633,7 +633,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             )
 
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=TestConfig.test_did,
@@ -693,7 +693,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             )
 
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=TestConfig.test_did,
@@ -735,7 +735,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             )
 
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=TestConfig.test_did,
@@ -802,7 +802,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             )
 
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=TestConfig.test_did,
@@ -863,7 +863,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             )
 
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=TestConfig.test_did,
@@ -910,7 +910,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             )
 
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=TestConfig.test_did,
@@ -1003,7 +1003,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             mock_conn_rec_state_request = ConnRecord.State.REQUEST
 
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=TestConfig.test_did,
@@ -1077,7 +1077,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             )
 
             await session.wallet.create_local_did(
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
                 seed=None,
                 did=TestConfig.test_did,
@@ -1253,7 +1253,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
                 TestConfig.test_did,
                 TestConfig.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             mock_create_did_doc.return_value = async_mock.MagicMock(
@@ -1670,7 +1670,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             TestConfig.test_did,
             TestConfig.test_verkey,
             None,
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 
@@ -1704,7 +1704,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             TestConfig.test_did,
             TestConfig.test_verkey,
             None,
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 
@@ -1732,7 +1732,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             TestConfig.test_did,
             TestConfig.test_verkey,
             None,
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 
@@ -1767,7 +1767,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             TestConfig.test_did,
             TestConfig.test_verkey,
             None,
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 
@@ -1805,7 +1805,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             TestConfig.test_did,
             TestConfig.test_verkey,
             None,
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 
@@ -1851,7 +1851,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             TestConfig.test_did,
             TestConfig.test_verkey,
             None,
-            method=DIDMethod.SOV,
+            method=SOV,
             key_type=KeyType.ED25519,
         )
 
@@ -1897,7 +1897,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
         public_did_info = None
         async with self.profile.session() as session:
             await session.wallet.create_public_did(
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             public_did_info = await session.wallet.get_public_did()

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/tests/test_manager.py
@@ -16,7 +16,7 @@ from .....ledger.base import BaseLedger
 from .....storage.error import StorageNotFoundError
 from .....wallet.base import BaseWallet
 from .....wallet.did_info import DIDInfo
-from .....wallet.did_method import DIDMethod
+from .....wallet.did_method import SOV
 from .....wallet.key_type import KeyType
 
 from ..manager import TransactionManager, TransactionManagerError
@@ -124,7 +124,7 @@ class TestTransactionManager(AsyncTestCase):
         async with self.profile.session() as session:
             self.wallet: BaseWallet = session.inject_or(BaseWallet)
             await self.wallet.create_local_did(
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
                 did="DJGEjaMunDtFtBVrn1qJMT",
                 metadata={"meta": "data"},

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/tests/test_routes.py
@@ -9,7 +9,7 @@ from .....core.in_memory import InMemoryProfile
 from .....ledger.base import BaseLedger
 from .....wallet.base import BaseWallet
 from .....wallet.did_info import DIDInfo
-from .....wallet.did_method import DIDMethod
+from .....wallet.did_method import SOV
 from .....wallet.key_type import KeyType
 
 from ..models.transaction_record import TransactionRecord
@@ -436,7 +436,7 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                         "did",
                         "verkey",
                         {"meta": "data"},
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
                 )
@@ -515,7 +515,7 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                         "did",
                         "verkey",
                         {"meta": "data"},
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
                 )
@@ -544,7 +544,7 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                         "did",
                         "verkey",
                         {"meta": "data"},
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
                 )
@@ -579,7 +579,7 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                         "did",
                         "verkey",
                         {"meta": "data"},
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
                 )
@@ -616,7 +616,7 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                         "did",
                         "verkey",
                         {"meta": "data"},
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
                 )
@@ -671,7 +671,7 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                         "did",
                         "verkey",
                         {"meta": "data"},
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
                 )
@@ -714,7 +714,7 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                         "did",
                         "verkey",
                         {"meta": "data"},
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
                 )
@@ -772,7 +772,7 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                         "did",
                         "verkey",
                         {"meta": "data"},
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
                 )
@@ -824,7 +824,7 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                         "did",
                         "verkey",
                         {"meta": "data"},
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
                 )
@@ -882,7 +882,7 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                         "did",
                         "verkey",
                         {"meta": "data"},
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
                 )
@@ -912,7 +912,7 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                         "did",
                         "verkey",
                         {"meta": "data"},
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
                 )
@@ -947,7 +947,7 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                         "did",
                         "verkey",
                         {"meta": "data"},
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
                 )
@@ -984,7 +984,7 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                         "did",
                         "verkey",
                         {"meta": "data"},
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
                 )
@@ -1027,7 +1027,7 @@ class TestEndorseTransactionRoutes(AsyncTestCase):
                         "did",
                         "verkey",
                         {"meta": "data"},
-                        method=DIDMethod.SOV,
+                        method=SOV,
                         key_type=KeyType.ED25519,
                     )
                 )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
@@ -28,7 +28,7 @@ from .......vc.ld_proofs.constants import SECURITY_CONTEXT_BBS_URL
 from .......vc.tests.document_loader import custom_document_loader
 from .......wallet.key_type import KeyType
 from .......wallet.error import WalletNotFoundError
-from .......wallet.did_method import DIDMethod
+from .......wallet.did_method import SOV
 from .......wallet.base import BaseWallet
 
 from ....models.detail.ld_proof import V20CredExRecordLDProof
@@ -217,7 +217,7 @@ class TestV20LDProofCredFormatHandler(AsyncTestCase):
                 did=TEST_DID_SOV,
                 verkey="verkey",
                 metadata={},
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             mock_did_info.return_value = did_info
@@ -229,7 +229,7 @@ class TestV20LDProofCredFormatHandler(AsyncTestCase):
                 did=TEST_DID_SOV,
                 verkey="verkey",
                 metadata={},
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.BLS12381G2,
             )
             mock_did_info.return_value = invalid_did_info

--- a/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
@@ -65,7 +65,7 @@ from .....protocols.present_proof.v2_0.messages.pres_request import V20PresReque
 from .....storage.error import StorageNotFoundError
 from .....transport.inbound.receipt import MessageReceipt
 from .....wallet.did_info import DIDInfo, KeyInfo
-from .....wallet.did_method import DIDMethod
+from .....wallet.did_method import SOV
 from .....wallet.in_memory import InMemoryWallet
 from .....wallet.key_type import KeyType
 from ....connections.v1_0.messages.connection_invitation import ConnectionInvitation
@@ -378,7 +378,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 TestConfig.test_did,
                 TestConfig.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             invi_rec = await self.manager.create_invitation(
@@ -438,7 +438,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 self.test_did,
                 self.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             await self.manager.create_invitation(
@@ -513,7 +513,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 TestConfig.test_did,
                 TestConfig.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             mock_retrieve_cxid.return_value = async_mock.MagicMock(
@@ -547,7 +547,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 TestConfig.test_did,
                 TestConfig.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             mock_retrieve_cxid.return_value = async_mock.MagicMock(
@@ -585,7 +585,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 TestConfig.test_did,
                 TestConfig.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             mock_retrieve_cxid_v1.side_effect = test_module.StorageNotFoundError()
@@ -623,7 +623,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 TestConfig.test_did,
                 TestConfig.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             mock_retrieve_pxid.return_value = async_mock.MagicMock(
@@ -662,7 +662,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 TestConfig.test_did,
                 TestConfig.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             mock_retrieve_pxid_1.side_effect = StorageNotFoundError()
@@ -750,7 +750,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 TestConfig.test_did,
                 TestConfig.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             with self.assertRaises(OutOfBandManagerError) as context:
@@ -834,7 +834,7 @@ class TestOOBManager(AsyncTestCase, TestConfig):
                 TestConfig.test_did,
                 TestConfig.test_verkey,
                 None,
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             with self.assertRaises(OutOfBandManagerError) as context:

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
@@ -12,7 +12,7 @@ from .....resolver.did_resolver import DIDResolver
 from .....storage.vc_holder.vc_record import VCRecord
 from .....wallet.base import BaseWallet, DIDInfo
 from .....wallet.crypto import KeyType
-from .....wallet.did_method import DIDMethod
+from .....wallet.did_method import SOV, KEY
 from .....wallet.error import WalletNotFoundError
 from .....vc.ld_proofs import (
     BbsBlsSignature2020,
@@ -79,10 +79,10 @@ async def setup_tuple(profile):
     async with profile.session() as session:
         wallet = session.inject_or(BaseWallet)
         await wallet.create_local_did(
-            method=DIDMethod.SOV, key_type=KeyType.ED25519, did="WgWxqztrNooG92RXvxSTWv"
+            method=SOV, key_type=KeyType.ED25519, did="WgWxqztrNooG92RXvxSTWv"
         )
         await wallet.create_local_did(
-            method=DIDMethod.KEY,
+            method=KEY,
             key_type=KeyType.BLS12381G2,
         )
         creds, pds = get_test_data()
@@ -2031,7 +2031,7 @@ class TestPresExchHandler:
                 did="did:sov:LjgpST2rjsoxYegQDRm7EL",
                 verkey="verkey",
                 metadata={},
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             mock_did_info.return_value = did_info
@@ -2096,7 +2096,7 @@ class TestPresExchHandler:
                 did="did:sov:LjgpST2rjsoxYegQDRm7EL",
                 verkey="verkey",
                 metadata={},
-                method=DIDMethod.SOV,
+                method=SOV,
                 key_type=KeyType.ED25519,
             )
             mock_did_info.return_value = did_info
@@ -2164,7 +2164,7 @@ class TestPresExchHandler:
                 did="did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL",
                 verkey="verkey",
                 metadata={},
-                method=DIDMethod.KEY,
+                method=KEY,
                 key_type=KeyType.BLS12381G2,
             )
             mock_did_info.return_value = did_info
@@ -2255,7 +2255,7 @@ class TestPresExchHandler:
                 did="did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL",
                 verkey="verkey",
                 metadata={},
-                method=DIDMethod.KEY,
+                method=KEY,
                 key_type=KeyType.BLS12381G2,
             )
             mock_did_info.return_value = did_info
@@ -2315,7 +2315,7 @@ class TestPresExchHandler:
                 did="did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL",
                 verkey="verkey",
                 metadata={},
-                method=DIDMethod.KEY,
+                method=KEY,
                 key_type=KeyType.BLS12381G2,
             )
             mock_did_info.return_value = did_info
@@ -2369,7 +2369,7 @@ class TestPresExchHandler:
                 did="did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL",
                 verkey="verkey",
                 metadata={},
-                method=DIDMethod.KEY,
+                method=KEY,
                 key_type=KeyType.BLS12381G2,
             )
             mock_did_info.return_value = did_info

--- a/aries_cloudagent/transport/tests/test_pack_format.py
+++ b/aries_cloudagent/transport/tests/test_pack_format.py
@@ -10,7 +10,7 @@ from ...protocols.didcomm_prefix import DIDCommPrefix
 from ...wallet.base import BaseWallet
 from ...wallet.error import WalletError
 from ...wallet.key_type import KeyType
-from ...wallet.did_method import DIDMethod
+from ...wallet.did_method import SOV
 
 from .. import pack_format as test_module
 from ..error import WireFormatEncodeError, WireFormatParseError, RecipientKeysError
@@ -140,7 +140,7 @@ class TestPackWireFormat(AsyncTestCase):
 
     async def test_encode_decode(self):
         local_did = await self.wallet.create_local_did(
-            method=DIDMethod.SOV, key_type=KeyType.ED25519, seed=self.test_seed
+            method=SOV, key_type=KeyType.ED25519, seed=self.test_seed
         )
         serializer = PackWireFormat()
         recipient_keys = (local_did.verkey,)
@@ -174,10 +174,10 @@ class TestPackWireFormat(AsyncTestCase):
 
     async def test_forward(self):
         local_did = await self.wallet.create_local_did(
-            method=DIDMethod.SOV, key_type=KeyType.ED25519, seed=self.test_seed
+            method=SOV, key_type=KeyType.ED25519, seed=self.test_seed
         )
         router_did = await self.wallet.create_local_did(
-            method=DIDMethod.SOV, key_type=KeyType.ED25519, seed=self.test_routing_seed
+            method=SOV, key_type=KeyType.ED25519, seed=self.test_routing_seed
         )
         serializer = PackWireFormat()
         recipient_keys = (local_did.verkey,)

--- a/aries_cloudagent/utils/tests/test_outofband.py
+++ b/aries_cloudagent/utils/tests/test_outofband.py
@@ -2,7 +2,7 @@ from asynctest import TestCase
 
 from ...protocols.out_of_band.v1_0.messages.invitation import InvitationMessage
 from ...wallet.key_type import KeyType
-from ...wallet.did_method import DIDMethod
+from ...wallet.did_method import SOV
 from ...wallet.did_info import DIDInfo
 
 from .. import outofband as test_module
@@ -12,7 +12,7 @@ class TestOutOfBand(TestCase):
     test_did = "55GkHamhTU1ZbTbV2ab9DE"
     test_verkey = "3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"
     test_did_info = DIDInfo(
-        test_did, test_verkey, None, method=DIDMethod.SOV, key_type=KeyType.ED25519
+        test_did, test_verkey, None, method=SOV, key_type=KeyType.ED25519
     )
 
     def test_serialize_oob(self):

--- a/aries_cloudagent/wallet/askar.py
+++ b/aries_cloudagent/wallet/askar.py
@@ -13,7 +13,6 @@ from aries_askar import (
     Key,
     KeyAlg,
     SeedMethod,
-    Session,
 )
 
 from ..askar.didcomm.v1 import pack_message, unpack_message

--- a/aries_cloudagent/wallet/askar.py
+++ b/aries_cloudagent/wallet/askar.py
@@ -740,6 +740,7 @@ class AskarWallet(BaseWallet):
             key_type=KeyType.from_key_type(did_info.get("verkey_type", "ed25519")),
         )
 
+
 def _create_keypair(key_type: KeyType, seed: Union[str, bytes] = None) -> Key:
     """Instantiate a new keypair with an optional seed value."""
     if key_type == KeyType.ED25519:
@@ -767,6 +768,3 @@ def _create_keypair(key_type: KeyType, seed: Union[str, bytes] = None) -> Key:
                 raise WalletError("Invalid seed for key generation") from None
     else:
         return Key.generate(alg)
-
-
-

--- a/aries_cloudagent/wallet/askar.py
+++ b/aries_cloudagent/wallet/askar.py
@@ -31,7 +31,7 @@ from .crypto import (
     validate_seed,
     verify_signed_message,
 )
-from .did_method import DIDMethod
+from .did_method import SOV, KEY, DIDMethod
 from .error import WalletError, WalletDuplicateError, WalletNotFoundError
 from .key_type import KeyType
 from .util import b58_to_bytes, bytes_to_b58
@@ -180,12 +180,12 @@ class AskarWallet(BaseWallet):
                 f" for DID method {method.method_name}"
             )
 
-        if method == DIDMethod.KEY and did:
+        if method == KEY and did:
             raise WalletError("Not allowed to set DID for DID method 'key'")
 
         if not metadata:
             metadata = {}
-        if method not in [DIDMethod.SOV, DIDMethod.KEY]:
+        if method not in [SOV, KEY]:
             raise WalletError(
                 f"Unsupported DID method for askar storage: {method.method_name}"
             )
@@ -206,7 +206,7 @@ class AskarWallet(BaseWallet):
                 else:
                     raise WalletError("Error inserting key") from err
 
-            if method == DIDMethod.KEY:
+            if method == KEY:
                 did = DIDKey.from_public_key(verkey_bytes, key_type).did
             elif not did:
                 did = bytes_to_b58(verkey_bytes[:16])
@@ -408,7 +408,7 @@ class AskarWallet(BaseWallet):
             info = did
             item = None
 
-        if info.method != DIDMethod.SOV:
+        if info.method != SOV:
             raise WalletError("Setting public DID is only allowed for did:sov DIDs")
 
         public = await self.get_public_did()
@@ -462,7 +462,7 @@ class AskarWallet(BaseWallet):
                 'endpoint' affects local wallet
         """
         did_info = await self.get_local_did(did)
-        if did_info.method != DIDMethod.SOV:
+        if did_info.method != SOV:
             raise WalletError("Setting DID endpoint is only allowed for did:sov DIDs")
         metadata = {**did_info.metadata}
         if not endpoint_type:

--- a/aries_cloudagent/wallet/askar.py
+++ b/aries_cloudagent/wallet/askar.py
@@ -735,7 +735,7 @@ class AskarWallet(BaseWallet):
             did=did_info["did"],
             verkey=did_info["verkey"],
             metadata=did_info.get("metadata"),
-            method=did_methods.from_method(did_info.get("method", "sov")),
+            method=did_methods.from_method(did_info.get("method", "sov")) or SOV,
             key_type=KeyType.from_key_type(did_info.get("verkey_type", "ed25519")),
         )
 

--- a/aries_cloudagent/wallet/base.py
+++ b/aries_cloudagent/wallet/base.py
@@ -9,7 +9,7 @@ from .error import WalletError
 
 from .did_info import DIDInfo, KeyInfo
 from .key_type import KeyType
-from .did_method import DIDMethod
+from .did_method import SOV, DIDMethod
 
 
 class BaseWallet(ABC):
@@ -241,7 +241,7 @@ class BaseWallet(ABC):
         """
         did_info = await self.get_local_did(did)
 
-        if did_info.method != DIDMethod.SOV:
+        if did_info.method != SOV:
             raise WalletError("Setting DID endpoint is only allowed for did:sov DIDs")
         metadata = {**did_info.metadata}
         if not endpoint_type:

--- a/aries_cloudagent/wallet/did_method.py
+++ b/aries_cloudagent/wallet/did_method.py
@@ -47,7 +47,7 @@ class DIDMethods:
     def __init__(self) -> None:
         self._registry: Dict[str, DIDMethod] = {
             SOV.method_name: SOV,
-            KEY.method_name: KEY
+            KEY.method_name: KEY,
         }
 
     def registered(self, method: str) -> bool:

--- a/aries_cloudagent/wallet/did_method.py
+++ b/aries_cloudagent/wallet/did_method.py
@@ -1,91 +1,68 @@
 """Did method enum."""
 
-from typing import List, Mapping, NamedTuple, Optional
-from enum import Enum
-
-from .key_type import KeyType
+from typing import Dict, List, Mapping, Optional
 from .error import BaseError
-
-DIDMethodSpec = NamedTuple(
-    "DIDMethodSpec",
-    [
-        ("method_name", str),
-        ("supported_key_types", List[KeyType]),
-        ("supports_rotation", bool),
-    ],
-)
+from .key_type import KeyType
 
 
-class DIDMethod(Enum):
-    """DID Method class specifying DID methods with supported key types."""
+class DIDMethod:
+    """Class to represent a did method."""
 
-    SOV = DIDMethodSpec(
-        method_name="sov", supported_key_types=[KeyType.ED25519], supports_rotation=True
-    )
-    KEY = DIDMethodSpec(
-        method_name="key",
-        supported_key_types=[KeyType.ED25519, KeyType.BLS12381G2],
-        supports_rotation=False,
-    )
+    def __init__(self, name, key_types, rotation) -> None:
+        self._method_name: str = name
+        self._supported_key_types: List[KeyType] = key_types
+        self._supports_rotation: bool = rotation
 
     @property
-    def method_name(self) -> str:
-        """Getter for did method name. e.g. sov or key."""
-        return self.value.method_name
+    def method_name(self):
+        """Get method name."""
+        return self._method_name
 
     @property
-    def supported_key_types(self) -> List[KeyType]:
-        """Getter for supported key types of method."""
-        return self.value.supported_key_types
+    def supports_rotation(self):
+        """Check rotation support."""
+        return self._supports_rotation
 
     @property
-    def supports_rotation(self) -> bool:
-        """Check whether the current method supports key rotation."""
-        return self.value.supports_rotation
+    def supported_key_types(self):
+        """Get supported key types."""
+        return self._supported_key_types
 
     def supports_key_type(self, key_type: KeyType) -> bool:
         """Check whether the current method supports the key type."""
         return key_type in self.supported_key_types
 
-    @classmethod
-    def from_metadata(cls, metadata: Mapping) -> "DIDMethod":
+
+class DIDMethods:
+    """DID Method class specifying DID methods with supported key types."""
+
+    def __init__(self) -> None:
+        self._registry: Dict[str, DIDMethod] = {}
+
+    def registered(self, method: str) -> bool:
+        """Check for a supported method."""
+        return method in list(self._registry.items())
+
+    def register(self, method: DIDMethod):
+        """Registers a new did method."""
+        self._registry[method.method_name] = method
+
+    def from_method(self, method_name: str) -> Optional[DIDMethod]:
+        """Retrieve a did method from method name."""
+        method: DIDMethod = self._registry[method_name]
+        if method:
+            return method
+        raise BaseError(f"Unsupported did method: {method_name}")
+
+    def from_metadata(self, metadata: Mapping) -> Optional[DIDMethod]:
         """Get DID method instance from metadata object.
 
-        Returns SOV if no metadata was found for backwards compatability.
+        Returns SOV if no metadata was found for backwards compatibility.
         """
-        method = metadata.get("method")
+        method_name: str = metadata.get("method", "sov")
+        return self.from_method(method_name)
 
-        # extract from metadata object
-        if method:
-            for did_method in DIDMethod:
-                if method == did_method.method_name:
-                    return did_method
-
-        # return default SOV for backward compat
-        return DIDMethod.SOV
-
-    @classmethod
-    def from_method(cls, method: str) -> Optional["DIDMethod"]:
-        """Get DID method instance from the method name."""
-        for did_method in DIDMethod:
-            if method == did_method.method_name:
-                return did_method
-
-        return None
-
-    @classmethod
-    def from_did(cls, did: str) -> "DIDMethod":
-        """Get DID method instance from the method name."""
-        if not did.startswith("did:"):
-            # sov has no prefix
-            return DIDMethod.SOV
-
-        parts = did.split(":")
-        method_str = parts[1]
-
-        method = DIDMethod.from_method(method_str)
-
-        if not method:
-            raise BaseError(f"Unsupported did method: {method_str}")
-
-        return method
+    def from_did(self, did: str) -> Optional[DIDMethod]:
+        """Get DID method instance from the did url."""
+        method_name = did.split(":")[1] if did.startswith("did:") else "sov"
+        return self.from_method(method_name)

--- a/aries_cloudagent/wallet/did_method.py
+++ b/aries_cloudagent/wallet/did_method.py
@@ -45,7 +45,10 @@ class DIDMethods:
     """DID Method class specifying DID methods with supported key types."""
 
     def __init__(self) -> None:
-        self._registry: Dict[str, DIDMethod] = {}
+        self._registry: Dict[str, DIDMethod] = {
+            SOV.method_name: SOV,
+            KEY.method_name: KEY
+        }
 
     def registered(self, method: str) -> bool:
         """Check for a supported method."""

--- a/aries_cloudagent/wallet/did_method.py
+++ b/aries_cloudagent/wallet/did_method.py
@@ -1,4 +1,4 @@
-"""Did method classes."""
+"""Did method registry classes."""
 
 from typing import Dict, List, Mapping, Optional
 from .error import BaseError
@@ -9,6 +9,7 @@ class DIDMethod:
     """Class to represent a did method."""
 
     def __init__(self, name, key_types, rotation) -> None:
+        """Constructor for did method class."""
         self._method_name: str = name
         self._supported_key_types: List[KeyType] = key_types
         self._supports_rotation: bool = rotation
@@ -45,6 +46,7 @@ class DIDMethods:
     """DID Method class specifying DID methods with supported key types."""
 
     def __init__(self) -> None:
+        """Constructor for did method registry."""
         self._registry: Dict[str, DIDMethod] = {
             SOV.method_name: SOV,
             KEY.method_name: KEY,
@@ -60,7 +62,7 @@ class DIDMethods:
 
     def from_method(self, method_name: str) -> Optional[DIDMethod]:
         """Retrieve a did method from method name."""
-        return self._registry[method_name]
+        return self._registry.get(method_name)
 
     def from_metadata(self, metadata: Mapping) -> Optional[DIDMethod]:
         """Get DID method instance from metadata object.

--- a/aries_cloudagent/wallet/did_method.py
+++ b/aries_cloudagent/wallet/did_method.py
@@ -1,4 +1,4 @@
-"""Did method registry classes."""
+"""did method.py contains registry for did methods."""
 
 from typing import Dict, List, Mapping, Optional
 from .error import BaseError
@@ -9,7 +9,7 @@ class DIDMethod:
     """Class to represent a did method."""
 
     def __init__(self, name, key_types, rotation) -> None:
-        """Constructor for did method class."""
+        """Construct did method class."""
         self._method_name: str = name
         self._supported_key_types: List[KeyType] = key_types
         self._supports_rotation: bool = rotation
@@ -46,7 +46,7 @@ class DIDMethods:
     """DID Method class specifying DID methods with supported key types."""
 
     def __init__(self) -> None:
-        """Constructor for did method registry."""
+        """Construct did method registry."""
         self._registry: Dict[str, DIDMethod] = {
             SOV.method_name: SOV,
             KEY.method_name: KEY,
@@ -57,7 +57,7 @@ class DIDMethods:
         return method in list(self._registry.items())
 
     def register(self, method: DIDMethod):
-        """Registers a new did method."""
+        """Register a new did method."""
         self._registry[method.method_name] = method
 
     def from_method(self, method_name: str) -> Optional[DIDMethod]:

--- a/aries_cloudagent/wallet/did_method.py
+++ b/aries_cloudagent/wallet/did_method.py
@@ -1,4 +1,4 @@
-"""Did method enum."""
+"""Did method classes."""
 
 from typing import Dict, List, Mapping, Optional
 from .error import BaseError
@@ -33,6 +33,14 @@ class DIDMethod:
         return key_type in self.supported_key_types
 
 
+SOV = DIDMethod(name="sov", key_types=[KeyType.ED25519], rotation=True)
+KEY = DIDMethod(
+    name="key",
+    key_types=[KeyType.ED25519, KeyType.BLS12381G2],
+    rotation=False,
+)
+
+
 class DIDMethods:
     """DID Method class specifying DID methods with supported key types."""
 
@@ -49,10 +57,7 @@ class DIDMethods:
 
     def from_method(self, method_name: str) -> Optional[DIDMethod]:
         """Retrieve a did method from method name."""
-        method: DIDMethod = self._registry[method_name]
-        if method:
-            return method
-        raise BaseError(f"Unsupported did method: {method_name}")
+        return self._registry[method_name]
 
     def from_metadata(self, metadata: Mapping) -> Optional[DIDMethod]:
         """Get DID method instance from metadata object.
@@ -62,7 +67,10 @@ class DIDMethods:
         method_name: str = metadata.get("method", "sov")
         return self.from_method(method_name)
 
-    def from_did(self, did: str) -> Optional[DIDMethod]:
+    def from_did(self, did: str) -> DIDMethod:
         """Get DID method instance from the did url."""
-        method_name = did.split(":")[1] if did.startswith("did:") else "sov"
-        return self.from_method(method_name)
+        method_name = did.split(":")[1] if did.startswith("did:") else SOV.method_name
+        method: DIDMethod | None = self.from_method(method_name)
+        if not method:
+            raise BaseError(f"Unsupported did method: {method_name}")
+        return method

--- a/aries_cloudagent/wallet/in_memory.py
+++ b/aries_cloudagent/wallet/in_memory.py
@@ -17,7 +17,7 @@ from .crypto import (
 )
 from .did_info import KeyInfo, DIDInfo
 from .did_posture import DIDPosture
-from .did_method import DIDMethod
+from .did_method import SOV, KEY, DIDMethod
 from .error import WalletError, WalletDuplicateError, WalletNotFoundError
 from .key_type import KeyType
 from .util import b58_to_bytes, bytes_to_b58, random_seed
@@ -223,12 +223,12 @@ class InMemoryWallet(BaseWallet):
 
         # We need some did method specific handling. If more did methods
         # are added it is probably better create a did method specific handler
-        if method == DIDMethod.KEY:
+        if method == KEY:
             if did:
                 raise WalletError("Not allowed to set DID for DID method 'key'")
 
             did = DIDKey.from_public_key(verkey, key_type).did
-        elif method == DIDMethod.SOV:
+        elif method == SOV:
             if not did:
                 did = bytes_to_b58(verkey[:16])
         else:
@@ -395,7 +395,7 @@ class InMemoryWallet(BaseWallet):
             info = did
             did = info.did
 
-        if info.method != DIDMethod.SOV:
+        if info.method != SOV:
             raise WalletError("Setting public DID is only allowed for did:sov DIDs")
 
         public = await self.get_public_did()

--- a/aries_cloudagent/wallet/in_memory.py
+++ b/aries_cloudagent/wallet/in_memory.py
@@ -17,7 +17,7 @@ from .crypto import (
 )
 from .did_info import KeyInfo, DIDInfo
 from .did_posture import DIDPosture
-from .did_method import SOV, KEY, DIDMethod
+from .did_method import SOV, KEY, DIDMethod, DIDMethods
 from .error import WalletError, WalletDuplicateError, WalletNotFoundError
 from .key_type import KeyType
 from .util import b58_to_bytes, bytes_to_b58, random_seed
@@ -132,8 +132,8 @@ class InMemoryWallet(BaseWallet):
         local_did = self.profile.local_dids.get(did)
         if not local_did:
             raise WalletNotFoundError("Wallet owns no such DID: {}".format(did))
-
-        did_method = DIDMethod.from_did(did)
+        did_methods: DIDMethods = self.profile.context.inject(DIDMethods)
+        did_method: DIDMethod = did_methods.from_did(did)
         if not did_method.supports_rotation:
             raise WalletError(
                 f"DID method '{did_method.method_name}' does not support key rotation."

--- a/aries_cloudagent/wallet/indy.py
+++ b/aries_cloudagent/wallet/indy.py
@@ -48,7 +48,7 @@ class IndySdkWallet(BaseWallet):
 
     def __init__(self, opened: IndyOpenWallet):
         """Create a new IndySdkWallet instance."""
-        self.opened = opened
+        self.opened: IndyOpenWallet = opened
 
     def __did_info_from_indy_info(self, info):
         metadata = json.loads(info["metadata"]) if info["metadata"] else {}
@@ -69,8 +69,8 @@ class IndySdkWallet(BaseWallet):
         metadata = info["metadata"]
         verkey = info["verkey"]
 
-        # this needs to change if other did methods are added
-        method = DIDMethod.from_method(info["metadata"].get("method", "key"))
+        # TODO: inject context to support did method registry
+        method = SOV if metadata.get("method", "key") == SOV.method_name else KEY
         key_type = KeyType.from_key_type(info["key_type"])
 
         if method == KEY:
@@ -270,7 +270,9 @@ class IndySdkWallet(BaseWallet):
 
         """
         # Check if DID can rotate keys
-        did_method = DIDMethod.from_did(did)
+        #TODO: inject context for did method registry support
+        method_name = did.split(":")[1] if did.startswith("did:") else SOV.method_name
+        did_method = SOV if method_name == SOV.method_name else KEY
         if not did_method.supports_rotation:
             raise WalletError(
                 f"DID method '{did_method.method_name}' does not support key rotation."
@@ -548,7 +550,9 @@ class IndySdkWallet(BaseWallet):
             WalletError: If there is a libindy error
 
         """
-        method = DIDMethod.from_did(did)
+        #TODO: inject context for did method registry support
+        method_name = did.split(":")[1] if did.startswith("did:") else SOV.method_name
+        method = SOV if method_name == SOV.method_name else KEY
         key_type = KeyType.ED25519
 
         # If did key, the key type can differ

--- a/aries_cloudagent/wallet/indy.py
+++ b/aries_cloudagent/wallet/indy.py
@@ -270,7 +270,7 @@ class IndySdkWallet(BaseWallet):
 
         """
         # Check if DID can rotate keys
-        #TODO: inject context for did method registry support
+        # TODO: inject context for did method registry support
         method_name = did.split(":")[1] if did.startswith("did:") else SOV.method_name
         did_method = SOV if method_name == SOV.method_name else KEY
         if not did_method.supports_rotation:
@@ -550,7 +550,7 @@ class IndySdkWallet(BaseWallet):
             WalletError: If there is a libindy error
 
         """
-        #TODO: inject context for did method registry support
+        # TODO: inject context for did method registry support
         method_name = did.split(":")[1] if did.startswith("did:") else SOV.method_name
         method = SOV if method_name == SOV.method_name else KEY
         key_type = KeyType.ED25519

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -38,7 +38,7 @@ from ..protocols.endorse_transaction.v1_0.util import (
 from ..storage.error import StorageError, StorageNotFoundError
 from .base import BaseWallet
 from .did_info import DIDInfo
-from .did_method import DIDMethod
+from .did_method import SOV, KEY, DIDMethod
 from .did_posture import DIDPosture
 from .error import WalletError, WalletNotFoundError
 from .key_type import KeyType
@@ -66,7 +66,7 @@ class DIDSchema(OpenAPISchema):
     )
     method = fields.Str(
         description="Did method associated with the DID",
-        example=DIDMethod.SOV.method_name,
+        example=SOV.method_name,
         validate=validate.OneOf([method.method_name for method in DIDMethod]),
     )
     key_type = fields.Str(
@@ -136,8 +136,8 @@ class DIDListQueryStringSchema(OpenAPISchema):
     )
     method = fields.Str(
         required=False,
-        example=DIDMethod.KEY.method_name,
-        validate=validate.OneOf([DIDMethod.KEY.method_name, DIDMethod.SOV.method_name]),
+        example=KEY.method_name,
+        validate=validate.OneOf([KEY.method_name, SOV.method_name]),
         description="DID method to query for. e.g. sov to only fetch indy/sov DIDs",
     )
     key_type = fields.Str(
@@ -173,9 +173,9 @@ class DIDCreateSchema(OpenAPISchema):
 
     method = fields.Str(
         required=False,
-        default=DIDMethod.SOV.method_name,
-        example=DIDMethod.SOV.method_name,
-        validate=validate.OneOf([DIDMethod.KEY.method_name, DIDMethod.SOV.method_name]),
+        default=SOV.method_name,
+        example=SOV.method_name,
+        validate=validate.OneOf([KEY.method_name, SOV.method_name]),
     )
 
     options = fields.Nested(
@@ -357,7 +357,7 @@ async def wallet_create_did(request: web.BaseRequest):
         KeyType.from_key_type(body.get("options", {}).get("key_type"))
         or KeyType.ED25519
     )
-    method = DIDMethod.from_method(body.get("method")) or DIDMethod.SOV
+    method = DIDMethod.from_method(body.get("method")) or SOV
 
     if not method.supports_key_type(key_type):
         raise web.HTTPForbidden(

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -67,7 +67,9 @@ class DIDSchema(OpenAPISchema):
     method = fields.Str(
         description="Did method associated with the DID",
         example=SOV.method_name,
-        validate=validate.OneOf([method.method_name for method in DIDMethod]),
+        validate=validate.OneOf(
+            [method.method_name for method in [SOV, KEY]]
+        ),  # TODO: support more methods
     )
     key_type = fields.Str(
         description="Key type associated with the DID",

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -249,7 +249,9 @@ async def wallet_did_list(request: web.BaseRequest):
     results = []
     async with context.session() as session:
         did_methods: DIDMethods = session.inject(DIDMethods)
-        filter_method: DIDMethod | None = did_methods.from_method(request.query.get("method"))
+        filter_method: DIDMethod | None = did_methods.from_method(
+            request.query.get("method")
+        )
         wallet = session.inject_or(BaseWallet)
         if not wallet:
             raise web.HTTPForbidden(reason="No wallet available")
@@ -365,7 +367,7 @@ async def wallet_create_did(request: web.BaseRequest):
     info = None
     async with context.session() as session:
         did_methods = session.inject(DIDMethods)
-        method = did_methods.from_method(body.get("method", '')) or SOV
+        method = did_methods.from_method(body.get("method", "")) or SOV
         if not method.supports_key_type(key_type):
             raise web.HTTPForbidden(
                 reason=(

--- a/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
@@ -1,6 +1,8 @@
 import pytest
 import time
 
+from aries_cloudagent.core.in_memory import profile
+
 from ...core.in_memory import InMemoryProfile
 from ...messaging.decorators.signature_decorator import SignatureDecorator
 from ...wallet.in_memory import InMemoryWallet
@@ -198,7 +200,7 @@ class TestInMemoryWallet:
 
     @pytest.mark.asyncio
     async def test_rotate_did_keypair(self, wallet: InMemoryWallet):
-        if wallet.profile:  # check incase indysdkwallet is being used
+        if hasattr(wallet, "profile"):  # check incase indysdkwallet is being used
             wallet.profile.context.injector.bind_instance(DIDMethods, DIDMethods())
         with pytest.raises(WalletNotFoundError):
             await wallet.rotate_did_keypair_start(self.test_sov_did)

--- a/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
@@ -5,7 +5,7 @@ from ...core.in_memory import InMemoryProfile
 from ...messaging.decorators.signature_decorator import SignatureDecorator
 from ...wallet.in_memory import InMemoryWallet
 from ...wallet.key_type import KeyType
-from ...wallet.did_method import SOV, KEY
+from ...wallet.did_method import SOV, KEY, DIDMethods
 from ...wallet.error import (
     WalletError,
     WalletDuplicateError,
@@ -198,6 +198,7 @@ class TestInMemoryWallet:
 
     @pytest.mark.asyncio
     async def test_rotate_did_keypair(self, wallet: InMemoryWallet):
+        wallet.profile.context.injector.bind_instance(DIDMethods, DIDMethods())
         with pytest.raises(WalletNotFoundError):
             await wallet.rotate_did_keypair_start(self.test_sov_did)
 

--- a/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
@@ -5,7 +5,7 @@ from ...core.in_memory import InMemoryProfile
 from ...messaging.decorators.signature_decorator import SignatureDecorator
 from ...wallet.in_memory import InMemoryWallet
 from ...wallet.key_type import KeyType
-from ...wallet.did_method import DIDMethod
+from ...wallet.did_method import SOV, KEY
 from ...wallet.error import (
     WalletError,
     WalletDuplicateError,
@@ -130,19 +130,19 @@ class TestInMemoryWallet:
 
     @pytest.mark.asyncio
     async def test_create_local_sov_random(self, wallet: InMemoryWallet):
-        info = await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519, None, None)
+        info = await wallet.create_local_did(SOV, KeyType.ED25519, None, None)
         assert info and info.did and info.verkey
 
     @pytest.mark.asyncio
     async def test_create_local_key_random_ed25519(self, wallet: InMemoryWallet):
-        info = await wallet.create_local_did(DIDMethod.KEY, KeyType.ED25519, None, None)
+        info = await wallet.create_local_did(KEY, KeyType.ED25519, None, None)
         assert info and info.did and info.verkey
 
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
     async def test_create_local_key_random_bls12381g2(self, wallet: InMemoryWallet):
         info = await wallet.create_local_did(
-            DIDMethod.KEY, KeyType.BLS12381G2, None, None
+            KEY, KeyType.BLS12381G2, None, None
         )
         assert info and info.did and info.verkey
 
@@ -151,61 +151,61 @@ class TestInMemoryWallet:
         self, wallet: InMemoryWallet
     ):
         with pytest.raises(WalletError):
-            await wallet.create_local_did(DIDMethod.SOV, KeyType.BLS12381G2, None, None)
+            await wallet.create_local_did(SOV, KeyType.BLS12381G2, None, None)
 
     @pytest.mark.asyncio
     async def test_create_local_sov_seeded(self, wallet: InMemoryWallet):
         info = await wallet.create_local_did(
-            DIDMethod.SOV, KeyType.ED25519, self.test_seed, None
+            SOV, KeyType.ED25519, self.test_seed, None
         )
         assert info.did == self.test_sov_did
         assert info.verkey == self.test_ed25519_verkey
 
         # should not raise WalletDuplicateError - same verkey
         await wallet.create_local_did(
-            DIDMethod.SOV, KeyType.ED25519, self.test_seed, None
+            SOV, KeyType.ED25519, self.test_seed, None
         )
 
         with pytest.raises(WalletError):
             _ = await wallet.create_local_did(
-                DIDMethod.SOV, KeyType.ED25519, "invalid-seed", None
+                SOV, KeyType.ED25519, "invalid-seed", None
             )
 
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
     async def test_create_local_key_seeded_bls12381g2(self, wallet: InMemoryWallet):
         info = await wallet.create_local_did(
-            DIDMethod.KEY, KeyType.BLS12381G2, self.test_seed, None
+            KEY, KeyType.BLS12381G2, self.test_seed, None
         )
         assert info.did == self.test_key_bls12381g2_did
         assert info.verkey == self.test_bls12381g2_verkey
 
         # should not raise WalletDuplicateError - same verkey
         await wallet.create_local_did(
-            DIDMethod.KEY, KeyType.BLS12381G2, self.test_seed, None
+            KEY, KeyType.BLS12381G2, self.test_seed, None
         )
 
         with pytest.raises(WalletError):
             _ = await wallet.create_local_did(
-                DIDMethod.KEY, KeyType.BLS12381G2, "invalid-seed", None
+                KEY, KeyType.BLS12381G2, "invalid-seed", None
             )
 
     @pytest.mark.asyncio
     async def test_create_local_key_seeded_ed25519(self, wallet: InMemoryWallet):
         info = await wallet.create_local_did(
-            DIDMethod.KEY, KeyType.ED25519, self.test_seed, None
+            KEY, KeyType.ED25519, self.test_seed, None
         )
         assert info.did == self.test_key_ed25519_did
         assert info.verkey == self.test_ed25519_verkey
 
         # should not raise WalletDuplicateError - same verkey
         await wallet.create_local_did(
-            DIDMethod.KEY, KeyType.ED25519, self.test_seed, None
+            KEY, KeyType.ED25519, self.test_seed, None
         )
 
         with pytest.raises(WalletError):
             _ = await wallet.create_local_did(
-                DIDMethod.KEY, KeyType.ED25519, "invalid-seed", None
+                KEY, KeyType.ED25519, "invalid-seed", None
             )
 
     @pytest.mark.asyncio
@@ -217,9 +217,9 @@ class TestInMemoryWallet:
             await wallet.rotate_did_keypair_apply(self.test_sov_did)
 
         info = await wallet.create_local_did(
-            DIDMethod.SOV, KeyType.ED25519, self.test_seed, self.test_sov_did
+            SOV, KeyType.ED25519, self.test_seed, self.test_sov_did
         )
-        key_info = await wallet.create_local_did(DIDMethod.KEY, KeyType.ED25519)
+        key_info = await wallet.create_local_did(KEY, KeyType.ED25519)
 
         with pytest.raises(WalletError):
             await wallet.rotate_did_keypair_apply(self.test_sov_did)
@@ -239,25 +239,25 @@ class TestInMemoryWallet:
     @pytest.mark.asyncio
     async def test_create_local_with_did(self, wallet: InMemoryWallet):
         info = await wallet.create_local_did(
-            DIDMethod.SOV, KeyType.ED25519, None, self.test_sov_did
+            SOV, KeyType.ED25519, None, self.test_sov_did
         )
         assert info.did == self.test_sov_did
 
         with pytest.raises(WalletDuplicateError):
             await wallet.create_local_did(
-                DIDMethod.SOV, KeyType.ED25519, None, self.test_sov_did
+                SOV, KeyType.ED25519, None, self.test_sov_did
             )
 
         with pytest.raises(WalletError) as context:
             await wallet.create_local_did(
-                DIDMethod.KEY, KeyType.ED25519, None, "did:sov:random"
+                KEY, KeyType.ED25519, None, "did:sov:random"
             )
         assert "Not allowed to set DID for DID method 'key'" in str(context.value)
 
     @pytest.mark.asyncio
     async def test_local_verkey(self, wallet: InMemoryWallet):
         info = await wallet.create_local_did(
-            DIDMethod.SOV, KeyType.ED25519, self.test_seed, self.test_sov_did
+            SOV, KeyType.ED25519, self.test_seed, self.test_sov_did
         )
         assert info.did == self.test_sov_did
         assert info.verkey == self.test_ed25519_verkey
@@ -273,7 +273,7 @@ class TestInMemoryWallet:
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
     async def test_local_verkey_bls12381g2(self, wallet: InMemoryWallet):
-        await wallet.create_local_did(DIDMethod.KEY, KeyType.BLS12381G2, self.test_seed)
+        await wallet.create_local_did(KEY, KeyType.BLS12381G2, self.test_seed)
         bls_info_get = await wallet.get_local_did_for_verkey(
             self.test_bls12381g2_verkey
         )
@@ -288,7 +288,7 @@ class TestInMemoryWallet:
     @pytest.mark.asyncio
     async def test_local_metadata(self, wallet: InMemoryWallet):
         info = await wallet.create_local_did(
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
             self.test_seed,
             self.test_sov_did,
@@ -318,7 +318,7 @@ class TestInMemoryWallet:
     @pytest.mark.ursa_bbs_signatures
     async def test_local_metadata_bbs(self, wallet: InMemoryWallet):
         info = await wallet.create_local_did(
-            DIDMethod.KEY,
+            KEY,
             KeyType.BLS12381G2,
             self.test_seed,
             None,
@@ -338,7 +338,7 @@ class TestInMemoryWallet:
     @pytest.mark.asyncio
     async def test_create_public_did(self, wallet: InMemoryWallet):
         info = await wallet.create_local_did(
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
             self.test_seed,
             self.test_sov_did,
@@ -350,7 +350,7 @@ class TestInMemoryWallet:
         assert not posted
 
         info_public = await wallet.create_public_did(
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
         )
         assert info_public.metadata.get("posted")
@@ -359,7 +359,7 @@ class TestInMemoryWallet:
 
         # test replace
         info_replace = await wallet.create_public_did(
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
         )
         assert info_replace.metadata.get("posted")
@@ -376,7 +376,7 @@ class TestInMemoryWallet:
     async def test_create_public_did_x_not_sov(self, wallet: InMemoryWallet):
         with pytest.raises(WalletError) as context:
             await wallet.create_public_did(
-                DIDMethod.KEY,
+                KEY,
                 KeyType.ED25519,
             )
         assert "Setting public DID is only allowed for did:sov DIDs" in str(
@@ -389,7 +389,7 @@ class TestInMemoryWallet:
     ):
         with pytest.raises(WalletError) as context:
             await wallet.create_public_did(
-                DIDMethod.SOV,
+                SOV,
                 KeyType.BLS12381G2,
             )
         assert "Invalid key type" in str(context.value)
@@ -397,7 +397,7 @@ class TestInMemoryWallet:
     @pytest.mark.asyncio
     async def test_set_public_did(self, wallet: InMemoryWallet):
         info = await wallet.create_local_did(
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
             self.test_seed,
             self.test_sov_did,
@@ -413,7 +413,7 @@ class TestInMemoryWallet:
         assert info_same.did == info.did
         assert info_same.metadata.get("posted")
 
-        info_new = await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519)
+        info_new = await wallet.create_local_did(SOV, KeyType.ED25519)
         assert info_new.did != info_same.did
 
         loc = await wallet.get_local_did(self.test_sov_did)
@@ -429,7 +429,7 @@ class TestInMemoryWallet:
     @pytest.mark.asyncio
     async def test_set_public_did_x_not_sov(self, wallet: InMemoryWallet):
         info = await wallet.create_local_did(
-            DIDMethod.KEY,
+            KEY,
             KeyType.ED25519,
         )
         with pytest.raises(WalletError) as context:
@@ -441,7 +441,7 @@ class TestInMemoryWallet:
     @pytest.mark.asyncio
     async def test_sign_verify(self, wallet: InMemoryWallet):
         info = await wallet.create_local_did(
-            DIDMethod.SOV, KeyType.ED25519, self.test_seed, self.test_sov_did
+            SOV, KeyType.ED25519, self.test_seed, self.test_sov_did
         )
         message_bin = self.test_message.encode("ascii")
         signature = await wallet.sign_message(message_bin, info.verkey)
@@ -493,7 +493,7 @@ class TestInMemoryWallet:
     @pytest.mark.ursa_bbs_signatures
     async def test_sign_verify_bbs(self, wallet: InMemoryWallet):
         info = await wallet.create_local_did(
-            DIDMethod.KEY, KeyType.BLS12381G2, self.test_seed
+            KEY, KeyType.BLS12381G2, self.test_seed
         )
         message_bin = self.test_message.encode("ascii")
         signature = await wallet.sign_message(message_bin, info.verkey)
@@ -552,7 +552,7 @@ class TestInMemoryWallet:
     @pytest.mark.asyncio
     async def test_pack_unpack(self, wallet: InMemoryWallet):
         await wallet.create_local_did(
-            DIDMethod.SOV, KeyType.ED25519, self.test_seed, self.test_sov_did
+            SOV, KeyType.ED25519, self.test_seed, self.test_sov_did
         )
 
         packed_anon = await wallet.pack_message(
@@ -568,7 +568,7 @@ class TestInMemoryWallet:
         assert "Message not provided" in str(excinfo.value)
 
         await wallet.create_local_did(
-            DIDMethod.SOV, KeyType.ED25519, self.test_target_seed, self.test_target_did
+            SOV, KeyType.ED25519, self.test_target_seed, self.test_target_did
         )
         packed_auth = await wallet.pack_message(
             self.test_message, [self.test_target_verkey], self.test_ed25519_verkey
@@ -600,7 +600,7 @@ class TestInMemoryWallet:
     @pytest.mark.asyncio
     async def test_set_did_endpoint_x_not_sov(self, wallet: InMemoryWallet):
         info = await wallet.create_local_did(
-            DIDMethod.KEY,
+            KEY,
             KeyType.ED25519,
         )
         with pytest.raises(WalletError) as context:

--- a/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
@@ -141,9 +141,7 @@ class TestInMemoryWallet:
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
     async def test_create_local_key_random_bls12381g2(self, wallet: InMemoryWallet):
-        info = await wallet.create_local_did(
-            KEY, KeyType.BLS12381G2, None, None
-        )
+        info = await wallet.create_local_did(KEY, KeyType.BLS12381G2, None, None)
         assert info and info.did and info.verkey
 
     @pytest.mark.asyncio
@@ -155,16 +153,12 @@ class TestInMemoryWallet:
 
     @pytest.mark.asyncio
     async def test_create_local_sov_seeded(self, wallet: InMemoryWallet):
-        info = await wallet.create_local_did(
-            SOV, KeyType.ED25519, self.test_seed, None
-        )
+        info = await wallet.create_local_did(SOV, KeyType.ED25519, self.test_seed, None)
         assert info.did == self.test_sov_did
         assert info.verkey == self.test_ed25519_verkey
 
         # should not raise WalletDuplicateError - same verkey
-        await wallet.create_local_did(
-            SOV, KeyType.ED25519, self.test_seed, None
-        )
+        await wallet.create_local_did(SOV, KeyType.ED25519, self.test_seed, None)
 
         with pytest.raises(WalletError):
             _ = await wallet.create_local_did(
@@ -181,9 +175,7 @@ class TestInMemoryWallet:
         assert info.verkey == self.test_bls12381g2_verkey
 
         # should not raise WalletDuplicateError - same verkey
-        await wallet.create_local_did(
-            KEY, KeyType.BLS12381G2, self.test_seed, None
-        )
+        await wallet.create_local_did(KEY, KeyType.BLS12381G2, self.test_seed, None)
 
         with pytest.raises(WalletError):
             _ = await wallet.create_local_did(
@@ -192,16 +184,12 @@ class TestInMemoryWallet:
 
     @pytest.mark.asyncio
     async def test_create_local_key_seeded_ed25519(self, wallet: InMemoryWallet):
-        info = await wallet.create_local_did(
-            KEY, KeyType.ED25519, self.test_seed, None
-        )
+        info = await wallet.create_local_did(KEY, KeyType.ED25519, self.test_seed, None)
         assert info.did == self.test_key_ed25519_did
         assert info.verkey == self.test_ed25519_verkey
 
         # should not raise WalletDuplicateError - same verkey
-        await wallet.create_local_did(
-            KEY, KeyType.ED25519, self.test_seed, None
-        )
+        await wallet.create_local_did(KEY, KeyType.ED25519, self.test_seed, None)
 
         with pytest.raises(WalletError):
             _ = await wallet.create_local_did(
@@ -244,14 +232,10 @@ class TestInMemoryWallet:
         assert info.did == self.test_sov_did
 
         with pytest.raises(WalletDuplicateError):
-            await wallet.create_local_did(
-                SOV, KeyType.ED25519, None, self.test_sov_did
-            )
+            await wallet.create_local_did(SOV, KeyType.ED25519, None, self.test_sov_did)
 
         with pytest.raises(WalletError) as context:
-            await wallet.create_local_did(
-                KEY, KeyType.ED25519, None, "did:sov:random"
-            )
+            await wallet.create_local_did(KEY, KeyType.ED25519, None, "did:sov:random")
         assert "Not allowed to set DID for DID method 'key'" in str(context.value)
 
     @pytest.mark.asyncio
@@ -492,9 +476,7 @@ class TestInMemoryWallet:
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
     async def test_sign_verify_bbs(self, wallet: InMemoryWallet):
-        info = await wallet.create_local_did(
-            KEY, KeyType.BLS12381G2, self.test_seed
-        )
+        info = await wallet.create_local_did(KEY, KeyType.BLS12381G2, self.test_seed)
         message_bin = self.test_message.encode("ascii")
         signature = await wallet.sign_message(message_bin, info.verkey)
         assert signature

--- a/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
@@ -198,7 +198,7 @@ class TestInMemoryWallet:
 
     @pytest.mark.asyncio
     async def test_rotate_did_keypair(self, wallet: InMemoryWallet):
-        if wallet.profile:
+        if wallet.profile:  # check incase indysdkwallet is being used
             wallet.profile.context.injector.bind_instance(DIDMethods, DIDMethods())
         with pytest.raises(WalletNotFoundError):
             await wallet.rotate_did_keypair_start(self.test_sov_did)

--- a/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_in_memory_wallet.py
@@ -198,7 +198,8 @@ class TestInMemoryWallet:
 
     @pytest.mark.asyncio
     async def test_rotate_did_keypair(self, wallet: InMemoryWallet):
-        wallet.profile.context.injector.bind_instance(DIDMethods, DIDMethods())
+        if wallet.profile:
+            wallet.profile.context.injector.bind_instance(DIDMethods, DIDMethods())
         with pytest.raises(WalletNotFoundError):
             await wallet.rotate_did_keypair_start(self.test_sov_did)
 

--- a/aries_cloudagent/wallet/tests/test_indy_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_indy_wallet.py
@@ -18,7 +18,7 @@ from ...indy.sdk.profile import IndySdkProfile, IndySdkProfileManager
 from ...indy.sdk.wallet_setup import IndyWalletConfig
 from ...ledger.endpoint_type import EndpointType
 from ...wallet.key_type import KeyType
-from ...wallet.did_method import DIDMethod
+from ...wallet.did_method import SOV
 from ...ledger.indy import IndySdkLedgerPool
 
 from .. import indy as test_module
@@ -67,7 +67,7 @@ class TestIndySdkWallet(test_in_memory_wallet.TestInMemoryWallet):
     @pytest.mark.asyncio
     async def test_rotate_did_keypair_x(self, wallet: IndySdkWallet):
         info = await wallet.create_local_did(
-            DIDMethod.SOV, KeyType.ED25519, self.test_seed, self.test_sov_did
+            SOV, KeyType.ED25519, self.test_seed, self.test_sov_did
         )
 
         with async_mock.patch.object(
@@ -111,7 +111,7 @@ class TestIndySdkWallet(test_in_memory_wallet.TestInMemoryWallet):
                 test_module.ErrorCode.CommonIOError, {"message": "outlier"}
             )
             with pytest.raises(test_module.WalletError) as excinfo:
-                await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519)
+                await wallet.create_local_did(SOV, KeyType.ED25519)
             assert "outlier" in str(excinfo.value)
 
     @pytest.mark.asyncio
@@ -120,7 +120,7 @@ class TestIndySdkWallet(test_in_memory_wallet.TestInMemoryWallet):
             read_only=False, update_endpoint_for_did=async_mock.CoroutineMock()
         )
         info_pub = await wallet.create_public_did(
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
         )
         await wallet.set_did_endpoint(info_pub.did, "https://example.com", mock_ledger)
@@ -147,7 +147,7 @@ class TestIndySdkWallet(test_in_memory_wallet.TestInMemoryWallet):
         mock_ledger = async_mock.MagicMock(
             read_only=False, update_endpoint_for_did=async_mock.CoroutineMock()
         )
-        info_pub = await wallet.create_public_did(DIDMethod.SOV, KeyType.ED25519)
+        info_pub = await wallet.create_public_did(SOV, KeyType.ED25519)
         await wallet.set_did_endpoint(
             info_pub.did, "https://example.com", mock_ledger, routing_keys=routing_keys
         )
@@ -167,7 +167,7 @@ class TestIndySdkWallet(test_in_memory_wallet.TestInMemoryWallet):
             read_only=True, update_endpoint_for_did=async_mock.CoroutineMock()
         )
         info_pub = await wallet.create_public_did(
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
         )
         await wallet.set_did_endpoint(info_pub.did, "https://example.com", mock_ledger)
@@ -206,7 +206,7 @@ class TestIndySdkWallet(test_in_memory_wallet.TestInMemoryWallet):
     @pytest.mark.asyncio
     async def test_replace_local_did_metadata_x(self, wallet: IndySdkWallet):
         info = await wallet.create_local_did(
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
             self.test_seed,
             self.test_sov_did,
@@ -283,13 +283,13 @@ class TestWalletCompat:
         Ensure that python-based pack/unpack is compatible with indy-sdk implementation
         """
         await in_memory_wallet.create_local_did(
-            DIDMethod.SOV, KeyType.ED25519, self.test_seed
+            SOV, KeyType.ED25519, self.test_seed
         )
         py_packed = await in_memory_wallet.pack_message(
             self.test_message, [self.test_verkey], self.test_verkey
         )
 
-        await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519, self.test_seed)
+        await wallet.create_local_did(SOV, KeyType.ED25519, self.test_seed)
         packed = await wallet.pack_message(
             self.test_message, [self.test_verkey], self.test_verkey
         )
@@ -820,7 +820,7 @@ class TestWalletCompat:
         opened = await postgres_wallet.create_wallet()
         wallet = IndySdkWallet(opened)
 
-        await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519, self.test_seed)
+        await wallet.create_local_did(SOV, KeyType.ED25519, self.test_seed)
         py_packed = await wallet.pack_message(
             self.test_message, [self.test_verkey], self.test_verkey
         )
@@ -862,7 +862,7 @@ class TestWalletCompat:
         assert "Wallet was not removed" in str(excinfo.value)
 
         wallet = IndySdkWallet(opened)
-        await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519, self.test_seed)
+        await wallet.create_local_did(SOV, KeyType.ED25519, self.test_seed)
         py_packed = await wallet.pack_message(
             self.test_message, [self.test_verkey], self.test_verkey
         )
@@ -899,7 +899,7 @@ class TestWalletCompat:
         opened = await postgres_wallet.create_wallet()
         wallet = IndySdkWallet(opened)
 
-        await wallet.create_local_did(DIDMethod.SOV, KeyType.ED25519, self.test_seed)
+        await wallet.create_local_did(SOV, KeyType.ED25519, self.test_seed)
         py_packed = await wallet.pack_message(
             self.test_message, [self.test_verkey], self.test_verkey
         )

--- a/aries_cloudagent/wallet/tests/test_indy_wallet.py
+++ b/aries_cloudagent/wallet/tests/test_indy_wallet.py
@@ -282,9 +282,7 @@ class TestWalletCompat:
         """
         Ensure that python-based pack/unpack is compatible with indy-sdk implementation
         """
-        await in_memory_wallet.create_local_did(
-            SOV, KeyType.ED25519, self.test_seed
-        )
+        await in_memory_wallet.create_local_did(SOV, KeyType.ED25519, self.test_seed)
         py_packed = await in_memory_wallet.pack_message(
             self.test_message, [self.test_verkey], self.test_verkey
         )

--- a/aries_cloudagent/wallet/tests/test_key_type.py
+++ b/aries_cloudagent/wallet/tests/test_key_type.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from ...core.error import BaseError
-from ..did_method import SOV, KEY, DIDMethod
+from ..did_method import SOV, KEY, DIDMethods
 from ..key_type import KeyType
 
 SOV_DID_METHOD_NAME = "sov"
@@ -10,32 +10,39 @@ KEY_DID_METHOD_NAME = "key"
 
 
 class TestDidMethod(TestCase):
+    """TestCases for did method"""
+    did_methods = DIDMethods()
+
     def test_from_metadata(self):
-        assert DIDMethod.from_metadata({"method": SOV_DID_METHOD_NAME}) == SOV
-        assert DIDMethod.from_metadata({"method": KEY_DID_METHOD_NAME}) == KEY
+        """Testing 'from_metadata'"""
+        assert self.did_methods.from_metadata({"method": SOV_DID_METHOD_NAME}) == SOV
+        assert self.did_methods.from_metadata({"method": KEY_DID_METHOD_NAME}) == KEY
 
         # test backwards compat
-        assert DIDMethod.from_metadata({}) == SOV
+        assert self.did_methods.from_metadata({}) == SOV
 
     def test_from_method(self):
-        assert DIDMethod.from_method(SOV_DID_METHOD_NAME) == SOV
-        assert DIDMethod.from_method(KEY_DID_METHOD_NAME) == KEY
-        assert DIDMethod.from_method("random") == None
+        """Testing 'from_method'"""
+        assert self.did_methods.from_method(SOV_DID_METHOD_NAME) == SOV
+        assert self.did_methods.from_method(KEY_DID_METHOD_NAME) == KEY
+        assert self.did_methods.from_method("random") is None
 
     def test_from_did(self):
-        assert DIDMethod.from_did(f"did:{SOV_DID_METHOD_NAME}:xxxx") == SOV
-        assert DIDMethod.from_did(f"did:{KEY_DID_METHOD_NAME}:xxxx") == KEY
+        """Testing 'from_did'"""
+        assert self.did_methods.from_did(f"did:{SOV_DID_METHOD_NAME}:xxxx") == SOV
+        assert self.did_methods.from_did(f"did:{KEY_DID_METHOD_NAME}:xxxx") == KEY
 
         with self.assertRaises(BaseError) as context:
-            DIDMethod.from_did("did:unknown:something")
+            self.did_methods.from_did("did:unknown:something")
         assert "Unsupported did method: unknown" in str(context.exception)
 
     def test_properties(self):
+        """Testing 'properties'"""
         method = SOV
 
         assert method.method_name == SOV_DID_METHOD_NAME
         assert method.supported_key_types == SOV_SUPPORTED_KEY_TYPES
-        assert method.supports_rotation == True
+        assert method.supports_rotation is True
 
-        assert method.supports_key_type(KeyType.ED25519) == True
-        assert method.supports_key_type(KeyType.BLS12381G2) == False
+        assert method.supports_key_type(KeyType.ED25519) is True
+        assert method.supports_key_type(KeyType.BLS12381G2) is False

--- a/aries_cloudagent/wallet/tests/test_key_type.py
+++ b/aries_cloudagent/wallet/tests/test_key_type.py
@@ -11,6 +11,7 @@ KEY_DID_METHOD_NAME = "key"
 
 class TestDidMethod(TestCase):
     """TestCases for did method"""
+
     did_methods = DIDMethods()
 
     def test_from_metadata(self):

--- a/aries_cloudagent/wallet/tests/test_key_type.py
+++ b/aries_cloudagent/wallet/tests/test_key_type.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from ...core.error import BaseError
-from ..did_method import DIDMethod
+from ..did_method import SOV, KEY, DIDMethod
 from ..key_type import KeyType
 
 SOV_DID_METHOD_NAME = "sov"
@@ -11,27 +11,27 @@ KEY_DID_METHOD_NAME = "key"
 
 class TestDidMethod(TestCase):
     def test_from_metadata(self):
-        assert DIDMethod.from_metadata({"method": SOV_DID_METHOD_NAME}) == DIDMethod.SOV
-        assert DIDMethod.from_metadata({"method": KEY_DID_METHOD_NAME}) == DIDMethod.KEY
+        assert DIDMethod.from_metadata({"method": SOV_DID_METHOD_NAME}) == SOV
+        assert DIDMethod.from_metadata({"method": KEY_DID_METHOD_NAME}) == KEY
 
         # test backwards compat
-        assert DIDMethod.from_metadata({}) == DIDMethod.SOV
+        assert DIDMethod.from_metadata({}) == SOV
 
     def test_from_method(self):
-        assert DIDMethod.from_method(SOV_DID_METHOD_NAME) == DIDMethod.SOV
-        assert DIDMethod.from_method(KEY_DID_METHOD_NAME) == DIDMethod.KEY
+        assert DIDMethod.from_method(SOV_DID_METHOD_NAME) == SOV
+        assert DIDMethod.from_method(KEY_DID_METHOD_NAME) == KEY
         assert DIDMethod.from_method("random") == None
 
     def test_from_did(self):
-        assert DIDMethod.from_did(f"did:{SOV_DID_METHOD_NAME}:xxxx") == DIDMethod.SOV
-        assert DIDMethod.from_did(f"did:{KEY_DID_METHOD_NAME}:xxxx") == DIDMethod.KEY
+        assert DIDMethod.from_did(f"did:{SOV_DID_METHOD_NAME}:xxxx") == SOV
+        assert DIDMethod.from_did(f"did:{KEY_DID_METHOD_NAME}:xxxx") == KEY
 
         with self.assertRaises(BaseError) as context:
             DIDMethod.from_did("did:unknown:something")
         assert "Unsupported did method: unknown" in str(context.exception)
 
     def test_properties(self):
-        method = DIDMethod.SOV
+        method = SOV
 
         assert method.method_name == SOV_DID_METHOD_NAME
         assert method.supported_key_types == SOV_SUPPORTED_KEY_TYPES

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -8,7 +8,7 @@ from ...admin.request_context import AdminRequestContext
 from ...core.in_memory import InMemoryProfile
 from ...ledger.base import BaseLedger
 from ...protocols.coordinate_mediation.v1_0.route_manager import RouteManager
-from ...wallet.did_method import DIDMethod
+from ...wallet.did_method import SOV
 from ...wallet.key_type import KeyType
 from ..base import BaseWallet
 from ..did_info import DIDInfo
@@ -71,7 +71,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             self.test_did,
             self.test_verkey,
             DIDPosture.WALLET_ONLY.metadata,
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
         )
         result = test_module.format_did_info(did_info)
@@ -85,7 +85,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             self.test_did,
             self.test_verkey,
             {"posted": True, "public": True},
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
         )
         result = test_module.format_did_info(did_info)
@@ -95,7 +95,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             self.test_did,
             self.test_verkey,
             {"posted": True, "public": False},
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
         )
         result = test_module.format_did_info(did_info)
@@ -109,7 +109,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 self.test_did,
                 self.test_verkey,
                 DIDPosture.WALLET_ONLY.metadata,
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             result = await test_module.wallet_create_did(self.request)
@@ -120,7 +120,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                         "verkey": self.test_verkey,
                         "posture": DIDPosture.WALLET_ONLY.moniker,
                         "key_type": KeyType.ED25519.key_type,
-                        "method": DIDMethod.SOV.method_name,
+                        "method": SOV.method_name,
                     }
                 }
             )
@@ -147,14 +147,14 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                     self.test_did,
                     self.test_verkey,
                     DIDPosture.WALLET_ONLY.metadata,
-                    DIDMethod.SOV,
+                    SOV,
                     KeyType.ED25519,
                 ),
                 DIDInfo(
                     self.test_posted_did,
                     self.test_posted_verkey,
                     DIDPosture.POSTED.metadata,
-                    DIDMethod.SOV,
+                    SOV,
                     KeyType.ED25519,
                 ),
             ]
@@ -167,14 +167,14 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                             "verkey": self.test_posted_verkey,
                             "posture": DIDPosture.POSTED.moniker,
                             "key_type": KeyType.ED25519.key_type,
-                            "method": DIDMethod.SOV.method_name,
+                            "method": SOV.method_name,
                         },
                         {
                             "did": self.test_did,
                             "verkey": self.test_verkey,
                             "posture": DIDPosture.WALLET_ONLY.moniker,
                             "key_type": KeyType.ED25519.key_type,
-                            "method": DIDMethod.SOV.method_name,
+                            "method": SOV.method_name,
                         },
                     ]
                 }
@@ -191,7 +191,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 self.test_did,
                 self.test_verkey,
                 DIDPosture.PUBLIC.metadata,
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             self.wallet.get_posted_dids.return_value = [
@@ -199,7 +199,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                     self.test_posted_did,
                     self.test_posted_verkey,
                     DIDPosture.POSTED.metadata,
-                    DIDMethod.SOV,
+                    SOV,
                     KeyType.ED25519,
                 )
             ]
@@ -212,7 +212,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                             "verkey": self.test_verkey,
                             "posture": DIDPosture.PUBLIC.moniker,
                             "key_type": KeyType.ED25519.key_type,
-                            "method": DIDMethod.SOV.method_name,
+                            "method": SOV.method_name,
                         }
                     ]
                 }
@@ -229,7 +229,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 self.test_did,
                 self.test_verkey,
                 DIDPosture.PUBLIC.metadata,
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             self.wallet.get_posted_dids.return_value = [
@@ -240,7 +240,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                         "posted": True,
                         "public": False,
                     },
-                    DIDMethod.SOV,
+                    SOV,
                     KeyType.ED25519,
                 )
             ]
@@ -253,7 +253,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                             "verkey": self.test_posted_verkey,
                             "posture": DIDPosture.POSTED.moniker,
                             "key_type": KeyType.ED25519.key_type,
-                            "method": DIDMethod.SOV.method_name,
+                            "method": SOV.method_name,
                         }
                     ]
                 }
@@ -270,7 +270,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 self.test_did,
                 self.test_verkey,
                 DIDPosture.WALLET_ONLY.metadata,
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             result = await test_module.wallet_did_list(self.request)
@@ -282,7 +282,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                             "verkey": self.test_verkey,
                             "posture": DIDPosture.WALLET_ONLY.moniker,
                             "key_type": KeyType.ED25519.key_type,
-                            "method": DIDMethod.SOV.method_name,
+                            "method": SOV.method_name,
                         }
                     ]
                 }
@@ -310,7 +310,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 self.test_did,
                 self.test_verkey,
                 DIDPosture.WALLET_ONLY.metadata,
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             result = await test_module.wallet_did_list(self.request)
@@ -322,7 +322,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                             "verkey": self.test_verkey,
                             "posture": DIDPosture.WALLET_ONLY.moniker,
                             "key_type": KeyType.ED25519.key_type,
-                            "method": DIDMethod.SOV.method_name,
+                            "method": SOV.method_name,
                         }
                     ]
                 }
@@ -349,7 +349,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 self.test_did,
                 self.test_verkey,
                 DIDPosture.PUBLIC.metadata,
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             result = await test_module.wallet_get_public_did(self.request)
@@ -360,7 +360,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                         "verkey": self.test_verkey,
                         "posture": DIDPosture.PUBLIC.moniker,
                         "key_type": KeyType.ED25519.key_type,
-                        "method": DIDMethod.SOV.method_name,
+                        "method": SOV.method_name,
                     }
                 }
             )
@@ -396,7 +396,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 self.test_did,
                 self.test_verkey,
                 DIDPosture.PUBLIC.metadata,
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             result = await test_module.wallet_set_public_did(self.request)
@@ -408,7 +408,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                         "verkey": self.test_verkey,
                         "posture": DIDPosture.PUBLIC.moniker,
                         "key_type": KeyType.ED25519.key_type,
-                        "method": DIDMethod.SOV.method_name,
+                        "method": SOV.method_name,
                     }
                 }
             )
@@ -494,7 +494,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 self.test_did,
                 self.test_verkey,
                 DIDPosture.PUBLIC.metadata,
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             self.wallet.set_public_did.side_effect = test_module.WalletError()
@@ -525,7 +525,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 self.test_did,
                 self.test_verkey,
                 DIDPosture.PUBLIC.metadata,
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             self.wallet.set_public_did.side_effect = test_module.WalletNotFoundError()
@@ -557,7 +557,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 self.test_did,
                 self.test_verkey,
                 {**DIDPosture.PUBLIC.metadata, "endpoint": "https://endpoint.com"},
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             result = await test_module.wallet_set_public_did(self.request)
@@ -569,7 +569,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                         "verkey": self.test_verkey,
                         "posture": DIDPosture.PUBLIC.moniker,
                         "key_type": KeyType.ED25519.key_type,
-                        "method": DIDMethod.SOV.method_name,
+                        "method": SOV.method_name,
                     }
                 }
             )
@@ -605,7 +605,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 self.test_did,
                 self.test_verkey,
                 DIDPosture.PUBLIC.metadata,
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
             self.wallet.get_local_did.return_value = did_info
@@ -627,7 +627,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                         "verkey": self.test_verkey,
                         "posture": DIDPosture.PUBLIC.moniker,
                         "key_type": KeyType.ED25519.key_type,
-                        "method": DIDMethod.SOV.method_name,
+                        "method": SOV.method_name,
                     }
                 }
             )
@@ -651,14 +651,14 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             self.test_did,
             self.test_verkey,
             {"public": False, "endpoint": "http://old-endpoint.ca"},
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
         )
         self.wallet.get_public_did.return_value = DIDInfo(
             self.test_did,
             self.test_verkey,
             DIDPosture.PUBLIC.metadata,
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
         )
 
@@ -680,14 +680,14 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             self.test_did,
             self.test_verkey,
             {"public": False, "endpoint": "http://old-endpoint.ca"},
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
         )
         self.wallet.get_public_did.return_value = DIDInfo(
             self.test_did,
             self.test_verkey,
             DIDPosture.PUBLIC.metadata,
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
         )
         self.wallet.set_did_endpoint.side_effect = test_module.LedgerConfigError()
@@ -740,7 +740,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             self.test_did,
             self.test_verkey,
             {"public": False, "endpoint": "http://old-endpoint.ca"},
-            DIDMethod.SOV,
+            SOV,
             KeyType.ED25519,
         )
 
@@ -788,7 +788,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                     "did",
                     "verkey",
                     {"public": False},
-                    DIDMethod.SOV,
+                    SOV,
                     KeyType.ED25519,
                 )
             )
@@ -823,7 +823,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 "did",
                 "verkey",
                 {"posted": True, "public": True},
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
         )
@@ -838,7 +838,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 "did",
                 "verkey",
                 {"public": False},
-                DIDMethod.SOV,
+                SOV,
                 KeyType.ED25519,
             )
         )

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -8,7 +8,7 @@ from ...admin.request_context import AdminRequestContext
 from ...core.in_memory import InMemoryProfile
 from ...ledger.base import BaseLedger
 from ...protocols.coordinate_mediation.v1_0.route_manager import RouteManager
-from ...wallet.did_method import SOV
+from ...wallet.did_method import SOV, DIDMethods
 from ...wallet.key_type import KeyType
 from ..base import BaseWallet
 from ..did_info import DIDInfo
@@ -38,6 +38,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         self.test_verkey = "verkey"
         self.test_posted_did = "posted-did"
         self.test_posted_verkey = "posted-verkey"
+        self.context.injector.bind_instance(DIDMethods, DIDMethods())
 
     async def test_missing_wallet(self):
         self.session_inject[BaseWallet] = None


### PR DESCRIPTION
To support different did methods in plugins we need to support did method pluggability. This PR changes the default methods to be static and registered into a registry of methods at start-up. This allows plugins to define new did methods that can be registered. The bulk of changes in this PR is updating the current code to use a did method registry.

Signed-off-by: Adam Burdett <burdettadam@gmail.com>