### PR TITLE
Fix/txn job setting

### DIFF
--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/handlers/tests/test_transaction_job_to_send_handler.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/handlers/tests/test_transaction_job_to_send_handler.py
@@ -34,26 +34,6 @@ class TestTransactionJobToSendHandler(AsyncTestCase):
         )
         assert not responder.messages
 
-    async def test_called_not_ready(self):
-        request_context = RequestContext.test_context()
-        request_context.message_receipt = MessageReceipt()
-        request_context.connection_record = async_mock.MagicMock()
-
-        with async_mock.patch.object(
-            test_module, "TransactionManager", autospec=True
-        ) as mock_tran_mgr:
-            mock_tran_mgr.return_value.set_transaction_their_job = (
-                async_mock.CoroutineMock()
-            )
-            request_context.message = TransactionJobToSend()
-            request_context.connection_ready = False
-            handler = test_module.TransactionJobToSendHandler()
-            responder = MockResponder()
-            with self.assertRaises(test_module.HandlerException):
-                await handler.handle(request_context, responder)
-
-            assert not responder.messages
-
     async def test_called_x(self):
         request_context = RequestContext.test_context()
         request_context.message_receipt = MessageReceipt()

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/handlers/transaction_job_to_send_handler.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/handlers/transaction_job_to_send_handler.py
@@ -3,7 +3,6 @@
 from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
-    HandlerException,
     RequestContext,
 )
 
@@ -25,9 +24,6 @@ class TransactionJobToSendHandler(BaseHandler):
 
         self._logger.debug(f"TransactionJobToSendHandler called with context {context}")
         assert isinstance(context.message, TransactionJobToSend)
-
-        if not context.connection_ready:
-            raise HandlerException("No connection established")
 
         mgr = TransactionManager(context.profile)
         try:


### PR DESCRIPTION
Fixes a timing issue where the endorser and author are connecting and trying to set connection met-data before the connection is "active".
