### PR TITLE
fix: Safely shutdown when root_profile uninitialized

### DIFF
--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -482,7 +482,8 @@ class Conductor:
     async def stop(self, timeout=1.0):
         """Stop the agent."""
         # notify protcols that we are shutting down
-        await self.root_profile.notify(SHUTDOWN_EVENT_TOPIC, {})
+        if self.root_profile:
+            await self.root_profile.notify(SHUTDOWN_EVENT_TOPIC, {})
 
         shutdown = TaskQueue()
         if self.dispatcher:
@@ -494,13 +495,13 @@ class Conductor:
         if self.outbound_transport_manager:
             shutdown.run(self.outbound_transport_manager.stop())
 
-        # close multitenant profiles
-        multitenant_mgr = self.context.inject_or(BaseMultitenantManager)
-        if multitenant_mgr:
-            for profile in multitenant_mgr.open_profiles:
-                shutdown.run(profile.close())
-
         if self.root_profile:
+            # close multitenant profiles
+            multitenant_mgr = self.context.inject_or(BaseMultitenantManager)
+            if multitenant_mgr:
+                for profile in multitenant_mgr.open_profiles:
+                    shutdown.run(profile.close())
+
             shutdown.run(self.root_profile.close())
 
         await shutdown.complete(timeout)


### PR DESCRIPTION
If an exception was thrown during the initialization of the root_profile, we would throw an exception during shutdown and fail to end the process. This would leave ACA-Py running, without accepting/handling any further requests. Adding guards for shutdown code that uses the root_profile should avoid this situation