### PR TITLE
fix: resolver api schema inconsistency

### DIFF
--- a/aries_cloudagent/resolver/routes.py
+++ b/aries_cloudagent/resolver/routes.py
@@ -53,7 +53,7 @@ from .did_resolver import DIDResolver
 class ResolutionResultSchema(OpenAPISchema):
     """Result schema for did document query."""
 
-    did_doc = fields.Dict(description="DID Document", required=True)
+    did_document = fields.Dict(description="DID Document", required=True)
     metadata = fields.Dict(description="Resolution metadata", required=True)
 
 


### PR DESCRIPTION
Fix a small inconsistency between the openapi schema and the actual return value for the `/resolver/resolve/{did}`.

This PR aligns the schema to the actual return value to avoid breaking any current implementation making use of the endpoint.

Signed-off-by: Clément Humbert <clement.humbert@sicpa.com>