### PR TITLE
Feature: enabled handling VPs (request, creation, verification) with different VCs

### DIFF
--- a/Multicredentials.md
+++ b/Multicredentials.md
@@ -1,0 +1,9 @@
+# Multi-Credentials
+
+It is a known fact that multiple AnonCreds can be combined to present a presentation proof with an "and" logical operator: For instance, a verifier can ask for the "name" claim from an eID and the "address" claim from a bank statement to have a single proof that is either valid or invalid. With the Present Proof Protocol v2, it is possible to have "and" and "or" logical operators for AnonCreds and/or W3C Verifiable Credentials.
+
+With the Present Proof Protocol v2, verifiers can ask for a combination of credentials as proof. For instance, a Verifier can ask a claim from an AnonCreds **and** a verifiable presentation from a W3C Verifiable Credential, which would open the possibilities of Aries Cloud Agent Python being used for rather complex presentation proof requests that wouldn't be possible without the support of AnonCreds or W3C Verifiable Credentials.
+
+Moreover, it is possible to make similar presentation proof requests using the or logical operator. For instance, a verifier can ask for either an eID in AnonCreds format or an eID in W3C Verifiable Credential format. This has the potential to solve the interoperability problem of different credential formats and ecosystems from a user point of view by shifting the requirement of holding/accepting different credential formats from identity holders to verifiers. Here again, using Aries Cloud Agent Python as the underlying verifier agent can tackle such complex presentation proof requests since the agent is capable of verifying both type of credential formats and proof types.
+
+In the future, it would be even possible to put mDoc as an attachment with an and or or logical operation, along with AnonCreds and/or W3C Verifiable Credentials. For this to happen, Aca-Py either needs the capabilities to validate mDocs internally or to connect third-party endpoints to validate and get a response.

--- a/aries_cloudagent/messaging/decorators/attach_decorator.py
+++ b/aries_cloudagent/messaging/decorators/attach_decorator.py
@@ -30,6 +30,7 @@ from ..models.base import BaseModel, BaseModelError, BaseModelSchema
 from ..valid import (
     BASE64,
     BASE64URL_NO_PAD,
+    DictOrDictListField,
     INDY_ISO8601_DATETIME,
     JWS_HEADER_KID,
     SHA256,
@@ -228,7 +229,7 @@ class AttachDecoratorData(BaseModel):
         sha256_: str = None,
         links_: Union[Sequence[str], str] = None,
         base64_: str = None,
-        json_: dict = None,
+        json_: Union[Sequence[dict], dict] = None,
     ):
         """
         Initialize decorator data.
@@ -492,7 +493,7 @@ class AttachDecoratorDataSchema(BaseModelSchema):
         required=False,
         data_key="jws",
     )
-    json_ = fields.Dict(
+    json_ = DictOrDictListField(
         description="JSON-serialized data",
         required=False,
         example='{"sample": "content"}',
@@ -619,7 +620,7 @@ class AttachDecorator(BaseModel):
     @classmethod
     def data_json(
         cls,
-        mapping: dict,
+        mapping: Union[Sequence[dict], dict],
         *,
         ident: str = None,
         description: str = None,

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -1248,13 +1248,15 @@ class DIFPresExchHandler:
         if req.nested_req:
             for nested_req in req.nested_req:
                 res = await self.apply_requirements(
-                    req=nested_req, credentials=credentials, records_filter=records_filter
+                    req=nested_req,
+                    credentials=credentials,
+                    records_filter=records_filter
                 )
                 result.append(res)
         else:
             res = await self.apply_requirements(
-                    req=req, credentials=credentials, records_filter=records_filter
-                )
+                req=req, credentials=credentials, records_filter=records_filter
+            )
             result.append(res)
 
         result_vp = []
@@ -1286,7 +1288,9 @@ class DIFPresExchHandler:
                     applicable_creds=applicable_creds
                 )
                 if not issuer_id and len(filtered_creds_list) == 0:
-                    vp = await create_presentation(credentials=applicable_creds_list)
+                    vp = await create_presentation(
+                        credentials=applicable_creds_list
+                    )
                     vp["presentation_submission"] = submission_property.serialize()
                     if self.proof_type is BbsBlsSignature2020.signature_type:
                         vp["@context"].append(SECURITY_CONTEXT_BBS_URL)
@@ -1396,19 +1400,21 @@ class DIFPresExchHandler:
         input_descriptors = pd.input_descriptors
         if isinstance(pres, Sequence):
             for pr in pres:
-                descriptor_map_list = pr["presentation_submission"].get("descriptor_map")
+                descriptor_map_list = pr["presentation_submission"].get(
+                    "descriptor_map"
+                )
                 await self.__verify_desc_map_list(
-                    descriptor_map_list,
-                    pr,
-                    input_descriptors)
+                    descriptor_map_list, pr, input_descriptors
+                )
         else:
             descriptor_map_list = pres["presentation_submission"].get("descriptor_map")
             await self.__verify_desc_map_list(
-                descriptor_map_list,
-                pres,
-                input_descriptors)
+                descriptor_map_list, pres, input_descriptors
+            )
 
-    async def __verify_desc_map_list(self, descriptor_map_list, pres, input_descriptors):
+    async def __verify_desc_map_list(
+        self, descriptor_map_list, pres, input_descriptors
+    ):
         inp_desc_id_contraint_map = {}
         inp_desc_id_schema_one_of_filter = set()
         inp_desc_id_schemas_map = {}

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -1230,7 +1230,7 @@ class DIFPresExchHandler:
         challenge: str = None,
         domain: str = None,
         records_filter: dict = None,
-    ) -> dict:
+    ) -> Union[Sequence[dict], dict]:
         """
         Create VerifiablePresentation.
 
@@ -1244,78 +1244,95 @@ class DIFPresExchHandler:
         req = await self.make_requirement(
             srs=pd.submission_requirements, descriptors=pd.input_descriptors
         )
-        result = await self.apply_requirements(
-            req=req, credentials=credentials, records_filter=records_filter
-        )
-        applicable_creds, descriptor_maps = await self.merge(result)
-        applicable_creds_list = []
-        for credential in applicable_creds:
-            applicable_creds_list.append(credential.cred_value)
-        if (
-            not self.profile.settings.get("debug.auto_respond_presentation_request")
-            and not records_filter
-            and len(applicable_creds_list) > 1
-        ):
-            raise DIFPresExchError(
-                "Multiple credentials are applicable for presentation_definition "
-                f"{pd.id} and --auto-respond-presentation-request setting is not "
-                "enabled. Please specify which credentials should be applied to "
-                "which input_descriptors using record_ids filter."
-            )
-        # submission_property
-        submission_property = PresentationSubmission(
-            id=str(uuid4()), definition_id=pd.id, descriptor_maps=descriptor_maps
-        )
-        if self.is_holder:
-            (
-                issuer_id,
-                filtered_creds_list,
-            ) = await self.get_sign_key_credential_subject_id(
-                applicable_creds=applicable_creds
-            )
-            if not issuer_id and len(filtered_creds_list) == 0:
-                vp = await create_presentation(credentials=applicable_creds_list)
-                vp["presentation_submission"] = submission_property.serialize()
-                if self.proof_type is BbsBlsSignature2020.signature_type:
-                    vp["@context"].append(SECURITY_CONTEXT_BBS_URL)
-                return vp
-            else:
-                vp = await create_presentation(credentials=filtered_creds_list)
+        result = []
+        if req.nested_req:
+            for nested_req in req.nested_req:
+                res = await self.apply_requirements(
+                    req=nested_req, credentials=credentials, records_filter=records_filter
+                )
+                result.append(res)
         else:
-            if not self.pres_signing_did:
+            res = await self.apply_requirements(
+                    req=req, credentials=credentials, records_filter=records_filter
+                )
+            result.append(res)
+
+        result_vp = []
+        for res in result:
+            applicable_creds, descriptor_maps = await self.merge(res)
+            applicable_creds_list = []
+            for credential in applicable_creds:
+                applicable_creds_list.append(credential.cred_value)
+            if (
+                not self.profile.settings.get("debug.auto_respond_presentation_request")
+                and not records_filter
+                and len(applicable_creds_list) > 1
+            ):
+                raise DIFPresExchError(
+                    "Multiple credentials are applicable for presentation_definition "
+                    f"{pd.id} and --auto-respond-presentation-request setting is not "
+                    "enabled. Please specify which credentials should be applied to "
+                    "which input_descriptors using record_ids filter."
+                )
+            # submission_property
+            submission_property = PresentationSubmission(
+                id=str(uuid4()), definition_id=pd.id, descriptor_maps=descriptor_maps
+            )
+            if self.is_holder:
                 (
                     issuer_id,
                     filtered_creds_list,
                 ) = await self.get_sign_key_credential_subject_id(
                     applicable_creds=applicable_creds
                 )
-                if not issuer_id:
+                if not issuer_id and len(filtered_creds_list) == 0:
                     vp = await create_presentation(credentials=applicable_creds_list)
                     vp["presentation_submission"] = submission_property.serialize()
                     if self.proof_type is BbsBlsSignature2020.signature_type:
                         vp["@context"].append(SECURITY_CONTEXT_BBS_URL)
-                    return vp
+                    result_vp.append(vp)
+                    continue
                 else:
                     vp = await create_presentation(credentials=filtered_creds_list)
             else:
-                issuer_id = self.pres_signing_did
-                vp = await create_presentation(credentials=applicable_creds_list)
-        vp["presentation_submission"] = submission_property.serialize()
-        if self.proof_type is BbsBlsSignature2020.signature_type:
-            vp["@context"].append(SECURITY_CONTEXT_BBS_URL)
-        async with self.profile.session() as session:
-            wallet = session.inject(BaseWallet)
-            issue_suite = await self._get_issue_suite(
-                wallet=wallet,
-                issuer_id=issuer_id,
-            )
-            signed_vp = await sign_presentation(
-                presentation=vp,
-                suite=issue_suite,
-                challenge=challenge,
-                document_loader=document_loader,
-            )
-            return signed_vp
+                if not self.pres_signing_did:
+                    (
+                        issuer_id,
+                        filtered_creds_list,
+                    ) = await self.get_sign_key_credential_subject_id(
+                        applicable_creds=applicable_creds
+                    )
+                    if not issuer_id:
+                        vp = await create_presentation(credentials=applicable_creds_list)
+                        vp["presentation_submission"] = submission_property.serialize()
+                        if self.proof_type is BbsBlsSignature2020.signature_type:
+                            vp["@context"].append(SECURITY_CONTEXT_BBS_URL)
+                        result_vp.append(vp)
+                        continue
+                    else:
+                        vp = await create_presentation(credentials=filtered_creds_list)
+                else:
+                    issuer_id = self.pres_signing_did
+                    vp = await create_presentation(credentials=applicable_creds_list)
+            vp["presentation_submission"] = submission_property.serialize()
+            if self.proof_type is BbsBlsSignature2020.signature_type:
+                vp["@context"].append(SECURITY_CONTEXT_BBS_URL)
+            async with self.profile.session() as session:
+                wallet = session.inject(BaseWallet)
+                issue_suite = await self._get_issue_suite(
+                    wallet=wallet,
+                    issuer_id=issuer_id,
+                )
+                signed_vp = await sign_presentation(
+                    presentation=vp,
+                    suite=issue_suite,
+                    challenge=challenge,
+                    document_loader=document_loader,
+                )
+            result_vp.append(signed_vp)
+        if len(result_vp) == 1:
+            return result_vp[0]
+        return result_vp
 
     def check_if_cred_id_derived(self, id: str) -> bool:
         """Check if credential or credentialSubjet id is derived."""
@@ -1367,7 +1384,7 @@ class DIFPresExchHandler:
     async def verify_received_pres(
         self,
         pd: PresentationDefinition,
-        pres: dict,
+        pres: Union[Sequence[dict], dict],
     ):
         """
         Verify credentials received in presentation.
@@ -1376,8 +1393,22 @@ class DIFPresExchHandler:
             pres: received VerifiablePresentation
             pd: PresentationDefinition
         """
-        descriptor_map_list = pres["presentation_submission"].get("descriptor_map")
         input_descriptors = pd.input_descriptors
