### PR TITLE
Feat: Multiple Credential Issuance [v2.1]

### DIFF
--- a/.github/workflows/publish-indy.yml
+++ b/.github/workflows/publish-indy.yml
@@ -2,7 +2,7 @@ name: Publish ACA-Py Image (Indy)
 run-name: Publish ACA-Py ${{ inputs.tag || github.event.release.tag_name }} Image (Indy ${{ inputs.indy_version || '1.16.0' }})
 on:
   release:
-    types: [released]
+    types: [published]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish ACA-Py Image
 run-name: Publish ACA-Py ${{ inputs.tag || github.event.release.tag_name }} Image
 on:
   release:
-    types: [released]
+    types: [published]
 
   workflow_dispatch:
     inputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,6 @@ that release will be finalized. Many of the PRs in this release were previously
 included in the `1.0.0-rc1` release. The categorized list of PRs separates those
 that are new from those in the `1.0.0-rc1` release candidate.
 
-With this release, a new automated process publishes container images in the
-Hyperledger container image repository. New images for the release are
-automatically published by the GitHubAction Workflows: [publish.yml] and
-[publish-indy.yml]. The actions are triggered when a release is tagged, so no
-manual action is needed. The images are published in the [Hyperledger Package
-Repository under aries-cloudagent-python] and a link to the packages added to
-the repositories main page (under "Packages"). Additional information about the
-container image publication process can be found in the document [Container
-Images and Github Actions].
-
 There are not a lot of new Aries Framework features in this release, as the
 focus has been on cleanup and optimization. The biggest addition is the
 inclusion with ACA-Py of a universal resolver interface, allowing an instance to
@@ -29,7 +19,19 @@ Endorsers. A new repo
 has been created that is a pre-configured instance of ACA-Py for use as an
 Endorser service.
 
