### PR TITLE
Additional integration tests for revocation scenarios

### DIFF
--- a/demo/bdd_support/agent_backchannel_client.py
+++ b/demo/bdd_support/agent_backchannel_client.py
@@ -130,10 +130,12 @@ def aries_container_receive_credential(
 def aries_container_request_proof(
     the_container: AgentContainer,
     proof_request: dict,
+    explicit_revoc_required: bool = False,
 ):
     return run_coroutine(
         the_container.request_proof,
         proof_request,
+        explicit_revoc_required=explicit_revoc_required,
     )
 
 

--- a/demo/features/0454-present-proof.feature
+++ b/demo/features/0454-present-proof.feature
@@ -117,6 +117,26 @@ Feature: RFC 0454 Aries agent present proof
          | issuer1 | Acme1_capabilities        | issuer2 | Acme2_capabilities | Bob_cap | Schema_name_1     | Credential_data_1 | Schema_name_2 | Credential_data_2 | Proof_request                    |
          | Acme1   | --revocation --public-did | Acme2   | --public-did       |         | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id |
 
+   @T003-RFC0454.1f
+   Scenario Outline: Present Proof for multiple credentials where the one is revocable and one isn't, neither credential is revoked, fails due to requesting request-level revocation
+      Given we have "4" agents
+         | name  | role     | capabilities         |
+         | Acme1 | issuer1  | <Acme1_capabilities> |
+         | Acme2 | issuer2  | <Acme2_capabilities> |
+         | Faber | verifier | <Acme1_capabilities> |
+         | Bob   | prover   | <Bob_cap>   |
+      And "<issuer1>" and "Bob" have an existing connection
+      And "Bob" has an issued <Schema_name_1> credential <Credential_data_1> from "<issuer1>"
+      And "<issuer2>" and "Bob" have an existing connection
+      And "Bob" has an issued <Schema_name_2> credential <Credential_data_2> from "<issuer2>"
+      And "Faber" and "Bob" have an existing connection
+      When "Faber" sends a request for proof presentation <Proof_request> to "Bob"
+      Then "Faber" has the proof verification fail
+
+      Examples:
+         | issuer1 | Acme1_capabilities        | issuer2 | Acme2_capabilities | Bob_cap | Schema_name_1     | Credential_data_1 | Schema_name_2 | Credential_data_2 | Proof_request                    |
+         | Acme1   | --revocation --public-did | Acme2   | --public-did       |         | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id_r2 |
+
    @T003-RFC0454.2 @GHA
    Scenario Outline: Present Proof for multiple credentials where the one is revocable and one isn't, and the revocable credential is revoked, and the proof checks for revocation and fails
       Given we have "4" agents

--- a/demo/features/0454-present-proof.feature
+++ b/demo/features/0454-present-proof.feature
@@ -98,7 +98,7 @@ Feature: RFC 0454 Aries agent present proof
          | Acme   | --revocation --public-did --multitenant    | --multitenant    | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
 
    @T003-RFC0454.1 @GHA
-   Scenario Outline: Present Proof for multiple credentials where the one is revocable and one isn't
+   Scenario Outline: Present Proof for multiple credentials where the one is revocable and one isn't, neither credential is revoked
       Given we have "4" agents
          | name  | role     | capabilities         |
          | Acme1 | issuer1  | <Acme1_capabilities> |
@@ -118,7 +118,7 @@ Feature: RFC 0454 Aries agent present proof
          | Acme1   | --revocation --public-did | Acme2   | --public-did       |         | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id |
 
    @T003-RFC0454.2 @GHA
-   Scenario Outline: Present Proof for multiple credentials where the one is revocable and one isn't, and the revocable credential is revoked
+   Scenario Outline: Present Proof for multiple credentials where the one is revocable and one isn't, and the revocable credential is revoked, and the proof checks for revocation and fails
       Given we have "4" agents
          | name  | role     | capabilities         |
          | Acme1 | issuer1  | <Acme1_capabilities> |
@@ -137,3 +137,25 @@ Feature: RFC 0454 Aries agent present proof
       Examples:
          | issuer1 | Acme1_capabilities        | issuer2 | Acme2_capabilities | Bob_cap | Schema_name_1     | Credential_data_1 | Schema_name_2 | Credential_data_2 | Proof_request                    |
          | Acme1   | --revocation --public-did | Acme2   | --public-did       |         | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id |
+         | Acme1   | --revocation --public-did | Acme2   | --public-did       |         | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id_r2 |
+
+   @T003-RFC0454.3 @GHA
+   Scenario Outline: Present Proof for multiple credentials where the one is revocable and one isn't, and the revocable credential is revoked, and the proof doesn't check for revocation and passes
+      Given we have "4" agents
+         | name  | role     | capabilities         |
+         | Acme1 | issuer1  | <Acme1_capabilities> |
+         | Acme2 | issuer2  | <Acme2_capabilities> |
+         | Faber | verifier | <Acme1_capabilities> |
+         | Bob   | prover   | <Bob_cap>   |
+      And "<issuer1>" and "Bob" have an existing connection
+      And "Bob" has an issued <Schema_name_1> credential <Credential_data_1> from "<issuer1>"
+      And "<issuer1>" revokes the credential
+      And "<issuer2>" and "Bob" have an existing connection
+      And "Bob" has an issued <Schema_name_2> credential <Credential_data_2> from "<issuer2>"
+      And "Faber" and "Bob" have an existing connection
+      When "Faber" sends a request with explicit revocation status for proof presentation <Proof_request> to "Bob"
+      Then "Faber" has the proof verified
+
+      Examples:
+         | issuer1 | Acme1_capabilities        | issuer2 | Acme2_capabilities | Bob_cap | Schema_name_1     | Credential_data_1 | Schema_name_2 | Credential_data_2 | Proof_request                             |
+         | Acme1   | --revocation --public-did | Acme2   | --public-did       |         | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id_no_revoc |

--- a/demo/features/data/presentation_DL_age_over_19_v2_with_health_id_no_revoc.json
+++ b/demo/features/data/presentation_DL_age_over_19_v2_with_health_id_no_revoc.json
@@ -1,0 +1,24 @@
+{
+    "presentation": {
+        "comment": "This is a comment for the send presentation.",
+        "requested_attributes": {
+            "address_attrs": {
+                "cred_type_name": "Schema_DriversLicense_v2",
+                "revealed": true,
+                "cred_id": "replace_me"
+            },
+            "health_attrs": {
+                "cred_type_name": "Schema_Health_ID",
+                "revealed": true,
+                "cred_id": "replace_me"
+            }
+        },
+        "requested_predicates": {
+            "age": {
+                "cred_type_name": "Schema_DriversLicense_v2",
+                "cred_id": "replace me"
+            }
+        },
+        "self_attested_attributes": {}
+    }
+}

--- a/demo/features/data/presentation_DL_age_over_19_v2_with_health_id_r2.json
+++ b/demo/features/data/presentation_DL_age_over_19_v2_with_health_id_r2.json
@@ -1,0 +1,24 @@
+{
+    "presentation": {
+        "comment": "This is a comment for the send presentation.",
+        "requested_attributes": {
+            "address_attrs": {
+                "cred_type_name": "Schema_DriversLicense_v2",
+                "revealed": true,
+                "cred_id": "replace_me"
+            },
+            "health_attrs": {
+                "cred_type_name": "Schema_Health_ID",
+                "revealed": true,
+                "cred_id": "replace_me"
+            }
+        },
+        "requested_predicates": {
+            "age": {
+                "cred_type_name": "Schema_DriversLicense_v2",
+                "cred_id": "replace me"
+            }
+        },
+        "self_attested_attributes": {}
+    }
+}

--- a/demo/features/data/proof_request_DL_age_over_19_v2_with_health_id_no_revoc.json
+++ b/demo/features/data/proof_request_DL_age_over_19_v2_with_health_id_no_revoc.json
@@ -1,0 +1,38 @@
+{
+   "presentation_proposal": {
+      "requested_attributes": {
+         "address_attrs": {
+            "name": "address",
+            "restrictions": [
+               {
+                  "schema_name": "Schema_DriversLicense_v2",
+                  "schema_version": "1.0.1"
+               }
+            ]
+         },
+         "health_attrs": {
+            "name": "health_id_num",
+            "restrictions": [
+               {
+                  "schema_name": "Schema_Health_ID",
+                  "schema_version": "1.0.0"
+               }
+            ]
+         }
+      },
+      "requested_predicates": {
+         "age": {
+            "name": "age",
+            "p_type": ">",
+            "p_value": 19,
+            "restrictions": [
+               {
+                  "schema_name": "Schema_DriversLicense_v2",
+                  "schema_version": "1.0.1"
+               }
+            ]
+         }
+      },
+      "version": "0.1.0"
+   }
+}

--- a/demo/features/data/proof_request_DL_age_over_19_v2_with_health_id_r2.json
+++ b/demo/features/data/proof_request_DL_age_over_19_v2_with_health_id_r2.json
@@ -1,0 +1,38 @@
+{
+   "presentation_proposal": {
+      "requested_attributes": {
+         "address_attrs": {
+            "name": "address",
+            "restrictions": [
+               {
+                  "schema_name": "Schema_DriversLicense_v2",
+                  "schema_version": "1.0.1"
+               }
+            ]
+         },
+         "health_attrs": {
+            "name": "health_id_num",
+            "restrictions": [
+               {
+                  "schema_name": "Schema_Health_ID",
+                  "schema_version": "1.0.0"
+               }
+            ]
+         }
+      },
+      "requested_predicates": {
+         "age": {
+            "name": "age",
+            "p_type": ">",
+            "p_value": 19,
+            "restrictions": [
+               {
+                  "schema_name": "Schema_DriversLicense_v2",
+                  "schema_version": "1.0.1"
+               }
+            ]
+         }
+      },
+      "version": "0.1.0"
+   }
+}

--- a/demo/features/steps/0454-present-proof.py
+++ b/demo/features/steps/0454-present-proof.py
@@ -51,7 +51,9 @@ def step_impl(context, verifier, request_for_proof, prover):
 
     proof_request_info = read_proof_req_data(request_for_proof)
 
-    proof_exchange = aries_container_request_proof(agent["agent"], proof_request_info, explicit_revoc_required=True)
+    proof_exchange = aries_container_request_proof(
+        agent["agent"], proof_request_info, explicit_revoc_required=True
+    )
 
     context.proof_request = proof_request_info
     context.proof_exchange = proof_exchange

--- a/demo/features/steps/0454-present-proof.py
+++ b/demo/features/steps/0454-present-proof.py
@@ -43,6 +43,20 @@ def step_impl(context, verifier, request_for_proof, prover):
     context.proof_exchange = proof_exchange
 
 
+@when(
+    '"{verifier}" sends a request with explicit revocation status for proof presentation {request_for_proof} to "{prover}"'
+)
+def step_impl(context, verifier, request_for_proof, prover):
+    agent = context.active_agents[verifier]
+
+    proof_request_info = read_proof_req_data(request_for_proof)
+
+    proof_exchange = aries_container_request_proof(agent["agent"], proof_request_info, explicit_revoc_required=True)
+
+    context.proof_request = proof_request_info
+    context.proof_exchange = proof_exchange
+
+
 @then('"{verifier}" has the proof verified')
 def step_impl(context, verifier):
     agent = context.active_agents[verifier]

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -928,7 +928,7 @@ class AgentContainer:
 
         return matched
 
-    async def request_proof(self, proof_request):
+    async def request_proof(self, proof_request, explicit_revoc_required: bool=False):
         log_status("#20 Request proof of degree from alice")
 
         if self.cred_type == CRED_FORMAT_INDY:
@@ -963,7 +963,7 @@ class AgentContainer:
                         ] = non_revoked
                         non_revoked_supplied = True
 
