### PR TITLE
ci: test additional versions of python nightly

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,0 +1,39 @@
+name: Nightly Tests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: Tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        include:
+          - os: "ubuntu-20.04"
+            python-version: "3.6"
+    uses: ./.github/workflows/tests.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      os: ${{ matrix.os }}
+
+  tests-indy:
+    name: Tests (Indy)
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        include:
+          - os: "ubuntu-20.04"
+            python-version: "3.6"
+
+    uses: ./.github/workflows/tests-indy.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      os: ${{ matrix.os }}
+      indy-version: "1.16.0"


### PR DESCRIPTION
This will help unblock efforts to move off of python 3.6.