### PR TITLE
fix: indy dependency version format

### DIFF
--- a/requirements.indy.txt
+++ b/requirements.indy.txt
@@ -1,1 +1,1 @@
-python3-indy>=1.11.1<2
+python3-indy>=1.11.1,<2


### PR DESCRIPTION
Fix python-indy version restrictions format.

Previous format was breaking for poetry-based builds: `Invalid constraint (python3-indy (>=1.11.1<2) ; extra == 'indy') found in aries-cloudagent-1.0.0rc1 dependencies, skipping`

Version restrictions are supposed to be conformant to: https://peps.python.org/pep-0440/#version-specifiers

Signed-off-by: Clément Humbert <clement.humbert@sicpa.com>