### PR TITLE
fix: fix connection timing bug

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -479,7 +479,7 @@ class ConnectionManager(BaseConnectionManager):
                 new_connection = ConnRecord(
                     invitation_key=connection_key,
                     my_did=my_info.did,
-                    state=ConnRecord.State.INVITATION.rfc160,
+                    state=ConnRecord.State.REQUEST.rfc160,
                     accept=connection.accept,
                     their_role=connection.their_role,
                     connection_protocol=CONN_PROTO,


### PR DESCRIPTION
This is an interesting bug that occurs under load in aca-py. It appears that on receive connection for a multi-use invitation, that we copy the object. The problem is for a short time the original search that takes places to find the multi-use invitation matches both the original and the copy. If this occurs, Aca-Py throws an un-caught error indicating that two connections records for the invitation were found. By setting Request on the clone object, this condition is avoided.

Signed-off-by: Kim Ebert <kim@indicio.tech>