+        if isinstance(pres, Sequence):
+            for pr in pres:
+                descriptor_map_list = pr["presentation_submission"].get("descriptor_map")
+                await self.__verify_desc_map_list(
+                    descriptor_map_list,
+                    pr,
+                    input_descriptors)
+        else:
+            descriptor_map_list = pres["presentation_submission"].get("descriptor_map")
+            await self.__verify_desc_map_list(
+                descriptor_map_list,
+                pres,
+                input_descriptors)
+
+    async def __verify_desc_map_list(self, descriptor_map_list, pres, input_descriptors):
         inp_desc_id_contraint_map = {}
         inp_desc_id_schema_one_of_filter = set()
         inp_desc_id_schemas_map = {}

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -1305,7 +1305,9 @@ class DIFPresExchHandler:
                         applicable_creds=applicable_creds
                     )
                     if not issuer_id:
-                        vp = await create_presentation(credentials=applicable_creds_list)
+                        vp = await create_presentation(
+                            credentials=applicable_creds_list
+                        )
                         vp["presentation_submission"] = submission_property.serialize()
                         if self.proof_type is BbsBlsSignature2020.signature_type:
                             vp["@context"].append(SECURITY_CONTEXT_BBS_URL)

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -1250,7 +1250,7 @@ class DIFPresExchHandler:
                 res = await self.apply_requirements(
                     req=nested_req,
                     credentials=credentials,
-                    records_filter=records_filter
+                    records_filter=records_filter,
                 )
                 result.append(res)
         else:
@@ -1288,9 +1288,7 @@ class DIFPresExchHandler:
                     applicable_creds=applicable_creds
                 )
                 if not issuer_id and len(filtered_creds_list) == 0:
-                    vp = await create_presentation(
-                        credentials=applicable_creds_list
-                    )
+                    vp = await create_presentation(credentials=applicable_creds_list)
                     vp["presentation_submission"] = submission_property.serialize()
                     if self.proof_type is BbsBlsSignature2020.signature_type:
                         vp["@context"].append(SECURITY_CONTEXT_BBS_URL)

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
@@ -108,7 +108,9 @@ class TestPresExchHandler:
             if isinstance(tmp_vp, Sequence):
                 cred_count_list = []
                 for tmp_vp_single in tmp_vp:
-                    cred_count_list.append(len(tmp_vp_single.get("verifiableCredential")))
+                    cred_count_list.append(
+                        len(tmp_vp_single.get("verifiableCredential"))
+                    )
 
                 assert min(cred_count_list) == tmp_pd[1]
             else:
@@ -133,7 +135,9 @@ class TestPresExchHandler:
             if isinstance(tmp_vp, Sequence):
                 cred_count_list = []
                 for tmp_vp_single in tmp_vp:
-                    cred_count_list.append(len(tmp_vp_single.get("verifiableCredential")))
+                    cred_count_list.append(
+                        len(tmp_vp_single.get("verifiableCredential"))
+                    )
 
                 assert min(cred_count_list) == tmp_pd[1]
             else:
@@ -2397,7 +2401,7 @@ class TestPresExchHandler:
                 pd=pd_list[0][0],
                 challenge="3fa85f64-5717-4562-b3fc-2c963f66afa7",
             )
-            #2 sub_reqs, vp is a sequence
+            # 2 sub_reqs, vp is a sequence
             for vp_single in vp:
                 assert vp_single["test"] == "1"
                 assert SECURITY_CONTEXT_BBS_URL in vp_single["@context"]

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
@@ -1,6 +1,7 @@
 import asyncio
 from copy import deepcopy
 from datetime import datetime
+from typing import Sequence
 from uuid import uuid4
 
 import mock as async_mock
@@ -103,7 +104,15 @@ class TestPresExchHandler:
                 pd=tmp_pd[0],
                 challenge="1f44d55f-f161-4938-a659-f8026467f126",
             )
-            assert len(tmp_vp.get("verifiableCredential")) == tmp_pd[1]
+
+            if isinstance(tmp_vp, Sequence):
+                cred_count_list = []
+                for tmp_vp_single in tmp_vp:
+                    cred_count_list.append(len(tmp_vp_single.get("verifiableCredential")))
+
+                assert min(cred_count_list) == tmp_pd[1]
+            else:
+                assert len(tmp_vp.get("verifiableCredential")) == tmp_pd[1]
 
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
@@ -120,7 +129,15 @@ class TestPresExchHandler:
                 pd=tmp_pd[0],
                 challenge="1f44d55f-f161-4938-a659-f8026467f126",
             )
-            assert len(tmp_vp.get("verifiableCredential")) == tmp_pd[1]
+
+            if isinstance(tmp_vp, Sequence):
+                cred_count_list = []
+                for tmp_vp_single in tmp_vp:
+                    cred_count_list.append(len(tmp_vp_single.get("verifiableCredential")))
+
+                assert min(cred_count_list) == tmp_pd[1]
+            else:
+                assert len(tmp_vp.get("verifiableCredential")) == tmp_pd[1]
 
     @pytest.mark.asyncio
     async def test_to_requirement_catch_errors(self, profile):
@@ -2264,11 +2281,12 @@ class TestPresExchHandler:
                 pd=pd_list[0][0],
                 challenge="3fa85f64-5717-4562-b3fc-2c963f66afa7",
             )
-            assert vp["test"] == "1"
-            assert (
-                vp["presentation_submission"]["definition_id"]
-                == "32f54163-7166-48f1-93d8-ff217bdb0653"
-            )
+            for vp_single in vp:
+                assert vp_single["test"] == "1"
+                assert (
+                    vp_single["presentation_submission"]["definition_id"]
+                    == "32f54163-7166-48f1-93d8-ff217bdb0653"
+                )
 
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
@@ -2324,8 +2342,9 @@ class TestPresExchHandler:
                 pd=pd_list[0][0],
                 challenge="3fa85f64-5717-4562-b3fc-2c963f66afa7",
             )
-            assert vp["test"] == "1"
-            assert SECURITY_CONTEXT_BBS_URL in vp["@context"]
+            for vp_single in vp:
+                assert vp_single["test"] == "1"
+                assert SECURITY_CONTEXT_BBS_URL in vp_single["@context"]
 
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
@@ -2378,8 +2397,10 @@ class TestPresExchHandler:
                 pd=pd_list[0][0],
                 challenge="3fa85f64-5717-4562-b3fc-2c963f66afa7",
             )
-            assert vp["test"] == "1"
-            assert SECURITY_CONTEXT_BBS_URL in vp["@context"]
+            #2 sub_reqs, vp is a sequence
+            for vp_single in vp:
+                assert vp_single["test"] == "1"
+                assert SECURITY_CONTEXT_BBS_URL in vp_single["@context"]
 
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
@@ -3055,6 +3076,8 @@ class TestPresExchHandler:
             pd=tmp_pd[0],
             challenge="1f44d55f-f161-4938-a659-f8026467f126",
         )
+        # only 1 sub_req
+        assert isinstance(tmp_vp, dict)
         assert len(tmp_vp["verifiableCredential"]) == 2
         assert (
             tmp_vp.get("verifiableCredential")[0]
@@ -3075,19 +3098,22 @@ class TestPresExchHandler:
             pd=tmp_pd[0],
             challenge="1f44d55f-f161-4938-a659-f8026467f126",
         )
-        assert len(tmp_vp["verifiableCredential"]) == 2
-        assert (
-            tmp_vp.get("verifiableCredential")[0]
-            .get("credentialSubject")
-            .get("givenName")
-            == "TEST"
-        )
-        assert (
-            tmp_vp.get("verifiableCredential")[1]
-            .get("credentialSubject")
-            .get("givenName")
-            == "TEST"
-        )
+        assert isinstance(tmp_vp, Sequence)
+        # 1 for each submission requirement group
+        assert len(tmp_vp) == 3
+        for tmp_vp_single in tmp_vp:
+            assert (
+                tmp_vp_single.get("verifiableCredential")[0]
+                .get("credentialSubject")
+                .get("givenName")
+                == "TEST"
+            )
+            assert (
+                tmp_vp_single.get("verifiableCredential")[1]
+                .get("credentialSubject")
+                .get("givenName")
+                == "TEST"
+            )
 
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
@@ -474,11 +474,22 @@ class DIFPresFormatHandler(V20PresFormatHandler):
                 challenge = pres_request["options"].get("challenge", str(uuid4()))
             if not challenge:
                 challenge = str(uuid4())
-            pres_ver_result = await verify_presentation(
-                presentation=dif_proof,
-                suites=await self._get_all_suites(wallet=wallet),
-                document_loader=self._profile.inject(DocumentLoader),
-                challenge=challenge,
-            )
+            if(isinstance(dif_proof, Sequence)):
+                for proof in dif_proof:
+                    pres_ver_result = await verify_presentation(
+                        presentation=proof,
+                        suites=await self._get_all_suites(wallet=wallet),
+                        document_loader=self._profile.inject(DocumentLoader),
+                        challenge=challenge,
+                    )
+                    if not pres_ver_result.verified:
+                        break
+            else:
+                pres_ver_result = await verify_presentation(
+                    presentation=dif_proof,
+                    suites=await self._get_all_suites(wallet=wallet),
+                    document_loader=self._profile.inject(DocumentLoader),
+                    challenge=challenge,
+                )
             pres_ex_record.verified = json.dumps(pres_ver_result.verified)
             return pres_ex_record

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
@@ -474,7 +474,7 @@ class DIFPresFormatHandler(V20PresFormatHandler):
                 challenge = pres_request["options"].get("challenge", str(uuid4()))
             if not challenge:
                 challenge = str(uuid4())
-            if(isinstance(dif_proof, Sequence)):
+            if isinstance(dif_proof, Sequence):
                 for proof in dif_proof:
                     pres_ver_result = await verify_presentation(
                         presentation=proof,

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
@@ -152,7 +152,7 @@ DIF_PRES_REQUEST_SEQUENCE = {
                 "rule": "pick",
                 "min": 1,
                 "from": "B",
-            }
+            },
         ],
         "input_descriptors": [
             {
@@ -198,7 +198,7 @@ DIF_PRES_REQUEST_SEQUENCE = {
                         }
                     ],
                 },
-            }
+            },
         ],
     },
 }
@@ -283,56 +283,58 @@ DIF_PRES = {
     },
 }
 