-                if not non_revoked_supplied:
+                if not non_revoked_supplied and not explicit_revoc_required:
                     # else just make it global
                     indy_proof_request["non_revoked"] = non_revoked
 
@@ -1009,6 +1009,8 @@ class AgentContainer:
             # no proof received
             print("No proof received")
             return None
+
+        # log_status(f">>> last proof received: {self.agent.last_proof_received}")
 
         if self.cred_type == CRED_FORMAT_INDY:
             # return verified status

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -928,7 +928,7 @@ class AgentContainer:
 
         return matched
 
-    async def request_proof(self, proof_request, explicit_revoc_required: bool=False):
+    async def request_proof(self, proof_request, explicit_revoc_required: bool = False):
         log_status("#20 Request proof of degree from alice")
 
         if self.cred_type == CRED_FORMAT_INDY:


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Additional tests for multi-credential proofs with a mix of revocable and non-revocable credentials

These tests pass:
- @T003-RFC0454.1 - two credentials, one revocable one not, neither revoked, "non_revoked" is requested at the attribute level
- @T003-RFC0454.2 - two credentials, one revocable one not, one revoked, proof checks for revocation (attribute level) and fails
- @T003-RFC0454.3 - two credentials, one revocable one not, one revoked, proof *doesn't* check for revocation (attribute level) and passes

This test "fails" - the proof doesn't verify even though it should:
- @T003-RFC0454.1f - two credentials, one revocable one not, neither revoked, "non_revoked" is requested at the*request* level

For the failing scenario, it fails with indy-sdk and credx.  I believe  the underlying library is not creating the proof properly, and/or the underlying anoncreds itself has a bug.
