### PR TITLE
Fix typos in alice-local.sh & faber-local.sh

### DIFF
--- a/demo/alice-local.sh
+++ b/demo/alice-local.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # this runs the Faber example as a local instace of instance of aca-py
 # you need to run a local von-network (in the von-network directory run "./manage start <your local ip> --logs")
-# ... and you need to install the local aca-py python libraries locally ("pip install -r ../requriements.txt -r ../requirements.indy.txt -r ../requirements.bbs.txt")
+# ... and you need to install the local aca-py python libraries locally ("pip install -r ../requirements.txt -r ../requirements.indy.txt -r ../requirements.bbs.txt")
 
 # the following will auto-respond on connection and credential requests, but not proof requests
 PYTHONPATH=.. ../bin/aca-py start \

--- a/demo/faber-local.sh
+++ b/demo/faber-local.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # this runs the Faber example as a local instace of instance of aca-py
 # you need to run a local von-network (in the von-network directory run "./manage start <your local ip> --logs")
-# ... and you need to install the local aca-py python libraries locally ("pip install -r ../requriements.txt -r ../requirements.indy.txt -r ../requirements.bbs.txt")
+# ... and you need to install the local aca-py python libraries locally ("pip install -r ../requirements.txt -r ../requirements.indy.txt -r ../requirements.bbs.txt")
 
 # the following will auto-respond on connection and credential requests, but not proof requests
 PYTHONPATH=.. ../bin/aca-py start \


### PR DESCRIPTION
There are typos in alice-local.sh & faber-local.sh to run pip install.

Signed-off-by: Nao Nishijima <nao.nishijima.xt@hitachi.com>