-DIF_PRES_SEQUENCE = [DIF_PRES,
-{
-    "@context": ["https://www.w3.org/2018/credentials/v1"],
-    "type": ["VerifiablePresentation"],
-    "verifiableCredential": [
-        {
-            "@context": [
-                "https://www.w3.org/2018/credentials/v1",
-                "https://w3id.org/citizenship/v1",
-                "https://w3id.org/security/bbs/v1",
-            ],
-            "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
-            "type": ["PermanentResidentCard", "VerifiableCredential"],
-            "credentialSubject": {
-                "id": "did:example:b34ca6cd37bbf23",
-                "type": ["Person", "PermanentResident"],
-                "givenName": "JOHN",
-            },
-            "issuanceDate": "2010-01-01T19:53:24Z",
-            "issuer": "did:key:zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v",
-            "proof": {
-                "type": "BbsBlsSignatureProof2020",
-                "nonce": "3AuruhJQrXtEgiagiJ+FwVf2S0SnzUDJvnO61YecQsJ7ImR1mPcoVjJJ0HOhfkFpoYI=",
-                "proofValue": "ABkBuAaPlP5A7JWY78Xf69oBnsMLcD1RXbIFYhcLoXPXW12CG9glnnqnPLsGri5xsA3LcP0kg74X+sAjKXGRGy3uvp412Dm0FuohYNboQcLne5KOAa5AxU4bjmwQsxdfduVqhriro1N+YTkuB4SMmO/5ooL0N3OHsYdExg7nSzWqmZoqgp+3CwIxF0a/oyKTcxJORuIqAAAAdInlL9teSIX49NJGEZfBO7IrdjT2iggH/G0AlPWoEvrWIbuCRQ69K83n5o7oJVjqhAAAAAIaVmlAD6+FEKA4eg0OaWOKPrd5Kq8rv0vIwjJ71egxll0Fqq4zDWQ/+yl3Pteh0Wyuyvpm19/sj6tiCWj4PkA+rpxtR2bXpnrCTKUffFFNBjVvVziXDS0KWkGUB7XU9mjUa4USC7Iub3bZZCnFjQA5AAAADzkGwGD837r33e7OTrGEti8eAkvFDcyCgA4ck/X+5HJjAJclHWbl4SNQR8CiNZyzJpvxW+jbNBcwmEvocYArddk3F78Ki0Qnp6aU9eDgfOOx1iW2BXLUjrhq5I2hP5/WQF3CEDYRjczGjzM9T8/coeC36YAp0zJunIXUKb8SPDSOISafibYRYFB4xhlWKXWloDelafyujOBST8KZNM8FmF4DSbXrO8vmZbjuR/8ntUcUK7X2rNbuZ3M5eWZDF8pL+SA9gQitKfPHEocoYAdhgEAM7ZNAJ+TgOcx9gtZIhDWKDNnFxIeoOAylbD1xZd9xbWtq3Bk3R79xqsKxFRJRNxk/9b6fJruP292+qM5lxcZ1jUz/dJUYFI93hH4Mso75CjGRN78MAY9SNifl6H8qcxTpBn4332LlFhRznLbtnc4YSWA/fvVqaN9h2zCH/6AdbLKXGffV34EF7DadwJsi9jsc+YlSMn6qaIUIDTdGLwh4KKpSH5bVbg/mVCcXPTJplFgYwRsOdiQbZY/740dJyo1lPjQ0Lvdio8W2M8c73ujeJU70CNLkgjJAMUPGrCFtGxBH2eeLBQ0P95qRZAIcJ7U0MibZLaRjoUOuTla5BIt2038PJ6XhcY6BEJaLyJOPEQ==",
-                "verificationMethod": "did:key:zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v#zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v",
-                "proofPurpose": "assertionMethod",
-                "created": "2021-05-05T15:22:30.523465",
-            },
-        }
-    ],
-    "presentation_submission": {
-        "id": "a5fcfe44-2c30-497d-af02-98e539da9a0f",
-        "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
-        "descriptor_map": [
-            {
-                "id": "citizenship_input_2",
-                "format": "ldp_vp",
-                "path": "$.verifiableCredential[0]",
+DIF_PRES_SEQUENCE = [
+    DIF_PRES,
+    {
+        "@context": ["https://www.w3.org/2018/credentials/v1"],
+        "type": ["VerifiablePresentation"],
+        "verifiableCredential": [
+             {
+                "@context": [
+                    "https://www.w3.org/2018/credentials/v1",
+                    "https://w3id.org/citizenship/v1",
+                    "https://w3id.org/security/bbs/v1",
+                ],
+                "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
+                "type": ["PermanentResidentCard", "VerifiableCredential"],
+                "credentialSubject": {
+                    "id": "did:example:b34ca6cd37bbf23",
+                    "type": ["Person", "PermanentResident"],
+                    "givenName": "JOHN",
+                },
+                "issuanceDate": "2010-01-01T19:53:24Z",
+                "issuer": "did:key:zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v",
+                "proof": {
+                    "type": "BbsBlsSignatureProof2020",
+                    "nonce": "3AuruhJQrXtEgiagiJ+FwVf2S0SnzUDJvnO61YecQsJ7ImR1mPcoVjJJ0HOhfkFpoYI=",
+                    "proofValue": "ABkBuAaPlP5A7JWY78Xf69oBnsMLcD1RXbIFYhcLoXPXW12CG9glnnqnPLsGri5xsA3LcP0kg74X+sAjKXGRGy3uvp412Dm0FuohYNboQcLne5KOAa5AxU4bjmwQsxdfduVqhriro1N+YTkuB4SMmO/5ooL0N3OHsYdExg7nSzWqmZoqgp+3CwIxF0a/oyKTcxJORuIqAAAAdInlL9teSIX49NJGEZfBO7IrdjT2iggH/G0AlPWoEvrWIbuCRQ69K83n5o7oJVjqhAAAAAIaVmlAD6+FEKA4eg0OaWOKPrd5Kq8rv0vIwjJ71egxll0Fqq4zDWQ/+yl3Pteh0Wyuyvpm19/sj6tiCWj4PkA+rpxtR2bXpnrCTKUffFFNBjVvVziXDS0KWkGUB7XU9mjUa4USC7Iub3bZZCnFjQA5AAAADzkGwGD837r33e7OTrGEti8eAkvFDcyCgA4ck/X+5HJjAJclHWbl4SNQR8CiNZyzJpvxW+jbNBcwmEvocYArddk3F78Ki0Qnp6aU9eDgfOOx1iW2BXLUjrhq5I2hP5/WQF3CEDYRjczGjzM9T8/coeC36YAp0zJunIXUKb8SPDSOISafibYRYFB4xhlWKXWloDelafyujOBST8KZNM8FmF4DSbXrO8vmZbjuR/8ntUcUK7X2rNbuZ3M5eWZDF8pL+SA9gQitKfPHEocoYAdhgEAM7ZNAJ+TgOcx9gtZIhDWKDNnFxIeoOAylbD1xZd9xbWtq3Bk3R79xqsKxFRJRNxk/9b6fJruP292+qM5lxcZ1jUz/dJUYFI93hH4Mso75CjGRN78MAY9SNifl6H8qcxTpBn4332LlFhRznLbtnc4YSWA/fvVqaN9h2zCH/6AdbLKXGffV34EF7DadwJsi9jsc+YlSMn6qaIUIDTdGLwh4KKpSH5bVbg/mVCcXPTJplFgYwRsOdiQbZY/740dJyo1lPjQ0Lvdio8W2M8c73ujeJU70CNLkgjJAMUPGrCFtGxBH2eeLBQ0P95qRZAIcJ7U0MibZLaRjoUOuTla5BIt2038PJ6XhcY6BEJaLyJOPEQ==",
+                    "verificationMethod": "did:key:zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v#zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v",
+                    "proofPurpose": "assertionMethod",
+                    "created": "2021-05-05T15:22:30.523465",
+                },
             }
         ],
+        "presentation_submission": {
+            "id": "a5fcfe44-2c30-497d-af02-98e539da9a0f",
+            "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+            "descriptor_map": [
+                {
+                    "id": "citizenship_input_2",
+                    "format": "ldp_vp",
+                    "path": "$.verifiableCredential[0]",
+                }
+            ],
+        },
+        "proof": {
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:sov:4QxzWk3ajdnEA37NdNU5Kt#key-1",
+            "created": "2021-05-05T15:23:03.023971",
+            "proofPurpose": "authentication",
+            "challenge": "40429d49-5e8f-4ffc-baf8-e332412f1247",
+            "jws": "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..2uBYmg7muE9ZPVeAGo_ibVfLkCjf2hGshr2o5i8pAwFyNBM-kDHXofuq1MzJgb19wzb01VIu91hY_ajjt9KFAA",
+        },
     },
-    "proof": {
-        "type": "Ed25519Signature2018",
-        "verificationMethod": "did:sov:4QxzWk3ajdnEA37NdNU5Kt#key-1",
-        "created": "2021-05-05T15:23:03.023971",
-        "proofPurpose": "authentication",
-        "challenge": "40429d49-5e8f-4ffc-baf8-e332412f1247",
-        "jws": "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..2uBYmg7muE9ZPVeAGo_ibVfLkCjf2hGshr2o5i8pAwFyNBM-kDHXofuq1MzJgb19wzb01VIu91hY_ajjt9KFAA",
-    },
-}]
+]
 
 
 TEST_CRED = {
@@ -1130,7 +1132,9 @@ class TestDIFFormatHandler(AsyncTestCase):
                     format_=ATTACHMENT_FORMAT[PRES_20][V20PresFormat.Format.DIF.api],
                 )
             ],
-            presentations_attach=[AttachDecorator.data_json(DIF_PRES_SEQUENCE, ident="dif")],
+            presentations_attach=[
+                AttachDecorator.data_json(DIF_PRES_SEQUENCE, ident="dif")
+            ],
         )
         dif_pres_request = V20PresRequest(
             formats=[

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
@@ -289,7 +289,7 @@ DIF_PRES_SEQUENCE = [
         "@context": ["https://www.w3.org/2018/credentials/v1"],
         "type": ["VerifiablePresentation"],
         "verifiableCredential": [
-             {
+            {
                 "@context": [
                     "https://www.w3.org/2018/credentials/v1",
                     "https://w3id.org/citizenship/v1",

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
@@ -179,7 +179,7 @@ DIF_PRES_REQUEST_SEQUENCE = {
             },
             {
                 "id": "citizenship_input_2",
-                "name": "EU Driver's License",
+                "name": "EU Driver's License v2",
                 "group": ["B"],
                 "schema": [
                     {"uri": "https://www.w3.org/2018/credentials#VerifiableCredential"},
@@ -283,55 +283,7 @@ DIF_PRES = {
     },
 }
 
-DIF_PRES_SEQUENCE = [{
-    "@context": ["https://www.w3.org/2018/credentials/v1"],
-    "type": ["VerifiablePresentation"],
-    "verifiableCredential": [
-        {
-            "@context": [
-                "https://www.w3.org/2018/credentials/v1",
-                "https://w3id.org/citizenship/v1",
-                "https://w3id.org/security/bbs/v1",
-            ],
-            "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
-            "type": ["PermanentResidentCard", "VerifiableCredential"],
-            "credentialSubject": {
-                "id": "did:example:b34ca6cd37bbf23",
-                "type": ["Person", "PermanentResident"],
-                "givenName": "JOHN",
-            },
-            "issuanceDate": "2010-01-01T19:53:24Z",
-            "issuer": "did:key:zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v",
-            "proof": {
-                "type": "BbsBlsSignatureProof2020",
-                "nonce": "3AuruhJQrXtEgiagiJ+FwVf2S0SnzUDJvnO61YecQsJ7ImR1mPcoVjJJ0HOhfkFpoYI=",
-                "proofValue": "ABkBuAaPlP5A7JWY78Xf69oBnsMLcD1RXbIFYhcLoXPXW12CG9glnnqnPLsGri5xsA3LcP0kg74X+sAjKXGRGy3uvp412Dm0FuohYNboQcLne5KOAa5AxU4bjmwQsxdfduVqhriro1N+YTkuB4SMmO/5ooL0N3OHsYdExg7nSzWqmZoqgp+3CwIxF0a/oyKTcxJORuIqAAAAdInlL9teSIX49NJGEZfBO7IrdjT2iggH/G0AlPWoEvrWIbuCRQ69K83n5o7oJVjqhAAAAAIaVmlAD6+FEKA4eg0OaWOKPrd5Kq8rv0vIwjJ71egxll0Fqq4zDWQ/+yl3Pteh0Wyuyvpm19/sj6tiCWj4PkA+rpxtR2bXpnrCTKUffFFNBjVvVziXDS0KWkGUB7XU9mjUa4USC7Iub3bZZCnFjQA5AAAADzkGwGD837r33e7OTrGEti8eAkvFDcyCgA4ck/X+5HJjAJclHWbl4SNQR8CiNZyzJpvxW+jbNBcwmEvocYArddk3F78Ki0Qnp6aU9eDgfOOx1iW2BXLUjrhq5I2hP5/WQF3CEDYRjczGjzM9T8/coeC36YAp0zJunIXUKb8SPDSOISafibYRYFB4xhlWKXWloDelafyujOBST8KZNM8FmF4DSbXrO8vmZbjuR/8ntUcUK7X2rNbuZ3M5eWZDF8pL+SA9gQitKfPHEocoYAdhgEAM7ZNAJ+TgOcx9gtZIhDWKDNnFxIeoOAylbD1xZd9xbWtq3Bk3R79xqsKxFRJRNxk/9b6fJruP292+qM5lxcZ1jUz/dJUYFI93hH4Mso75CjGRN78MAY9SNifl6H8qcxTpBn4332LlFhRznLbtnc4YSWA/fvVqaN9h2zCH/6AdbLKXGffV34EF7DadwJsi9jsc+YlSMn6qaIUIDTdGLwh4KKpSH5bVbg/mVCcXPTJplFgYwRsOdiQbZY/740dJyo1lPjQ0Lvdio8W2M8c73ujeJU70CNLkgjJAMUPGrCFtGxBH2eeLBQ0P95qRZAIcJ7U0MibZLaRjoUOuTla5BIt2038PJ6XhcY6BEJaLyJOPEQ==",
-                "verificationMethod": "did:key:zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v#zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v",
-                "proofPurpose": "assertionMethod",
-                "created": "2021-05-05T15:22:30.523465",
-            },
-        }
-    ],
-    "presentation_submission": {
-        "id": "a5fcfe44-2c30-497d-af02-98e539da9a0f",
-        "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
-        "descriptor_map": [
-            {
-                "id": "citizenship_input_1",
-                "format": "ldp_vp",
-                "path": "$.verifiableCredential[0]",
-            }
-        ],
-    },
-    "proof": {
-        "type": "Ed25519Signature2018",
-        "verificationMethod": "did:sov:4QxzWk3ajdnEA37NdNU5Kt#key-1",
-        "created": "2021-05-05T15:23:03.023971",
-        "proofPurpose": "authentication",
-        "challenge": "40429d49-5e8f-4ffc-baf8-e332412f1247",
-        "jws": "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..2uBYmg7muE9ZPVeAGo_ibVfLkCjf2hGshr2o5i8pAwFyNBM-kDHXofuq1MzJgb19wzb01VIu91hY_ajjt9KFAA",
-    },
-},
+DIF_PRES_SEQUENCE = [DIF_PRES,
 {
     "@context": ["https://www.w3.org/2018/credentials/v1"],
     "type": ["VerifiablePresentation"],
@@ -1216,43 +1168,6 @@ class TestDIFFormatHandler(AsyncTestCase):
         ):
             output = await self.handler.verify_pres(record)
             assert output.verified
-
-    async def test_verify_pres_sequence_one_pres_false(self):
-        dif_pres = V20Pres(
-            formats=[
-                V20PresFormat(
-                    attach_id="dif",
-                    format_=ATTACHMENT_FORMAT[PRES_20][V20PresFormat.Format.DIF.api],
-                )
-            ],
-            presentations_attach=[AttachDecorator.data_json([DIF_PRES, {}], ident="dif")],
-        )
-        dif_pres_request = V20PresRequest(
-            formats=[
-                V20PresFormat(
-                    attach_id="dif",
-                    format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
-                        V20PresFormat.Format.DIF.api
-                    ],
-                )
-            ],
-            request_presentations_attach=[
-                AttachDecorator.data_json(DIF_PRES_REQUEST_SEQUENCE, ident="dif")
-            ],
-        )
-        record = V20PresExRecord(
-            pres_ex_id="pxid",
-            thread_id="thid",
-            connection_id="conn_id",
-            initiator="init",
-            role="role",
-            state="state",
-            pres_request=dif_pres_request,
-            pres=dif_pres,
-            verified="false",
-            auto_present=True,
-            error_msg="error",
-        )
 
         with async_mock.patch.object(
             test_module,

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
@@ -134,6 +134,75 @@ DIF_PRES_REQUEST_B = {
     },
 }
 
+DIF_PRES_REQUEST_SEQUENCE = {
+    "options": {
+        "challenge": "3fa85f64-5717-4562-b3fc-2c963f66afa7",
+        "domain": "4jt78h47fh47",
+    },
+    "presentation_definition": {
+        "id": "32f54163-7166-48f1-93d8-ff217bdb0654",
+        "submission_requirements": [
+            {
+                "name": "Citizenship Information",
+                "rule": "all",
+                "from": "A",
+            },
+            {
+                "name": "Citizenship Information v2",
+                "rule": "pick",
+                "min": 1,
+                "from": "B",
+            }
+        ],
+        "input_descriptors": [
+            {
+                "id": "citizenship_input_1",
+                "name": "EU Driver's License",
+                "group": ["A"],
+                "schema": [
+                    {"uri": "https://www.w3.org/2018/credentials#VerifiableCredential"},
+                    {"uri": "https://w3id.org/citizenship#PermanentResidentCard"},
+                ],
+                "constraints": {
+                    "limit_disclosure": "required",
+                    "fields": [
+                        {
+                            "path": ["$.credentialSubject.givenName"],
+                            "purpose": "The claim must be from one of the specified issuers",
+                            "filter": {
+                                "type": "string",
+                                "enum": ["JOHN", "CAI"],
+                            },
+                        }
+                    ],
+                },
+            },
+            {
+                "id": "citizenship_input_2",
+                "name": "EU Driver's License",
+                "group": ["B"],
+                "schema": [
+                    {"uri": "https://www.w3.org/2018/credentials#VerifiableCredential"},
+                    {"uri": "https://w3id.org/citizenship#PermanentResidentCard"},
+                ],
+                "constraints": {
+                    "limit_disclosure": "required",
+                    "fields": [
+                        {
+                            "path": ["$.credentialSubject.givenName"],
+                            "purpose": "The claim must be from one of the specified issuers",
+                            "filter": {
+                                "type": "string",
+                                "enum": ["JOHN", "CAI"],
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+    },
+}
+
 DIF_PRES_PROPOSAL = {
     "input_descriptors": [
         {
@@ -213,6 +282,106 @@ DIF_PRES = {
         "jws": "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..2uBYmg7muE9ZPVeAGo_ibVfLkCjf2hGshr2o5i8pAwFyNBM-kDHXofuq1MzJgb19wzb01VIu91hY_ajjt9KFAA",
     },
 }
+
+DIF_PRES_SEQUENCE = [{
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "type": ["VerifiablePresentation"],
+    "verifiableCredential": [
+        {
+            "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                "https://w3id.org/citizenship/v1",
+                "https://w3id.org/security/bbs/v1",
+            ],
+            "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
+            "type": ["PermanentResidentCard", "VerifiableCredential"],
+            "credentialSubject": {
+                "id": "did:example:b34ca6cd37bbf23",
+                "type": ["Person", "PermanentResident"],
+                "givenName": "JOHN",
+            },
+            "issuanceDate": "2010-01-01T19:53:24Z",
+            "issuer": "did:key:zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v",
+            "proof": {
+                "type": "BbsBlsSignatureProof2020",
+                "nonce": "3AuruhJQrXtEgiagiJ+FwVf2S0SnzUDJvnO61YecQsJ7ImR1mPcoVjJJ0HOhfkFpoYI=",
+                "proofValue": "ABkBuAaPlP5A7JWY78Xf69oBnsMLcD1RXbIFYhcLoXPXW12CG9glnnqnPLsGri5xsA3LcP0kg74X+sAjKXGRGy3uvp412Dm0FuohYNboQcLne5KOAa5AxU4bjmwQsxdfduVqhriro1N+YTkuB4SMmO/5ooL0N3OHsYdExg7nSzWqmZoqgp+3CwIxF0a/oyKTcxJORuIqAAAAdInlL9teSIX49NJGEZfBO7IrdjT2iggH/G0AlPWoEvrWIbuCRQ69K83n5o7oJVjqhAAAAAIaVmlAD6+FEKA4eg0OaWOKPrd5Kq8rv0vIwjJ71egxll0Fqq4zDWQ/+yl3Pteh0Wyuyvpm19/sj6tiCWj4PkA+rpxtR2bXpnrCTKUffFFNBjVvVziXDS0KWkGUB7XU9mjUa4USC7Iub3bZZCnFjQA5AAAADzkGwGD837r33e7OTrGEti8eAkvFDcyCgA4ck/X+5HJjAJclHWbl4SNQR8CiNZyzJpvxW+jbNBcwmEvocYArddk3F78Ki0Qnp6aU9eDgfOOx1iW2BXLUjrhq5I2hP5/WQF3CEDYRjczGjzM9T8/coeC36YAp0zJunIXUKb8SPDSOISafibYRYFB4xhlWKXWloDelafyujOBST8KZNM8FmF4DSbXrO8vmZbjuR/8ntUcUK7X2rNbuZ3M5eWZDF8pL+SA9gQitKfPHEocoYAdhgEAM7ZNAJ+TgOcx9gtZIhDWKDNnFxIeoOAylbD1xZd9xbWtq3Bk3R79xqsKxFRJRNxk/9b6fJruP292+qM5lxcZ1jUz/dJUYFI93hH4Mso75CjGRN78MAY9SNifl6H8qcxTpBn4332LlFhRznLbtnc4YSWA/fvVqaN9h2zCH/6AdbLKXGffV34EF7DadwJsi9jsc+YlSMn6qaIUIDTdGLwh4KKpSH5bVbg/mVCcXPTJplFgYwRsOdiQbZY/740dJyo1lPjQ0Lvdio8W2M8c73ujeJU70CNLkgjJAMUPGrCFtGxBH2eeLBQ0P95qRZAIcJ7U0MibZLaRjoUOuTla5BIt2038PJ6XhcY6BEJaLyJOPEQ==",
+                "verificationMethod": "did:key:zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v#zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v",
+                "proofPurpose": "assertionMethod",
+                "created": "2021-05-05T15:22:30.523465",
+            },
+        }
+    ],
+    "presentation_submission": {
+        "id": "a5fcfe44-2c30-497d-af02-98e539da9a0f",
+        "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+        "descriptor_map": [
+            {
+                "id": "citizenship_input_1",
+                "format": "ldp_vp",
+                "path": "$.verifiableCredential[0]",
+            }
+        ],
+    },
+    "proof": {
+        "type": "Ed25519Signature2018",
+        "verificationMethod": "did:sov:4QxzWk3ajdnEA37NdNU5Kt#key-1",
+        "created": "2021-05-05T15:23:03.023971",
+        "proofPurpose": "authentication",
+        "challenge": "40429d49-5e8f-4ffc-baf8-e332412f1247",
+        "jws": "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..2uBYmg7muE9ZPVeAGo_ibVfLkCjf2hGshr2o5i8pAwFyNBM-kDHXofuq1MzJgb19wzb01VIu91hY_ajjt9KFAA",
+    },
+},
+{
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "type": ["VerifiablePresentation"],
+    "verifiableCredential": [
+        {
+            "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                "https://w3id.org/citizenship/v1",
+                "https://w3id.org/security/bbs/v1",
+            ],
+            "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
+            "type": ["PermanentResidentCard", "VerifiableCredential"],
+            "credentialSubject": {
+                "id": "did:example:b34ca6cd37bbf23",
+                "type": ["Person", "PermanentResident"],
+                "givenName": "JOHN",
+            },
+            "issuanceDate": "2010-01-01T19:53:24Z",
+            "issuer": "did:key:zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v",
+            "proof": {
+                "type": "BbsBlsSignatureProof2020",
+                "nonce": "3AuruhJQrXtEgiagiJ+FwVf2S0SnzUDJvnO61YecQsJ7ImR1mPcoVjJJ0HOhfkFpoYI=",
+                "proofValue": "ABkBuAaPlP5A7JWY78Xf69oBnsMLcD1RXbIFYhcLoXPXW12CG9glnnqnPLsGri5xsA3LcP0kg74X+sAjKXGRGy3uvp412Dm0FuohYNboQcLne5KOAa5AxU4bjmwQsxdfduVqhriro1N+YTkuB4SMmO/5ooL0N3OHsYdExg7nSzWqmZoqgp+3CwIxF0a/oyKTcxJORuIqAAAAdInlL9teSIX49NJGEZfBO7IrdjT2iggH/G0AlPWoEvrWIbuCRQ69K83n5o7oJVjqhAAAAAIaVmlAD6+FEKA4eg0OaWOKPrd5Kq8rv0vIwjJ71egxll0Fqq4zDWQ/+yl3Pteh0Wyuyvpm19/sj6tiCWj4PkA+rpxtR2bXpnrCTKUffFFNBjVvVziXDS0KWkGUB7XU9mjUa4USC7Iub3bZZCnFjQA5AAAADzkGwGD837r33e7OTrGEti8eAkvFDcyCgA4ck/X+5HJjAJclHWbl4SNQR8CiNZyzJpvxW+jbNBcwmEvocYArddk3F78Ki0Qnp6aU9eDgfOOx1iW2BXLUjrhq5I2hP5/WQF3CEDYRjczGjzM9T8/coeC36YAp0zJunIXUKb8SPDSOISafibYRYFB4xhlWKXWloDelafyujOBST8KZNM8FmF4DSbXrO8vmZbjuR/8ntUcUK7X2rNbuZ3M5eWZDF8pL+SA9gQitKfPHEocoYAdhgEAM7ZNAJ+TgOcx9gtZIhDWKDNnFxIeoOAylbD1xZd9xbWtq3Bk3R79xqsKxFRJRNxk/9b6fJruP292+qM5lxcZ1jUz/dJUYFI93hH4Mso75CjGRN78MAY9SNifl6H8qcxTpBn4332LlFhRznLbtnc4YSWA/fvVqaN9h2zCH/6AdbLKXGffV34EF7DadwJsi9jsc+YlSMn6qaIUIDTdGLwh4KKpSH5bVbg/mVCcXPTJplFgYwRsOdiQbZY/740dJyo1lPjQ0Lvdio8W2M8c73ujeJU70CNLkgjJAMUPGrCFtGxBH2eeLBQ0P95qRZAIcJ7U0MibZLaRjoUOuTla5BIt2038PJ6XhcY6BEJaLyJOPEQ==",
+                "verificationMethod": "did:key:zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v#zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v",
+                "proofPurpose": "assertionMethod",
+                "created": "2021-05-05T15:22:30.523465",
+            },
+        }
+    ],
+    "presentation_submission": {
+        "id": "a5fcfe44-2c30-497d-af02-98e539da9a0f",
+        "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+        "descriptor_map": [
+            {
+                "id": "citizenship_input_2",
+                "format": "ldp_vp",
+                "path": "$.verifiableCredential[0]",
+            }
+        ],
+    },
+    "proof": {
+        "type": "Ed25519Signature2018",
+        "verificationMethod": "did:sov:4QxzWk3ajdnEA37NdNU5Kt#key-1",
+        "created": "2021-05-05T15:23:03.023971",
+        "proofPurpose": "authentication",
+        "challenge": "40429d49-5e8f-4ffc-baf8-e332412f1247",
+        "jws": "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..2uBYmg7muE9ZPVeAGo_ibVfLkCjf2hGshr2o5i8pAwFyNBM-kDHXofuq1MzJgb19wzb01VIu91hY_ajjt9KFAA",
+    },
+}]
+
 
 TEST_CRED = {
     "@context": [
@@ -1001,6 +1170,100 @@ class TestDIFFormatHandler(AsyncTestCase):
             )
             assert output[1].data.json_ == DIF_PRES
 
+    async def test_verify_pres_sequence(self):
+        dif_pres = V20Pres(
+            formats=[
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20][V20PresFormat.Format.DIF.api],
+                )
+            ],
+            presentations_attach=[AttachDecorator.data_json(DIF_PRES_SEQUENCE, ident="dif")],
+        )
+        dif_pres_request = V20PresRequest(
+            formats=[
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
+                        V20PresFormat.Format.DIF.api
+                    ],
+                )
+            ],
+            request_presentations_attach=[
+                AttachDecorator.data_json(DIF_PRES_REQUEST_SEQUENCE, ident="dif")
+            ],
+        )
+        record = V20PresExRecord(
+            pres_ex_id="pxid",
+            thread_id="thid",
+            connection_id="conn_id",
+            initiator="init",
+            role="role",
+            state="state",
+            pres_request=dif_pres_request,
+            pres=dif_pres,
+            verified="false",
+            auto_present=True,
+            error_msg="error",
+        )
+
+        with async_mock.patch.object(
+            test_module,
+            "verify_presentation",
+            async_mock.CoroutineMock(
+                return_value=PresentationVerificationResult(verified=True)
+            ),
+        ):
+            output = await self.handler.verify_pres(record)
+            assert output.verified
+
+    async def test_verify_pres_sequence_one_pres_false(self):
+        dif_pres = V20Pres(
+            formats=[
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20][V20PresFormat.Format.DIF.api],
+                )
+            ],
+            presentations_attach=[AttachDecorator.data_json([DIF_PRES, {}], ident="dif")],
+        )
+        dif_pres_request = V20PresRequest(
+            formats=[
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
+                        V20PresFormat.Format.DIF.api
+                    ],
+                )
+            ],
+            request_presentations_attach=[
+                AttachDecorator.data_json(DIF_PRES_REQUEST_SEQUENCE, ident="dif")
+            ],
+        )
+        record = V20PresExRecord(
+            pres_ex_id="pxid",
+            thread_id="thid",
+            connection_id="conn_id",
+            initiator="init",
+            role="role",
+            state="state",
+            pres_request=dif_pres_request,
+            pres=dif_pres,
+            verified="false",
+            auto_present=True,
+            error_msg="error",
+        )
+
+        with async_mock.patch.object(
+            test_module,
+            "verify_presentation",
+            async_mock.CoroutineMock(
+                return_value=PresentationVerificationResult(verified=False)
+            ),
+        ):
+            output = await self.handler.verify_pres(record)
+            assert output.verified == "false"
+
     async def test_verify_pres(self):
         dif_pres = V20Pres(
             formats=[
@@ -1497,6 +1760,49 @@ class TestDIFFormatHandler(AsyncTestCase):
             ],
             request_presentations_attach=[
                 AttachDecorator.data_json(dif_proof_req, ident="dif")
+            ],
+        )
+        record = V20PresExRecord(
+            pres_ex_id="pxid",
+            thread_id="thid",
+            connection_id="conn_id",
+            initiator="init",
+            role="role",
+            state="state",
+            pres_request=dif_pres_request,
+            pres=dif_pres,
+            verified="false",
+            auto_present=True,
+            error_msg="error",
+        )
+        await self.handler.receive_pres(message=dif_pres, pres_ex_record=record)
+
+    async def test_verify_received_pres_sequence(self):
+        dif_pres = V20Pres(
+            formats=[
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20][V20PresFormat.Format.DIF.api],
+                )
+            ],
+            presentations_attach=[
+                AttachDecorator.data_json(
+                    mapping=DIF_PRES_SEQUENCE,
+                    ident="dif",
+                )
+            ],
+        )
+        dif_pres_request = V20PresRequest(
+            formats=[
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
+                        V20PresFormat.Format.DIF.api
+                    ],
+                )
+            ],
+            request_presentations_attach=[
+                AttachDecorator.data_json(DIF_PRES_REQUEST_SEQUENCE, ident="dif")
             ],
         )
         record = V20PresExRecord(

--- a/aries_cloudagent/protocols/present_proof/v2_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/manager.py
@@ -393,7 +393,7 @@ class V20PresManager:
                 ).verify_pres(
                     pres_ex_record,
                 )
-                if pres_ex_record.verified == 'false':
+                if pres_ex_record.verified == "false":
                     break
 
         pres_ex_record.state = V20PresExRecord.STATE_DONE

--- a/aries_cloudagent/protocols/present_proof/v2_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/manager.py
@@ -263,9 +263,15 @@ class V20PresManager:
             pres_exch_format = V20PresFormat.Format.get(format.format)
 
             if pres_exch_format:
+                if not request_data:
+                    request_data_pres_exch = {}
+                else:
+                    request_data_pres_exch = {
+                        pres_exch_format.api: request_data.get(pres_exch_format.api)
+                    }
                 pres_tuple = await pres_exch_format.handler(self._profile).create_pres(
                     pres_ex_record,
-                    request_data,
+                    request_data_pres_exch,
                 )
                 if pres_tuple:
                     pres_formats.append(pres_tuple)
@@ -387,6 +393,8 @@ class V20PresManager:
                 ).verify_pres(
                     pres_ex_record,
                 )
+                if pres_ex_record.verified == 'false':
+                    break
 
         pres_ex_record.state = V20PresExRecord.STATE_DONE
 

--- a/aries_cloudagent/protocols/present_proof/v2_0/messages/pres.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/messages/pres.py
@@ -118,7 +118,7 @@ class V20PresSchema(AgentMessageSchema):
             atch = get_attach_by_id(fmt.attach_id)
             pres_format = V20PresFormat.Format.get(fmt.format)
             if pres_format:
-                if(isinstance(atch.content, Sequence)):
+                if isinstance(atch.content, Sequence):
                     for el in atch.content:
                         pres_format.validate_fields(PRES_20, el)
                 else:

--- a/aries_cloudagent/protocols/present_proof/v2_0/messages/pres.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/messages/pres.py
@@ -118,4 +118,8 @@ class V20PresSchema(AgentMessageSchema):
             atch = get_attach_by_id(fmt.attach_id)
             pres_format = V20PresFormat.Format.get(fmt.format)
             if pres_format:
-                pres_format.validate_fields(PRES_20, atch.content)
+                if(isinstance(atch.content, Sequence)):
+                    for el in atch.content:
+                        pres_format.validate_fields(PRES_20, el)
+                else:
+                    pres_format.validate_fields(PRES_20, atch.content)

--- a/aries_cloudagent/protocols/present_proof/v2_0/messages/tests/test_pres.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/messages/tests/test_pres.py
@@ -1818,7 +1818,6 @@ PRES_DIF = V20Pres(
 )
 
 
-
 class TestV20Pres(TestCase):
     """Presentation tests."""
 

--- a/aries_cloudagent/protocols/present_proof/v2_0/messages/tests/test_pres.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/messages/tests/test_pres.py
@@ -1662,6 +1662,129 @@ INDY_PROOF = json.loads(  # indy returns proof json-encoded: json-decode before 
     }"""
 )
 
+DIF_PROOF = json.loads(
+    """[
+        {
+            "@context":[
+                "https://www.w3.org/2018/credentials/v1"
+            ],
+            "type":[
+                "VerifiablePresentation"
+            ],
+            "verifiableCredential":[
+                {
+                    "@context":[
+                        "https://www.w3.org/2018/credentials/v1",
+                        "https://w3id.org/citizenship/v1",
+                        "https://w3id.org/security/bbs/v1"
+                    ],
+                    "id":"https://issuer.oidp.uscis.gov/credentials/83627465",
+                    "type":[
+                        "PermanentResidentCard",
+                        "VerifiableCredential"
+                    ],
+                    "credentialSubject":{
+                        "id":"did:example:b34ca6cd37bbf23",
+                        "type":[
+                            "Person",
+                            "PermanentResident"
+                        ],
+                        "givenName":"JOHN"
+                    },
+                    "issuanceDate":"2010-01-01T19:53:24Z",
+                    "issuer":"did:key:zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v",
+                    "proof":{
+                        "type":"BbsBlsSignatureProof2020",
+                        "nonce":"3AuruhJQrXtEgiagiJ+FwVf2S0SnzUDJvnO61YecQsJ7ImR1mPcoVjJJ0HOhfkFpoYI=",
+                        "proofValue":"ABkBuAaPlP5A7JWY78Xf69oBnsMLcD1RXbIFYhcLoXPXW12CG9glnnqnPLsGri5xsA3LcP0kg74X+sAjKXGRGy3uvp412Dm0FuohYNboQcLne5KOAa5AxU4bjmwQsxdfduVqhriro1N+YTkuB4SMmO/5ooL0N3OHsYdExg7nSzWqmZoqgp+3CwIxF0a/oyKTcxJORuIqAAAAdInlL9teSIX49NJGEZfBO7IrdjT2iggH/G0AlPWoEvrWIbuCRQ69K83n5o7oJVjqhAAAAAIaVmlAD6+FEKA4eg0OaWOKPrd5Kq8rv0vIwjJ71egxll0Fqq4zDWQ/+yl3Pteh0Wyuyvpm19/sj6tiCWj4PkA+rpxtR2bXpnrCTKUffFFNBjVvVziXDS0KWkGUB7XU9mjUa4USC7Iub3bZZCnFjQA5AAAADzkGwGD837r33e7OTrGEti8eAkvFDcyCgA4ck/X+5HJjAJclHWbl4SNQR8CiNZyzJpvxW+jbNBcwmEvocYArddk3F78Ki0Qnp6aU9eDgfOOx1iW2BXLUjrhq5I2hP5/WQF3CEDYRjczGjzM9T8/coeC36YAp0zJunIXUKb8SPDSOISafibYRYFB4xhlWKXWloDelafyujOBST8KZNM8FmF4DSbXrO8vmZbjuR/8ntUcUK7X2rNbuZ3M5eWZDF8pL+SA9gQitKfPHEocoYAdhgEAM7ZNAJ+TgOcx9gtZIhDWKDNnFxIeoOAylbD1xZd9xbWtq3Bk3R79xqsKxFRJRNxk/9b6fJruP292+qM5lxcZ1jUz/dJUYFI93hH4Mso75CjGRN78MAY9SNifl6H8qcxTpBn4332LlFhRznLbtnc4YSWA/fvVqaN9h2zCH/6AdbLKXGffV34EF7DadwJsi9jsc+YlSMn6qaIUIDTdGLwh4KKpSH5bVbg/mVCcXPTJplFgYwRsOdiQbZY/740dJyo1lPjQ0Lvdio8W2M8c73ujeJU70CNLkgjJAMUPGrCFtGxBH2eeLBQ0P95qRZAIcJ7U0MibZLaRjoUOuTla5BIt2038PJ6XhcY6BEJaLyJOPEQ==",
+                        "verificationMethod":"did:key:zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v#zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v",
+                        "proofPurpose":"assertionMethod",
+                        "created":"2021-05-05T15:22:30.523465"
+                    }
+                }
+            ],
+            "presentation_submission":{
+                "id":"a5fcfe44-2c30-497d-af02-98e539da9a0f",
+                "definition_id":"32f54163-7166-48f1-93d8-ff217bdb0653",
+                "descriptor_map":[
+                    {
+                        "id":"citizenship_input_1",
+                        "format":"ldp_vp",
+                        "path":"$.verifiableCredential[0]"
+                    }
+                ]
+            },
+            "proof":{
+                "type":"Ed25519Signature2018",
+                "verificationMethod":"did:sov:4QxzWk3ajdnEA37NdNU5Kt#key-1",
+                "created":"2021-05-05T15:23:03.023971",
+                "proofPurpose":"authentication",
+                "challenge":"40429d49-5e8f-4ffc-baf8-e332412f1247",
+                "jws":"eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..2uBYmg7muE9ZPVeAGo_ibVfLkCjf2hGshr2o5i8pAwFyNBM-kDHXofuq1MzJgb19wzb01VIu91hY_ajjt9KFAA"
+            }
+        },
+        {
+            "@context":[
+                "https://www.w3.org/2018/credentials/v1"
+            ],
+            "type":[
+                "VerifiablePresentation"
+            ],
+            "verifiableCredential":[
+                {
+                    "@context":[
+                        "https://www.w3.org/2018/credentials/v1",
+                        "https://w3id.org/citizenship/v1",
+                        "https://w3id.org/security/bbs/v1"
+                    ],
+                    "id":"https://issuer.oidp.uscis.gov/credentials/83627465",
+                    "type":[
+                        "PermanentResidentCard",
+                        "VerifiableCredential"
+                    ],
+                    "credentialSubject":{
+                        "id":"did:example:b34ca6cd37bbf23",
+                        "type":[
+                            "Person",
+                            "PermanentResident"
+                        ],
+                        "givenName":"JOHN"
+                    },
+                    "issuanceDate":"2010-01-01T19:53:24Z",
+                    "issuer":"did:key:zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v",
+                    "proof":{
+                        "type":"BbsBlsSignatureProof2020",
+                        "nonce":"3AuruhJQrXtEgiagiJ+FwVf2S0SnzUDJvnO61YecQsJ7ImR1mPcoVjJJ0HOhfkFpoYI=",
+                        "proofValue":"ABkBuAaPlP5A7JWY78Xf69oBnsMLcD1RXbIFYhcLoXPXW12CG9glnnqnPLsGri5xsA3LcP0kg74X+sAjKXGRGy3uvp412Dm0FuohYNboQcLne5KOAa5AxU4bjmwQsxdfduVqhriro1N+YTkuB4SMmO/5ooL0N3OHsYdExg7nSzWqmZoqgp+3CwIxF0a/oyKTcxJORuIqAAAAdInlL9teSIX49NJGEZfBO7IrdjT2iggH/G0AlPWoEvrWIbuCRQ69K83n5o7oJVjqhAAAAAIaVmlAD6+FEKA4eg0OaWOKPrd5Kq8rv0vIwjJ71egxll0Fqq4zDWQ/+yl3Pteh0Wyuyvpm19/sj6tiCWj4PkA+rpxtR2bXpnrCTKUffFFNBjVvVziXDS0KWkGUB7XU9mjUa4USC7Iub3bZZCnFjQA5AAAADzkGwGD837r33e7OTrGEti8eAkvFDcyCgA4ck/X+5HJjAJclHWbl4SNQR8CiNZyzJpvxW+jbNBcwmEvocYArddk3F78Ki0Qnp6aU9eDgfOOx1iW2BXLUjrhq5I2hP5/WQF3CEDYRjczGjzM9T8/coeC36YAp0zJunIXUKb8SPDSOISafibYRYFB4xhlWKXWloDelafyujOBST8KZNM8FmF4DSbXrO8vmZbjuR/8ntUcUK7X2rNbuZ3M5eWZDF8pL+SA9gQitKfPHEocoYAdhgEAM7ZNAJ+TgOcx9gtZIhDWKDNnFxIeoOAylbD1xZd9xbWtq3Bk3R79xqsKxFRJRNxk/9b6fJruP292+qM5lxcZ1jUz/dJUYFI93hH4Mso75CjGRN78MAY9SNifl6H8qcxTpBn4332LlFhRznLbtnc4YSWA/fvVqaN9h2zCH/6AdbLKXGffV34EF7DadwJsi9jsc+YlSMn6qaIUIDTdGLwh4KKpSH5bVbg/mVCcXPTJplFgYwRsOdiQbZY/740dJyo1lPjQ0Lvdio8W2M8c73ujeJU70CNLkgjJAMUPGrCFtGxBH2eeLBQ0P95qRZAIcJ7U0MibZLaRjoUOuTla5BIt2038PJ6XhcY6BEJaLyJOPEQ==",
+                        "verificationMethod":"did:key:zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v#zUC74bgefTdc43KS1psXgXf4jLaHyaj2qCQqQTXrtmSYGf1PxiJhrH6LGpaBMyj6tqAKmjGyMaS4RfNo2an77vT1HfzJUNPk4H7TCuJvSp4vet4Cu67kn2JSegoQNFSA1tbwU8v",
+                        "proofPurpose":"assertionMethod",
+                        "created":"2021-05-05T15:22:30.523465"
+                    }
+                }
+            ],
+            "presentation_submission":{
+                "id":"a5fcfe44-2c30-497d-af02-98e539da9a0f",
+                "definition_id":"32f54163-7166-48f1-93d8-ff217bdb0653",
+                "descriptor_map":[
+                    {
+                        "id":"citizenship_input_2",
+                        "format":"ldp_vp",
+                        "path":"$.verifiableCredential[0]"
+                    }
+                ]
+            },
+            "proof":{
+                "type":"Ed25519Signature2018",
+                "verificationMethod":"did:sov:4QxzWk3ajdnEA37NdNU5Kt#key-1",
+                "created":"2021-05-05T15:23:03.023971",
+                "proofPurpose":"authentication",
+                "challenge":"40429d49-5e8f-4ffc-baf8-e332412f1247",
+                "jws":"eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..2uBYmg7muE9ZPVeAGo_ibVfLkCjf2hGshr2o5i8pAwFyNBM-kDHXofuq1MzJgb19wzb01VIu91hY_ajjt9KFAA"
+            }
+        }
+    ]"""
+)
+
 PRES = V20Pres(
     comment="Test",
     formats=[
@@ -1678,6 +1801,23 @@ PRES = V20Pres(
     ],
 )
 
+PRES_DIF = V20Pres(
+    comment="Test",
+    formats=[
+        V20PresFormat(
+            attach_id="dif",
+            format_=ATTACHMENT_FORMAT[PRES_20][V20PresFormat.Format.DIF.api],
+        )
+    ],
+    presentations_attach=[
+        AttachDecorator.data_json(
+            mapping=DIF_PROOF,
+            ident="dif",
+        )
+    ],
+)
+
+
 
 class TestV20Pres(TestCase):
     """Presentation tests."""
@@ -1688,6 +1828,11 @@ class TestV20Pres(TestCase):
         assert len(PRES.formats) == len(PRES.presentations_attach)
         assert PRES.attachment(V20PresFormat.Format.INDY) == INDY_PROOF
         assert PRES._type == DIDCommPrefix.qualify_current(PRES_20)
+        
+        assert PRES_DIF.presentations_attach[0].content == DIF_PROOF
+        assert len(PRES_DIF.formats) == len(PRES.presentations_attach)
+        assert PRES_DIF.attachment(V20PresFormat.Format.DIF) == DIF_PROOF
+        assert PRES_DIF._type == DIDCommPrefix.qualify_current(PRES_20)
 
     def test_attachment_no_target_format(self):
         """Test attachment behaviour for only unknown formats."""
@@ -1740,3 +1885,10 @@ class TestV20Pres(TestCase):
             }
         )
         V20Pres.deserialize(pres_dict)
+
+    def test_serde_dif(self):
+        """Test deserialization dif."""
+        pres_dict = PRES_DIF.serialize()
+        pres_obj = V20Pres.deserialize(pres_dict)
+        assert type(pres_obj) == V20Pres
+

--- a/aries_cloudagent/protocols/present_proof/v2_0/messages/tests/test_pres.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/messages/tests/test_pres.py
@@ -1828,7 +1828,7 @@ class TestV20Pres(TestCase):
         assert len(PRES.formats) == len(PRES.presentations_attach)
         assert PRES.attachment(V20PresFormat.Format.INDY) == INDY_PROOF
         assert PRES._type == DIDCommPrefix.qualify_current(PRES_20)
-        
+
         assert PRES_DIF.presentations_attach[0].content == DIF_PROOF
         assert len(PRES_DIF.formats) == len(PRES.presentations_attach)
         assert PRES_DIF.attachment(V20PresFormat.Format.DIF) == DIF_PROOF
@@ -1891,4 +1891,3 @@ class TestV20Pres(TestCase):
         pres_dict = PRES_DIF.serialize()
         pres_obj = V20Pres.deserialize(pres_dict)
         assert type(pres_obj) == V20Pres
-

--- a/aries_cloudagent/protocols/present_proof/v2_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/routes.py
@@ -273,9 +273,10 @@ class V20PresSpecByFormatRequestSchema(AdminAPIMessageTracingSchema):
             ValidationError: if data does not have exactly one format.
 
         """
-        if len(data.keys() & {f.api for f in V20PresFormat.Format}) != 1:
+        if len(data.keys() & {f.api for f in V20PresFormat.Format}) < 1:
             raise ValidationError(
-                "V20PresSpecByFormatRequestSchema must specify one presentation format"
+                "V20PresSpecByFormatRequestSchema must specify "
+                "at least one presentation format"
             )
 
 
@@ -1057,11 +1058,8 @@ async def present_proof_send_presentation(request: web.BaseRequest):
     outbound_handler = request["outbound_message_router"]
     pres_ex_id = request.match_info["pres_ex_id"]
     body = await request.json()
-    if "dif" in body:
-        fmt = V20PresFormat.Format.get("dif").api
-    elif "indy" in body:
-        fmt = V20PresFormat.Format.get("indy").api
-    else:
+    supported_formats = ["dif", "indy"]
+    if not any(x in body for x in supported_formats):
         raise web.HTTPBadRequest(
             reason=(
                 "No presentation format specification provided, "
@@ -1106,10 +1104,9 @@ async def present_proof_send_presentation(request: web.BaseRequest):
 
     pres_manager = V20PresManager(profile)
     try:
-        request_data = {fmt: body.get(fmt)}
         pres_ex_record, pres_message = await pres_manager.create_pres(
             pres_ex_record,
-            request_data=request_data,
+            request_data=body,
             comment=comment,
         )
         result = pres_ex_record.serialize()

--- a/aries_cloudagent/protocols/present_proof/v2_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/tests/test_manager.py
@@ -31,6 +31,7 @@ from ..formats.handler import V20PresFormatHandlerError
 from ..formats.dif.handler import DIFPresFormatHandler
 from ..formats.dif.tests.test_handler import (
     DIF_PRES_REQUEST_B as DIF_PRES_REQ,
+    DIF_PRES_REQUEST_A as DIF_PRES_REQ_ALT,
     DIF_PRES,
 )
 from ..formats.indy import handler as test_indy_handler
@@ -47,6 +48,10 @@ from ..messages.pres_problem_report import V20PresProblemReport
 from ..messages.pres_proposal import V20PresProposal
 from ..messages.pres_request import V20PresRequest
 from ..models.pres_exchange import V20PresExRecord
+
+from .....vc.vc_ld.validation_result import PresentationVerificationResult
+from .....vc.tests.document_loader import custom_document_loader
+from .....vc.ld_proofs import DocumentLoader
 
 CONN_ID = "connection_id"
 ISSUER_DID = "NcYxiDXkpYi6ov5FcYDi1e"
@@ -796,6 +801,65 @@ class TestV20PresManager(AsyncTestCase):
                 INDY_PROOF_REQ_NAME, preview=None, holder=self.holder
             )
             request_data = {"indy": req_creds}
+            assert not req_creds["self_attested_attributes"]
+            assert len(req_creds["requested_attributes"]) == 2
+            assert len(req_creds["requested_predicates"]) == 1
+
+            (px_rec_out, pres_msg) = await self.manager.create_pres(
+                px_rec_in, request_data
+            )
+            save_ex.assert_called_once()
+            assert px_rec_out.state == V20PresExRecord.STATE_PRESENTATION_SENT
+
+    async def test_create_pres_indy_and_dif(self):
+        pres_request = V20PresRequest(
+            formats=[
+                V20PresFormat(
+                    attach_id="indy",
+                    format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
+                        V20PresFormat.Format.INDY.api
+                    ],
+                ),
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
+                        V20PresFormat.Format.DIF.api
+                    ],
+                )
+            ],
+            request_presentations_attach=[
+                AttachDecorator.data_base64(INDY_PROOF_REQ_NAME, ident="indy"),
+                AttachDecorator.data_json(DIF_PRES_REQ, ident="dif")
+            ],
+
+        )
+        px_rec_in = V20PresExRecord(pres_request=pres_request.serialize())
+        more_magic_rr = async_mock.MagicMock(
+            get_or_fetch_local_tails_path=async_mock.CoroutineMock(
+                return_value="/tmp/sample/tails/path"
+            )
+        )
+        with async_mock.patch.object(
+            V20PresExRecord, "save", autospec=True
+        ) as save_ex, async_mock.patch.object(
+            test_indy_handler, "AttachDecorator", autospec=True
+        ) as mock_attach_decorator_indy, async_mock.patch.object(
+            test_indy_util_module, "RevocationRegistry", autospec=True
+        ) as mock_rr, async_mock.patch.object(
+            DIFPresFormatHandler, "create_pres", autospec=True
+        ) as mock_create_pres:
+            mock_rr.from_definition = async_mock.MagicMock(return_value=more_magic_rr)
+
+            mock_attach_decorator_indy.data_base64 = async_mock.MagicMock(
+                return_value=mock_attach_decorator_indy
+            )
+
+            mock_create_pres.return_value = (PRES_20, AttachDecorator.data_json(DIF_PRES, ident="dif"))
+
+            req_creds = await indy_proof_req_preview2indy_requested_creds(
+                INDY_PROOF_REQ_NAME, preview=None, holder=self.holder
+            )
+            request_data = {"indy": req_creds, "dif": DIF_PRES_REQ}
             assert not req_creds["self_attested_attributes"]
             assert len(req_creds["requested_attributes"]) == 2
             assert len(req_creds["requested_predicates"]) == 1
