### PR TITLE
feat: update pynacl version from 1.4.0 to 1.50

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ markupsafe==2.0.1
 marshmallow==3.5.1
 msgpack~=1.0
 prompt_toolkit~=2.0.9
-pynacl~=1.4.0
+pynacl~=1.5.0
 requests~=2.25.0
 packaging~=20.4
 pyld~=2.0.3


### PR DESCRIPTION
this fixes install for m1 mac arm64 arch

closes #1980 

Signed-off-by: Moriarty <moritz@animo.id>