### PR TITLE
Allow using YAML configuration file with run_docker

### DIFF
--- a/scripts/run_docker
+++ b/scripts/run_docker
@@ -70,6 +70,23 @@ if [ -n "${NETWORK_NAME}" ]; then
 else
   echo "No Docker network specified."
 fi
-echo ""
 
-$CONTAINER_RUNTIME run --rm -ti $ARGS aries-cloudagent-run "$@"
+if [ -n "${ARG_FILE}" ]; then
+  if [ -f "${ARG_FILE}" ]; then
+    ARG_FILE_IN_DOCKER="/home/indy/arg-file.yml"
+    ARGS="${ARGS} -v ${ARG_FILE}:${ARG_FILE_IN_DOCKER}"
+    echo ""
+    echo "Using acapy config file: ${ARG_FILE}"
+  else
+    echo "Config file not found: ${ARG_FILE}" || exit 1
+  fi
+fi
+
+ACAPY_ARGUMENTS=("$@")
+if [ -n "${ARG_FILE_IN_DOCKER}" ]; then
+  ACAPY_ARGUMENTS=("${ACAPY_ARGUMENTS[@]}" "--arg-file" "${ARG_FILE_IN_DOCKER}")
+fi
+
+echo ""
+# shellcheck disable=SC2086,SC2090
+$CONTAINER_RUNTIME run --rm -ti $ARGS aries-cloudagent-run "${ACAPY_ARGUMENTS[@]}"


### PR DESCRIPTION
This will allow using scripts like this:

```bash
#!/usr/bin/env bash

# Uncomment for debugging
# set -o xtrace

set -eo pipefail  # Exit the script if any statement returns error.

SCRIPT_DIR="$( dirname "$(readlink -f "$0")" )"

export CONTAINER_NAME="aries_issuer"
export NETWORK_NAME="aries-mediator-service_mediator-network"
export PORTS="8002 11002"
export ARG_FILE="${SCRIPT_DIR}/cfg_issuer.yml"

../aries-cloudagent-python/scripts/run_docker start
```

I find working with yaml files easier/faster than very, very long command line when testing and debugging (because I can simply comment out some configs and uncomment others at the same time).