@@ -2065,6 +2129,135 @@ class TestV20PresManager(AsyncTestCase):
             save_ex.assert_called_once()
 
             assert px_rec_out.state == (V20PresExRecord.STATE_DONE)
+
+    async def test_verify_pres_indy_and_dif(self):
+        pres_request = V20PresRequest(
+            formats=[
+                V20PresFormat(
+                    attach_id="indy",
+                    format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
+                        V20PresFormat.Format.INDY.api
+                    ],
+                ),
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
+                        V20PresFormat.Format.DIF.api
+                    ],
+                )
+            ],
+            will_confirm=True,
+            request_presentations_attach=[
+                AttachDecorator.data_base64(INDY_PROOF_REQ_NAME, ident="indy"),
+                AttachDecorator.data_json(DIF_PRES_REQ, ident="dif")
+            ],
+        )
+        pres = V20Pres(
+            formats=[
+                V20PresFormat(
+                    attach_id="indy",
+                    format_=ATTACHMENT_FORMAT[PRES_20][V20PresFormat.Format.INDY.api],
+                ),
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20][V20PresFormat.Format.DIF.api],
+                )
+            ],
+            presentations_attach=[
+                AttachDecorator.data_base64(INDY_PROOF, ident="indy"),
+                AttachDecorator.data_json(DIF_PRES, ident="dif")
+            ],
+        )
+        px_rec_in = V20PresExRecord(
+            pres_request=pres_request,
+            pres=pres,
+        )
+        
+        self.profile.context.injector.bind_instance(DocumentLoader, custom_document_loader)
+        self.profile.context.injector.bind_instance(
+            BaseMultitenantManager,
+            async_mock.MagicMock(MultitenantManager, autospec=True),
+        )
+        with async_mock.patch.object(
+            IndyLedgerRequestsExecutor,
+            "get_ledger_for_identifier",
+            async_mock.CoroutineMock(return_value=("test_ledger_id", self.ledger)),
+        ), async_mock.patch.object(V20PresExRecord, "save", autospec=True) as save_ex:
+            px_rec_out = await self.manager.verify_pres(px_rec_in)
+            save_ex.assert_called_once()
+
+            assert px_rec_out.state == (V20PresExRecord.STATE_DONE)
+
+    async def test_verify_pres_indy_and_dif_false(self):    
+        pres_request = V20PresRequest(
+            formats=[
+                V20PresFormat(
+                    attach_id="indy",
+                    format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
+                        V20PresFormat.Format.INDY.api
+                    ],
+                ),
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
+                        V20PresFormat.Format.DIF.api
+                    ],
+                )
+            ],
+            will_confirm=True,
+            request_presentations_attach=[
+                AttachDecorator.data_base64(INDY_PROOF_REQ_NAME, ident="indy"),
+                AttachDecorator.data_json(DIF_PRES_REQ_ALT, ident="dif")
+            ],
+        )
+        pres = V20Pres(
+            formats=[
+                V20PresFormat(
+                    attach_id="indy",
+                    format_=ATTACHMENT_FORMAT[PRES_20][V20PresFormat.Format.INDY.api],
+                ),
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20][V20PresFormat.Format.DIF.api],
+                )
+            ],
+            presentations_attach=[
+                AttachDecorator.data_base64(INDY_PROOF, ident="indy"),
+                AttachDecorator.data_json(DIF_PRES, ident="dif")
+            ],
+        )
+        px_rec_in = V20PresExRecord(
+            pres_request=pres_request,
+            pres=pres,
+        )
+        self.profile.context.injector.bind_instance(DocumentLoader, custom_document_loader)
+        self.profile.context.injector.bind_instance(
+            BaseMultitenantManager,
+            async_mock.MagicMock(MultitenantManager, autospec=True),
+        )
+        with async_mock.patch.object(
+            IndyLedgerRequestsExecutor,
+            "get_ledger_for_identifier",
+            async_mock.CoroutineMock(return_value=("test_ledger_id", self.ledger)),
+        ), async_mock.patch(
+            "aries_cloudagent.vc.vc_ld.verify.verify_presentation",
+            async_mock.CoroutineMock(
+                return_value=PresentationVerificationResult(verified=False)
+            ),
+        ), async_mock.patch.object(
+            IndyVerifier,
+            "verify_presentation",
+            async_mock.CoroutineMock(
+                return_value=PresentationVerificationResult(verified=True)
+            ),
+        ), async_mock.patch.object(
+            V20PresExRecord, "save", autospec=True
+        ) as save_ex:
+            px_rec_out = await self.manager.verify_pres(px_rec_in)
+            save_ex.assert_called_once()
+
+            assert px_rec_out.state == (V20PresExRecord.STATE_DONE)
+            assert px_rec_out.verified == 'false'
 
     async def test_send_pres_ack(self):
         px_rec = V20PresExRecord()

