### PR TITLE
Improved validation of record attributes

### DIFF
--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -677,11 +677,7 @@ class ConnRecordSchema(BaseRecordSchema):
         required=False,
         description="Routing state of connection",
         validate=validate.OneOf(
-            [
-                getattr(ConnRecord, m)
-                for m in vars(ConnRecord)
-                if m.startswith("ROUTING_STATE_")
-            ]
+            ConnRecord.get_attributes_by_prefix("ROUTING_STATE_", walk_mro=False)
         ),
         example=ConnRecord.ROUTING_STATE_ACTIVE,
     )
@@ -690,11 +686,7 @@ class ConnRecordSchema(BaseRecordSchema):
         description="Connection acceptance: manual or auto",
         example=ConnRecord.ACCEPT_AUTO,
         validate=validate.OneOf(
-            [
-                getattr(ConnRecord, a)
-                for a in vars(ConnRecord)
-                if a.startswith("ACCEPT_")
-            ]
+            ConnRecord.get_attributes_by_prefix("ACCEPT_", walk_mro=False)
         ),
     )
     error_msg = fields.Str(
@@ -707,11 +699,7 @@ class ConnRecordSchema(BaseRecordSchema):
         description="Invitation mode",
         example=ConnRecord.INVITATION_MODE_ONCE,
         validate=validate.OneOf(
-            [
-                getattr(ConnRecord, i)
-                for i in vars(ConnRecord)
-                if i.startswith("INVITATION_MODE_")
-            ]
+            ConnRecord.get_attributes_by_prefix("INVITATION_MODE_", walk_mro=False)
         ),
     )
     alias = fields.Str(

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -81,6 +81,7 @@ class BaseRecord(BaseModel):
     EVENT_NAMESPACE: str = "acapy::record"
     LOG_STATE_FLAG = None
     TAG_NAMES = {"state"}
+    STATE_DELETED = "deleted"
 
     def __init__(
         self,
@@ -420,7 +421,7 @@ class BaseRecord(BaseModel):
             storage = session.inject(BaseStorage)
             if self.state:
                 self._previous_state = self.state
-                self.state = "deleted"
+                self.state = BaseRecord.STATE_DELETED
                 await self.emit_event(session, self.serialize())
             await storage.delete_record(self.storage_record)
 

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -498,6 +498,24 @@ class BaseRecord(BaseModel):
             return self.value == other.value and self.tags == other.tags
         return False
 
+    @classmethod
+    def get_attributes_by_prefix(cls, prefix: str, walk_mro: bool = True):
+        """
+        List all values for attributes with common prefix.
+
+        Args:
+            prefix: Common prefix to look for
+            walk_mro: Walk MRO to find attributes inherited from superclasses
+        """
+
+        bases = cls.__mro__ if walk_mro else [cls]
+        return [
+            vars(base)[name]
+            for base in bases
+            for name in vars(base)
+            if name.startswith(prefix)
+        ]
+
 
 class BaseExchangeRecord(BaseRecord):
     """Represents a base record with event tracing capability."""

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
@@ -296,11 +296,7 @@ class V20CredExRecordSchema(BaseExchangeSchema):
         description="Issue-credential exchange initiator: self or external",
         example=V20CredExRecord.INITIATOR_SELF,
         validate=validate.OneOf(
-            [
-                getattr(V20CredExRecord, m)
-                for m in vars(V20CredExRecord)
-                if m.startswith("INITIATOR_")
-            ]
+            V20CredExRecord.get_attributes_by_prefix("INITIATOR_", walk_mro=False)
         ),
     )
     role = fields.Str(
@@ -308,11 +304,7 @@ class V20CredExRecordSchema(BaseExchangeSchema):
         description="Issue-credential exchange role: holder or issuer",
         example=V20CredExRecord.ROLE_ISSUER,
         validate=validate.OneOf(
-            [
-                getattr(V20CredExRecord, m)
-                for m in vars(V20CredExRecord)
-                if m.startswith("ROLE_")
-            ]
+            V20CredExRecord.get_attributes_by_prefix("ROLE_", walk_mro=False)
         ),
     )
     state = fields.Str(
@@ -320,11 +312,7 @@ class V20CredExRecordSchema(BaseExchangeSchema):
         description="Issue-credential exchange state",
         example=V20CredExRecord.STATE_DONE,
         validate=validate.OneOf(
-            [
-                getattr(V20CredExRecord, m)
-                for m in vars(V20CredExRecord)
-                if m.startswith("STATE_")
-            ]
+            V20CredExRecord.get_attributes_by_prefix("STATE_", walk_mro=True)
         ),
     )
     cred_preview = fields.Nested(

--- a/aries_cloudagent/protocols/out_of_band/v1_0/models/oob_record.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/models/oob_record.py
@@ -3,7 +3,7 @@
 import json
 from typing import Any, Mapping, Optional, Union
 
-from marshmallow import fields
+from marshmallow import fields, validate
 
 from .....connections.models.conn_record import ConnRecord
 from .....core.profile import ProfileSession
@@ -248,6 +248,9 @@ class OobRecordSchema(BaseExchangeSchema):
         required=True,
         description="Out of band message exchange state",
         example=OobRecord.STATE_AWAIT_RESPONSE,
+        validate=validate.OneOf(
+            OobRecord.get_attributes_by_prefix("STATE_", walk_mro=True)
+        ),
     )
     invi_msg_id = fields.Str(
         required=True,
@@ -287,4 +290,7 @@ class OobRecordSchema(BaseExchangeSchema):
         description="OOB Role",
         required=False,
         example=OobRecord.ROLE_RECEIVER,
+        validate=validate.OneOf(
+            OobRecord.get_attributes_by_prefix("ROLE_", walk_mro=False)
+        ),
     )

--- a/aries_cloudagent/protocols/present_proof/v2_0/models/pres_exchange.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/models/pres_exchange.py
@@ -244,11 +244,7 @@ class V20PresExRecordSchema(BaseExchangeSchema):
         description="Present-proof exchange initiator: self or external",
         example=V20PresExRecord.INITIATOR_SELF,
         validate=validate.OneOf(
-            [
-                getattr(V20PresExRecord, m)
-                for m in vars(V20PresExRecord)
-                if m.startswith("INITIATOR_")
-            ]
+            V20PresExRecord.get_attributes_by_prefix("INITIATOR_", walk_mro=False)
         ),
     )
     role = fields.Str(
@@ -256,22 +252,14 @@ class V20PresExRecordSchema(BaseExchangeSchema):
         description="Present-proof exchange role: prover or verifier",
         example=V20PresExRecord.ROLE_PROVER,
         validate=validate.OneOf(
-            [
-                getattr(V20PresExRecord, m)
-                for m in vars(V20PresExRecord)
-                if m.startswith("ROLE_")
-            ]
+            V20PresExRecord.get_attributes_by_prefix("ROLE_", walk_mro=False)
         ),
     )
     state = fields.Str(
         required=False,
         description="Present-proof exchange state",
         validate=validate.OneOf(
-            [
-                getattr(V20PresExRecord, m)
-                for m in vars(V20PresExRecord)
-                if m.startswith("STATE_")
-            ]
+            V20PresExRecord.get_attributes_by_prefix("STATE_", walk_mro=True)
         ),
     )
     pres_proposal = fields.Nested(


### PR DESCRIPTION
We ran into the issue that our generated client would throw an exception whenever a CredExRecord was deleted. The reason was the record's state parameter being set to "deleted" - a value which is not in the set of allowed values as per the swagger definition.

Changes:
- `STATE_DELETED` attribute added to BaseRecord
- added a function which lists the values of all attributes that start with a common prefix (e.g. `"STATE_"`), optionally including inherited attributes. The resulting list can be used for validation.

I took the occasion to clean up validation a bit (conn-, cred_ex- and pres_ex_records) and add it where it was missing (OobRecord).