### PR TITLE
Fix: `--mediator-invitation` with OOB invitation + cleanup 

### DIFF
--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -296,10 +296,10 @@ class Dispatcher:
         if not isinstance(parsed_msg, dict):
             raise MessageParseError("Expected a JSON object")
         message_type = parsed_msg.get("@type")
-        message_type_rec_version = get_version_from_message_type(message_type)
 
         if not message_type:
             raise MessageParseError("Message does not contain '@type' parameter")
+        message_type_rec_version = get_version_from_message_type(message_type)
 
         registry: ProtocolRegistry = self.profile.inject(ProtocolRegistry)
         try:

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/routes.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/routes.py
@@ -764,11 +764,15 @@ async def on_startup_event(profile: Profile, event: Event):
         invite = InvitationMessage.from_url(endorser_invitation)
         if invite:
             oob_mgr = OutOfBandManager(profile)
-            conn_record = await oob_mgr.receive_invitation(
+            oob_record = await oob_mgr.receive_invitation(
                 invitation=invite,
                 auto_accept=True,
                 alias=endorser_alias,
             )
+            async with profile.session() as session:
+                conn_record = await ConnRecord.retrieve_by_id(
+                    session, oob_record.connection_id
+                )
         else:
             invite = ConnectionInvitation.from_url(endorser_invitation)
             if invite:


### PR DESCRIPTION
Signed-off-by: Shaanjot Gill <gill.shaanjots@gmail.com>

The following issues were found as part of loadgenerator test setup.
- `--mediator-invitation` was failing with OOB invitation, this should be fixed now.
- `invitation_url` when creating an implicit invitation using `/connections/create-invitation` didn't include endpoint, this should be fixed now.