--- a/aries_cloudagent/protocols/present_proof/v2_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/tests/test_manager.py
@@ -2188,53 +2188,6 @@ class TestV20PresManager(AsyncTestCase):
 
             assert px_rec_out.state == (V20PresExRecord.STATE_DONE)
 
-    async def test_verify_pres_indy_and_dif_false(self):    
-        pres_request = V20PresRequest(
-            formats=[
-                V20PresFormat(
-                    attach_id="indy",
-                    format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
-                        V20PresFormat.Format.INDY.api
-                    ],
-                ),
-                V20PresFormat(
-                    attach_id="dif",
-                    format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
-                        V20PresFormat.Format.DIF.api
-                    ],
-                )
-            ],
-            will_confirm=True,
-            request_presentations_attach=[
-                AttachDecorator.data_base64(INDY_PROOF_REQ_NAME, ident="indy"),
-                AttachDecorator.data_json(DIF_PRES_REQ_ALT, ident="dif")
-            ],
-        )
-        pres = V20Pres(
-            formats=[
-                V20PresFormat(
-                    attach_id="indy",
-                    format_=ATTACHMENT_FORMAT[PRES_20][V20PresFormat.Format.INDY.api],
-                ),
-                V20PresFormat(
-                    attach_id="dif",
-                    format_=ATTACHMENT_FORMAT[PRES_20][V20PresFormat.Format.DIF.api],
-                )
-            ],
-            presentations_attach=[
-                AttachDecorator.data_base64(INDY_PROOF, ident="indy"),
-                AttachDecorator.data_json(DIF_PRES, ident="dif")
-            ],
-        )
-        px_rec_in = V20PresExRecord(
-            pres_request=pres_request,
-            pres=pres,
-        )
-        self.profile.context.injector.bind_instance(DocumentLoader, custom_document_loader)
-        self.profile.context.injector.bind_instance(
-            BaseMultitenantManager,
-            async_mock.MagicMock(MultitenantManager, autospec=True),
-        )
         with async_mock.patch.object(
             IndyLedgerRequestsExecutor,
             "get_ledger_for_identifier",
@@ -2255,7 +2208,6 @@ class TestV20PresManager(AsyncTestCase):
         ) as save_ex:
             px_rec_out = await self.manager.verify_pres(px_rec_in)
             save_ex.assert_called_once()