-The images are based on [Python 3.6 and 3.9 `slim-bullseye`
+### Container Publishing Updated
+
+With this release, a new automated process publishes container images in the
+Hyperledger container image repository. New images for the release are
+automatically published by the GitHubAction Workflows: [publish.yml] and
+[publish-indy.yml]. The actions are triggered when a release is tagged, so no
+manual action is needed. The images are published in the [Hyperledger Package
+Repository under aries-cloudagent-python] and a link to the packages added to
+the repositories main page (under "Packages"). Additional information about the
+container image publication process can be found in the document [Container
+Images and Github Actions].
+
+The ACA-Py container images are based on [Python 3.6 and 3.9 `slim-bullseye`
 images](https://hub.docker.com/_/python), and are built to support `linux/386
 (x86)`, `linux/amd64 (x64)`, and `linux/arm64`. There are two flavors of image
 built for each Python version. One contains only the Indy/Aries Shared Libraries
@@ -50,6 +52,10 @@ those published to the [Hyperledger Package Repository under
 aries-cloudagent-python].
 
 [Hyperledger Package Repository under aries-cloudagent-python]: https://github.com/orgs/hyperledger/packages?repo_name=aries-cloudagent-python
+[publish.yml]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/.github/workflows/publish.yml
+[publish-indy.yml]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/.github/workflows/publish-indy.yml
+[Container Images and Github Actions]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/ContainerImagesAndGithubActions.md
+
 
 ## Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,109 +1,164 @@
-# 1.0.0-rc1
+# 0.8.0-rc0
 
-## November 6, 2022
+## February 8, 2023
 
-1.0.0 is a breaking update to ACA-Py whose version is intended to indicate the
-maturity of the implementation. The final 1.0.0 release will be Aries Interop
-Profile 2.0-complete, and based on Python 3.7 or higher.
+0.8.0 is a breaking change that contains all updates since release 0.7.5. It
+extends the previously tagged `1.0.0-rc1` release because it is not clear
+when that release will be finalized.
 
-### Breaking Changes
+With this release, a new automated process publishes container
+images in the Hyperledger container image repository for this version of ACA-Py
+based on both Python 3.6 and 3.9. We recommend using Python 3.9 with ACA-Py.
 
-As of release candidate 1.0.0-rc1, the only identified breaking change is the
-handling of "unrevealed attributes" during verification (see
-[\#1913](https://github.com/hyperledger/aries-cloudagent-python/pull/1913) for
-details). As few implementations of Aries Wallets support unrevealed attributes
-in an AnonCreds presentation, this is unlikely to impact any deployments.
-
-### Categorized List of Pull Requests
-
-In rc1, there are not a lot of new features, as the focus is on cleanup and
-optimization. The biggest is the inclusion with ACA-Py of a universal resolver
-interface, allowing an instance to have both local resolvers for some DID
-Methods and a call out to an external universal resolver for other DID Methods.
-Another significant feature is full support for Hyperledger Indy transaction
-endorsement for Authors and Endorsers. A new repo
+There are not a lot of new features in this release, as the focus has been on
+cleanup and optimization. The biggest addition is the inclusion with ACA-Py of a
+universal resolver interface, allowing an instance to have both local resolvers
+for some DID Methods and a call out to an external universal resolver for other
+DID Methods. Another significant new capability is full support for Hyperledger
+Indy transaction endorsement for Authors and Endorsers. A new repo
 [aries-endorser-service](https://github.com/hyperledger/aries-endorser-service)
 has been created that is a pre-configured instance of ACA-Py for use as an
-Endorser service. While some work has been done on moving the default Python
-version beyond 3.6, more work is still to be done on that before the final
-v1.0.0 release.
+Endorser service.
+
+## Breaking Changes
+
+### PR [\#2034](https://github.com/hyperledger/aries-cloudagent-python/pull/2034) -- Implicit connections
+
+The break impacts existing  deployments that supported connections coming via a
+public DID. Such deployments need to add the configuration parameter
+`--requests-through-public-did` to continue to support that feature. The use
+case is that an ACA-Py instance publishes a public DID on a ledger with a
+DIDComm `service` in the DIDDoc. Other agents resolve that DID, and attempt to
+establish a connection with the ACA-Py instance using the `service` endpoint.
+This is called an "implicit" connection in [RFC 0023 DID
+Exchange](https://github.com/hyperledger/aries-rfcs/blob/main/features/0023-did-exchange/README.md).
+
+### PR [\#1913](https://github.com/hyperledger/aries-cloudagent-python/pull/1913) -- Unrevealed attributes in presentations
+
+Updates the handling of "unrevealed attributes" during verification of AnonCreds
+presentations, allowing them to be used in a presentation, with additional data
+that can be checked if for unrevealed attributes. As few implementations of
+Aries wallets support unrevealed attributes in an AnonCreds presentation, this
+is unlikely to impact any deployments.
 
 ### Categorized List of Pull Requests
 
 - Verifiable credential, presentation and revocation handling updates
-  - Refactor ledger correction code and insert into revocation error handling [\#1892](https://github.com/hyperledger/aries-cloudagent-python/pull/1892) ([ianco](https://github.com/ianco))
-  - Indy ledger fixes and cleanups [\#1870](https://github.com/hyperledger/aries-cloudagent-python/pull/1870) ([andrewwhitehead](https://github.com/andrewwhitehead))
-  - Refactoring of revocation registry creation [\#1813](https://github.com/hyperledger/aries-cloudagent-python/pull/1813) ([andrewwhitehead](https://github.com/andrewwhitehead))
-  - Fix: the type of tails file path to string. [\#1925](https://github.com/hyperledger/aries-cloudagent-python/pull/1925) ([baegjae](https://github.com/baegjae))
-  - Pre-populate revoc\_reg\_id on IssuerRevRegRecord [\#1924](https://github.com/hyperledger/aries-cloudagent-python/pull/1924) ([andrewwhitehead](https://github.com/andrewwhitehead))
-  - Leave credentialStatus element in the LD credential [\#1921](https://github.com/hyperledger/aries-cloudagent-python/pull/1921) ([tsabolov](https://github.com/tsabolov))
-  - **BREAKING:** Remove aca-py check for unrevealed revealed attrs on proof validation [\#1913](https://github.com/hyperledger/aries-cloudagent-python/pull/1913) ([ianco](https://github.com/ianco))
-  - Send webhooks upon record/credential deletion [\#1906](https://github.com/hyperledger/aries-cloudagent-python/pull/1906) ([frostyfrog](https://github.com/frostyfrog))
+  - Feature: enabled handling VPs \(request, creation, verification\) with different VCs [\#1956](https://github.com/hyperledger/aries-cloudagent-python/pull/1956) ([teanas](https://github.com/teanas))
+  - fix: update issue-credential endpoint summaries [\#1997](https://github.com/hyperledger/aries-cloudagent-python/pull/1997) ([PeterStrob](https://github.com/PeterStrob))
+  - fix claim format designation in presentation submission [\#2013](https://github.com/hyperledger/aries-cloudagent-python/pull/2013) ([rmnre](https://github.com/rmnre))
+  - \#2041 - Issue JSON-LD has invalid Admin API documentation [\#2046](https://github.com/hyperledger/aries-cloudagent-python/pull/2046) ([jfblier-amplitude](https://github.com/jfblier-amplitude))
+  - Previously flagged in release 1.0.0-rc1
+    - Refactor ledger correction code and insert into revocation error handling [\#1892](https://github.com/hyperledger/aries-cloudagent-python/pull/1892) ([ianco](https://github.com/ianco))
+    - Indy ledger fixes and cleanups [\#1870](https://github.com/hyperledger/aries-cloudagent-python/pull/1870) ([andrewwhitehead](https://github.com/andrewwhitehead))
+    - Refactoring of revocation registry creation [\#1813](https://github.com/hyperledger/aries-cloudagent-python/pull/1813) ([andrewwhitehead](https://github.com/andrewwhitehead))
+    - Fix: the type of tails file path to string. [\#1925](https://github.com/hyperledger/aries-cloudagent-python/pull/1925) ([baegjae](https://github.com/baegjae))
+    - Pre-populate revoc\_reg\_id on IssuerRevRegRecord [\#1924](https://github.com/hyperledger/aries-cloudagent-python/pull/1924) ([andrewwhitehead](https://github.com/andrewwhitehead))
+    - Leave credentialStatus element in the LD credential [\#1921](https://github.com/hyperledger/aries-cloudagent-python/pull/1921) ([tsabolov](https://github.com/tsabolov))
+    - **BREAKING:** Remove aca-py check for unrevealed revealed attrs on proof validation [\#1913](https://github.com/hyperledger/aries-cloudagent-python/pull/1913) ([ianco](https://github.com/ianco))
+    - Send webhooks upon record/credential deletion [\#1906](https://github.com/hyperledger/aries-cloudagent-python/pull/1906) ([frostyfrog](https://github.com/frostyfrog))
 
-- Out of Band (OOB)  and DID Exchange / Connection Handling
-  - Fix: `--mediator-invitation` with OOB invitation + cleanup  [\#1970](https://github.com/hyperledger/aries-cloudagent-python/pull/1970) ([shaangill025](https://github.com/shaangill025))
-  - include image\_url in oob invitation [\#1966](https://github.com/hyperledger/aries-cloudagent-python/pull/1966) ([Zzocker](https://github.com/Zzocker))
-  - feat: 00B v1.1 support [\#1962](https://github.com/hyperledger/aries-cloudagent-python/pull/1962) ([shaangill025](https://github.com/shaangill025))
-  - Fix: OOB - Handling of minor versions [\#1940](https://github.com/hyperledger/aries-cloudagent-python/pull/1940) ([shaangill025](https://github.com/shaangill025))
-  - fix: failed connectionless proof request on some case [\#1933](https://github.com/hyperledger/aries-cloudagent-python/pull/1933) ([kukgini](https://github.com/kukgini))
-  - fix: propagate endpoint from mediation record [\#1922](https://github.com/hyperledger/aries-cloudagent-python/pull/1922) ([cjhowland](https://github.com/cjhowland))
-  - Feat/public did endpoints for agents behind mediators [\#1899](https://github.com/hyperledger/aries-cloudagent-python/pull/1899) ([cjhowland](https://github.com/cjhowland))
+- Out of Band (OOB) and DID Exchange / Connection Handling / Mediator
+  - fix: public did mediator routing keys as did keys [\#1977](https://github.com/hyperledger/aries-cloudagent-python/pull/1977) ([dbluhm](https://github.com/dbluhm))
+  - Fix for mediator load testing race condition when scaling horizontally [\#2009](https://github.com/hyperledger/aries-cloudagent-python/pull/2009) ([ianco](https://github.com/ianco))
+  - BREAKING: Allow multi-use public invites and public invites with metadata [\#2034](https://github.com/hyperledger/aries-cloudagent-python/pull/2034) ([mepeltier](https://github.com/mepeltier))
+  - Do not reject OOB invitation with unknown handshake protocol\(s\) [\#2060](https://github.com/hyperledger/aries-cloudagent-python/pull/2060) ([andrewwhitehead](https://github.com/andrewwhitehead))
+  - fix: fix connection timing bug [\#2099](https://github.com/hyperledger/aries-cloudagent-python/pull/2099) ([reflectivedevelopment](https://github.com/reflectivedevelopment))
+  - Previously flagged in release 1.0.0-rc1
+    - Fix: `--mediator-invitation` with OOB invitation + cleanup  [\#1970](https://github.com/hyperledger/aries-cloudagent-python/pull/1970) ([shaangill025](https://github.com/shaangill025))
+    - include image\_url in oob invitation [\#1966](https://github.com/hyperledger/aries-cloudagent-python/pull/1966) ([Zzocker](https://github.com/Zzocker))
+    - feat: 00B v1.1 support [\#1962](https://github.com/hyperledger/aries-cloudagent-python/pull/1962) ([shaangill025](https://github.com/shaangill025))
+    - Fix: OOB - Handling of minor versions [\#1940](https://github.com/hyperledger/aries-cloudagent-python/pull/1940) ([shaangill025](https://github.com/shaangill025))
+    - fix: failed connectionless proof request on some case [\#1933](https://github.com/hyperledger/aries-cloudagent-python/pull/1933) ([kukgini](https://github.com/kukgini))
+    - fix: propagate endpoint from mediation record [\#1922](https://github.com/hyperledger/aries-cloudagent-python/pull/1922) ([cjhowland](https://github.com/cjhowland))
+    - Feat/public did endpoints for agents behind mediators [\#1899](https://github.com/hyperledger/aries-cloudagent-python/pull/1899) ([cjhowland](https://github.com/cjhowland))
 
 - DID Registration and Resolution related updates
-  - feat: add universal resolver [\#1866](https://github.com/hyperledger/aries-cloudagent-python/pull/1866) ([dbluhm](https://github.com/dbluhm))
-  - fix: resolve dids following new endpoint rules [\#1863](https://github.com/hyperledger/aries-cloudagent-python/pull/1863) ([dbluhm](https://github.com/dbluhm))
-  - fix: didx request cannot be accepted [\#1881](https://github.com/hyperledger/aries-cloudagent-python/pull/1881) ([rmnre](https://github.com/rmnre))
-  - did method & key type registry [\#1986](https://github.com/hyperledger/aries-cloudagent-python/pull/1986) ([burdettadam](https://github.com/burdettadam))
-  - Fix/endpoint attrib structure [\#1934](https://github.com/hyperledger/aries-cloudagent-python/pull/1934) ([cjhowland](https://github.com/cjhowland))
-  - Simple did registry [\#1920](https://github.com/hyperledger/aries-cloudagent-python/pull/1920) ([burdettadam](https://github.com/burdettadam))
-  - Use did:key for recipient keys [\#1886](https://github.com/hyperledger/aries-cloudagent-python/pull/1886) ([frostyfrog](https://github.com/frostyfrog))
+  - feat: enable creation of DIDs for all registered methods [\#2067](https://github.com/hyperledger/aries-cloudagent-python/pull/2067) ([chumbert](https://github.com/chumbert))
+  - fix: create local DID return schema [\#2086](https://github.com/hyperledger/aries-cloudagent-python/pull/2086) ([chumbert](https://github.com/chumbert))
+  - feat: universal resolver - configurable authentication [\#2095](https://github.com/hyperledger/aries-cloudagent-python/pull/2095) ([chumbert](https://github.com/chumbert))
+  - Previously flagged in release 1.0.0-rc1
+    - feat: add universal resolver [\#1866](https://github.com/hyperledger/aries-cloudagent-python/pull/1866) ([dbluhm](https://github.com/dbluhm))
+    - fix: resolve dids following new endpoint rules [\#1863](https://github.com/hyperledger/aries-cloudagent-python/pull/1863) ([dbluhm](https://github.com/dbluhm))
+    - fix: didx request cannot be accepted [\#1881](https://github.com/hyperledger/aries-cloudagent-python/pull/1881) ([rmnre](https://github.com/rmnre))
+    - did method & key type registry [\#1986](https://github.com/hyperledger/aries-cloudagent-python/pull/1986) ([burdettadam](https://github.com/burdettadam))
+    - Fix/endpoint attrib structure [\#1934](https://github.com/hyperledger/aries-cloudagent-python/pull/1934) ([cjhowland](https://github.com/cjhowland))
+    - Simple did registry [\#1920](https://github.com/hyperledger/aries-cloudagent-python/pull/1920) ([burdettadam](https://github.com/burdettadam))
+    - Use did:key for recipient keys [\#1886](https://github.com/hyperledger/aries-cloudagent-python/pull/1886) ([frostyfrog](https://github.com/frostyfrog))
 
 - Hyperledger Indy Endorser/Author Transaction Handling
-  - Fix/txn job setting [\#1994](https://github.com/hyperledger/aries-cloudagent-python/pull/1994) ([ianco](https://github.com/ianco))
-  - chore: fix ACAPY\_PROMOTE-AUTHOR-DID flag  [\#1978](https://github.com/hyperledger/aries-cloudagent-python/pull/1978) ([morrieinmaas](https://github.com/morrieinmaas))
-
-  - Endorser write DID transaction [\#1938](https://github.com/hyperledger/aries-cloudagent-python/pull/1938) ([ianco](https://github.com/ianco))
-  - Endorser doc updates and some bug fixes [\#1926](https://github.com/hyperledger/aries-cloudagent-python/pull/1926) ([ianco](https://github.com/ianco))
+  - Special handling for the write ledger [\#2030](https://github.com/hyperledger/aries-cloudagent-python/pull/2030) ([ianco](https://github.com/ianco))
+  - Previously flagged in release 1.0.0-rc1
+    - Fix/txn job setting [\#1994](https://github.com/hyperledger/aries-cloudagent-python/pull/1994) ([ianco](https://github.com/ianco))
+    - chore: fix ACAPY\_PROMOTE-AUTHOR-DID flag  [\#1978](https://github.com/hyperledger/aries-cloudagent-python/pull/1978) ([morrieinmaas](https://github.com/morrieinmaas))
+    - Endorser write DID transaction [\#1938](https://github.com/hyperledger/aries-cloudagent-python/pull/1938) ([ianco](https://github.com/ianco))
+    - Endorser doc updates and some bug fixes [\#1926](https://github.com/hyperledger/aries-cloudagent-python/pull/1926) ([ianco](https://github.com/ianco))
 
 - Startup Command Line / Environment / YAML Parameter Updates
-  - Add seed command line parameter but use only if also an "allow insecure seed" parameter is set [\#1714](https://github.com/hyperledger/aries-cloudagent-python/pull/1714) ([DaevMithran](https://github.com/DaevMithran))
+  - Add missing --mediator-connections-invite cmd arg info to docs [\#2051](https://github.com/hyperledger/aries-cloudagent-python/pull/2051) ([matrixik](https://github.com/matrixik))
+  - Issue \#2068 boolean flag change to support HEAD requests to default route [\#2077](https://github.com/hyperledger/aries-cloudagent-python/pull/2077) ([johnekent](https://github.com/johnekent))
+  - Previously flagged in release 1.0.0-rc1
+    - Add seed command line parameter but use only if also an "allow insecure seed" parameter is set [\#1714](https://github.com/hyperledger/aries-cloudagent-python/pull/1714) ([DaevMithran](https://github.com/DaevMithran))
 
 - Internal Aries framework data handling updates
-  - fix: update RouteManager methods use to pass profile as parameter [\#1902](https://github.com/hyperledger/aries-cloudagent-python/pull/1902) ([chumbert](https://github.com/chumbert))
-  - Allow fully qualified class names for profile managers [\#1880](https://github.com/hyperledger/aries-cloudagent-python/pull/1880) ([chumbert](https://github.com/chumbert))
-  - fix: unable to use askar with in memory db [\#1878](https://github.com/hyperledger/aries-cloudagent-python/pull/1878) ([dbluhm](https://github.com/dbluhm))
-  - Enable manually triggering keylist updates during connection [\#1851](https://github.com/hyperledger/aries-cloudagent-python/pull/1851) ([dbluhm](https://github.com/dbluhm))
-  - feat: make base wallet route access configurable [\#1836](https://github.com/hyperledger/aries-cloudagent-python/pull/1836) ([dbluhm](https://github.com/dbluhm))
-  - feat: event and webhook on keylist update stored [\#1769](https://github.com/hyperledger/aries-cloudagent-python/pull/1769) ([dbluhm](https://github.com/dbluhm))
-  - fix: Safely shutdown when root\_profile uninitialized [\#1960](https://github.com/hyperledger/aries-cloudagent-python/pull/1960) ([frostyfrog](https://github.com/frostyfrog))
-  - feat: include connection ids in keylist update webhook [\#1914](https://github.com/hyperledger/aries-cloudagent-python/pull/1914) ([dbluhm](https://github.com/dbluhm))
-  - fix: incorrect response schema for discover features [\#1912](https://github.com/hyperledger/aries-cloudagent-python/pull/1912) ([dbluhm](https://github.com/dbluhm))
-  - Fix: SchemasInputDescriptorFilter: broken deserialization renders generated clients unusable [\#1894](https://github.com/hyperledger/aries-cloudagent-python/pull/1894) ([rmnre](https://github.com/rmnre))
-  - fix: schema class can set Meta.unknown [\#1885](https://github.com/hyperledger/aries-cloudagent-python/pull/1885) ([dbluhm](https://github.com/dbluhm))
+  - fix: return if return route but no response [\#1853](https://github.com/hyperledger/aries-cloudagent-python/pull/1853) ([TimoGlastra](https://github.com/TimoGlastra))
+  - Multi-ledger/Multi-tenant issues [\#2022](https://github.com/hyperledger/aries-cloudagent-python/pull/2022) ([ianco](https://github.com/ianco))
+  - fix: Correct typo in model -- required spelled incorrectly [\#2031](https://github.com/hyperledger/aries-cloudagent-python/pull/2031) ([swcurran](https://github.com/swcurran))
+  - Code formatting [\#2053](https://github.com/hyperledger/aries-cloudagent-python/pull/2053) ([ianco](https://github.com/ianco))
+  - Improved validation of record state attributes [\#2071](https://github.com/hyperledger/aries-cloudagent-python/pull/2071) ([rmnre](https://github.com/rmnre))
+  - Previously flagged in release 1.0.0-rc1
+    - fix: update RouteManager methods use to pass profile as parameter [\#1902](https://github.com/hyperledger/aries-cloudagent-python/pull/1902) ([chumbert](https://github.com/chumbert))
+    - Allow fully qualified class names for profile managers [\#1880](https://github.com/hyperledger/aries-cloudagent-python/pull/1880) ([chumbert](https://github.com/chumbert))
+    - fix: unable to use askar with in memory db [\#1878](https://github.com/hyperledger/aries-cloudagent-python/pull/1878) ([dbluhm](https://github.com/dbluhm))
+    - Enable manually triggering keylist updates during connection [\#1851](https://github.com/hyperledger/aries-cloudagent-python/pull/1851) ([dbluhm](https://github.com/dbluhm))
+    - feat: make base wallet route access configurable [\#1836](https://github.com/hyperledger/aries-cloudagent-python/pull/1836) ([dbluhm](https://github.com/dbluhm))
+    - feat: event and webhook on keylist update stored [\#1769](https://github.com/hyperledger/aries-cloudagent-python/pull/1769) ([dbluhm](https://github.com/dbluhm))
+    - fix: Safely shutdown when root\_profile uninitialized [\#1960](https://github.com/hyperledger/aries-cloudagent-python/pull/1960) ([frostyfrog](https://github.com/frostyfrog))
+    - feat: include connection ids in keylist update webhook [\#1914](https://github.com/hyperledger/aries-cloudagent-python/pull/1914) ([dbluhm](https://github.com/dbluhm))
+    - fix: incorrect response schema for discover features [\#1912](https://github.com/hyperledger/aries-cloudagent-python/pull/1912) ([dbluhm](https://github.com/dbluhm))
+    - Fix: SchemasInputDescriptorFilter: broken deserialization renders generated clients unusable [\#1894](https://github.com/hyperledger/aries-cloudagent-python/pull/1894) ([rmnre](https://github.com/rmnre))
+    - fix: schema class can set Meta.unknown [\#1885](https://github.com/hyperledger/aries-cloudagent-python/pull/1885) ([dbluhm](https://github.com/dbluhm))
 
-- Unit, Integration and Aries Agent Test Harness Test updates 
-  - Fixes a few AATH failures [\#1897](https://github.com/hyperledger/aries-cloudagent-python/pull/1897) ([ianco](https://github.com/ianco))
-  - fix: warnings in tests from IndySdkProfile [\#1865](https://github.com/hyperledger/aries-cloudagent-python/pull/1865) ([dbluhm](https://github.com/dbluhm))
-  - Unit test fixes for python 3.9 [\#1858](https://github.com/hyperledger/aries-cloudagent-python/pull/1858) ([andrewwhitehead](https://github.com/andrewwhitehead))
-  - Update pip-audit.yml [\#1945](https://github.com/hyperledger/aries-cloudagent-python/pull/1945) ([ryjones](https://github.com/ryjones))
-  - Update pip-audit.yml [\#1944](https://github.com/hyperledger/aries-cloudagent-python/pull/1944) ([ryjones](https://github.com/ryjones))
+- Unit, Integration, and Aries Agent Test Harness Test updates 
+  - Additional integration tests for revocation scenarios [\#2055](https://github.com/hyperledger/aries-cloudagent-python/pull/2055) ([ianco](https://github.com/ianco))
+  - Previously flagged in release 1.0.0-rc1
+    - Fixes a few AATH failures [\#1897](https://github.com/hyperledger/aries-cloudagent-python/pull/1897) ([ianco](https://github.com/ianco))
+    - fix: warnings in tests from IndySdkProfile [\#1865](https://github.com/hyperledger/aries-cloudagent-python/pull/1865) ([dbluhm](https://github.com/dbluhm))
+    - Unit test fixes for python 3.9 [\#1858](https://github.com/hyperledger/aries-cloudagent-python/pull/1858) ([andrewwhitehead](https://github.com/andrewwhitehead))
+    - Update pip-audit.yml [\#1945](https://github.com/hyperledger/aries-cloudagent-python/pull/1945) ([ryjones](https://github.com/ryjones))
+    - Update pip-audit.yml [\#1944](https://github.com/hyperledger/aries-cloudagent-python/pull/1944) ([ryjones](https://github.com/ryjones))
 
-- Dependency Updates
-  - feat: update pynacl version from 1.4.0 to 1.50 [\#1981](https://github.com/hyperledger/aries-cloudagent-python/pull/1981) ([morrieinmaas](https://github.com/morrieinmaas))
-  - Fix: web.py dependency - integration tests & demos [\#1973](https://github.com/hyperledger/aries-cloudagent-python/pull/1973) ([shaangill025](https://github.com/shaangill025))
-  - chore: update pydid [\#1915](https://github.com/hyperledger/aries-cloudagent-python/pull/1915) ([dbluhm](https://github.com/dbluhm))
+- Dependency, Python version, GitHub Actions and Container Image Changes
+  - fix: indy dependency version format [\#2054](https://github.com/hyperledger/aries-cloudagent-python/pull/2054) ([chumbert](https://github.com/chumbert))
+  - ci: add gha for pr-tests [\#2058](https://github.com/hyperledger/aries-cloudagent-python/pull/2058) ([dbluhm](https://github.com/dbluhm))
+  - ci: test additional versions of python nightly [\#2059](https://github.com/hyperledger/aries-cloudagent-python/pull/2059) ([dbluhm](https://github.com/dbluhm))
+  - Update github actions dependencies \(for node16 support\) [\#2066](https://github.com/hyperledger/aries-cloudagent-python/pull/2066) ([andrewwhitehead](https://github.com/andrewwhitehead))
+  - Docker images and GHA for publishing images [\#2076](https://github.com/hyperledger/aries-cloudagent-python/pull/2076) ([dbluhm](https://github.com/dbluhm))
+  - Update dockerfiles to use python 3.9 [\#2109](https://github.com/hyperledger/aries-cloudagent-python/pull/2109) ([ianco](https://github.com/ianco))
+  - Updating base images from slim-buster to slim-bullseye [\#2105](https://github.com/hyperledger/aries-cloudagent-python/pull/2105) ([pradeepp88](https://github.com/pradeepp88))
+  - Previously flagged in release 1.0.0-rc1
+    - feat: update pynacl version from 1.4.0 to 1.50 [\#1981](https://github.com/hyperledger/aries-cloudagent-python/pull/1981) ([morrieinmaas](https://github.com/morrieinmaas))
+    - Fix: web.py dependency - integration tests & demos [\#1973](https://github.com/hyperledger/aries-cloudagent-python/pull/1973) ([shaangill025](https://github.com/shaangill025))
+    - chore: update pydid [\#1915](https://github.com/hyperledger/aries-cloudagent-python/pull/1915) ([dbluhm](https://github.com/dbluhm))
 
 - Demo and Documentation Updates
-  - Fixes to acme exercise code [\#1990](https://github.com/hyperledger/aries-cloudagent-python/pull/1990) ([ianco](https://github.com/ianco))
-  - Fixed bug in run\_demo script [\#1982](https://github.com/hyperledger/aries-cloudagent-python/pull/1982) ([pasquale95](https://github.com/pasquale95))
-  - Transaction Author with Endorser demo [\#1975](https://github.com/hyperledger/aries-cloudagent-python/pull/1975) ([ianco](https://github.com/ianco))
-  - Redis Plugins \[redis\_cache & redis\_queue\] related updates [\#1937](https://github.com/hyperledger/aries-cloudagent-python/pull/1937) ([shaangill025](https://github.com/shaangill025))
+  - Fix typos in alice-local.sh & faber-local.sh [\#2010](https://github.com/hyperledger/aries-cloudagent-python/pull/2010) ([naonishijima](https://github.com/naonishijima))
+  - Added a bit about manually creating a revoc reg tails file [\#2012](https://github.com/hyperledger/aries-cloudagent-python/pull/2012) ([ianco](https://github.com/ianco))
+  - Add ability to set docker container name [\#2024](https://github.com/hyperledger/aries-cloudagent-python/pull/2024) ([matrixik](https://github.com/matrixik))
+  - Doc updates for json demo [\#2026](https://github.com/hyperledger/aries-cloudagent-python/pull/2026) ([ianco](https://github.com/ianco))
+  - Multitenancy demo \(docker-compose with postgres and ngrok\) [\#2089](https://github.com/hyperledger/aries-cloudagent-python/pull/2089) ([ianco](https://github.com/ianco))
+  - Allow using YAML configuration file with run\_docker [\#2091](https://github.com/hyperledger/aries-cloudagent-python/pull/2091) ([matrixik](https://github.com/matrixik))
+  - Previously flagged in release 1.0.0-rc1
+    - Fixes to acme exercise code [\#1990](https://github.com/hyperledger/aries-cloudagent-python/pull/1990) ([ianco](https://github.com/ianco))
+    - Fixed bug in run\_demo script [\#1982](https://github.com/hyperledger/aries-cloudagent-python/pull/1982) ([pasquale95](https://github.com/pasquale95))
+    - Transaction Author with Endorser demo [\#1975](https://github.com/hyperledger/aries-cloudagent-python/pull/1975) ([ianco](https://github.com/ianco))
+    - Redis Plugins \[redis\_cache & redis\_queue\] related updates [\#1937](https://github.com/hyperledger/aries-cloudagent-python/pull/1937) ([shaangill025](https://github.com/shaangill025))
 
 - Release management pull requests
-  - Release 1.0.0-rc0 [\#1904](https://github.com/hyperledger/aries-cloudagent-python/pull/1904) ([swcurran](https://github.com/swcurran))
-  - Add 0.7.5 patch Changelog entry to main branch Changelog [\#1996](https://github.com/hyperledger/aries-cloudagent-python/pull/1996) ([swcurran](https://github.com/swcurran))
-  - Release 1.0.0-rc1 [\#2005](https://github.com/hyperledger/aries-cloudagent-python/pull/2005) ([swcurran](https://github.com/swcurran))
-
+  - Previously flagged in release 1.0.0-rc1
+    - Release 1.0.0-rc0 [\#1904](https://github.com/hyperledger/aries-cloudagent-python/pull/1904) ([swcurran](https://github.com/swcurran))
+    - Add 0.7.5 patch Changelog entry to main branch Changelog [\#1996](https://github.com/hyperledger/aries-cloudagent-python/pull/1996) ([swcurran](https://github.com/swcurran))
+    - Release 1.0.0-rc1 [\#2005](https://github.com/hyperledger/aries-cloudagent-python/pull/2005) ([swcurran](https://github.com/swcurran))
 
 # 0.7.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ is unlikely to impact any deployments.
     - Add seed command line parameter but use only if also an "allow insecure seed" parameter is set [\#1714](https://github.com/hyperledger/aries-cloudagent-python/pull/1714) ([DaevMithran](https://github.com/DaevMithran))
 
 - Internal Aries framework data handling updates
+  - fix: resolver api schema inconsistency [\#2112](https://github.com/hyperledger/aries-cloudagent-python/pull/2112) ([TimoGlastra](https://github.com/chumbert))
   - fix: return if return route but no response [\#1853](https://github.com/hyperledger/aries-cloudagent-python/pull/1853) ([TimoGlastra](https://github.com/TimoGlastra))
   - Multi-ledger/Multi-tenant issues [\#2022](https://github.com/hyperledger/aries-cloudagent-python/pull/2022) ([ianco](https://github.com/ianco))
   - fix: Correct typo in model -- required spelled incorrectly [\#2031](https://github.com/hyperledger/aries-cloudagent-python/pull/2031) ([swcurran](https://github.com/swcurran))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ included in the `1.0.0-rc1` release. The categorized list of PRs separates those
 that are new from those in the `1.0.0-rc1` release candidate.
 
 With this release, a new automated process publishes container images in the
-Hyperledger container image repository. New images for the release are automatically published by the GitHubAction
-Workflows: [publish.yml] and [publish-indy.yml]. The actions are triggered when
-a release is tagged, so no manual action is needed. The images are published in
-the [Hyperledger Package Repository under
-aries-cloudagent-python](https://github.com/orgs/hyperledger/packages?repo_name=aries-cloudagent-python)
-and a link to the packages added to the repositories main page (under
-"Packages"). Additional information about the container image publication process can be
-found in the document [Container Images and Github Actions].
+Hyperledger container image repository. New images for the release are
+automatically published by the GitHubAction Workflows: [publish.yml] and
+[publish-indy.yml]. The actions are triggered when a release is tagged, so no
+manual action is needed. The images are published in the [Hyperledger Package
+Repository under aries-cloudagent-python] and a link to the packages added to
+the repositories main page (under "Packages"). Additional information about the
+container image publication process can be found in the document [Container
+Images and Github Actions].
 
 There are not a lot of new Aries Framework features in this release, as the
 focus has been on cleanup and optimization. The biggest addition is the
@@ -32,18 +32,24 @@ Endorser service.
 The images are based on [Python 3.6 and 3.9 `slim-bullseye`
 images](https://hub.docker.com/_/python), and are built to support `linux/386
 (x86)`, `linux/amd64 (x64)`, and `linux/arm64`. There are two flavors of image
-built for each Python version. One containing the Indy/Aries Shared Libraries
+built for each Python version. One contains only the Indy/Aries Shared Libraries
 only ([Aries Askar](https://github.com/hyperledger/aries-askar), [Indy
 VDR](https://github.com/hyperledger/indy-vdr) and [Indy Shared
 RS](https://github.com/hyperledger/indy-shared-rs), supporting only the use of
-`--wallet-type askar`), and one containing the Indy/Aries shared libraries and
-the Indy SDK (considered deprecated). The images containing the Indy SDK are
-labeled `indy`. For new deployments, we recommend using the Python 3.9 Shared
-Library images. For existing deployments, we recommend migrating to those
-images. For those migrating an Indy SDK deployment, a new secure storage
-migration capability from Indy SDK to Aries Askar is available--contact the
-ACA-Py maintainers on Hyperledger Discord for details.
+`--wallet-type askar`). The other (labelled `indy`) contains the Indy/Aries
+shared libraries and the Indy SDK (considered deprecated). For new deployments,
+we recommend using the Python 3.9 Shared Library images. For existing
+deployments, we recommend migrating to those images. For those migrating an Indy
+SDK deployment, a new secure storage database migration capability from Indy SDK
+to Aries Askar is available--contact the ACA-Py maintainers on Hyperledger
+Discord for details.
 
+Those currently using the container images published by [BC Gov on Docker
+Hub](https://hub.docker.com/r/bcgovimages/aries-cloudagent) should change to use
+those published to the [Hyperledger Package Repository under
+aries-cloudagent-python].
+
+[Hyperledger Package Repository under aries-cloudagent-python]: https://github.com/orgs/hyperledger/packages?repo_name=aries-cloudagent-python
 
 ## Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## February 8, 2023
 
 0.8.0 is a breaking change that contains all updates since release 0.7.5. It
-extends the previously tagged `1.0.0-rc1` release because it is not clear
-when that release will be finalized.
+extends the previously tagged `1.0.0-rc1` release because it is not clear when
+that release will be finalized. Many of the PRs in this release were previously
+included in the `1.0.0-rc1` release. The categorized list of PRs separates those
+that are new from those in the `1.0.0-rc1` release candidate.
 
 With this release, a new automated process publishes container
 images in the Hyperledger container image repository for this version of ACA-Py
@@ -155,6 +157,7 @@ is unlikely to impact any deployments.
     - Redis Plugins \[redis\_cache & redis\_queue\] related updates [\#1937](https://github.com/hyperledger/aries-cloudagent-python/pull/1937) ([shaangill025](https://github.com/shaangill025))
 
 - Release management pull requests
+  - 0.8.0-rc0 release updates [\#2115](https://github.com/hyperledger/aries-cloudagent-python/pull/2115) ([swcurran](https://github.com/swcurran))
   - Previously flagged in release 1.0.0-rc1
     - Release 1.0.0-rc0 [\#1904](https://github.com/hyperledger/aries-cloudagent-python/pull/1904) ([swcurran](https://github.com/swcurran))
     - Add 0.7.5 patch Changelog entry to main branch Changelog [\#1996](https://github.com/hyperledger/aries-cloudagent-python/pull/1996) ([swcurran](https://github.com/swcurran))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,26 +8,50 @@ that release will be finalized. Many of the PRs in this release were previously
 included in the `1.0.0-rc1` release. The categorized list of PRs separates those
 that are new from those in the `1.0.0-rc1` release candidate.
 
-With this release, a new automated process publishes container
-images in the Hyperledger container image repository for this version of ACA-Py
-based on both Python 3.6 and 3.9. We recommend using Python 3.9 with ACA-Py.
+With this release, a new automated process publishes container images in the
+Hyperledger container image repository. New images for the release are automatically published by the GitHubAction
+Workflows: [publish.yml] and [publish-indy.yml]. The actions are triggered when
+a release is tagged, so no manual action is needed. The images are published in
+the [Hyperledger Package Repository under
+aries-cloudagent-python](https://github.com/orgs/hyperledger/packages?repo_name=aries-cloudagent-python)
+and a link to the packages added to the repositories main page (under
+"Packages"). Additional information about the container image publication process can be
+found in the document [Container Images and Github Actions].
 
-There are not a lot of new features in this release, as the focus has been on
-cleanup and optimization. The biggest addition is the inclusion with ACA-Py of a
-universal resolver interface, allowing an instance to have both local resolvers
-for some DID Methods and a call out to an external universal resolver for other
-DID Methods. Another significant new capability is full support for Hyperledger
-Indy transaction endorsement for Authors and Endorsers. A new repo
+There are not a lot of new Aries Framework features in this release, as the
+focus has been on cleanup and optimization. The biggest addition is the
+inclusion with ACA-Py of a universal resolver interface, allowing an instance to
+have both local resolvers for some DID Methods and a call out to an external
+universal resolver for other DID Methods. Another significant new capability is
+full support for Hyperledger Indy transaction endorsement for Authors and
+Endorsers. A new repo
 [aries-endorser-service](https://github.com/hyperledger/aries-endorser-service)
 has been created that is a pre-configured instance of ACA-Py for use as an
 Endorser service.
+
+The images are based on [Python 3.6 and 3.9 `slim-bullseye`
+images](https://hub.docker.com/_/python), and are built to support `linux/386
+(x86)`, `linux/amd64 (x64)`, and `linux/arm64`. There are two flavors of image
+built for each Python version. One containing the Indy/Aries Shared Libraries
+only ([Aries Askar](https://github.com/hyperledger/aries-askar), [Indy
+VDR](https://github.com/hyperledger/indy-vdr) and [Indy Shared
+RS](https://github.com/hyperledger/indy-shared-rs), supporting only the use of
+`--wallet-type askar`), and one containing the Indy/Aries shared libraries and
+the Indy SDK (considered deprecated). The images containing the Indy SDK are
+labeled `indy`. For new deployments, we recommend using the Python 3.9 Shared
+Library images. For existing deployments, we recommend migrating to those
+images. For those migrating an Indy SDK deployment, a new secure storage
+migration capability from Indy SDK to Aries Askar is available--contact the
+ACA-Py maintainers on Hyperledger Discord for details.
+
 
 ## Breaking Changes
 
 ### PR [\#2034](https://github.com/hyperledger/aries-cloudagent-python/pull/2034) -- Implicit connections
 
-The break impacts existing  deployments that supported connections coming via a
-public DID. Such deployments need to add the configuration parameter
+The break impacts existing deployments that support implicit connections, those
+initiated by another agent using a Public DID for this instance instead of an
+explicit invitation. Such deployments need to add the configuration parameter
 `--requests-through-public-did` to continue to support that feature. The use
 case is that an ACA-Py instance publishes a public DID on a ledger with a
 DIDComm `service` in the DIDDoc. Other agents resolve that DID, and attempt to

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -12,23 +12,108 @@ Once ready to do a release, create a local branch that includes the following up
 
 3. Include details of the merged PRs included in this release. General process to follow:
 
-- Gather the set of PRs since the last release and put them into a list. A good tool to use for this is the [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator). Steps:
-  - Create a read only GitHub token for your account on this page: [https://github.com/settings/tokens](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token) with a scope of `repo` / `public_repo`.
-  - Use a command like the following, adjusting the tag parameters as appropriate. `docker run -it --rm -v "$(pwd)":/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator --user hyperledger --project aries-cloudagent-python --output 0.7.4-rc0.md --since-tag 0.7.3 --future-release 0.7.4-rc0 --release-branch main --token <your-token>`
-  - In the generated file, use only the PR list -- we don't include the list of closed issues in the Change Log.
+- Gather the set of PRs since the last release and put them into a list. A good
+  tool to use for this is the
+  [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator).
+  Steps:
+  - Create a read only GitHub token for your account on this page:
+    [https://github.com/settings/tokens](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token)
+    with a scope of `repo` / `public_repo`.
+  - Use a command like the following, adjusting the tag parameters as
+    appropriate. `docker run -it --rm -v "$(pwd)":/usr/local/src/your-app
+    githubchangeloggenerator/github-changelog-generator --user hyperledger
+    --project aries-cloudagent-python --output 0.7.4-rc0.md --since-tag 0.7.3
+    --future-release 0.7.4-rc0 --release-branch main --token <your-token>`
+  - In the generated file, use only the PR list -- we don't include the list of
+    closed issues in the Change Log.
+
+In some cases, the approach above fails because of too many API calls. An
+alternate approach to getting the list of PRs in the right format is to use this
+scary `sed` pipeline process to get the same output.¥
+
+- Put the following commands into a file called `changelog.sed`
+
+``` bash
+/Approved/d
+/updated /d
+/^$/d
+/^ [0-9]/d
+s/was merged.*//
+/^@/d
+s# by \(.*\) # [\1](https://github.com/\1)#
+s/^ //
+s#  \#\([0-9]*\)# [\#\1](https://github.com/hyperledger/aries-cloudagent-python/pull/\1) #
+s/  / /g
+/^Version/d
+/tasks done/d
+s/^/- /
+```
+
+- Navigate in your browser to the paged list of PRs merged since the last
+  release (using in the GitHub UI a filter such as `is:pr is:merged sort:updated
+  merged:>2022-04-07`) and for each page, highlight, and copy the text
+  of only the list of PRs on the page to use in the following step.
+- For each page, run the command `sed -e :a -e '$!N;s/\n#/ #/;ta' -e 'P;D' <<EOF
+  | sed -f changelog.sed`, paste in the copied text and then type `EOF`.
+  Redirect the output to a file, appending each page of output to the file.
+  - The first `sed` command in the pipeline merges the PR title and PR number
+    plus author lines onto a single line. The commands in the `changelog.sed`
+    file just clean up the data, removing unwanted lines, etc.
+- At the end of that process, you should have a list of all of the PRs in a form you can
+  use in the CHANGELOG.md file.
+- To verify you have right contents, you can do a `wc` of the file and there
+  should be one line per PR. You should scan the file as well, looking for
+  anomalies. It's a pretty ugly process.
+  - Using a `curl` command and the GitHub API is probably a much better and more
+  robust way to do this, but this was quick and dirty...
+
+Once you have the list of PRs:
+
 - Organize the list into suitable categories, update (if necessary) the PR description and add notes to clarify the changes. See previous release entries to understand the style -- a format should help developers.
 - Add a narrative about the release above the PR that highlights what has gone into the release.
 
-4. Update the ReadTheDocs in the `/docs` folder by following the instructions in the `docs/README.md` file. That will likely add a number of new and modified files to the PR. Eliminate all of the errors in the generation process, either by mocking external dependencies or by fixing ACA-Py code. If necessary, create an issue with the errors and assign it to the appropriate developer. Experience has demonstrated to use that documentation generation errors should be fixed in the code.
+4. Update the ReadTheDocs in the `/docs` folder by following the instructions in
+   the `docs/README.md` file. That will likely add a number of new and modified
+   files to the PR. Eliminate all of the errors in the generation process,
+   either by mocking external dependencies or by fixing ACA-Py code. If
+   necessary, create an issue with the errors and assign it to the appropriate
+   developer. Experience has demonstrated to use that documentation generation
+   errors should be fixed in the code.
 
-5. Update the version number listed in [aries_cloudagent/version.py](aries_cloudagent/version.py) and, prefixed with a "v" in [open-api/openapi.json](open-api/openapi.json) (e.g. "0.7.2" in the version.py file and "v0.7.2" in the openapi.json file). The incremented version number should adhere to the [Semantic Versioning Specification](https://semver.org/#semantic-versioning-specification-semver) based on the changes since the last published release. For Release Candidates, the form of the tag is "0.7.2-rc0".
+5. Update the version number listed in
+   [aries_cloudagent/version.py](aries_cloudagent/version.py) and, prefixed with
+   a "v" in [open-api/openapi.json](open-api/openapi.json) (e.g. "0.7.2" in the
+   version.py file and "v0.7.2" in the openapi.json file). The incremented
+   version number should adhere to the [Semantic Versioning
+   Specification](https://semver.org/#semantic-versioning-specification-semver)
+   based on the changes since the last published release. For Release
+   Candidates, the form of the tag is "0.7.2-rc0".
   
-6. An extra search of the repo for the existing tag is recommended to see if there are any other instances of the tag in the repo. If any are found to be required (other than in CHANGELOG.md and the examples in this file, of course), finding a way to not need them is best, but if they are needed, please update this document to note where the tag can be found.
+6. An extra search of the repo for the existing tag is recommended to see if
+   there are any other instances of the tag in the repo. If any are found to be
+   required (other than in CHANGELOG.md and the examples in this file, of
+   course), finding a way to not need them is best, but if they are needed,
+   please update this document to note where the tag can be found.
 
-7. Double check all of these steps above, and then submit a PR from the branch. If there are still further changes to be merged, mark the PR as "Draft", repeat **ALL** of the steps again, and then mark this PR as ready and then wait until it is merged.
+7. Double check all of these steps above, and then submit a PR from the branch.
+   If there are still further changes to be merged, mark the PR as "Draft",
+   repeat **ALL** of the steps again, and then mark this PR as ready and then
+   wait until it is merged.
 
-8. Immediately after it is merged, create a new GitHub tag representing the version. The tag name and title of the release should be the same as the version in [aries_cloudagent/version.py](aries_cloudagent/version.py). Use the "Generate Release Notes" capability to get a sequential listing of the PRs in the release, to complement the manually curated Changelog. Verify on PyPi that the version is published.
+8. Immediately after it is merged, create a new GitHub tag representing the
+   version. The tag name and title of the release should be the same as the
+   version in [aries_cloudagent/version.py](aries_cloudagent/version.py). Use
+   the "Generate Release Notes" capability to get a sequential listing of the
+   PRs in the release, to complement the manually curated Changelog. Verify on
+   PyPi that the version is published.
 
-9. Publish a new docker container on Docker Hub ([bcgovimages/aries-cloudagent](https://hub.docker.com/r/bcgovimages/aries-cloudagent/)) by following the README.md instructions to create a PR for the release in the repository [https://github.com/bcgov/aries-cloudagent-container](https://github.com/bcgov/aries-cloudagent-container). Appropriate permissions are required to publish the image.
+9. Publish a new docker container on Docker Hub
+   ([bcgovimages/aries-cloudagent](https://hub.docker.com/r/bcgovimages/aries-cloudagent/))
+   by following the README.md instructions to create a PR for the release in the
+   repository
+   [https://github.com/bcgov/aries-cloudagent-container](https://github.com/bcgov/aries-cloudagent-container).
+   Appropriate permissions are required to publish the image.
 
-10. Update the ACA-Py Read The Docs site by building the new "latest" (main branch) and activating and building the new release. Appropriate permissions are required to publish the new documentation version.
+10. Update the ACA-Py Read The Docs site by building the new "latest" (main
+    branch) and activating and building the new release. Appropriate permissions
+    are required to publish the new documentation version.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -107,12 +107,20 @@ Once you have the list of PRs:
    PRs in the release, to complement the manually curated Changelog. Verify on
    PyPi that the version is published.
 
-9. Publish a new docker container on Docker Hub
-   ([bcgovimages/aries-cloudagent](https://hub.docker.com/r/bcgovimages/aries-cloudagent/))
-   by following the README.md instructions to create a PR for the release in the
-   repository
-   [https://github.com/bcgov/aries-cloudagent-container](https://github.com/bcgov/aries-cloudagent-container).
-   Appropriate permissions are required to publish the image.
+9. New images for the release are automatically published by the GitHubAction
+   Workflows: [publish.yml] and [publish-indy.yml]. The actions are triggered
+   when a release is tagged, so no manual action is needed. The images are
+   published in the [Hyperledger Package Repository under
+   aries-cloudagent-python](https://github.com/orgs/hyperledger/packages?repo_name=aries-cloudagent-python)
+   and a link to the packages added to the repositories main page (under
+   "Packages").
+
+   Additional information about the container image publication process can be
+   found in the document [Container Images and Github Actions]().
+
+[publish.yml]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/.github/workflows/publish.yml
+[publish-indy.yml]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/.github/workflows/publish-indy.yml
+[Container Images and Github Actions]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/ContainerImagesAndGithubActions.md
 
 10. Update the ACA-Py Read The Docs site by building the new "latest" (main
     branch) and activating and building the new release. Appropriate permissions

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -360,6 +360,12 @@ class DebugGroup(ArgumentGroup):
             ),
         )
         parser.add_argument(
+            "--disable-multiple-credential-flow",
+            action="store_true",
+            env_var="ACAPY_DISABLE_MULTIPLE_CREDENTIAL_FLOW",
+            help=("Disable multiple credential flow"),
+        )
+        parser.add_argument(
             "--auto-respond-credential-offer",
             action="store_true",
             env_var="ACAPY_AUTO_RESPOND_CREDENTIAL_OFFER",
@@ -461,6 +467,8 @@ class DebugGroup(ArgumentGroup):
             settings["debug.auto_accept_requests"] = True
         if args.auto_respond_messages:
             settings["debug.auto_respond_messages"] = True
+        if args.disable_multiple_credential_flow:
+            settings["debug.disable_multiple_credential_flow"] = True
         return settings
 
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
@@ -83,7 +83,7 @@ class V20CredFormatHandler(ABC):
 
     @abstractmethod
     async def create_offer(
-        self, cred_proposal_message: V20CredProposal
+        self, cred_proposal_message: V20CredProposal, attach_id: str = None
     ) -> CredFormatAttachment:
         """Create format specific credential offer attachment data."""
 
@@ -95,7 +95,10 @@ class V20CredFormatHandler(ABC):
 
     @abstractmethod
     async def create_request(
-        self, cred_ex_record: V20CredExRecord, request_data: Mapping = None
+        self,
+        cred_ex_record: V20CredExRecord,
+        request_data: Mapping = None,
+        attach_id: str = None,
     ) -> CredFormatAttachment:
         """Create format specific credential request attachment data."""
 
@@ -107,7 +110,7 @@ class V20CredFormatHandler(ABC):
 
     @abstractmethod
     async def issue_credential(
-        self, cred_ex_record: V20CredExRecord, retries: int = 5
+        self, cred_ex_record: V20CredExRecord, retries: int = 5, attach_id: str = None
     ) -> CredFormatAttachment:
         """Create format specific issue credential attachment data."""
 
@@ -119,6 +122,9 @@ class V20CredFormatHandler(ABC):
 
     @abstractmethod
     async def store_credential(
-        self, cred_ex_record: V20CredExRecord, cred_id: str = None
+        self,
+        cred_ex_record: V20CredExRecord,
+        cred_id: str = None,
+        attach_id: str = None,
     ) -> None:
         """Store format specific credential from issue credential message."""

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
@@ -116,7 +116,10 @@ class V20CredFormatHandler(ABC):
 
     @abstractmethod
     async def receive_credential(
-        self, cred_ex_record: V20CredExRecord, cred_issue_message: V20CredIssue
+        self,
+        cred_ex_record: V20CredExRecord,
+        cred_issue_message: V20CredIssue,
+        attach_id: str = None,
     ) -> None:
         """Create format specific issue credential message."""
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
@@ -60,7 +60,9 @@ class V20CredFormatHandler(ABC):
         """
 
     @abstractmethod
-    def get_format_data(self, message_type: str, data: dict) -> CredFormatAttachment:
+    def get_format_data(
+        self, message_type: str, data: dict, attach_id: str = None
+    ) -> CredFormatAttachment:
         """Get credential format and attachment objects for use in cred ex messages."""
 
     @abstractclassmethod

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
@@ -99,6 +99,7 @@ class V20CredFormatHandler(ABC):
         cred_ex_record: V20CredExRecord,
         request_data: Mapping = None,
         attach_id: str = None,
+        init_cred_req_flow: bool = False,
     ) -> CredFormatAttachment:
         """Create format specific credential request attachment data."""
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
@@ -524,7 +524,7 @@ class IndyCredFormatHandler(V20CredFormatHandler):
         holder = self.profile.inject(IndyHolder)
         cred_offer_message = cred_ex_record.cred_offer
         mime_types = None
-        if cred_offer_message and cred_offer_message.credential_preview:
+        if cred_offer_message and cred_offer_message.credential_preview is not None:
             if attach_id:
                 mime_types = (
                     cred_offer_message.credential_preview.mime_types(attach_id) or None

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/handler.py
@@ -270,6 +270,7 @@ class IndyCredFormatHandler(V20CredFormatHandler):
         cred_ex_record: V20CredExRecord,
         request_data: Mapping = None,
         attach_id: str = None,
+        init_cred_req_flow: bool = False,
     ) -> CredFormatAttachment:
         """Create indy credential request."""
         if cred_ex_record.state != V20CredExRecord.STATE_OFFER_RECEIVED:

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/tests/test_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/indy/tests/test_handler.py
@@ -294,8 +294,7 @@ class TestV20IndyCredFormatHandler(AsyncTestCase):
         with async_mock.patch.object(
             INDY_LOGGER, "warning", async_mock.MagicMock()
         ) as mock_warning:
-            assert await self.handler.get_detail_record(cred_ex_id) in details_indy
-            mock_warning.assert_called_once()
+            assert await self.handler.get_detail_record(cred_ex_id) == details_indy
 
     async def test_check_uniqueness(self):
         with async_mock.patch.object(
@@ -1495,15 +1494,30 @@ class TestV20IndyCredFormatHandler(AsyncTestCase):
                     get_or_fetch_local_tails_path=async_mock.CoroutineMock()
                 )
             )
-            mock_get_detail_record.return_value = async_mock.MagicMock(
-                cred_request_metadata=cred_req_meta,
-                save=async_mock.CoroutineMock(),
-            )
+            mock_get_detail_record.return_value = [
+                async_mock.MagicMock(
+                    cred_request_metadata=cred_req_meta,
+                    attach_id="indy-0",
+                    save=async_mock.CoroutineMock(),
+                )
+            ]
 
             self.ledger.get_credential_definition.reset_mock()
             await self.handler.store_credential(
                 stored_cx_rec, cred_id=cred_id, attach_id="indy-0"
             )
+            mock_get_detail_record.return_value = [
+                async_mock.MagicMock(
+                    cred_request_metadata=cred_req_meta,
+                    attach_id="indy-0",
+                    save=async_mock.CoroutineMock(),
+                ),
+                async_mock.MagicMock(
+                    cred_request_metadata=cred_req_meta,
+                    attach_id="indy-1",
+                    save=async_mock.CoroutineMock(),
+                ),
+            ]
             await self.handler.store_credential(
                 stored_cx_rec, cred_id=cred_id, attach_id="indy-1"
             )
@@ -1611,10 +1625,12 @@ class TestV20IndyCredFormatHandler(AsyncTestCase):
                     get_or_fetch_local_tails_path=async_mock.CoroutineMock()
                 )
             )
-            mock_get_detail_record.return_value = async_mock.MagicMock(
-                cred_request_metadata=cred_req_meta,
-                save=async_mock.CoroutineMock(),
-            )
+            mock_get_detail_record.return_value = [
+                async_mock.MagicMock(
+                    cred_request_metadata=cred_req_meta,
+                    save=async_mock.CoroutineMock(),
+                )
+            ]
 
             self.ledger.get_credential_definition.reset_mock()
             await self.handler.store_credential(stored_cx_rec, cred_id=cred_id)
@@ -1706,10 +1722,13 @@ class TestV20IndyCredFormatHandler(AsyncTestCase):
         ) as mock_get_detail_record, async_mock.patch.object(
             test_module.RevocationRegistry, "from_definition", async_mock.MagicMock()
         ) as mock_rev_reg:
-            mock_get_detail_record.return_value = async_mock.MagicMock(
-                cred_request_metadata=cred_req_meta,
-                save=async_mock.CoroutineMock(),
-            )
+            mock_get_detail_record.return_value = [
+                async_mock.MagicMock(
+                    cred_request_metadata=cred_req_meta,
+                    attach_id="0",
+                    save=async_mock.CoroutineMock(),
+                )
+            ]
             mock_rev_reg.return_value = async_mock.MagicMock(
                 get_or_fetch_local_tails_path=async_mock.CoroutineMock()
             )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
@@ -558,6 +558,47 @@ class TestV20LDProofCredFormatHandler(AsyncTestCase):
         # assert data is encoded as base64
         assert attachment.data.base64
 
+    async def test_create_request_from_cred_spec(self):
+        cred_proposal = V20CredProposal(
+            formats=[
+                V20CredFormat(
+                    attach_id="ld_proof-0",
+                    format_=ATTACHMENT_FORMAT[CRED_20_PROPOSAL][
+                        V20CredFormat.Format.LD_PROOF.api
+                    ],
+                ),
+                V20CredFormat(
+                    attach_id="ld_proof-1",
+                    format_=ATTACHMENT_FORMAT[CRED_20_PROPOSAL][
+                        V20CredFormat.Format.LD_PROOF.api
+                    ],
+                ),
+            ],
+            filters_attach=[
+                AttachDecorator.data_base64(LD_PROOF_VC_DETAIL, ident="ld_proof-0"),
+                AttachDecorator.data_base64(LD_PROOF_VC_DETAIL, ident="ld_proof-1"),
+            ],
+        )
+        cred_ex_record = V20CredExRecord(
+            cred_ex_id="dummy-id",
+            state=V20CredExRecord.STATE_OFFER_RECEIVED,
+        )
+
+        (cred_format, attachment) = await self.handler.create_request(
+            cred_ex_record=cred_ex_record,
+            request_data={"ld_proof-0": cred_proposal.attachment_by_id("ld_proof-0")},
+            attach_id="ld_proof-0",
+        )
+
+        # assert identifier match
+        assert cred_format.attach_id == attachment.ident
+
+        # assert content of attachment is proposal data
+        assert attachment.content == LD_PROOF_VC_DETAIL
+
+        # assert data is encoded as base64
+        assert attachment.data.base64
+
     async def test_create_bound_request_multiple_cred_flow_from_offer(self):
         cred_offer = V20CredOffer(
             formats=[

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
@@ -187,8 +187,7 @@ class TestV20LDProofCredFormatHandler(AsyncTestCase):
         with async_mock.patch.object(
             LD_PROOF_LOGGER, "warning", async_mock.MagicMock()
         ) as mock_warning:
-            assert await self.handler.get_detail_record(cred_ex_id) in details_ld_proof
-            mock_warning.assert_called_once()
+            assert await self.handler.get_detail_record(cred_ex_id) == details_ld_proof
 
     async def test_assert_can_issue_with_id_and_proof_type(self):
         with self.assertRaises(V20CredFormatError) as context:

--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -388,12 +388,10 @@ class V20CredManager:
             input_formats = cred_proposal.formats
 
         if cred_ex_record.multiple_issuance_state:
-            if (
-                cred_ex_record.multiple_issuance_state
-                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE
-                or cred_ex_record.multiple_issuance_state
-                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_ABANDONED
-            ):
+            if cred_ex_record.multiple_issuance_state in [
+                V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE,
+                V20CredExRecord.STATE_MULTIPLE_ISSUANCE_ABANDONED,
+            ]:
                 raise V20CredManagerError(
                     f"Credential exchange {cred_ex_record.cred_ex_id} "
                     f"in {cred_ex_record.multiple_issuance_state} "
@@ -509,12 +507,10 @@ class V20CredManager:
             cred_ex_record.connection_id = connection_record.connection_id
 
         if cred_ex_record.multiple_issuance_state:
-            if (
-                cred_ex_record.multiple_issuance_state
-                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE
-                or cred_ex_record.multiple_issuance_state
-                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_ABANDONED
-            ):
+            if cred_ex_record.multiple_issuance_state in [
+                V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE,
+                V20CredExRecord.STATE_MULTIPLE_ISSUANCE_ABANDONED,
+            ]:
                 raise V20CredManagerError(
                     f"Credential exchange {cred_ex_record.cred_ex_id} "
                     f"in {cred_ex_record.multiple_issuance_state} "
@@ -584,12 +580,10 @@ class V20CredManager:
             )
 
         if cred_ex_record.multiple_issuance_state:
-            if (
-                cred_ex_record.multiple_issuance_state
-                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE
-                or cred_ex_record.multiple_issuance_state
-                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_ABANDONED
-            ):
+            if cred_ex_record.multiple_issuance_state in [
+                V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE,
+                V20CredExRecord.STATE_MULTIPLE_ISSUANCE_ABANDONED,
+            ]:
                 raise V20CredManagerError(
                     f"Credential exchange {cred_ex_record.cred_ex_id} "
                     f"in {cred_ex_record.multiple_issuance_state} "
@@ -704,12 +698,10 @@ class V20CredManager:
             )
 
         if cred_ex_record.multiple_issuance_state:
-            if (
-                cred_ex_record.multiple_issuance_state
-                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE
-                or cred_ex_record.multiple_issuance_state
-                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_ABANDONED
-            ):
+            if cred_ex_record.multiple_issuance_state in [
+                V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE,
+                V20CredExRecord.STATE_MULTIPLE_ISSUANCE_ABANDONED,
+            ]:
                 raise V20CredManagerError(
                     f"Credential exchange {cred_ex_record.cred_ex_id} "
                     f"in {cred_ex_record.multiple_issuance_state} "

--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -12,7 +12,6 @@ from ....core.profile import Profile
 from ....messaging.responder import BaseResponder
 from ....storage.error import StorageError, StorageNotFoundError
 
-from .message_types import CRED_20_REQUEST
 from .messages.cred_ack import V20CredAck
 from .messages.cred_format import V20CredFormat
 from .messages.cred_issue import V20CredIssue
@@ -244,7 +243,8 @@ class V20CredManager:
         elif len(formats) >= 2:
             if not multiple_available and multiple_available <= 1:
                 raise V20CredManagerError(
-                    f"Multiple formats included but multiple_available is set as {str(multiple_available)}"
+                    "Multiple formats included but multiple_available"
+                    f" is set as {str(multiple_available)}"
                 )
             cred_ex_record.multiple_credentials = True
 
@@ -392,7 +392,8 @@ class V20CredManager:
             ):
                 raise V20CredManagerError(
                     f"Credential exchange {cred_ex_record.cred_ex_id} "
-                    f"in {cred_ex_record.multiple_issuance_state} multiple_issuance_state "
+                    f"in {cred_ex_record.multiple_issuance_state} "
+                    "multiple_issuance_state"
                 )
 
         request_formats = []
@@ -507,7 +508,8 @@ class V20CredManager:
             ):
                 raise V20CredManagerError(
                     f"Credential exchange {cred_ex_record.cred_ex_id} "
-                    f"in {cred_ex_record.multiple_issuance_state} multiple_issuance_state "
+                    f"in {cred_ex_record.multiple_issuance_state} "
+                    "multiple_issuance_state"
                 )
 
         handled_formats = []
@@ -583,7 +585,8 @@ class V20CredManager:
             ):
                 raise V20CredManagerError(
                     f"Credential exchange {cred_ex_record.cred_ex_id} "
-                    f"in {cred_ex_record.multiple_issuance_state} multiple_issuance_state "
+                    f"in {cred_ex_record.multiple_issuance_state} "
+                    "multiple_issuance_state "
                 )
 
         cred_issue_exists = False
@@ -697,7 +700,8 @@ class V20CredManager:
             ):
                 raise V20CredManagerError(
                     f"Credential exchange {cred_ex_record.cred_ex_id} "
-                    f"in {cred_ex_record.multiple_issuance_state} multiple_issuance_state "
+                    f"in {cred_ex_record.multiple_issuance_state} "
+                    "multiple_issuance_state"
                 )
 
         cred_request_message = cred_ex_record.cred_request
@@ -757,9 +761,12 @@ class V20CredManager:
                     report = V20CredProblemReport(
                         description={
                             "en": (
-                                "Holder requests no more credentials of this type to be issued."
+                                "Holder requests no more credentials "
+                                "of this type to be issued."
                             ),
-                            "code": ProblemReportReason.STOP_MORE_CREDENTIAL_ISSUANCE.value,
+                            "code": (
+                                ProblemReportReason.STOP_MORE_CREDENTIAL_ISSUANCE.value
+                            ),
                         }
                     )
                     if cred_ex_record.thread_id:

--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -2,7 +2,8 @@
 
 import logging
 
-from typing import Mapping, Optional, Tuple
+from typing import Mapping, Optional, Tuple, Sequence
+from uuid import uuid4
 
 from ....connections.models.conn_record import ConnRecord
 from ....core.oob_processor import OobRecord
@@ -11,6 +12,7 @@ from ....core.profile import Profile
 from ....messaging.responder import BaseResponder
 from ....storage.error import StorageError, StorageNotFoundError
 
+from .message_types import CRED_20_REQUEST
 from .messages.cred_ack import V20CredAck
 from .messages.cred_format import V20CredFormat
 from .messages.cred_issue import V20CredIssue
@@ -200,6 +202,7 @@ class V20CredManager:
         counter_proposal: V20CredProposal = None,
         replacement_id: str = None,
         comment: str = None,
+        multiple_available: int = None,
     ) -> Tuple[V20CredExRecord, V20CredOffer]:
         """
         Create credential offer, update credential exchange record.
@@ -225,11 +228,12 @@ class V20CredManager:
         # Format specific create_offer handler
         for format in cred_proposal_message.formats:
             cred_format = V20CredFormat.Format.get(format.format)
+            attach_id = format.attach_id if format.attach_id != cred_format else None
 
             if cred_format:
                 formats.append(
                     await cred_format.handler(self.profile).create_offer(
-                        cred_proposal_message
+                        cred_proposal_message, attach_id
                     )
                 )
 
@@ -237,6 +241,12 @@ class V20CredManager:
             raise V20CredManagerError(
                 "Unable to create credential offer. No supported formats"
             )
+        elif len(formats) >= 2:
+            if not multiple_available and multiple_available <= 1:
+                raise V20CredManagerError(
+                    f"Multiple formats included but multiple_available is set as {str(multiple_available)}"
+                )
+            cred_ex_record.multiple_credentials = True
 
         cred_offer_message = V20CredOffer(
             replacement_id=replacement_id,
@@ -244,6 +254,7 @@ class V20CredManager:
             credential_preview=cred_proposal_message.credential_preview,
             formats=[format for (format, _) in formats],
             offers_attach=[attach for (_, attach) in formats],
+            multiple_available=multiple_available,
         )
 
         cred_offer_message._thread = {"thid": cred_ex_record.thread_id}
@@ -299,7 +310,7 @@ class V20CredManager:
                 auto_remove=not self._profile.settings.get("preserve_exchange_records"),
                 trace=(cred_offer_message._trace is not None),
             )
-
+        handled_formats = []
         # Format specific receive_offer handler
         for format in cred_offer_message.formats:
             cred_format = V20CredFormat.Format.get(format.format)
@@ -308,6 +319,12 @@ class V20CredManager:
                 await cred_format.handler(self.profile).receive_offer(
                     cred_ex_record, cred_offer_message
                 )
+                handled_formats.append(cred_format)
+
+        if len(handled_formats) == 0:
+            raise V20CredManagerError("No supported credential formats received.")
+        elif len(handled_formats) >= 2:
+            cred_ex_record.multiple_credentials = True
 
         cred_ex_record.cred_offer = cred_offer_message
         cred_ex_record.state = V20CredExRecord.STATE_OFFER_RECEIVED
@@ -318,7 +335,12 @@ class V20CredManager:
         return cred_ex_record
 
     async def create_request(
-        self, cred_ex_record: V20CredExRecord, holder_did: str, comment: str = None
+        self,
+        cred_ex_record: V20CredExRecord,
+        holder_did: str,
+        exclude_attach_ids: Sequence[str] = [],
+        comment: str = None,
+        multiple_credential_flow: bool = False,
     ) -> Tuple[V20CredExRecord, V20CredRequest]:
         """
         Create a credential request.
@@ -327,16 +349,21 @@ class V20CredManager:
             cred_ex_record: credential exchange record for which to create request
             holder_did: holder DID
             comment: optional human-readable comment to set in request message
-
+             :
+            multiple_credential_flow:
         Returns:
             A tuple (credential exchange record, credential request message)
 
         """
+        cred_request_exists = False
         if cred_ex_record.cred_request:
-            raise V20CredManagerError(
-                "create_request() called multiple times for "
-                f"v2.0 credential exchange {cred_ex_record.cred_ex_id}"
-            )
+            if multiple_credential_flow:
+                cred_request_exists = True
+            else:
+                raise V20CredManagerError(
+                    "create_request() called multiple times for "
+                    f"v2.0 credential exchange {cred_ex_record.cred_ex_id}"
+                )
 
         # react to credential offer, use offer formats
         if cred_ex_record.state:
@@ -356,21 +383,42 @@ class V20CredManager:
             cred_proposal = cred_ex_record.cred_proposal
             input_formats = cred_proposal.formats
 
+        if cred_ex_record.multiple_issuance_state:
+            if (
+                cred_ex_record.multiple_issuance_state
+                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE
+                or cred_ex_record.multiple_issuance_state
+                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_ABANDONED
+            ):
+                raise V20CredManagerError(
+                    f"Credential exchange {cred_ex_record.cred_ex_id} "
+                    f"in {cred_ex_record.multiple_issuance_state} multiple_issuance_state "
+                )
+
         request_formats = []
         # Format specific create_request handler
         for format in input_formats:
             cred_format = V20CredFormat.Format.get(format.format)
-
+            attach_id = format.attach_id if format.attach_id != cred_format else None
+            if not attach_id and cred_request_exists:
+                attach_id = f"{attach_id}-{str(uuid4())}"
+            if attach_id in exclude_attach_ids:
+                continue
             if cred_format:
                 request_formats.append(
                     await cred_format.handler(self.profile).create_request(
-                        cred_ex_record, {"holder_did": holder_did}
+                        cred_ex_record, {"holder_did": holder_did}, attach_id
                     )
                 )
 
         if len(request_formats) == 0:
             raise V20CredManagerError(
                 "Unable to create credential request. No supported formats"
+            )
+        elif len(request_formats) >= 2:
+            cred_ex_record.multiple_credentials = True
+            cred_ex_record.multiple_issuance_state = (
+                V20CredExRecord.STATE_MULTIPLE_ISSUANCE_PENDING
             )
 
         cred_request_message = V20CredRequest(
@@ -387,7 +435,14 @@ class V20CredManager:
 
         cred_ex_record.thread_id = cred_request_message._thread_id
         cred_ex_record.state = V20CredExRecord.STATE_REQUEST_SENT
-        cred_ex_record.cred_request = cred_request_message
+        if cred_request_exists:
+            existing_cred_request = cred_ex_record.cred_request
+            for (fmt, atch) in request_formats:
+                existing_cred_request.add_attachments(fmt, atch)
+            cred_ex_record.cred_request = existing_cred_request
+            cred_ex_record.multiple_credentials = True
+        else:
+            cred_ex_record.cred_request = cred_request_message
 
         async with self._profile.session() as session:
             await cred_ex_record.save(session, reason="create v2.0 credential request")
@@ -443,12 +498,46 @@ class V20CredManager:
         if connection_record:
             cred_ex_record.connection_id = connection_record.connection_id
 
+        if cred_ex_record.multiple_issuance_state:
+            if (
+                cred_ex_record.multiple_issuance_state
+                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE
+                or cred_ex_record.multiple_issuance_state
+                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_ABANDONED
+            ):
+                raise V20CredManagerError(
+                    f"Credential exchange {cred_ex_record.cred_ex_id} "
+                    f"in {cred_ex_record.multiple_issuance_state} multiple_issuance_state "
+                )
+
+        handled_formats = []
         for format in cred_request_message.formats:
             cred_format = V20CredFormat.Format.get(format.format)
             if cred_format:
                 await cred_format.handler(self.profile).receive_request(
                     cred_ex_record, cred_request_message
                 )
+                handled_formats.append(cred_format)
+
+        if len(handled_formats) == 0:
+            raise V20CredManagerError("No supported credential formats received.")
+        elif len(handled_formats) >= 2:
+            cred_ex_record.multiple_credentials = True
+            cred_ex_record.multiple_issuance_state = (
+                V20CredExRecord.STATE_MULTIPLE_ISSUANCE_PENDING
+            )
+
+        if cred_ex_record.cred_request:
+            existing_cred_request = cred_ex_record.cred_request
+
+            existing_cred_request.add_formats(cred_request_message.formats)
+            existing_cred_request.add_requests_attach(
+                cred_request_message.requests_attach
+            )
+            cred_ex_record.cred_request = existing_cred_request
+            cred_ex_record.multiple_credentials = True
+        else:
+            cred_ex_record.cred_request = cred_request_message
 
         cred_ex_record.cred_request = cred_request_message
         cred_ex_record.state = V20CredExRecord.STATE_REQUEST_RECEIVED
@@ -463,6 +552,7 @@ class V20CredManager:
         cred_ex_record: V20CredExRecord,
         *,
         comment: str = None,
+        more_available: int = 0,
     ) -> Tuple[V20CredExRecord, V20CredIssue]:
         """
         Issue a credential.
@@ -470,7 +560,8 @@ class V20CredManager:
         Args:
             cred_ex_record: credential exchange record for which to issue credential
             comment: optional human-readable comment pertaining to credential issue
-
+            more_available: Count of the verifiable credential type for the Holder
+                that the Issuer is willing to issue
         Returns:
             Tuple: (Updated credential exchange record, credential issue message)
 
@@ -483,11 +574,27 @@ class V20CredManager:
                 f"(must be {V20CredExRecord.STATE_REQUEST_RECEIVED})"
             )
 
+        if cred_ex_record.multiple_issuance_state:
+            if (
+                cred_ex_record.multiple_issuance_state
+                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE
+                or cred_ex_record.multiple_issuance_state
+                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_ABANDONED
+            ):
+                raise V20CredManagerError(
+                    f"Credential exchange {cred_ex_record.cred_ex_id} "
+                    f"in {cred_ex_record.multiple_issuance_state} multiple_issuance_state "
+                )
+
+        cred_issue_exists = False
         if cred_ex_record.cred_issue:
-            raise V20CredManagerError(
-                "issue_credential() called multiple times for "
-                f"cred ex record {cred_ex_record.cred_ex_id}"
-            )
+            if cred_ex_record.multiple_credentials:
+                cred_issue_exists = True
+            else:
+                raise V20CredManagerError(
+                    "issue_credential() called multiple times for "
+                    f"cred ex record {cred_ex_record.cred_ex_id}"
+                )
 
         replacement_id = None
         input_formats = cred_ex_record.cred_request.formats
@@ -498,15 +605,20 @@ class V20CredManager:
 
         # Format specific issue_credential handler
         issue_formats = []
+        to_exclude = cred_ex_record.processed_attach_ids
         for format in input_formats:
             cred_format = V20CredFormat.Format.get(format.format)
-
+            attach_id = format.attach_id if format.attach_id != cred_format else None
+            if not attach_id and cred_issue_exists:
+                attach_id = f"{attach_id}-{str(uuid4())}"
             if cred_format:
                 issue_formats.append(
                     await cred_format.handler(self.profile).issue_credential(
-                        cred_ex_record
+                        cred_ex_record, attach_id
                     )
                 )
+                if attach_id and attach_id not in to_exclude:
+                    cred_ex_record.add_attach_ids([attach_id])
 
         if len(issue_formats) == 0:
             raise V20CredManagerError(
@@ -518,10 +630,27 @@ class V20CredManager:
             comment=comment,
             formats=[format for (format, _) in issue_formats],
             credentials_attach=[attach for (_, attach) in issue_formats],
+            more_available=more_available,
         )
-
-        cred_ex_record.state = V20CredExRecord.STATE_ISSUED
-        cred_ex_record.cred_issue = cred_issue_message
+        if not more_available or more_available == 0:
+            cred_ex_record.state = V20CredExRecord.STATE_ISSUED
+            if cred_ex_record.multiple_credentials:
+                cred_ex_record.multiple_issuance_state = (
+                    V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE
+                )
+        else:
+            cred_ex_record.state = V20CredExRecord.STATE_OFFER_SENT
+            cred_ex_record.multiple_issuance_state = (
+                V20CredExRecord.STATE_MULTIPLE_ISSUANCE_PENDING
+            )
+        if cred_issue_exists:
+            existing_cred_issue = cred_ex_record.cred_issue
+            for (fmt, atch) in issue_formats:
+                existing_cred_issue.add_attachments(fmt, atch)
+            cred_ex_record.cred_request = existing_cred_issue
+            cred_ex_record.multiple_credentials = True
+        else:
+            cred_ex_record.cred_issue = cred_issue_message
         async with self._profile.session() as session:
             # FIXME - re-fetch record to check state, apply transactional update
             await cred_ex_record.save(session, reason="v2.0 issue credential")
@@ -534,7 +663,10 @@ class V20CredManager:
         return (cred_ex_record, cred_issue_message)
 
     async def receive_credential(
-        self, cred_issue_message: V20CredIssue, connection_id: Optional[str]
+        self,
+        cred_issue_message: V20CredIssue,
+        connection_id: Optional[str],
+        stop_multiple_cred_flow: bool = False,
     ) -> V20CredExRecord:
         """
         Receive a credential issue message from an issuer.
@@ -556,37 +688,98 @@ class V20CredManager:
                 role=V20CredExRecord.ROLE_HOLDER,
             )
 
+        if cred_ex_record.multiple_issuance_state:
+            if (
+                cred_ex_record.multiple_issuance_state
+                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE
+                or cred_ex_record.multiple_issuance_state
+                != V20CredExRecord.STATE_MULTIPLE_ISSUANCE_ABANDONED
+            ):
+                raise V20CredManagerError(
+                    f"Credential exchange {cred_ex_record.cred_ex_id} "
+                    f"in {cred_ex_record.multiple_issuance_state} multiple_issuance_state "
+                )
+
         cred_request_message = cred_ex_record.cred_request
-        req_formats = [
+        req_format_ids = [
             V20CredFormat.Format.get(fmt.format)
             for fmt in cred_request_message.formats
             if V20CredFormat.Format.get(fmt.format)
         ]
-        issue_formats = [
+        issue_format_ids = [
             V20CredFormat.Format.get(fmt.format)
             for fmt in cred_issue_message.formats
             if V20CredFormat.Format.get(fmt.format)
         ]
+        issue_formats = cred_issue_message.formats
         handled_formats = []
+        more_available = cred_issue_message.more_available
 
         # check that we didn't receive any formats not present in the request
-        if set(issue_formats) - set(req_formats):
+        if set(issue_format_ids) - set(req_format_ids):
             raise V20CredManagerError(
                 "Received issue credential format(s) not present in credential "
-                f"request: {set(issue_formats) - set(req_formats)}"
+                f"request: {set(issue_format_ids) - set(req_format_ids)}"
+            )
+        for issue_format in issue_formats:
+            cred_format = V20CredFormat.Format.get(issue_format.format)
+            attach_id = (
+                issue_format.attach_id
+                if issue_format.attach_id != cred_format
+                else None
             )
 
-        for issue_format in issue_formats:
-            await issue_format.handler(self.profile).receive_credential(
-                cred_ex_record, cred_issue_message
-            )
-            handled_formats.append(issue_format)
+            if cred_format:
+                await cred_format.handler(self.profile).receive_credential(
+                    cred_ex_record, cred_issue_message, attach_id
+                )
+                handled_formats.append(cred_format)
 
         if len(handled_formats) == 0:
             raise V20CredManagerError("No supported credential formats received.")
 
-        cred_ex_record.cred_issue = cred_issue_message
-        cred_ex_record.state = V20CredExRecord.STATE_CREDENTIAL_RECEIVED
+        if cred_ex_record.cred_issue:
+            existing_cred_issue = cred_ex_record.cred_issue
+
+            existing_cred_issue.add_formats(cred_request_message.formats)
+            existing_cred_issue.add_credentials_attach(
+                cred_request_message.requests_attach
+            )
+            cred_ex_record.cred_issue = existing_cred_issue
+            cred_ex_record.multiple_credentials = True
+        else:
+            cred_ex_record.cred_issue = cred_issue_message
+        if more_available > 0:
+            if stop_multiple_cred_flow:
+                cred_ex_record.state = V20CredExRecord.STATE_CREDENTIAL_RECEIVED
+                responder = self._profile.inject_or(BaseResponder)
+                if responder:
+                    report = V20CredProblemReport(
+                        description={
+                            "en": (
+                                "Holder requests no more credentials of this type to be issued."
+                            ),
+                            "code": ProblemReportReason.STOP_MORE_CREDENTIAL_ISSUANCE.value,
+                        }
+                    )
+                    if cred_ex_record.thread_id:
+                        report.assign_thread_id(cred_ex_record.thread_id)
+                    await responder.send_reply(
+                        report, connection_id=cred_ex_record.connection_id
+                    )
+                cred_ex_record.multiple_issuance_state = (
+                    V20CredExRecord.STATE_MULTIPLE_ISSUANCE_ABANDONED
+                )
+            else:
+                cred_ex_record.state = V20CredExRecord.STATE_OFFER_RECEIVED
+                cred_ex_record.multiple_issuance_state = (
+                    V20CredExRecord.STATE_MULTIPLE_ISSUANCE_PENDING
+                )
+        else:
+            cred_ex_record.state = V20CredExRecord.STATE_CREDENTIAL_RECEIVED
+            cred_ex_record.multiple_issuance_state = (
+                V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE
+            )
 
         async with self._profile.session() as session:
             await cred_ex_record.save(session, reason="receive v2.0 credential issue")
@@ -612,17 +805,19 @@ class V20CredManager:
                 f"in {cred_ex_record.state} state "
                 f"(must be {V20CredExRecord.STATE_CREDENTIAL_RECEIVED})"
             )
-
+        to_exclude = cred_ex_record.processed_attach_ids
         # Format specific store_credential handler
         for format in cred_ex_record.cred_issue.formats:
             cred_format = V20CredFormat.Format.get(format.format)
-
+            attach_id = format.attach_id if format.attach_id != cred_format else None
             if cred_format:
                 await cred_format.handler(self.profile).store_credential(
-                    cred_ex_record, cred_id
+                    cred_ex_record, cred_id, attach_id
                 )
                 # TODO: if storing multiple credentials we can't reuse the same id
                 cred_id = None
+                if attach_id and attach_id not in to_exclude:
+                    cred_ex_record.add_attach_ids([attach_id])
 
         return cred_ex_record
 
@@ -738,11 +933,16 @@ class V20CredManager:
                 message._thread_id,
             )
 
-            cred_ex_record.state = V20CredExRecord.STATE_ABANDONED
             code = message.description.get(
                 "code",
                 ProblemReportReason.ISSUANCE_ABANDONED.value,
             )
+            if code == ProblemReportReason.ISSUANCE_ABANDONED.value:
+                cred_ex_record.state = V20CredExRecord.STATE_ABANDONED
+            elif code == ProblemReportReason.STOP_MORE_CREDENTIAL_ISSUANCE.value:
+                cred_ex_record.multiple_issuance_state = (
+                    V20CredExRecord.STATE_MULTIPLE_ISSUANCE_ABANDONED
+                )
             cred_ex_record.error_msg = f"{code}: {message.description.get('en', code)}"
             await cred_ex_record.save(session, reason="received problem report")
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -796,9 +796,10 @@ class V20CredManager:
                 )
         else:
             cred_ex_record.state = V20CredExRecord.STATE_CREDENTIAL_RECEIVED
-            cred_ex_record.multiple_issuance_state = (
-                V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE
-            )
+            if cred_ex_record.multiple_credentials:
+                cred_ex_record.multiple_issuance_state = (
+                    V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE
+                )
 
         async with self._profile.session() as session:
             await cred_ex_record.save(session, reason="receive v2.0 credential issue")

--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -201,7 +201,7 @@ class V20CredManager:
         counter_proposal: V20CredProposal = None,
         replacement_id: str = None,
         comment: str = None,
-        multiple_available: int = None,
+        multiple_available: int = 1,
     ) -> Tuple[V20CredExRecord, V20CredOffer]:
         """
         Create credential offer, update credential exchange record.
@@ -753,7 +753,7 @@ class V20CredManager:
             cred_ex_record.multiple_credentials = True
         else:
             cred_ex_record.cred_issue = cred_issue_message
-        if more_available > 0:
+        if more_available and more_available > 0:
             if stop_multiple_cred_flow:
                 cred_ex_record.state = V20CredExRecord.STATE_CREDENTIAL_RECEIVED
                 responder = self._profile.inject_or(BaseResponder)

--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -829,16 +829,19 @@ class V20CredManager:
         # Format specific store_credential handler
         for format in cred_ex_record.cred_issue.formats:
             cred_format = V20CredFormat.Format.get(format.format)
-            attach_id = (
-                format.attach_id if format.attach_id != cred_format.api else None
-            )
+
             if cred_format:
+                attach_id = (
+                    format.attach_id if format.attach_id != cred_format.api else None
+                )
+                if attach_id in to_exclude:
+                    continue
                 await cred_format.handler(self.profile).store_credential(
-                    cred_ex_record, cred_id, attach_id
+                    cred_ex_record=cred_ex_record, cred_id=cred_id, attach_id=attach_id
                 )
                 # TODO: if storing multiple credentials we can't reuse the same id
                 cred_id = None
-                if attach_id and attach_id not in to_exclude:
+                if attach_id:
                     cred_ex_record.store_attach_id(attach_id)
 
         return cred_ex_record

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_format.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_format.py
@@ -104,6 +104,18 @@ class V20CredFormat(BaseModel):
 
             return None
 
+        def get_attachment_data_by_id(
+            self,
+            attach_id: str,
+            attachments: Sequence[AttachDecorator],
+        ):
+            """Find attachment by attachment identifier."""
+            for atch in attachments:
+                if atch.ident == attach_id:
+                    return atch.content
+
+            return None
+
     def __init__(
         self,
         *,

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_issue.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_issue.py
@@ -90,11 +90,14 @@ class V20CredIssue(AgentMessage):
             attach_id: string identifier
 
         """
-        target_format = [
+        _format_list = [
             V20CredFormat.Format.get(f.format)
             for f in self.formats
             if f.attach_id == attach_id
-        ][0]
+        ]
+        if len(_format_list) == 0:
+            return None
+        target_format = _format_list[0]
         return (
             target_format.get_attachment_data_by_id(attach_id, self.credentials_attach)
             if target_format
@@ -111,26 +114,6 @@ class V20CredIssue(AgentMessage):
         """
         self.formats.append(fmt)
         self.credentials_attach.append(atch)
-
-    def add_formats(self, fmt_list: Sequence[V20CredFormat]) -> None:
-        """
-        Add format.
-
-        Args:
-            fmt_list: list of format attachment
-        """
-        for fmt in fmt_list:
-            self.formats.append(fmt)
-
-    def add_credentials_attach(self, atch_list: Sequence[AttachDecorator]) -> None:
-        """
-        Add credentials_attach.
-
-        Args:
-            atch_list: list of attachment
-        """
-        for atch in atch_list:
-            self.credentials_attach.append(atch)
 
 
 class V20CredIssueSchema(AgentMessageSchema):

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_issue.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_issue.py
@@ -32,7 +32,7 @@ class V20CredIssue(AgentMessage):
         self,
         _id: str = None,
         *,
-        more_available: int = 0,
+        more_available: int = None,
         replacement_id: str = None,
         comment: str = None,
         formats: Sequence[V20CredFormat] = None,
@@ -152,7 +152,10 @@ class V20CredIssueSchema(AgentMessageSchema):
         description="Human-readable comment", required=False, allow_none=True
     )
     more_available = fields.Int(
-        description="Count of the verifiable credential type for the Holder that the Issuer is willing to issue",
+        description=(
+            "Count of the verifiable credential type for the Holder "
+            "that the Issuer is willing to issue"
+        ),
         required=False,
         strict=True,
     )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_offer.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_offer.py
@@ -94,11 +94,14 @@ class V20CredOffer(AgentMessage):
             attach_id: string identifier
 
         """
-        target_format = [
+        _format_list = [
             V20CredFormat.Format.get(f.format)
             for f in self.formats
             if f.attach_id == attach_id
-        ][0]
+        ]
+        if len(_format_list) == 0:
+            return None
+        target_format = _format_list[0]
         return (
             target_format.get_attachment_data_by_id(attach_id, self.offers_attach)
             if target_format

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_offer.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_offer.py
@@ -33,7 +33,7 @@ class V20CredOffer(AgentMessage):
         self,
         _id: str = None,
         *,
-        multiple_available: int = 1,
+        multiple_available: int = None,
         replacement_id: str = None,
         comment: str = None,
         credential_preview: V20CredPreview = None,
@@ -127,7 +127,10 @@ class V20CredOfferSchema(AgentMessageSchema):
         allow_none=True,
     )
     multiple_available = fields.Int(
-        description="Count of verifiable credentials of the indicated type available for issuance",
+        description=(
+            "Count of verifiable credentials of the indicated "
+            "type available for issuance"
+        ),
         required=False,
         strict=True,
     )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_offer.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_offer.py
@@ -33,6 +33,7 @@ class V20CredOffer(AgentMessage):
         self,
         _id: str = None,
         *,
+        multiple_available: int = 1,
         replacement_id: str = None,
         comment: str = None,
         credential_preview: V20CredPreview = None,
@@ -49,6 +50,7 @@ class V20CredOffer(AgentMessage):
             credential_preview: credential preview
             formats: acceptable attachment formats
             offers_attach: list of offer attachments
+            multiple_available: count of verifiable credentials available for issuance
 
         """
         super().__init__(_id=_id, **kwargs)
@@ -57,6 +59,7 @@ class V20CredOffer(AgentMessage):
         self.credential_preview = credential_preview
         self.formats = list(formats) if formats else []
         self.offers_attach = list(offers_attach) if offers_attach else []
+        self.multiple_available = multiple_available
 
     def attachment(self, fmt: V20CredFormat.Format = None) -> dict:
         """
@@ -83,6 +86,25 @@ class V20CredOffer(AgentMessage):
             else None
         )
 
+    def attachment_by_id(self, attach_id: str) -> dict:
+        """
+        Return attached offer.
+
+        Args:
+            attach_id: string identifier
+
+        """
+        target_format = [
+            V20CredFormat.Format.get(f.format)
+            for f in self.formats
+            if f.attach_id == attach_id
+        ][0]
+        return (
+            target_format.get_attachment_data_by_id(attach_id, self.offers_attach)
+            if target_format
+            else None
+        )
+
 
 class V20CredOfferSchema(AgentMessageSchema):
     """Credential offer schema."""
@@ -103,6 +125,11 @@ class V20CredOfferSchema(AgentMessageSchema):
         description="Human-readable comment",
         required=False,
         allow_none=True,
+    )
+    multiple_available = fields.Int(
+        description="Count of verifiable credentials of the indicated type available for issuance",
+        required=False,
+        strict=True,
     )
     credential_preview = fields.Nested(V20CredPreviewSchema, required=False)
     formats = fields.Nested(

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_problem_report.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_problem_report.py
@@ -21,6 +21,7 @@ class ProblemReportReason(Enum):
     """Supported reason codes."""
 
     ISSUANCE_ABANDONED = "issuance-abandoned"
+    STOP_MORE_CREDENTIAL_ISSUANCE = "stop-more-credential-issuance"
 
 
 class V20CredProblemReport(ProblemReport):

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_proposal.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_proposal.py
@@ -89,11 +89,14 @@ class V20CredProposal(AgentMessage):
             attach_id: string identifier
 
         """
-        target_format = [
+        _format_list = [
             V20CredFormat.Format.get(f.format)
             for f in self.formats
             if f.attach_id == attach_id
-        ][0]
+        ]
+        if len(_format_list) == 0:
+            return None
+        target_format = _format_list[0]
         return (
             target_format.get_attachment_data_by_id(attach_id, self.filters_attach)
             if target_format

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_proposal.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_proposal.py
@@ -81,6 +81,25 @@ class V20CredProposal(AgentMessage):
             else None
         )
 
+    def attachment_by_id(self, attach_id: str) -> dict:
+        """
+        Return attached filter by attach identifier.
+
+        Args:
+            attach_id: string identifier
+
+        """
+        target_format = [
+            V20CredFormat.Format.get(f.format)
+            for f in self.formats
+            if f.attach_id == attach_id
+        ][0]
+        return (
+            target_format.get_attachment_data_by_id(attach_id, self.filters_attach)
+            if target_format
+            else None
+        )
+
 
 class V20CredProposalSchema(AgentMessageSchema):
     """Credential proposal schema."""

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_request.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_request.py
@@ -78,6 +78,56 @@ class V20CredRequest(AgentMessage):
             else None
         )
 
+    def attachment_by_id(self, attach_id: str) -> dict:
+        """
+        Return attached credential request.
+
+        Args:
+            attach_id: string identifier
+
+        """
+        target_format = [
+            V20CredFormat.Format.get(f.format)
+            for f in self.formats
+            if f.attach_id == attach_id
+        ][0]
+        return (
+            target_format.get_attachment_data_by_id(attach_id, self.requests_attach)
+            if target_format
+            else None
+        )
+
+    def add_attachments(self, fmt: V20CredFormat, atch: AttachDecorator) -> None:
+        """
+        Update attachment format and requests attachment.
+
+        Args:
+            fmt: format of attachment
+            atch: attachment
+        """
+        self.formats.append(fmt)
+        self.requests_attach.append(atch)
+
+    def add_formats(self, fmt_list: Sequence[V20CredFormat]) -> None:
+        """
+        Add format.
+
+        Args:
+            fmt_list: list of format attachment
+        """
+        for fmt in fmt_list:
+            self.formats.append(fmt)
+
+    def add_requests_attach(self, atch_list: Sequence[AttachDecorator]) -> None:
+        """
+        Add request_attach.
+
+        Args:
+            atch_list: list of attachment
+        """
+        for atch in atch_list:
+            self.requests_attach.append(atch)
+
 
 class V20CredRequestSchema(AgentMessageSchema):
     """Credential request schema."""

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_request.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_request.py
@@ -86,11 +86,14 @@ class V20CredRequest(AgentMessage):
             attach_id: string identifier
 
         """
-        target_format = [
+        _format_list = [
             V20CredFormat.Format.get(f.format)
             for f in self.formats
             if f.attach_id == attach_id
-        ][0]
+        ]
+        if len(_format_list) == 0:
+            return None
+        target_format = _format_list[0]
         return (
             target_format.get_attachment_data_by_id(attach_id, self.requests_attach)
             if target_format
@@ -107,26 +110,6 @@ class V20CredRequest(AgentMessage):
         """
         self.formats.append(fmt)
         self.requests_attach.append(atch)
-
-    def add_formats(self, fmt_list: Sequence[V20CredFormat]) -> None:
-        """
-        Add format.
-
-        Args:
-            fmt_list: list of format attachment
-        """
-        for fmt in fmt_list:
-            self.formats.append(fmt)
-
-    def add_requests_attach(self, atch_list: Sequence[AttachDecorator]) -> None:
-        """
-        Add request_attach.
-
-        Args:
-            atch_list: list of attachment
-        """
-        for atch in atch_list:
-            self.requests_attach.append(atch)
 
 
 class V20CredRequestSchema(AgentMessageSchema):

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/inner/cred_preview.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/inner/cred_preview.py
@@ -1,6 +1,6 @@
 """Credential preview inner object."""
 
-from typing import Sequence
+from typing import Sequence, Mapping
 
 from marshmallow import EXCLUDE, fields, ValidationError, pre_load, post_dump
 
@@ -94,15 +94,6 @@ class V20CredAttrSpecSchema(BaseModelSchema):
     )
 
 
-class DictOrV20CredAttrSpecSchema(fields.Field):
-    """Mapping of ids to V20CredAttrSpecSchema or V20CredAttrSpecSchema."""
-
-    def _deserialize(self, value, attr, data, **kwargs):
-        if not isinstance(value, (V20CredAttrSpecSchema, dict)):
-            raise ValidationError("Field should be dict or V20CredAttrSpecSchema")
-        return super()._deserialize(value, attr, data, **kwargs)
-
-
 class V20CredPreview(BaseModel):
     """Credential preview."""
 
@@ -117,6 +108,7 @@ class V20CredPreview(BaseModel):
         *,
         _type: str = None,
         attributes: Sequence[V20CredAttrSpec] = None,
+        attributes_dict: Mapping = None,
         **kwargs,
     ):
         """
@@ -139,13 +131,14 @@ class V20CredPreview(BaseModel):
         """
         super().__init__(**kwargs)
         self.attributes = list(attributes) if attributes else []
+        self.attributes_dict = attributes_dict
 
     @property
     def _type(self):
         """Accessor for message type."""
         return DIDCommPrefix.qualify_current(V20CredPreview.Meta.message_type)
 
-    def attr_dict(self, decode: bool = False):
+    def attr_dict(self, decode: bool = False, attach_id: str = None):
         """
         Return name:value pair per attribute.
 
@@ -153,22 +146,38 @@ class V20CredPreview(BaseModel):
             decode: whether first to decode attributes with MIME type
 
         """
+        if attach_id:
+            return {
+                attr.name: b64_to_str(attr.value)
+                if attr.mime_type and decode
+                else attr.value
+                for attr in self.attributes_dict.get(attach_id)
+            }
+        else:
+            return {
+                attr.name: b64_to_str(attr.value)
+                if attr.mime_type and decode
+                else attr.value
+                for attr in self.attributes
+            }
 
-        return {
-            attr.name: b64_to_str(attr.value)
-            if attr.mime_type and decode
-            else attr.value
-            for attr in self.attributes
-        }
-
-    def mime_types(self):
+    def mime_types(self, attach_id: str = None):
         """
         Return per-attribute mapping from name to MIME type.
 
         Return empty dict if no attribute has MIME type.
 
         """
-        return {attr.name: attr.mime_type for attr in self.attributes if attr.mime_type}
+        if attach_id:
+            return {
+                attr.name: attr.mime_type
+                for attr in self.attributes_dict.get(attach_id)
+                if attr.mime_type
+            }
+        else:
+            return {
+                attr.name: attr.mime_type for attr in self.attributes if attr.mime_type
+            }
 
 
 class V20CredPreviewSchema(BaseModelSchema):
@@ -205,18 +214,21 @@ class V20CredPreviewSchema(BaseModelSchema):
     @pre_load
     def extract_and_process_attributes(self, data, **kwargs):
         """Process attributes and populate attributes_dict accordingly."""
-        if not data.get("attributes"):
+        if not data.get("attributes") and not data.get("attributes_dict"):
             raise ValidationError("Missing attributes dict")
-        attr_data = data.get("attributes")
-        if isinstance(attr_data, dict) and self.check_cred_ident_in_keys(attr_data):
-            data["attributes_dict"] = attr_data
-            del data["attributes"]
+        elif data.get("attributes") and data.get("attributes_dict"):
+            raise ValidationError("Only specify either attributes or attributes_dict")
+        elif data.get("attributes") and not data.get("attributes_dict"):
+            attr_data = data.get("attributes")
+            if isinstance(attr_data, dict) and self.check_cred_ident_in_keys(attr_data):
+                data["attributes_dict"] = attr_data
+                del data["attributes"]
         return data
 
     @post_dump
     def cleanup_attributes(self, data, **kwargs):
         """Cleanup attributes_dict and return as attributes."""
-        if not data.get("attributes") and data.get("attributes_dict"):
+        if data.get("attributes_dict"):
             data["attributes"] = data.get("attributes_dict")
             del data["attributes_dict"]
         return data

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/inner/cred_preview.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/inner/cred_preview.py
@@ -196,6 +196,7 @@ class V20CredPreviewSchema(BaseModelSchema):
     )
 
     def check_cred_ident_in_keys(self, attr_dict):
+        """Check for indy or ld_proof in attachment identifier."""
         for key, value in attr_dict.items():
             if "indy" in key or "ld_proof" in key:
                 return True
@@ -203,16 +204,18 @@ class V20CredPreviewSchema(BaseModelSchema):
 
     @pre_load
     def extract_and_process_attributes(self, data, **kwargs):
+        """Process attributes and populate attributes_dict accordingly."""
         if not data.get("attributes"):
-            raise ValidationError("test")
+            raise ValidationError("Missing attributes dict")
         attr_data = data.get("attributes")
-        if isinstance(attr_data, dict) and self.check_ident_in_keys(attr_data):
+        if isinstance(attr_data, dict) and self.check_cred_ident_in_keys(attr_data):
             data["attributes_dict"] = attr_data
             del data["attributes"]
         return data
 
     @post_dump
     def cleanup_attributes(self, data, **kwargs):
+        """Cleanup attributes_dict and return as attributes."""
         if not data.get("attributes") and data.get("attributes_dict"):
             data["attributes"] = data.get("attributes_dict")
             del data["attributes_dict"]

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/inner/cred_preview.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/inner/cred_preview.py
@@ -147,7 +147,7 @@ class V20CredPreview(BaseModel):
             decode: whether first to decode attributes with MIME type
 
         """
-        if attach_id:
+        if attach_id and attach_id != V20CredFormat.Format.INDY.api:
             return {
                 attr.name: b64_to_str(attr.value)
                 if attr.mime_type and decode
@@ -169,7 +169,7 @@ class V20CredPreview(BaseModel):
         Return empty dict if no attribute has MIME type.
 
         """
-        if attach_id:
+        if attach_id and attach_id != V20CredFormat.Format.INDY.api:
             return {
                 attr.name: attr.mime_type
                 for attr in self.attributes_dict.get(attach_id)

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/inner/cred_preview.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/inner/cred_preview.py
@@ -9,6 +9,7 @@ from ......wallet.util import b64_to_str
 
 from .....didcomm_prefix import DIDCommPrefix
 
+from ...messages.cred_format import V20CredFormat
 from ...message_types import CRED_20_PREVIEW
 
 
@@ -207,7 +208,7 @@ class V20CredPreviewSchema(BaseModelSchema):
     def check_cred_ident_in_keys(self, attr_dict):
         """Check for indy or ld_proof in attachment identifier."""
         for key, value in attr_dict.items():
-            if "indy" in key or "ld_proof" in key:
+            if V20CredFormat.Format.INDY.api in key:
                 return True
         return False
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/inner/cred_preview.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/inner/cred_preview.py
@@ -147,7 +147,7 @@ class V20CredPreview(BaseModel):
             decode: whether first to decode attributes with MIME type
 
         """
-        if attach_id and attach_id != V20CredFormat.Format.INDY.api:
+        if attach_id:
             return {
                 attr.name: b64_to_str(attr.value)
                 if attr.mime_type and decode
@@ -169,7 +169,7 @@ class V20CredPreview(BaseModel):
         Return empty dict if no attribute has MIME type.
 
         """
-        if attach_id and attach_id != V20CredFormat.Format.INDY.api:
+        if attach_id:
             return {
                 attr.name: attr.mime_type
                 for attr in self.attributes_dict.get(attach_id)

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/inner/tests/test_cred_preview.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/inner/tests/test_cred_preview.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from .......messaging.models.base import BaseModelError
+
 from ......didcomm_prefix import DIDCommPrefix
 
 from ....message_types import CRED_20_PREVIEW
@@ -98,6 +100,57 @@ class TestV20CredPreview(TestCase):
                 {"name": "icon", "mime-type": "image/png", "value": "cG90YXRv"},
             ],
         }
+
+    def test_check_cred_ident_in_keys(self):
+        """Test serialization."""
+
+        attr_dict = {
+            "@type": DIDCommPrefix.qualify_current(CRED_20_PREVIEW),
+            "attributes": {
+                "indy-0": [
+                    {"name": "test", "value": "123"},
+                    {"name": "hello", "value": "world"},
+                    {"name": "icon", "mime-type": "image/png", "value": "cG90YXRv"},
+                ]
+            },
+        }
+        cred20_preview = V20CredPreview.deserialize(attr_dict)
+        assert "indy-0" in cred20_preview.attributes_dict
+        assert cred20_preview.attributes == []
+        attr_dict = {
+            "@type": DIDCommPrefix.qualify_current(CRED_20_PREVIEW),
+            "attributes": {
+                "test-0": [
+                    {"name": "test", "value": "123"},
+                    {"name": "hello", "value": "world"},
+                    {"name": "icon", "mime-type": "image/png", "value": "cG90YXRv"},
+                ]
+            },
+        }
+        with self.assertRaises(BaseModelError):
+            cred20_preview = V20CredPreview.deserialize(attr_dict)
+        attr_dict = {
+            "@type": DIDCommPrefix.qualify_current(CRED_20_PREVIEW),
+        }
+        with self.assertRaises(BaseModelError):
+            cred20_preview = V20CredPreview.deserialize(attr_dict)
+        attr_dict = {
+            "@type": DIDCommPrefix.qualify_current(CRED_20_PREVIEW),
+            "attributes": [
+                {"name": "test", "value": "123"},
+                {"name": "hello", "value": "world"},
+                {"name": "icon", "mime-type": "image/png", "value": "cG90YXRv"},
+            ],
+            "attributes_dict": {
+                "indy-0": [
+                    {"name": "test", "value": "123"},
+                    {"name": "hello", "value": "world"},
+                    {"name": "icon", "mime-type": "image/png", "value": "cG90YXRv"},
+                ]
+            },
+        }
+        with self.assertRaises(BaseModelError):
+            cred20_preview = V20CredPreview.deserialize(attr_dict)
 
 
 class TestV20CredPreviewSchema(TestCase):

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_format.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_format.py
@@ -74,3 +74,14 @@ class TestV20FormatFormat(TestCase):
             )
             is None
         )
+
+    def test_get_attachment_data_by_id(self):
+        assert (
+            V20CredFormat.Format.INDY.get_attachment_data_by_id(
+                attach_id="indy-1",
+                attachments=[
+                    AttachDecorator.data_base64(TEST_INDY_FILTER, ident="indy-1")
+                ],
+            )
+            == TEST_INDY_FILTER
+        )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_format.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_format.py
@@ -85,3 +85,11 @@ class TestV20FormatFormat(TestCase):
             )
             == TEST_INDY_FILTER
         )
+        assert not (
+            V20CredFormat.Format.INDY.get_attachment_data_by_id(
+                attach_id="indy",
+                attachments=[
+                    AttachDecorator.data_base64(TEST_INDY_FILTER, ident="indy-1")
+                ],
+            )
+        )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_issue.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_issue.py
@@ -144,27 +144,6 @@ class TestV20CredIssue(AsyncTestCase):
         assert (
             cred_issue_single.attachment_by_id("indy-abc") == TestV20CredIssue.INDY_CRED
         )
-        cred_issue_single.add_credentials_attach(
-            [
-                AttachDecorator.data_base64(
-                    mapping=TestV20CredIssue.INDY_CRED,
-                    ident="indy-123",
-                )
-            ]
-        )
-        cred_issue_single.add_formats(
-            [
-                V20CredFormat(
-                    attach_id="indy-123",
-                    format_=ATTACHMENT_FORMAT[CRED_20_ISSUE][
-                        V20CredFormat.Format.INDY.api
-                    ],
-                )
-            ]
-        )
-        assert (
-            cred_issue_single.attachment_by_id("indy-123") == TestV20CredIssue.INDY_CRED
-        )
 
     async def test_attachment_no_target_format(self):
         """Test attachment behaviour for only unknown formats."""

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_issue.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_issue.py
@@ -130,6 +130,7 @@ class TestV20CredIssue(AsyncTestCase):
             TestV20CredIssue.CRED_ISSUE_MULTIPLE.attachment_by_id("indy-1")
             == TestV20CredIssue.INDY_CRED
         )
+        assert not TestV20CredIssue.CRED_ISSUE_MULTIPLE.attachment_by_id("indy")
         cred_issue_single = deepcopy(TestV20CredIssue.CRED_ISSUE)
         cred_issue_single.add_attachments(
             V20CredFormat(

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_offer.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_offer.py
@@ -63,6 +63,31 @@ class TestV20CredOffer(AsyncTestCase):
         ],
     )
 
+    CRED_OFFER_MULTIPLE = V20CredOffer(
+        comment="shaken, not stirred",
+        credential_preview=preview,
+        formats=[
+            V20CredFormat(
+                attach_id="indy-0",
+                format_=ATTACHMENT_FORMAT[CRED_20_OFFER][V20CredFormat.Format.INDY.api],
+            ),
+            V20CredFormat(
+                attach_id="indy-1",
+                format_=ATTACHMENT_FORMAT[CRED_20_OFFER][V20CredFormat.Format.INDY.api],
+            ),
+        ],
+        offers_attach=[
+            AttachDecorator.data_base64(
+                mapping=indy_offer,
+                ident="indy-0",
+            ),
+            AttachDecorator.data_base64(
+                mapping=indy_offer,
+                ident="indy-1",
+            ),
+        ],
+    )
+
     async def test_init_type(self):
         """Test initializer and type."""
         assert (
@@ -76,6 +101,11 @@ class TestV20CredOffer(AsyncTestCase):
         assert TestV20CredOffer.CRED_OFFER._type == DIDCommPrefix.qualify_current(
             CRED_20_OFFER
         )
+        assert (
+            TestV20CredOffer.CRED_OFFER_MULTIPLE.attachment_by_id("indy-1")
+            == TestV20CredOffer.indy_offer
+        )
+        assert not TestV20CredOffer.CRED_OFFER_MULTIPLE.attachment_by_id("indy")
 
     async def test_attachment_no_target_format(self):
         """Test attachment behaviour for only unknown formats."""

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_proposal.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_proposal.py
@@ -47,6 +47,8 @@ class TestV20CredProposal(AsyncTestCase):
         )
         assert cred_proposal.credential_preview == TEST_PREVIEW
         assert cred_proposal.attachment() == TEST_INDY_FILTER
+        assert cred_proposal.attachment_by_id("indy") == TEST_INDY_FILTER
+        assert not cred_proposal.attachment_by_id("random")
         assert cred_proposal._type == DIDCommPrefix.qualify_current(CRED_20_PROPOSAL)
 
     async def test_attachment_no_target_format(self):

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_request.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_request.py
@@ -129,28 +129,6 @@ class TestV20CredRequest(AsyncTestCase):
             cred_req_single.attachment_by_id("indy-abc")
             == TestV20CredRequest.indy_cred_req
         )
-        cred_req_single.add_requests_attach(
-            [
-                AttachDecorator.data_base64(
-                    ident="indy-123",
-                    mapping=TestV20CredRequest.indy_cred_req,
-                )
-            ]
-        )
-        cred_req_single.add_formats(
-            [
-                V20CredFormat(
-                    attach_id="indy-123",
-                    format_=ATTACHMENT_FORMAT[CRED_20_REQUEST][
-                        V20CredFormat.Format.INDY.api
-                    ],
-                )
-            ]
-        )
-        assert (
-            cred_req_single.attachment_by_id("indy-123")
-            == TestV20CredRequest.indy_cred_req
-        )
 
     async def test_attachment_no_target_format(self):
         """Test attachment behaviour for only unknown formats."""

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_request.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/tests/test_cred_request.py
@@ -112,6 +112,7 @@ class TestV20CredRequest(AsyncTestCase):
             TestV20CredRequest.CRED_REQUEST_MULTIPLE.attachment_by_id("indy-1")
             == TestV20CredRequest.indy_cred_req
         )
+        assert not TestV20CredRequest.CRED_REQUEST_MULTIPLE.attachment_by_id("indy")
         cred_req_single = deepcopy(TestV20CredRequest.CRED_REQUEST)
         cred_req_single.add_attachments(
             V20CredFormat(

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
@@ -111,11 +111,6 @@ class V20CredExRecord(BaseExchangeRecord):
         return self._id
 
     @property
-    def multiple_issuance_state(self) -> str:
-        """Accessor for the multiple_issuance_state with this exchange."""
-        return self.multiple_issuance_state
-
-    @property
     def cred_preview(self) -> Mapping:
         """Credential preview (deserialized view) from credential proposal."""
         return self.cred_proposal and self.cred_proposal.credential_preview or None

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
@@ -79,7 +79,7 @@ class V20CredExRecord(BaseExchangeRecord):
         cred_id_stored: str = None,  # backward compat: BaseRecord.from_storage()
         conn_id: str = None,  # backward compat: BaseRecord.from_storage()
         by_format: Mapping = None,  # backward compat: BaseRecord.from_storage()
-        multiple_credentials: bool = False,
+        multiple_credentials: bool = None,
         processed_attach_ids: Sequence[str] = [],
         multiple_issuance_state: str = None,
         **kwargs,
@@ -412,4 +412,9 @@ class V20CredExRecordSchema(BaseExchangeSchema):
         fields.Str(description="Attachment ID", required=True),
         required=False,
         description="List of processed attachment IDs",
+    )
+    multiple_issuance_state = fields.Str(
+        required=False,
+        description="Multiple credential issuance flow state",
+        example=V20CredExRecord.STATE_MULTIPLE_ISSUANCE_COMPLETE,
     )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
@@ -231,7 +231,6 @@ class V20CredExRecord(BaseExchangeRecord):
                     "multiple_credentials",
                     "multiple_issuance_state",
                     "processed_attach_ids",
-                    "stored_attach_ids",
                 )
             },
             **{

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
@@ -285,13 +285,17 @@ class V20CredExRecord(BaseExchangeRecord):
         }.items():
             msg = getattr(self, item)
             if msg:
+                attach_ids_list = [
+                    V20CredFormat.Format.get(f.format).api
+                    if f.attach_id == V20CredFormat.Format.get(f.format).api
+                    else f.attach_id
+                    for f in msg.formats
+                ]
                 result.update(
                     {
                         item: {
-                            V20CredFormat.Format.get(f.format).api: msg.attachment(
-                                V20CredFormat.Format.get(f.format)
-                            )
-                            for f in msg.formats
+                            attach_id: msg.attachment_by_id(attach_id)
+                            for attach_id in attach_ids_list
                         }
                     }
                 )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/detail/indy.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/detail/indy.py
@@ -10,6 +10,8 @@ from ......messaging.valid import INDY_CRED_REV_ID, INDY_REV_REG_ID, UUIDFour
 
 from .. import UNENCRYPTED_TAGS
 
+INDY_KEY = "indy"
+
 
 class V20CredExRecordIndy(BaseRecord):
     """Credential exchange indy detail record."""
@@ -33,6 +35,7 @@ class V20CredExRecordIndy(BaseRecord):
         cred_request_metadata: Mapping = None,
         rev_reg_id: str = None,
         cred_rev_id: str = None,
+        attach_id: str = None,
         **kwargs,
     ):
         """Initialize indy credential exchange record details."""
@@ -43,6 +46,7 @@ class V20CredExRecordIndy(BaseRecord):
         self.cred_request_metadata = cred_request_metadata
         self.rev_reg_id = rev_reg_id
         self.cred_rev_id = cred_rev_id
+        self.attach_id = attach_id or INDY_KEY
 
     @property
     def cred_ex_indy_id(self) -> str:
@@ -59,6 +63,7 @@ class V20CredExRecordIndy(BaseRecord):
                 "cred_request_metadata",
                 "rev_reg_id",
                 "cred_rev_id",
+                "attach_id",
             )
         }
 
@@ -115,4 +120,8 @@ class V20CredExRecordIndySchema(BaseRecordSchema):
         required=False,
         description="Credential revocation identifier within revocation registry",
         **INDY_CRED_REV_ID,
+    )
+    attach_id = fields.Str(
+        required=False,
+        description="Format attachment identifier",
     )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/detail/ld_proof.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/detail/ld_proof.py
@@ -10,6 +10,8 @@ from ......messaging.valid import UUIDFour
 
 from .. import UNENCRYPTED_TAGS
 
+LD_PROOF_KEY = "ld_proof"
+
 
 class V20CredExRecordLDProof(BaseRecord):
     """Credential exchange linked data proof detail record."""
@@ -30,6 +32,7 @@ class V20CredExRecordLDProof(BaseRecord):
         *,
         cred_ex_id: str = None,
         cred_id_stored: str = None,
+        attach_id: str = None,
         **kwargs,
     ):
         """Initialize LD Proof credential exchange record details."""
@@ -37,6 +40,7 @@ class V20CredExRecordLDProof(BaseRecord):
 
         self.cred_ex_id = cred_ex_id
         self.cred_id_stored = cred_id_stored
+        self.attach_id = attach_id or LD_PROOF_KEY
 
     @property
     def cred_ex_ld_proof_id(self) -> str:
@@ -46,7 +50,13 @@ class V20CredExRecordLDProof(BaseRecord):
     @property
     def record_value(self) -> dict:
         """Accessor for the JSON record value generated for this credential exchange."""
-        return {prop: getattr(self, prop) for prop in ("cred_id_stored",)}
+        return {
+            prop: getattr(self, prop)
+            for prop in (
+                "cred_id_stored",
+                "attach_id",
+            )
+        }
 
     @classmethod
     async def query_by_cred_ex_id(
@@ -88,4 +98,8 @@ class V20CredExRecordLDProofSchema(BaseRecordSchema):
         required=False,
         description="Credential identifier stored in wallet",
         example=UUIDFour.EXAMPLE,
+    )
+    attach_id = fields.Str(
+        required=False,
+        description="Format attachment identifier",
     )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
@@ -879,7 +879,7 @@ async def _create_free_offer(
     preview_spec: dict = None,
     comment: str = None,
     trace_msg: bool = None,
-    multiple_available: bool = None,
+    multiple_available: int = 1,
 ):
     """Create a credential offer and related exchange record."""
 
@@ -962,7 +962,9 @@ async def credential_exchange_create_free_offer(request: web.BaseRequest):
             preview_spec=preview_spec,
             comment=comment,
             trace_msg=trace_msg,
-            multiple_available=multiple_available,
+            multiple_available=multiple_available
+            if multiple_available and isinstance(multiple_available, int)
+            else 1,
         )
         result = cred_ex_record.serialize()
     except (
@@ -1043,7 +1045,9 @@ async def credential_exchange_send_free_offer(request: web.BaseRequest):
             preview_spec=preview_spec,
             comment=comment,
             trace_msg=trace_msg,
-            multiple_available=multiple_available,
+            multiple_available=multiple_available
+            if multiple_available and isinstance(multiple_available, int)
+            else 1,
         )
         result = cred_ex_record.serialize()
 
@@ -1149,7 +1153,9 @@ async def credential_exchange_send_bound_offer(request: web.BaseRequest):
             if preview_spec
             else None,
             comment=None,
-            multiple_available=multiple_available,
+            multiple_available=multiple_available
+            if multiple_available and isinstance(multiple_available, int)
+            else 1,
         )
 
         result = cred_ex_record.serialize()
@@ -1467,7 +1473,9 @@ async def credential_exchange_issue(request: web.BaseRequest):
         (cred_ex_record, cred_issue_message) = await cred_manager.issue_credential(
             cred_ex_record,
             comment=comment,
-            more_available=more_available,
+            more_available=more_available
+            if more_available and isinstance(more_available, int)
+            else 0,
         )
 
         details = await _get_attached_credentials(profile, cred_ex_record)

--- a/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
@@ -244,7 +244,8 @@ class V20IssueCredSchemaCore(AdminAPIMessageTracingSchema):
                         LDProofVCDetailSchema().load(filter_dict.get(attach_id))
                     except ValidationError:
                         raise ValidationError(
-                            f"LDProofVCDetailSchema schema validation failed for {attach_id}"
+                            "LDProofVCDetailSchema schema validation "
+                            f"failed for {attach_id}"
                         )
                     filter_attach_ids_handled.append(attach_id)
             if len(filter_attach_ids_handled) == 0:
@@ -308,7 +309,8 @@ class V20CredRequestFreeSchema(AdminAPIMessageTracingSchema):
                         LDProofVCDetailSchema().load(filter_dict.get(attach_id))
                     except ValidationError:
                         raise ValidationError(
-                            f"LDProofVCDetailSchema schema validation failed for {attach_id}"
+                            "LDProofVCDetailSchema schema validation "
+                            f"failed for {attach_id}"
                         )
                     filter_attach_ids_handled.append(attach_id)
             if len(filter_attach_ids_handled) == 0:
@@ -387,7 +389,8 @@ class V20CredBoundOfferRequestSchema(OpenAPISchema):
                         LDProofVCDetailSchema().load(filter_dict.get(attach_id))
                     except ValidationError:
                         raise ValidationError(
-                            f"LDProofVCDetailSchema schema validation failed for {attach_id}"
+                            "LDProofVCDetailSchema schema validation "
+                            f"failed for {attach_id}"
                         )
                     filter_attach_ids_handled.append(attach_id)
             if len(filter_attach_ids_handled) == 0:

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_manager.py
@@ -356,7 +356,7 @@ class TestV20CredManager(AsyncTestCase):
             mock_save.assert_called_once()
 
             mock_handler.return_value.create_offer.assert_called_once_with(
-                cx_rec.cred_proposal
+                cx_rec.cred_proposal, "0"
             )
 
             assert cx_rec.cred_ex_id == ret_cx_rec._id  # cover property
@@ -430,7 +430,7 @@ class TestV20CredManager(AsyncTestCase):
             mock_save.assert_called_once()
 
             mock_handler.return_value.create_offer.assert_called_once_with(
-                cred_proposal
+                cred_proposal, "0"
             )
 
             assert cx_rec.thread_id == ret_offer._thread_id
@@ -642,7 +642,7 @@ class TestV20CredManager(AsyncTestCase):
             )
 
             mock_handler.return_value.create_request.assert_called_once_with(
-                stored_cx_rec, {"holder_did": holder_did}
+                stored_cx_rec, {"holder_did": holder_did}, "0"
             )
 
             assert ret_cred_req.attachment() == INDY_CRED_REQ
@@ -729,7 +729,7 @@ class TestV20CredManager(AsyncTestCase):
             )
 
             mock_handler.return_value.create_request.assert_called_once_with(
-                stored_cx_rec, {"holder_did": holder_did}
+                stored_cx_rec, {"holder_did": holder_did}, "0"
             )
 
             assert ret_cred_req.attachment() == LD_PROOF_VC_DETAIL
@@ -999,7 +999,7 @@ class TestV20CredManager(AsyncTestCase):
 
             mock_save.assert_called_once()
             mock_handler.return_value.issue_credential.assert_called_once_with(
-                ret_cx_rec
+                ret_cx_rec, "0"
             )
 
             assert ret_cx_rec.cred_issue.attachment() == INDY_CRED
@@ -1107,7 +1107,7 @@ class TestV20CredManager(AsyncTestCase):
             )
             mock_save.assert_called_once()
             mock_handler.return_value.receive_credential.assert_called_once_with(
-                ret_cx_rec, cred_issue
+                ret_cx_rec, cred_issue, "0"
             )
             assert ret_cx_rec.cred_issue.attachment() == INDY_CRED
             assert ret_cx_rec.state == V20CredExRecord.STATE_CREDENTIAL_RECEIVED
@@ -1246,7 +1246,7 @@ class TestV20CredManager(AsyncTestCase):
             )
 
             mock_handler.return_value.store_credential.assert_called_once_with(
-                ret_cx_rec, cred_id
+                ret_cx_rec, cred_id, "0"
             )
 
             assert ret_cx_rec.cred_issue.attachment() == INDY_CRED

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_manager.py
@@ -2722,7 +2722,7 @@ class TestV20CredManager(AsyncTestCase):
             )
 
             mock_handler.return_value.store_credential.assert_called_once_with(
-                ret_cx_rec, cred_id, "0"
+                cred_ex_record=ret_cx_rec, cred_id=cred_id, attach_id="0"
             )
 
             assert ret_cx_rec.cred_issue.attachment() == INDY_CRED

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_manager.py
@@ -356,7 +356,7 @@ class TestV20CredManager(AsyncTestCase):
             mock_save.assert_called_once()
 
             mock_handler.return_value.create_offer.assert_called_once_with(
-                cx_rec.cred_proposal, "0"
+                cred_proposal_message=cx_rec.cred_proposal, attach_id="0"
             )
 
             assert cx_rec.cred_ex_id == ret_cx_rec._id  # cover property
@@ -430,7 +430,7 @@ class TestV20CredManager(AsyncTestCase):
             mock_save.assert_called_once()
 
             mock_handler.return_value.create_offer.assert_called_once_with(
-                cred_proposal, "0"
+                cred_proposal_message=cred_proposal, attach_id="0"
             )
 
             assert cx_rec.thread_id == ret_offer._thread_id
@@ -642,7 +642,9 @@ class TestV20CredManager(AsyncTestCase):
             )
 
             mock_handler.return_value.create_request.assert_called_once_with(
-                stored_cx_rec, {"holder_did": holder_did}, "0"
+                cred_ex_record=stored_cx_rec,
+                request_data={"holder_did": holder_did},
+                attach_id="0",
             )
 
             assert ret_cred_req.attachment() == INDY_CRED_REQ
@@ -729,7 +731,9 @@ class TestV20CredManager(AsyncTestCase):
             )
 
             mock_handler.return_value.create_request.assert_called_once_with(
-                stored_cx_rec, {"holder_did": holder_did}, "0"
+                cred_ex_record=stored_cx_rec,
+                request_data={"holder_did": holder_did},
+                attach_id="0",
             )
 
             assert ret_cred_req.attachment() == LD_PROOF_VC_DETAIL
@@ -999,7 +1003,7 @@ class TestV20CredManager(AsyncTestCase):
 
             mock_save.assert_called_once()
             mock_handler.return_value.issue_credential.assert_called_once_with(
-                ret_cx_rec, "0"
+                cred_ex_record=ret_cx_rec, attach_id="0"
             )
 
             assert ret_cx_rec.cred_issue.attachment() == INDY_CRED

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
@@ -383,7 +383,10 @@ class TestV20CredRoutes(AsyncTestCase):
             await test_module.credential_exchange_send_bound_request(self.request)
 
             mock_cred_mgr.return_value.create_request.assert_called_once_with(
-                mock_cred_ex.retrieve_by_id.return_value, "holder-did", []
+                cred_ex_record=mock_cred_ex.retrieve_by_id.return_value,
+                holder_did="holder-did",
+                exclude_attach_ids=[],
+                multiple_credential_flow=False,
             )
             mock_response.assert_called_once_with(
                 mock_cred_ex_record.serialize.return_value

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
@@ -383,7 +383,7 @@ class TestV20CredRoutes(AsyncTestCase):
             await test_module.credential_exchange_send_bound_request(self.request)
 
             mock_cred_mgr.return_value.create_request.assert_called_once_with(
-                mock_cred_ex.retrieve_by_id.return_value, "holder-did"
+                mock_cred_ex.retrieve_by_id.return_value, "holder-did", []
             )
             mock_response.assert_called_once_with(
                 mock_cred_ex_record.serialize.return_value

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
@@ -146,9 +146,12 @@ class TestV20CredRoutes(AsyncTestCase):
 
             mock_handler.return_value.get_detail_record = async_mock.CoroutineMock(
                 side_effect=[
-                    async_mock.MagicMock(  # indy
-                        serialize=async_mock.MagicMock(return_value={"...": "..."})
-                    ),
+                    [
+                        async_mock.MagicMock(  # indy
+                            serialize=async_mock.MagicMock(return_value={"...": "..."}),
+                            attach_id="indy",
+                        )
+                    ],
                     None,  # ld_proof
                 ]
             )
@@ -182,12 +185,20 @@ class TestV20CredRoutes(AsyncTestCase):
 
             mock_handler.return_value.get_detail_record = async_mock.CoroutineMock(
                 side_effect=[
-                    async_mock.MagicMock(  # indy
-                        serialize=async_mock.MagicMock(return_value={"in": "dy"})
-                    ),
-                    async_mock.MagicMock(  # ld_proof
-                        serialize=async_mock.MagicMock(return_value={"ld": "proof"})
-                    ),
+                    [
+                        async_mock.MagicMock(  # indy
+                            serialize=async_mock.MagicMock(return_value={"in": "dy"}),
+                            attach_id=None,
+                        )
+                    ],
+                    [
+                        async_mock.MagicMock(  # ld_proof
+                            serialize=async_mock.MagicMock(
+                                return_value={"ld": "proof"}
+                            ),
+                            attach_id="ld_proof",
+                        )
+                    ],
                 ]
             )
 
@@ -1214,9 +1225,12 @@ class TestV20CredRoutes(AsyncTestCase):
 
             mock_handler.return_value.get_detail_record = async_mock.CoroutineMock(
                 side_effect=[
-                    async_mock.MagicMock(  # indy
-                        serialize=async_mock.MagicMock(return_value={"...": "..."})
-                    ),
+                    [
+                        async_mock.MagicMock(  # indy
+                            serialize=async_mock.MagicMock(return_value={"...": "..."}),
+                            attach_id=None,
+                        )
+                    ],
                     None,  # ld_proof
                 ]
             )
@@ -1407,9 +1421,12 @@ class TestV20CredRoutes(AsyncTestCase):
             )
             mock_handler.return_value.get_detail_record = async_mock.CoroutineMock(
                 side_effect=[
-                    async_mock.MagicMock(  # indy
-                        serialize=async_mock.MagicMock(return_value={"...": "..."})
-                    ),
+                    [
+                        async_mock.MagicMock(  # indy
+                            serialize=async_mock.MagicMock(return_value={"...": "..."}),
+                            attach_id="indy",
+                        )
+                    ],
                     None,  # ld_proof
                 ]
             )
@@ -1458,9 +1475,12 @@ class TestV20CredRoutes(AsyncTestCase):
 
             mock_cx_rec = async_mock.MagicMock()
 
-            mock_indy_get_detail_record.return_value = async_mock.MagicMock(  # indy
-                serialize=async_mock.MagicMock(return_value={"...": "..."})
-            )
+            mock_indy_get_detail_record.return_value = [
+                async_mock.MagicMock(  # indy
+                    serialize=async_mock.MagicMock(return_value={"...": "..."}),
+                    attach_id="indy-0",
+                )
+            ]
             mock_ld_proof_get_detail_record.return_value = None  # ld_proof
 
             mock_cred_mgr.return_value.store_credential.return_value = mock_cx_rec
@@ -1474,7 +1494,7 @@ class TestV20CredRoutes(AsyncTestCase):
             mock_response.assert_called_once_with(
                 {
                     "cred_ex_record": mock_cx_rec.serialize.return_value,
-                    "indy": {"...": "..."},
+                    "indy-0": {"...": "..."},
                     "ld_proof": None,
                 }
             )

--- a/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/tests/test_routes.py
@@ -49,6 +49,18 @@ class TestV20CredRoutes(AsyncTestCase):
         with self.assertRaises(test_module.ValidationError):
             schema.validate({"filter_": {"random": {"..": ".."}}})
 
+    async def test_validate_cred_issue_schema(self):
+        schema = test_module.V20CredIssueRequestSchema()
+        schema.validate(
+            {
+                "filter_": {"ld_proof": ld_proof_test_module.VC_DETAIL},
+                "more_available": 1,
+                "comment": "test",
+            }
+        )
+        with self.assertRaises(test_module.ValidationError):
+            schema.validate({"filter_": {"ld_proof": {"...": "..."}}})
+
     async def test_validate_request_free_schema(self):
         schema = test_module.V20CredRequestFreeSchema()
         schema.validate({"filter_": {"ld_proof": ld_proof_test_module.VC_DETAIL}})

--- a/aries_cloudagent/resolver/routes.py
+++ b/aries_cloudagent/resolver/routes.py
@@ -53,7 +53,7 @@ from .did_resolver import DIDResolver
 class ResolutionResultSchema(OpenAPISchema):
     """Result schema for did document query."""
 
-    did_doc = fields.Dict(description="DID Document", required=True)
+    did_document = fields.Dict(description="DID Document", required=True)
     metadata = fields.Dict(description="Resolution metadata", required=True)
 
 

--- a/aries_cloudagent/version.py
+++ b/aries_cloudagent/version.py
@@ -1,4 +1,4 @@
 """Library version information."""
 
-__version__ = "1.0.0-rc1"
+__version__ = "0.8.0-rc0"
 RECORD_TYPE_ACAPY_VERSION = "acapy_version"

--- a/docs/generated/aries_cloudagent.wallet.rst
+++ b/docs/generated/aries_cloudagent.wallet.rst
@@ -65,6 +65,14 @@ aries\_cloudagent.wallet.did\_method module
    :undoc-members:
    :show-inheritance:
 
+aries\_cloudagent.wallet.did\_parameters\_validation module
+-----------------------------------------------------------
+
+.. automodule:: aries_cloudagent.wallet.did_parameters_validation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 aries\_cloudagent.wallet.did\_posture module
 --------------------------------------------
 

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -1,7 +1,7 @@
 {
   "swagger" : "2.0",
   "info" : {
-    "version" : "v1.0.0-rc1",
+    "version" : "v0.8.0-rc0",
     "title" : "Aries Cloud Agent"
   },
   "tags" : [ {


### PR DESCRIPTION
Signed-off-by: Shaanjot Gill <gill.shaanjots@gmail.com>

- ~~Ran `black` code formatter with version `23.1.0` to pass the check, all file changes outside `./aries_cloudagent/protocols/issue_credential/v2_0` directory and `aries_cloudagent/config/argparse.py` [22 files] were triggered by this. A special case [collision between flake8 and black 23.1.0] needed to be handled in `aries_cloudagent/ledger/indy.py`.~~
- resolves #1979
- pending final Admin API testing and addition of integration tests [I can maybe leave this for a separate PR (combine tests for both issue-cred and present-proof 2.1)]