-
             assert px_rec_out.state == (V20PresExRecord.STATE_DONE)
             assert px_rec_out.verified == 'false'
 

--- a/aries_cloudagent/protocols/present_proof/v2_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/tests/test_manager.py
@@ -854,7 +854,7 @@ class TestV20PresManager(AsyncTestCase):
             )
 
             mock_create_pres.return_value = (
-                PRES_20, 
+                PRES_20,
                 AttachDecorator.data_json(DIF_PRES, ident="dif"),
             )
 

--- a/aries_cloudagent/protocols/present_proof/v2_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/tests/test_manager.py
@@ -831,7 +831,6 @@ class TestV20PresManager(AsyncTestCase):
                 AttachDecorator.data_base64(INDY_PROOF_REQ_NAME, ident="indy"),
                 AttachDecorator.data_json(DIF_PRES_REQ, ident="dif"),
             ],
-
         )
         px_rec_in = V20PresExRecord(pres_request=pres_request.serialize())
         more_magic_rr = async_mock.MagicMock(
@@ -856,7 +855,7 @@ class TestV20PresManager(AsyncTestCase):
 
             mock_create_pres.return_value = (
                 PRES_20, 
-                AttachDecorator.data_json(DIF_PRES, ident="dif")
+                AttachDecorator.data_json(DIF_PRES, ident="dif"),
             )
 
             req_creds = await indy_proof_req_preview2indy_requested_creds(
@@ -2175,7 +2174,7 @@ class TestV20PresManager(AsyncTestCase):
             pres_request=pres_request,
             pres=pres,
         )
-        
+
         self.profile.context.injector.bind_instance(
             DocumentLoader, custom_document_loader
         )

--- a/aries_cloudagent/protocols/present_proof/v2_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/tests/test_manager.py
@@ -825,11 +825,11 @@ class TestV20PresManager(AsyncTestCase):
                     format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
                         V20PresFormat.Format.DIF.api
                     ],
-                )
+                ),
             ],
             request_presentations_attach=[
                 AttachDecorator.data_base64(INDY_PROOF_REQ_NAME, ident="indy"),
-                AttachDecorator.data_json(DIF_PRES_REQ, ident="dif")
+                AttachDecorator.data_json(DIF_PRES_REQ, ident="dif"),
             ],
 
         )
@@ -854,7 +854,10 @@ class TestV20PresManager(AsyncTestCase):
                 return_value=mock_attach_decorator_indy
             )
 
-            mock_create_pres.return_value = (PRES_20, AttachDecorator.data_json(DIF_PRES, ident="dif"))
+            mock_create_pres.return_value = (
+                PRES_20, 
+                AttachDecorator.data_json(DIF_PRES, ident="dif")
+            )
 
             req_creds = await indy_proof_req_preview2indy_requested_creds(
                 INDY_PROOF_REQ_NAME, preview=None, holder=self.holder
@@ -2144,12 +2147,12 @@ class TestV20PresManager(AsyncTestCase):
                     format_=ATTACHMENT_FORMAT[PRES_20_REQUEST][
                         V20PresFormat.Format.DIF.api
                     ],
-                )
+                ),
             ],
             will_confirm=True,
             request_presentations_attach=[
                 AttachDecorator.data_base64(INDY_PROOF_REQ_NAME, ident="indy"),
-                AttachDecorator.data_json(DIF_PRES_REQ, ident="dif")
+                AttachDecorator.data_json(DIF_PRES_REQ, ident="dif"),
             ],
         )
         pres = V20Pres(
@@ -2161,11 +2164,11 @@ class TestV20PresManager(AsyncTestCase):
                 V20PresFormat(
                     attach_id="dif",
                     format_=ATTACHMENT_FORMAT[PRES_20][V20PresFormat.Format.DIF.api],
-                )
+                ),
             ],
             presentations_attach=[
                 AttachDecorator.data_base64(INDY_PROOF, ident="indy"),
-                AttachDecorator.data_json(DIF_PRES, ident="dif")
+                AttachDecorator.data_json(DIF_PRES, ident="dif"),
             ],
         )
         px_rec_in = V20PresExRecord(
@@ -2173,7 +2176,9 @@ class TestV20PresManager(AsyncTestCase):
             pres=pres,
         )
         
-        self.profile.context.injector.bind_instance(DocumentLoader, custom_document_loader)
+        self.profile.context.injector.bind_instance(
+            DocumentLoader, custom_document_loader
+        )
         self.profile.context.injector.bind_instance(
             BaseMultitenantManager,
             async_mock.MagicMock(MultitenantManager, autospec=True),
@@ -2209,7 +2214,7 @@ class TestV20PresManager(AsyncTestCase):
             px_rec_out = await self.manager.verify_pres(px_rec_in)
             save_ex.assert_called_once()
             assert px_rec_out.state == (V20PresExRecord.STATE_DONE)
-            assert px_rec_out.verified == 'false'
+            assert px_rec_out.verified == "false"
 
     async def test_send_pres_ack(self):
         px_rec = V20PresExRecord()

--- a/aries_cloudagent/protocols/present_proof/v2_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/tests/test_routes.py
@@ -1842,67 +1842,6 @@ class TestPresentProofRoutes(AsyncTestCase):
                 mock_px_rec_inst.serialize.return_value
             )
 
-    async def test_present_proof_send_presentation_indy_and_dif(self):
-        proof_req = deepcopy(DIF_PROOF_REQ)
-        proof_req["issuer_id"] = "test123"
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "dif": proof_req,
-                "indy": {
-                    "comment": "dummy",
-                    "self_attested_attributes": {},
-                    "requested_attributes": {},
-                    "requested_predicates": {},
-                }
-            }
-        )
-        self.request.match_info = {
-            "pres_ex_id": "dummy",
-        }
-        self.profile.context.injector.bind_instance(
-            IndyVerifier,
-            async_mock.MagicMock(
-                verify_presentation=async_mock.CoroutineMock(),
-            ),
-        )
-
-        with async_mock.patch.object(
-            test_module, "ConnRecord", autospec=True
-        ) as mock_conn_rec_cls, async_mock.patch.object(
-            test_module, "V20PresManager", autospec=True
-        ) as mock_pres_mgr_cls, async_mock.patch.object(
-            test_module, "V20PresExRecord", autospec=True
-        ) as mock_px_rec_cls, async_mock.patch.object(
-            test_module.web, "json_response"
-        ) as mock_response:
-            mock_px_rec_inst = async_mock.MagicMock(
-                connection_id="dummy",
-                state=test_module.V20PresExRecord.STATE_REQUEST_RECEIVED,
-                serialize=async_mock.MagicMock(
-                    return_value={"thread_id": "sample-thread-id"}
-                ),
-            )
-            mock_px_rec_cls.retrieve_by_id = async_mock.CoroutineMock(
-                return_value=mock_px_rec_inst
-            )
-
-            mock_conn_rec_inst = async_mock.MagicMock(is_ready=True)
-            mock_conn_rec_cls.retrieve_by_id = async_mock.CoroutineMock(
-                return_value=mock_conn_rec_inst
-            )
-
-            mock_pres_mgr_inst = async_mock.MagicMock(
-                create_pres=async_mock.CoroutineMock(
-                    return_value=(mock_px_rec_inst, async_mock.MagicMock())
-                )
-            )
-            mock_pres_mgr_cls.return_value = mock_pres_mgr_inst
-
-            await test_module.present_proof_send_presentation(self.request)
-            mock_response.assert_called_once_with(
-                mock_px_rec_inst.serialize.return_value
-            )
-
     async def test_present_proof_send_presentation_dif_error(self):
         self.request.json = async_mock.CoroutineMock(
             return_value={"dif": DIF_PROOF_REQ}

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -395,6 +395,10 @@ class AriesAgent(DemoAgent):
             )
             pres_request_indy = message["by_format"].get("pres_request", {}).get("indy")
             pres_request_dif = message["by_format"].get("pres_request", {}).get("dif")
+            request = {}
+
+            if not pres_request_dif and not pres_request_indy:
+                raise Exception("Invalid presentation request received")
 
             if pres_request_indy:
                 # include self-attested attributes (not included in credentials)
@@ -409,6 +413,8 @@ class AriesAgent(DemoAgent):
                         f"/present-proof-2.0/records/{pres_ex_id}/credentials"
                     )
                     if creds:
+                        # select only indy credentials
+                        creds = [x for x in creds if "cred_info" in x]
                         if "timestamp" in creds[0]["cred_info"]["attrs"]:
                             sorted_creds = sorted(
                                 creds,
@@ -444,46 +450,58 @@ class AriesAgent(DemoAgent):
                                 ]
                             }
 
-                    log_status("#25 Generate the proof")
-                    request = {
+                    log_status("#25 Generate the indy proof")
+                    indy_request = {
                         "indy": {
                             "requested_predicates": predicates,
                             "requested_attributes": revealed,
                             "self_attested_attributes": self_attested,
                         }
                     }
+                    request.update(indy_request)
                 except ClientError:
                     pass
 
-            elif pres_request_dif:
+            if pres_request_dif:
                 try:
                     # select credentials to provide for the proof
                     creds = await self.admin_GET(
                         f"/present-proof-2.0/records/{pres_ex_id}/credentials"
                     )
                     if creds and 0 < len(creds):
+                        # select only dif credentials
+                        creds = [x for x in creds if "issuanceDate" in x]
                         creds = sorted(
                             creds,
                             key=lambda c: c["issuanceDate"],
                             reverse=True,
                         )
-                        record_id = creds[0]["record_id"]
+                        records = creds
                     else:
-                        record_id = None
+                        records = []
 
-                    log_status("#25 Generate the proof")
-                    request = {
+                    log_status("#25 Generate the dif proof")
+                    dif_request = {
                         "dif": {},
                     }
                     # specify the record id for each input_descriptor id:
-                    request["dif"]["record_ids"] = {}
+                    dif_request["dif"]["record_ids"] = {}
                     for input_descriptor in pres_request_dif["presentation_definition"][
                         "input_descriptors"
                     ]:
-                        request["dif"]["record_ids"][input_descriptor["id"]] = [
-                            record_id,
-                        ]
-                    log_msg("presenting ld-presentation:", request)
+                        input_descriptor_schema_uri = []
+                        for element in input_descriptor["schema"]:
+                            input_descriptor_schema_uri.append(element["uri"])
+
+                        for record in records:
+                            if self.check_input_descriptor_record_id(input_descriptor_schema_uri, record):
+                                record_id = record["record_id"]
+                                dif_request["dif"]["record_ids"][input_descriptor["id"]] = [
+                                    record_id,
+                                ]
+                                break
+                    log_msg("presenting ld-presentation:", dif_request)
+                    request.update(dif_request)
 
                     # NOTE that the holder/prover can also/or specify constraints by including the whole proof request
                     # and constraining the presented credentials by adding filters, for example:
@@ -507,9 +525,6 @@ class AriesAgent(DemoAgent):
 
                 except ClientError:
                     pass
-
-            else:
-                raise Exception("Invalid presentation request received")
 
             log_status("#26 Send the proof to X: " + json.dumps(request))
             await self.admin_POST(
@@ -610,6 +625,17 @@ class AriesAgent(DemoAgent):
                 revocation_registry_size=TAILS_FILE_COUNT if revocation else None,
             )
             return cred_def_id
+
+    def check_input_descriptor_record_id(self, input_descriptor_schema_uri, record) -> bool:
+        result = False
+        for uri in input_descriptor_schema_uri:
+            for record_type in record["type"]:
+                if record_type in uri:
+                    result = True
+                    break
+                result = False
+        
+        return result
 
 
 class AgentContainer:

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -494,9 +494,13 @@ class AriesAgent(DemoAgent):
                             input_descriptor_schema_uri.append(element["uri"])
 
                         for record in records:
-                            if self.check_input_descriptor_record_id(input_descriptor_schema_uri, record):
+                            if self.check_input_descriptor_record_id(
+                                input_descriptor_schema_uri, record
+                            ):
                                 record_id = record["record_id"]
-                                dif_request["dif"]["record_ids"][input_descriptor["id"]] = [
+                                dif_request["dif"]["record_ids"][
+                                    input_descriptor["id"]
+                                ] = [
                                     record_id,
                                 ]
                                 break
@@ -626,7 +630,9 @@ class AriesAgent(DemoAgent):
             )
             return cred_def_id
 
-    def check_input_descriptor_record_id(self, input_descriptor_schema_uri, record) -> bool:
+    def check_input_descriptor_record_id(
+        self, input_descriptor_schema_uri, record
+    ) -> bool:
         result = False
         for uri in input_descriptor_schema_uri:
             for record_type in record["type"]:
@@ -634,7 +640,7 @@ class AriesAgent(DemoAgent):
                     result = True
                     break
                 result = False
-        
+
         return result
 
 


### PR DESCRIPTION
* Enabled handing presentation requests with indy **and** dif
* Enabled handling presentation requests with requests for claims from different JSON-LD VCs (verifier has to create separate submission requirement groups for each claim from different VC) In case, multiple claims should come from the same VC, the descriptors can be included in the same group

* Updated demo/agent_controller to correctly construct presentations.

Signed-off-by: Anastasiia Sivirina [sivirina99@mail.ru](mailto:sivirina99@mail.ru)
