### PR TITLE
0.8.0-rc0 release updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,6 @@ that release will be finalized. Many of the PRs in this release were previously
 included in the `1.0.0-rc1` release. The categorized list of PRs separates those
 that are new from those in the `1.0.0-rc1` release candidate.
 
-With this release, a new automated process publishes container images in the
-Hyperledger container image repository. New images for the release are
-automatically published by the GitHubAction Workflows: [publish.yml] and
-[publish-indy.yml]. The actions are triggered when a release is tagged, so no
-manual action is needed. The images are published in the [Hyperledger Package
-Repository under aries-cloudagent-python] and a link to the packages added to
-the repositories main page (under "Packages"). Additional information about the
-container image publication process can be found in the document [Container
-Images and Github Actions].
-
 There are not a lot of new Aries Framework features in this release, as the
 focus has been on cleanup and optimization. The biggest addition is the
 inclusion with ACA-Py of a universal resolver interface, allowing an instance to
@@ -29,7 +19,19 @@ Endorsers. A new repo
 has been created that is a pre-configured instance of ACA-Py for use as an
 Endorser service.
 
-The images are based on [Python 3.6 and 3.9 `slim-bullseye`
+### Container Publishing Updated
+
+With this release, a new automated process publishes container images in the
+Hyperledger container image repository. New images for the release are
+automatically published by the GitHubAction Workflows: [publish.yml] and
+[publish-indy.yml]. The actions are triggered when a release is tagged, so no
+manual action is needed. The images are published in the [Hyperledger Package
+Repository under aries-cloudagent-python] and a link to the packages added to
+the repositories main page (under "Packages"). Additional information about the
+container image publication process can be found in the document [Container
+Images and Github Actions].
+
+The ACA-Py container images are based on [Python 3.6 and 3.9 `slim-bullseye`
 images](https://hub.docker.com/_/python), and are built to support `linux/386
 (x86)`, `linux/amd64 (x64)`, and `linux/arm64`. There are two flavors of image
 built for each Python version. One contains only the Indy/Aries Shared Libraries
@@ -50,6 +52,10 @@ those published to the [Hyperledger Package Repository under
 aries-cloudagent-python].
 
 [Hyperledger Package Repository under aries-cloudagent-python]: https://github.com/orgs/hyperledger/packages?repo_name=aries-cloudagent-python
+[publish.yml]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/.github/workflows/publish.yml
+[publish-indy.yml]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/.github/workflows/publish-indy.yml
+[Container Images and Github Actions]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/ContainerImagesAndGithubActions.md
+
 
 ## Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,109 +1,164 @@
-# 1.0.0-rc1
+# 0.8.0-rc0
 
-## November 6, 2022
+## February 8, 2023
 
-1.0.0 is a breaking update to ACA-Py whose version is intended to indicate the
-maturity of the implementation. The final 1.0.0 release will be Aries Interop
-Profile 2.0-complete, and based on Python 3.7 or higher.
+0.8.0 is a breaking change that contains all updates since release 0.7.5. It
+extends the previously tagged `1.0.0-rc1` release because it is not clear
+when that release will be finalized.
 
-### Breaking Changes
+With this release, a new automated process publishes container
+images in the Hyperledger container image repository for this version of ACA-Py
+based on both Python 3.6 and 3.9. We recommend using Python 3.9 with ACA-Py.
 
-As of release candidate 1.0.0-rc1, the only identified breaking change is the
-handling of "unrevealed attributes" during verification (see
-[\#1913](https://github.com/hyperledger/aries-cloudagent-python/pull/1913) for
-details). As few implementations of Aries Wallets support unrevealed attributes
-in an AnonCreds presentation, this is unlikely to impact any deployments.
-
-### Categorized List of Pull Requests
-
-In rc1, there are not a lot of new features, as the focus is on cleanup and
-optimization. The biggest is the inclusion with ACA-Py of a universal resolver
-interface, allowing an instance to have both local resolvers for some DID
-Methods and a call out to an external universal resolver for other DID Methods.
-Another significant feature is full support for Hyperledger Indy transaction
-endorsement for Authors and Endorsers. A new repo
+There are not a lot of new features in this release, as the focus has been on
+cleanup and optimization. The biggest addition is the inclusion with ACA-Py of a
+universal resolver interface, allowing an instance to have both local resolvers
+for some DID Methods and a call out to an external universal resolver for other
+DID Methods. Another significant new capability is full support for Hyperledger
+Indy transaction endorsement for Authors and Endorsers. A new repo
 [aries-endorser-service](https://github.com/hyperledger/aries-endorser-service)
 has been created that is a pre-configured instance of ACA-Py for use as an
-Endorser service. While some work has been done on moving the default Python
-version beyond 3.6, more work is still to be done on that before the final
-v1.0.0 release.
+Endorser service.
+
+## Breaking Changes
+
+### PR [\#2034](https://github.com/hyperledger/aries-cloudagent-python/pull/2034) -- Implicit connections
+
+The break impacts existing  deployments that supported connections coming via a
+public DID. Such deployments need to add the configuration parameter
+`--requests-through-public-did` to continue to support that feature. The use
+case is that an ACA-Py instance publishes a public DID on a ledger with a
+DIDComm `service` in the DIDDoc. Other agents resolve that DID, and attempt to
+establish a connection with the ACA-Py instance using the `service` endpoint.
+This is called an "implicit" connection in [RFC 0023 DID
+Exchange](https://github.com/hyperledger/aries-rfcs/blob/main/features/0023-did-exchange/README.md).
+
+### PR [\#1913](https://github.com/hyperledger/aries-cloudagent-python/pull/1913) -- Unrevealed attributes in presentations
+
+Updates the handling of "unrevealed attributes" during verification of AnonCreds
+presentations, allowing them to be used in a presentation, with additional data
+that can be checked if for unrevealed attributes. As few implementations of
+Aries wallets support unrevealed attributes in an AnonCreds presentation, this
+is unlikely to impact any deployments.
 
 ### Categorized List of Pull Requests
 
 - Verifiable credential, presentation and revocation handling updates
-  - Refactor ledger correction code and insert into revocation error handling [\#1892](https://github.com/hyperledger/aries-cloudagent-python/pull/1892) ([ianco](https://github.com/ianco))
-  - Indy ledger fixes and cleanups [\#1870](https://github.com/hyperledger/aries-cloudagent-python/pull/1870) ([andrewwhitehead](https://github.com/andrewwhitehead))
-  - Refactoring of revocation registry creation [\#1813](https://github.com/hyperledger/aries-cloudagent-python/pull/1813) ([andrewwhitehead](https://github.com/andrewwhitehead))
-  - Fix: the type of tails file path to string. [\#1925](https://github.com/hyperledger/aries-cloudagent-python/pull/1925) ([baegjae](https://github.com/baegjae))
-  - Pre-populate revoc\_reg\_id on IssuerRevRegRecord [\#1924](https://github.com/hyperledger/aries-cloudagent-python/pull/1924) ([andrewwhitehead](https://github.com/andrewwhitehead))
-  - Leave credentialStatus element in the LD credential [\#1921](https://github.com/hyperledger/aries-cloudagent-python/pull/1921) ([tsabolov](https://github.com/tsabolov))
-  - **BREAKING:** Remove aca-py check for unrevealed revealed attrs on proof validation [\#1913](https://github.com/hyperledger/aries-cloudagent-python/pull/1913) ([ianco](https://github.com/ianco))
-  - Send webhooks upon record/credential deletion [\#1906](https://github.com/hyperledger/aries-cloudagent-python/pull/1906) ([frostyfrog](https://github.com/frostyfrog))
+  - Feature: enabled handling VPs \(request, creation, verification\) with different VCs [\#1956](https://github.com/hyperledger/aries-cloudagent-python/pull/1956) ([teanas](https://github.com/teanas))
+  - fix: update issue-credential endpoint summaries [\#1997](https://github.com/hyperledger/aries-cloudagent-python/pull/1997) ([PeterStrob](https://github.com/PeterStrob))
+  - fix claim format designation in presentation submission [\#2013](https://github.com/hyperledger/aries-cloudagent-python/pull/2013) ([rmnre](https://github.com/rmnre))
+  - \#2041 - Issue JSON-LD has invalid Admin API documentation [\#2046](https://github.com/hyperledger/aries-cloudagent-python/pull/2046) ([jfblier-amplitude](https://github.com/jfblier-amplitude))
+  - Previously flagged in release 1.0.0-rc1
+    - Refactor ledger correction code and insert into revocation error handling [\#1892](https://github.com/hyperledger/aries-cloudagent-python/pull/1892) ([ianco](https://github.com/ianco))
+    - Indy ledger fixes and cleanups [\#1870](https://github.com/hyperledger/aries-cloudagent-python/pull/1870) ([andrewwhitehead](https://github.com/andrewwhitehead))
+    - Refactoring of revocation registry creation [\#1813](https://github.com/hyperledger/aries-cloudagent-python/pull/1813) ([andrewwhitehead](https://github.com/andrewwhitehead))
+    - Fix: the type of tails file path to string. [\#1925](https://github.com/hyperledger/aries-cloudagent-python/pull/1925) ([baegjae](https://github.com/baegjae))
+    - Pre-populate revoc\_reg\_id on IssuerRevRegRecord [\#1924](https://github.com/hyperledger/aries-cloudagent-python/pull/1924) ([andrewwhitehead](https://github.com/andrewwhitehead))
+    - Leave credentialStatus element in the LD credential [\#1921](https://github.com/hyperledger/aries-cloudagent-python/pull/1921) ([tsabolov](https://github.com/tsabolov))
+    - **BREAKING:** Remove aca-py check for unrevealed revealed attrs on proof validation [\#1913](https://github.com/hyperledger/aries-cloudagent-python/pull/1913) ([ianco](https://github.com/ianco))
+    - Send webhooks upon record/credential deletion [\#1906](https://github.com/hyperledger/aries-cloudagent-python/pull/1906) ([frostyfrog](https://github.com/frostyfrog))
 
-- Out of Band (OOB)  and DID Exchange / Connection Handling
-  - Fix: `--mediator-invitation` with OOB invitation + cleanup  [\#1970](https://github.com/hyperledger/aries-cloudagent-python/pull/1970) ([shaangill025](https://github.com/shaangill025))
-  - include image\_url in oob invitation [\#1966](https://github.com/hyperledger/aries-cloudagent-python/pull/1966) ([Zzocker](https://github.com/Zzocker))
-  - feat: 00B v1.1 support [\#1962](https://github.com/hyperledger/aries-cloudagent-python/pull/1962) ([shaangill025](https://github.com/shaangill025))
-  - Fix: OOB - Handling of minor versions [\#1940](https://github.com/hyperledger/aries-cloudagent-python/pull/1940) ([shaangill025](https://github.com/shaangill025))
-  - fix: failed connectionless proof request on some case [\#1933](https://github.com/hyperledger/aries-cloudagent-python/pull/1933) ([kukgini](https://github.com/kukgini))
-  - fix: propagate endpoint from mediation record [\#1922](https://github.com/hyperledger/aries-cloudagent-python/pull/1922) ([cjhowland](https://github.com/cjhowland))
-  - Feat/public did endpoints for agents behind mediators [\#1899](https://github.com/hyperledger/aries-cloudagent-python/pull/1899) ([cjhowland](https://github.com/cjhowland))
+- Out of Band (OOB) and DID Exchange / Connection Handling / Mediator
+  - fix: public did mediator routing keys as did keys [\#1977](https://github.com/hyperledger/aries-cloudagent-python/pull/1977) ([dbluhm](https://github.com/dbluhm))
+  - Fix for mediator load testing race condition when scaling horizontally [\#2009](https://github.com/hyperledger/aries-cloudagent-python/pull/2009) ([ianco](https://github.com/ianco))
+  - BREAKING: Allow multi-use public invites and public invites with metadata [\#2034](https://github.com/hyperledger/aries-cloudagent-python/pull/2034) ([mepeltier](https://github.com/mepeltier))
+  - Do not reject OOB invitation with unknown handshake protocol\(s\) [\#2060](https://github.com/hyperledger/aries-cloudagent-python/pull/2060) ([andrewwhitehead](https://github.com/andrewwhitehead))
+  - fix: fix connection timing bug [\#2099](https://github.com/hyperledger/aries-cloudagent-python/pull/2099) ([reflectivedevelopment](https://github.com/reflectivedevelopment))
+  - Previously flagged in release 1.0.0-rc1
+    - Fix: `--mediator-invitation` with OOB invitation + cleanup  [\#1970](https://github.com/hyperledger/aries-cloudagent-python/pull/1970) ([shaangill025](https://github.com/shaangill025))
+    - include image\_url in oob invitation [\#1966](https://github.com/hyperledger/aries-cloudagent-python/pull/1966) ([Zzocker](https://github.com/Zzocker))
+    - feat: 00B v1.1 support [\#1962](https://github.com/hyperledger/aries-cloudagent-python/pull/1962) ([shaangill025](https://github.com/shaangill025))
+    - Fix: OOB - Handling of minor versions [\#1940](https://github.com/hyperledger/aries-cloudagent-python/pull/1940) ([shaangill025](https://github.com/shaangill025))
+    - fix: failed connectionless proof request on some case [\#1933](https://github.com/hyperledger/aries-cloudagent-python/pull/1933) ([kukgini](https://github.com/kukgini))
+    - fix: propagate endpoint from mediation record [\#1922](https://github.com/hyperledger/aries-cloudagent-python/pull/1922) ([cjhowland](https://github.com/cjhowland))
+    - Feat/public did endpoints for agents behind mediators [\#1899](https://github.com/hyperledger/aries-cloudagent-python/pull/1899) ([cjhowland](https://github.com/cjhowland))
 
 - DID Registration and Resolution related updates
-  - feat: add universal resolver [\#1866](https://github.com/hyperledger/aries-cloudagent-python/pull/1866) ([dbluhm](https://github.com/dbluhm))
-  - fix: resolve dids following new endpoint rules [\#1863](https://github.com/hyperledger/aries-cloudagent-python/pull/1863) ([dbluhm](https://github.com/dbluhm))
-  - fix: didx request cannot be accepted [\#1881](https://github.com/hyperledger/aries-cloudagent-python/pull/1881) ([rmnre](https://github.com/rmnre))
-  - did method & key type registry [\#1986](https://github.com/hyperledger/aries-cloudagent-python/pull/1986) ([burdettadam](https://github.com/burdettadam))
-  - Fix/endpoint attrib structure [\#1934](https://github.com/hyperledger/aries-cloudagent-python/pull/1934) ([cjhowland](https://github.com/cjhowland))
-  - Simple did registry [\#1920](https://github.com/hyperledger/aries-cloudagent-python/pull/1920) ([burdettadam](https://github.com/burdettadam))
-  - Use did:key for recipient keys [\#1886](https://github.com/hyperledger/aries-cloudagent-python/pull/1886) ([frostyfrog](https://github.com/frostyfrog))
+  - feat: enable creation of DIDs for all registered methods [\#2067](https://github.com/hyperledger/aries-cloudagent-python/pull/2067) ([chumbert](https://github.com/chumbert))
+  - fix: create local DID return schema [\#2086](https://github.com/hyperledger/aries-cloudagent-python/pull/2086) ([chumbert](https://github.com/chumbert))
+  - feat: universal resolver - configurable authentication [\#2095](https://github.com/hyperledger/aries-cloudagent-python/pull/2095) ([chumbert](https://github.com/chumbert))
+  - Previously flagged in release 1.0.0-rc1
+    - feat: add universal resolver [\#1866](https://github.com/hyperledger/aries-cloudagent-python/pull/1866) ([dbluhm](https://github.com/dbluhm))
+    - fix: resolve dids following new endpoint rules [\#1863](https://github.com/hyperledger/aries-cloudagent-python/pull/1863) ([dbluhm](https://github.com/dbluhm))
+    - fix: didx request cannot be accepted [\#1881](https://github.com/hyperledger/aries-cloudagent-python/pull/1881) ([rmnre](https://github.com/rmnre))
+    - did method & key type registry [\#1986](https://github.com/hyperledger/aries-cloudagent-python/pull/1986) ([burdettadam](https://github.com/burdettadam))
+    - Fix/endpoint attrib structure [\#1934](https://github.com/hyperledger/aries-cloudagent-python/pull/1934) ([cjhowland](https://github.com/cjhowland))
+    - Simple did registry [\#1920](https://github.com/hyperledger/aries-cloudagent-python/pull/1920) ([burdettadam](https://github.com/burdettadam))
+    - Use did:key for recipient keys [\#1886](https://github.com/hyperledger/aries-cloudagent-python/pull/1886) ([frostyfrog](https://github.com/frostyfrog))
 
 - Hyperledger Indy Endorser/Author Transaction Handling
-  - Fix/txn job setting [\#1994](https://github.com/hyperledger/aries-cloudagent-python/pull/1994) ([ianco](https://github.com/ianco))
-  - chore: fix ACAPY\_PROMOTE-AUTHOR-DID flag  [\#1978](https://github.com/hyperledger/aries-cloudagent-python/pull/1978) ([morrieinmaas](https://github.com/morrieinmaas))
-
-  - Endorser write DID transaction [\#1938](https://github.com/hyperledger/aries-cloudagent-python/pull/1938) ([ianco](https://github.com/ianco))
-  - Endorser doc updates and some bug fixes [\#1926](https://github.com/hyperledger/aries-cloudagent-python/pull/1926) ([ianco](https://github.com/ianco))
+  - Special handling for the write ledger [\#2030](https://github.com/hyperledger/aries-cloudagent-python/pull/2030) ([ianco](https://github.com/ianco))
+  - Previously flagged in release 1.0.0-rc1
+    - Fix/txn job setting [\#1994](https://github.com/hyperledger/aries-cloudagent-python/pull/1994) ([ianco](https://github.com/ianco))
+    - chore: fix ACAPY\_PROMOTE-AUTHOR-DID flag  [\#1978](https://github.com/hyperledger/aries-cloudagent-python/pull/1978) ([morrieinmaas](https://github.com/morrieinmaas))
+    - Endorser write DID transaction [\#1938](https://github.com/hyperledger/aries-cloudagent-python/pull/1938) ([ianco](https://github.com/ianco))
+    - Endorser doc updates and some bug fixes [\#1926](https://github.com/hyperledger/aries-cloudagent-python/pull/1926) ([ianco](https://github.com/ianco))
 
 - Startup Command Line / Environment / YAML Parameter Updates
-  - Add seed command line parameter but use only if also an "allow insecure seed" parameter is set [\#1714](https://github.com/hyperledger/aries-cloudagent-python/pull/1714) ([DaevMithran](https://github.com/DaevMithran))
+  - Add missing --mediator-connections-invite cmd arg info to docs [\#2051](https://github.com/hyperledger/aries-cloudagent-python/pull/2051) ([matrixik](https://github.com/matrixik))
+  - Issue \#2068 boolean flag change to support HEAD requests to default route [\#2077](https://github.com/hyperledger/aries-cloudagent-python/pull/2077) ([johnekent](https://github.com/johnekent))
+  - Previously flagged in release 1.0.0-rc1
+    - Add seed command line parameter but use only if also an "allow insecure seed" parameter is set [\#1714](https://github.com/hyperledger/aries-cloudagent-python/pull/1714) ([DaevMithran](https://github.com/DaevMithran))
 
 - Internal Aries framework data handling updates
-  - fix: update RouteManager methods use to pass profile as parameter [\#1902](https://github.com/hyperledger/aries-cloudagent-python/pull/1902) ([chumbert](https://github.com/chumbert))
-  - Allow fully qualified class names for profile managers [\#1880](https://github.com/hyperledger/aries-cloudagent-python/pull/1880) ([chumbert](https://github.com/chumbert))
-  - fix: unable to use askar with in memory db [\#1878](https://github.com/hyperledger/aries-cloudagent-python/pull/1878) ([dbluhm](https://github.com/dbluhm))
-  - Enable manually triggering keylist updates during connection [\#1851](https://github.com/hyperledger/aries-cloudagent-python/pull/1851) ([dbluhm](https://github.com/dbluhm))
-  - feat: make base wallet route access configurable [\#1836](https://github.com/hyperledger/aries-cloudagent-python/pull/1836) ([dbluhm](https://github.com/dbluhm))
-  - feat: event and webhook on keylist update stored [\#1769](https://github.com/hyperledger/aries-cloudagent-python/pull/1769) ([dbluhm](https://github.com/dbluhm))
-  - fix: Safely shutdown when root\_profile uninitialized [\#1960](https://github.com/hyperledger/aries-cloudagent-python/pull/1960) ([frostyfrog](https://github.com/frostyfrog))
-  - feat: include connection ids in keylist update webhook [\#1914](https://github.com/hyperledger/aries-cloudagent-python/pull/1914) ([dbluhm](https://github.com/dbluhm))
-  - fix: incorrect response schema for discover features [\#1912](https://github.com/hyperledger/aries-cloudagent-python/pull/1912) ([dbluhm](https://github.com/dbluhm))
-  - Fix: SchemasInputDescriptorFilter: broken deserialization renders generated clients unusable [\#1894](https://github.com/hyperledger/aries-cloudagent-python/pull/1894) ([rmnre](https://github.com/rmnre))
-  - fix: schema class can set Meta.unknown [\#1885](https://github.com/hyperledger/aries-cloudagent-python/pull/1885) ([dbluhm](https://github.com/dbluhm))
+  - fix: return if return route but no response [\#1853](https://github.com/hyperledger/aries-cloudagent-python/pull/1853) ([TimoGlastra](https://github.com/TimoGlastra))
+  - Multi-ledger/Multi-tenant issues [\#2022](https://github.com/hyperledger/aries-cloudagent-python/pull/2022) ([ianco](https://github.com/ianco))
+  - fix: Correct typo in model -- required spelled incorrectly [\#2031](https://github.com/hyperledger/aries-cloudagent-python/pull/2031) ([swcurran](https://github.com/swcurran))
+  - Code formatting [\#2053](https://github.com/hyperledger/aries-cloudagent-python/pull/2053) ([ianco](https://github.com/ianco))
+  - Improved validation of record state attributes [\#2071](https://github.com/hyperledger/aries-cloudagent-python/pull/2071) ([rmnre](https://github.com/rmnre))
+  - Previously flagged in release 1.0.0-rc1
+    - fix: update RouteManager methods use to pass profile as parameter [\#1902](https://github.com/hyperledger/aries-cloudagent-python/pull/1902) ([chumbert](https://github.com/chumbert))
+    - Allow fully qualified class names for profile managers [\#1880](https://github.com/hyperledger/aries-cloudagent-python/pull/1880) ([chumbert](https://github.com/chumbert))
+    - fix: unable to use askar with in memory db [\#1878](https://github.com/hyperledger/aries-cloudagent-python/pull/1878) ([dbluhm](https://github.com/dbluhm))
+    - Enable manually triggering keylist updates during connection [\#1851](https://github.com/hyperledger/aries-cloudagent-python/pull/1851) ([dbluhm](https://github.com/dbluhm))
+    - feat: make base wallet route access configurable [\#1836](https://github.com/hyperledger/aries-cloudagent-python/pull/1836) ([dbluhm](https://github.com/dbluhm))
+    - feat: event and webhook on keylist update stored [\#1769](https://github.com/hyperledger/aries-cloudagent-python/pull/1769) ([dbluhm](https://github.com/dbluhm))
+    - fix: Safely shutdown when root\_profile uninitialized [\#1960](https://github.com/hyperledger/aries-cloudagent-python/pull/1960) ([frostyfrog](https://github.com/frostyfrog))
+    - feat: include connection ids in keylist update webhook [\#1914](https://github.com/hyperledger/aries-cloudagent-python/pull/1914) ([dbluhm](https://github.com/dbluhm))
+    - fix: incorrect response schema for discover features [\#1912](https://github.com/hyperledger/aries-cloudagent-python/pull/1912) ([dbluhm](https://github.com/dbluhm))
+    - Fix: SchemasInputDescriptorFilter: broken deserialization renders generated clients unusable [\#1894](https://github.com/hyperledger/aries-cloudagent-python/pull/1894) ([rmnre](https://github.com/rmnre))
+    - fix: schema class can set Meta.unknown [\#1885](https://github.com/hyperledger/aries-cloudagent-python/pull/1885) ([dbluhm](https://github.com/dbluhm))
 
-- Unit, Integration and Aries Agent Test Harness Test updates 
-  - Fixes a few AATH failures [\#1897](https://github.com/hyperledger/aries-cloudagent-python/pull/1897) ([ianco](https://github.com/ianco))
-  - fix: warnings in tests from IndySdkProfile [\#1865](https://github.com/hyperledger/aries-cloudagent-python/pull/1865) ([dbluhm](https://github.com/dbluhm))
-  - Unit test fixes for python 3.9 [\#1858](https://github.com/hyperledger/aries-cloudagent-python/pull/1858) ([andrewwhitehead](https://github.com/andrewwhitehead))
-  - Update pip-audit.yml [\#1945](https://github.com/hyperledger/aries-cloudagent-python/pull/1945) ([ryjones](https://github.com/ryjones))
-  - Update pip-audit.yml [\#1944](https://github.com/hyperledger/aries-cloudagent-python/pull/1944) ([ryjones](https://github.com/ryjones))
+- Unit, Integration, and Aries Agent Test Harness Test updates 
+  - Additional integration tests for revocation scenarios [\#2055](https://github.com/hyperledger/aries-cloudagent-python/pull/2055) ([ianco](https://github.com/ianco))
+  - Previously flagged in release 1.0.0-rc1
+    - Fixes a few AATH failures [\#1897](https://github.com/hyperledger/aries-cloudagent-python/pull/1897) ([ianco](https://github.com/ianco))
+    - fix: warnings in tests from IndySdkProfile [\#1865](https://github.com/hyperledger/aries-cloudagent-python/pull/1865) ([dbluhm](https://github.com/dbluhm))
+    - Unit test fixes for python 3.9 [\#1858](https://github.com/hyperledger/aries-cloudagent-python/pull/1858) ([andrewwhitehead](https://github.com/andrewwhitehead))
+    - Update pip-audit.yml [\#1945](https://github.com/hyperledger/aries-cloudagent-python/pull/1945) ([ryjones](https://github.com/ryjones))
+    - Update pip-audit.yml [\#1944](https://github.com/hyperledger/aries-cloudagent-python/pull/1944) ([ryjones](https://github.com/ryjones))
 
-- Dependency Updates
-  - feat: update pynacl version from 1.4.0 to 1.50 [\#1981](https://github.com/hyperledger/aries-cloudagent-python/pull/1981) ([morrieinmaas](https://github.com/morrieinmaas))
-  - Fix: web.py dependency - integration tests & demos [\#1973](https://github.com/hyperledger/aries-cloudagent-python/pull/1973) ([shaangill025](https://github.com/shaangill025))
-  - chore: update pydid [\#1915](https://github.com/hyperledger/aries-cloudagent-python/pull/1915) ([dbluhm](https://github.com/dbluhm))
+- Dependency, Python version, GitHub Actions and Container Image Changes
+  - fix: indy dependency version format [\#2054](https://github.com/hyperledger/aries-cloudagent-python/pull/2054) ([chumbert](https://github.com/chumbert))
+  - ci: add gha for pr-tests [\#2058](https://github.com/hyperledger/aries-cloudagent-python/pull/2058) ([dbluhm](https://github.com/dbluhm))
+  - ci: test additional versions of python nightly [\#2059](https://github.com/hyperledger/aries-cloudagent-python/pull/2059) ([dbluhm](https://github.com/dbluhm))
+  - Update github actions dependencies \(for node16 support\) [\#2066](https://github.com/hyperledger/aries-cloudagent-python/pull/2066) ([andrewwhitehead](https://github.com/andrewwhitehead))
+  - Docker images and GHA for publishing images [\#2076](https://github.com/hyperledger/aries-cloudagent-python/pull/2076) ([dbluhm](https://github.com/dbluhm))
+  - Update dockerfiles to use python 3.9 [\#2109](https://github.com/hyperledger/aries-cloudagent-python/pull/2109) ([ianco](https://github.com/ianco))
+  - Updating base images from slim-buster to slim-bullseye [\#2105](https://github.com/hyperledger/aries-cloudagent-python/pull/2105) ([pradeepp88](https://github.com/pradeepp88))
+  - Previously flagged in release 1.0.0-rc1
+    - feat: update pynacl version from 1.4.0 to 1.50 [\#1981](https://github.com/hyperledger/aries-cloudagent-python/pull/1981) ([morrieinmaas](https://github.com/morrieinmaas))
+    - Fix: web.py dependency - integration tests & demos [\#1973](https://github.com/hyperledger/aries-cloudagent-python/pull/1973) ([shaangill025](https://github.com/shaangill025))
+    - chore: update pydid [\#1915](https://github.com/hyperledger/aries-cloudagent-python/pull/1915) ([dbluhm](https://github.com/dbluhm))
 
 - Demo and Documentation Updates
-  - Fixes to acme exercise code [\#1990](https://github.com/hyperledger/aries-cloudagent-python/pull/1990) ([ianco](https://github.com/ianco))
-  - Fixed bug in run\_demo script [\#1982](https://github.com/hyperledger/aries-cloudagent-python/pull/1982) ([pasquale95](https://github.com/pasquale95))
-  - Transaction Author with Endorser demo [\#1975](https://github.com/hyperledger/aries-cloudagent-python/pull/1975) ([ianco](https://github.com/ianco))
-  - Redis Plugins \[redis\_cache & redis\_queue\] related updates [\#1937](https://github.com/hyperledger/aries-cloudagent-python/pull/1937) ([shaangill025](https://github.com/shaangill025))
+  - Fix typos in alice-local.sh & faber-local.sh [\#2010](https://github.com/hyperledger/aries-cloudagent-python/pull/2010) ([naonishijima](https://github.com/naonishijima))
+  - Added a bit about manually creating a revoc reg tails file [\#2012](https://github.com/hyperledger/aries-cloudagent-python/pull/2012) ([ianco](https://github.com/ianco))
+  - Add ability to set docker container name [\#2024](https://github.com/hyperledger/aries-cloudagent-python/pull/2024) ([matrixik](https://github.com/matrixik))
+  - Doc updates for json demo [\#2026](https://github.com/hyperledger/aries-cloudagent-python/pull/2026) ([ianco](https://github.com/ianco))
+  - Multitenancy demo \(docker-compose with postgres and ngrok\) [\#2089](https://github.com/hyperledger/aries-cloudagent-python/pull/2089) ([ianco](https://github.com/ianco))
+  - Allow using YAML configuration file with run\_docker [\#2091](https://github.com/hyperledger/aries-cloudagent-python/pull/2091) ([matrixik](https://github.com/matrixik))
+  - Previously flagged in release 1.0.0-rc1
+    - Fixes to acme exercise code [\#1990](https://github.com/hyperledger/aries-cloudagent-python/pull/1990) ([ianco](https://github.com/ianco))
+    - Fixed bug in run\_demo script [\#1982](https://github.com/hyperledger/aries-cloudagent-python/pull/1982) ([pasquale95](https://github.com/pasquale95))
+    - Transaction Author with Endorser demo [\#1975](https://github.com/hyperledger/aries-cloudagent-python/pull/1975) ([ianco](https://github.com/ianco))
+    - Redis Plugins \[redis\_cache & redis\_queue\] related updates [\#1937](https://github.com/hyperledger/aries-cloudagent-python/pull/1937) ([shaangill025](https://github.com/shaangill025))
 
 - Release management pull requests
-  - Release 1.0.0-rc0 [\#1904](https://github.com/hyperledger/aries-cloudagent-python/pull/1904) ([swcurran](https://github.com/swcurran))
-  - Add 0.7.5 patch Changelog entry to main branch Changelog [\#1996](https://github.com/hyperledger/aries-cloudagent-python/pull/1996) ([swcurran](https://github.com/swcurran))
-  - Release 1.0.0-rc1 [\#2005](https://github.com/hyperledger/aries-cloudagent-python/pull/2005) ([swcurran](https://github.com/swcurran))
-
+  - Previously flagged in release 1.0.0-rc1
+    - Release 1.0.0-rc0 [\#1904](https://github.com/hyperledger/aries-cloudagent-python/pull/1904) ([swcurran](https://github.com/swcurran))
+    - Add 0.7.5 patch Changelog entry to main branch Changelog [\#1996](https://github.com/hyperledger/aries-cloudagent-python/pull/1996) ([swcurran](https://github.com/swcurran))
+    - Release 1.0.0-rc1 [\#2005](https://github.com/hyperledger/aries-cloudagent-python/pull/2005) ([swcurran](https://github.com/swcurran))
 
 # 0.7.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ is unlikely to impact any deployments.
     - Add seed command line parameter but use only if also an "allow insecure seed" parameter is set [\#1714](https://github.com/hyperledger/aries-cloudagent-python/pull/1714) ([DaevMithran](https://github.com/DaevMithran))
 
 - Internal Aries framework data handling updates
+  - fix: resolver api schema inconsistency [\#2112](https://github.com/hyperledger/aries-cloudagent-python/pull/2112) ([TimoGlastra](https://github.com/chumbert))
   - fix: return if return route but no response [\#1853](https://github.com/hyperledger/aries-cloudagent-python/pull/1853) ([TimoGlastra](https://github.com/TimoGlastra))
   - Multi-ledger/Multi-tenant issues [\#2022](https://github.com/hyperledger/aries-cloudagent-python/pull/2022) ([ianco](https://github.com/ianco))
   - fix: Correct typo in model -- required spelled incorrectly [\#2031](https://github.com/hyperledger/aries-cloudagent-python/pull/2031) ([swcurran](https://github.com/swcurran))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ included in the `1.0.0-rc1` release. The categorized list of PRs separates those
 that are new from those in the `1.0.0-rc1` release candidate.
 
 With this release, a new automated process publishes container images in the
-Hyperledger container image repository. New images for the release are automatically published by the GitHubAction
-Workflows: [publish.yml] and [publish-indy.yml]. The actions are triggered when
-a release is tagged, so no manual action is needed. The images are published in
-the [Hyperledger Package Repository under
-aries-cloudagent-python](https://github.com/orgs/hyperledger/packages?repo_name=aries-cloudagent-python)
-and a link to the packages added to the repositories main page (under
-"Packages"). Additional information about the container image publication process can be
-found in the document [Container Images and Github Actions].
+Hyperledger container image repository. New images for the release are
+automatically published by the GitHubAction Workflows: [publish.yml] and
+[publish-indy.yml]. The actions are triggered when a release is tagged, so no
+manual action is needed. The images are published in the [Hyperledger Package
+Repository under aries-cloudagent-python] and a link to the packages added to
+the repositories main page (under "Packages"). Additional information about the
+container image publication process can be found in the document [Container
+Images and Github Actions].
 
 There are not a lot of new Aries Framework features in this release, as the
 focus has been on cleanup and optimization. The biggest addition is the
@@ -32,18 +32,24 @@ Endorser service.
 The images are based on [Python 3.6 and 3.9 `slim-bullseye`
 images](https://hub.docker.com/_/python), and are built to support `linux/386
 (x86)`, `linux/amd64 (x64)`, and `linux/arm64`. There are two flavors of image
-built for each Python version. One containing the Indy/Aries Shared Libraries
+built for each Python version. One contains only the Indy/Aries Shared Libraries
 only ([Aries Askar](https://github.com/hyperledger/aries-askar), [Indy
 VDR](https://github.com/hyperledger/indy-vdr) and [Indy Shared
 RS](https://github.com/hyperledger/indy-shared-rs), supporting only the use of
-`--wallet-type askar`), and one containing the Indy/Aries shared libraries and
-the Indy SDK (considered deprecated). The images containing the Indy SDK are
-labeled `indy`. For new deployments, we recommend using the Python 3.9 Shared
-Library images. For existing deployments, we recommend migrating to those
-images. For those migrating an Indy SDK deployment, a new secure storage
-migration capability from Indy SDK to Aries Askar is available--contact the
-ACA-Py maintainers on Hyperledger Discord for details.
+`--wallet-type askar`). The other (labelled `indy`) contains the Indy/Aries
+shared libraries and the Indy SDK (considered deprecated). For new deployments,
+we recommend using the Python 3.9 Shared Library images. For existing
+deployments, we recommend migrating to those images. For those migrating an Indy
+SDK deployment, a new secure storage database migration capability from Indy SDK
+to Aries Askar is available--contact the ACA-Py maintainers on Hyperledger
+Discord for details.
 
+Those currently using the container images published by [BC Gov on Docker
+Hub](https://hub.docker.com/r/bcgovimages/aries-cloudagent) should change to use
+those published to the [Hyperledger Package Repository under
+aries-cloudagent-python].
+
+[Hyperledger Package Repository under aries-cloudagent-python]: https://github.com/orgs/hyperledger/packages?repo_name=aries-cloudagent-python
 
 ## Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## February 8, 2023
 
 0.8.0 is a breaking change that contains all updates since release 0.7.5. It
-extends the previously tagged `1.0.0-rc1` release because it is not clear
-when that release will be finalized.
+extends the previously tagged `1.0.0-rc1` release because it is not clear when
+that release will be finalized. Many of the PRs in this release were previously
+included in the `1.0.0-rc1` release. The categorized list of PRs separates those
+that are new from those in the `1.0.0-rc1` release candidate.
 
 With this release, a new automated process publishes container
 images in the Hyperledger container image repository for this version of ACA-Py
@@ -155,6 +157,7 @@ is unlikely to impact any deployments.
     - Redis Plugins \[redis\_cache & redis\_queue\] related updates [\#1937](https://github.com/hyperledger/aries-cloudagent-python/pull/1937) ([shaangill025](https://github.com/shaangill025))
 
 - Release management pull requests
+  - 0.8.0-rc0 release updates [\#2115](https://github.com/hyperledger/aries-cloudagent-python/pull/2115) ([swcurran](https://github.com/swcurran))
   - Previously flagged in release 1.0.0-rc1
     - Release 1.0.0-rc0 [\#1904](https://github.com/hyperledger/aries-cloudagent-python/pull/1904) ([swcurran](https://github.com/swcurran))
     - Add 0.7.5 patch Changelog entry to main branch Changelog [\#1996](https://github.com/hyperledger/aries-cloudagent-python/pull/1996) ([swcurran](https://github.com/swcurran))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,26 +8,50 @@ that release will be finalized. Many of the PRs in this release were previously
 included in the `1.0.0-rc1` release. The categorized list of PRs separates those
 that are new from those in the `1.0.0-rc1` release candidate.
 
-With this release, a new automated process publishes container
-images in the Hyperledger container image repository for this version of ACA-Py
-based on both Python 3.6 and 3.9. We recommend using Python 3.9 with ACA-Py.
+With this release, a new automated process publishes container images in the
+Hyperledger container image repository. New images for the release are automatically published by the GitHubAction
+Workflows: [publish.yml] and [publish-indy.yml]. The actions are triggered when
+a release is tagged, so no manual action is needed. The images are published in
+the [Hyperledger Package Repository under
+aries-cloudagent-python](https://github.com/orgs/hyperledger/packages?repo_name=aries-cloudagent-python)
+and a link to the packages added to the repositories main page (under
+"Packages"). Additional information about the container image publication process can be
+found in the document [Container Images and Github Actions].
 
-There are not a lot of new features in this release, as the focus has been on
-cleanup and optimization. The biggest addition is the inclusion with ACA-Py of a
-universal resolver interface, allowing an instance to have both local resolvers
-for some DID Methods and a call out to an external universal resolver for other
-DID Methods. Another significant new capability is full support for Hyperledger
-Indy transaction endorsement for Authors and Endorsers. A new repo
+There are not a lot of new Aries Framework features in this release, as the
+focus has been on cleanup and optimization. The biggest addition is the
+inclusion with ACA-Py of a universal resolver interface, allowing an instance to
+have both local resolvers for some DID Methods and a call out to an external
+universal resolver for other DID Methods. Another significant new capability is
+full support for Hyperledger Indy transaction endorsement for Authors and
+Endorsers. A new repo
 [aries-endorser-service](https://github.com/hyperledger/aries-endorser-service)
 has been created that is a pre-configured instance of ACA-Py for use as an
 Endorser service.
+
+The images are based on [Python 3.6 and 3.9 `slim-bullseye`
+images](https://hub.docker.com/_/python), and are built to support `linux/386
+(x86)`, `linux/amd64 (x64)`, and `linux/arm64`. There are two flavors of image
+built for each Python version. One containing the Indy/Aries Shared Libraries
+only ([Aries Askar](https://github.com/hyperledger/aries-askar), [Indy
+VDR](https://github.com/hyperledger/indy-vdr) and [Indy Shared
+RS](https://github.com/hyperledger/indy-shared-rs), supporting only the use of
+`--wallet-type askar`), and one containing the Indy/Aries shared libraries and
+the Indy SDK (considered deprecated). The images containing the Indy SDK are
+labeled `indy`. For new deployments, we recommend using the Python 3.9 Shared
+Library images. For existing deployments, we recommend migrating to those
+images. For those migrating an Indy SDK deployment, a new secure storage
+migration capability from Indy SDK to Aries Askar is available--contact the
+ACA-Py maintainers on Hyperledger Discord for details.
+
 
 ## Breaking Changes
 
 ### PR [\#2034](https://github.com/hyperledger/aries-cloudagent-python/pull/2034) -- Implicit connections
 
-The break impacts existing  deployments that supported connections coming via a
-public DID. Such deployments need to add the configuration parameter
+The break impacts existing deployments that support implicit connections, those
+initiated by another agent using a Public DID for this instance instead of an
+explicit invitation. Such deployments need to add the configuration parameter
 `--requests-through-public-did` to continue to support that feature. The use
 case is that an ACA-Py instance publishes a public DID on a ledger with a
 DIDComm `service` in the DIDDoc. Other agents resolve that DID, and attempt to

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -12,23 +12,108 @@ Once ready to do a release, create a local branch that includes the following up
 
 3. Include details of the merged PRs included in this release. General process to follow:
 
-- Gather the set of PRs since the last release and put them into a list. A good tool to use for this is the [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator). Steps:
-  - Create a read only GitHub token for your account on this page: [https://github.com/settings/tokens](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token) with a scope of `repo` / `public_repo`.
-  - Use a command like the following, adjusting the tag parameters as appropriate. `docker run -it --rm -v "$(pwd)":/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator --user hyperledger --project aries-cloudagent-python --output 0.7.4-rc0.md --since-tag 0.7.3 --future-release 0.7.4-rc0 --release-branch main --token <your-token>`
-  - In the generated file, use only the PR list -- we don't include the list of closed issues in the Change Log.
+- Gather the set of PRs since the last release and put them into a list. A good
+  tool to use for this is the
+  [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator).
+  Steps:
+  - Create a read only GitHub token for your account on this page:
+    [https://github.com/settings/tokens](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token)
+    with a scope of `repo` / `public_repo`.
+  - Use a command like the following, adjusting the tag parameters as
+    appropriate. `docker run -it --rm -v "$(pwd)":/usr/local/src/your-app
+    githubchangeloggenerator/github-changelog-generator --user hyperledger
+    --project aries-cloudagent-python --output 0.7.4-rc0.md --since-tag 0.7.3
+    --future-release 0.7.4-rc0 --release-branch main --token <your-token>`
+  - In the generated file, use only the PR list -- we don't include the list of
+    closed issues in the Change Log.
+
+In some cases, the approach above fails because of too many API calls. An
+alternate approach to getting the list of PRs in the right format is to use this
+scary `sed` pipeline process to get the same output.¥
+
+- Put the following commands into a file called `changelog.sed`
+
+``` bash
+/Approved/d
+/updated /d
+/^$/d
+/^ [0-9]/d
+s/was merged.*//
+/^@/d
+s# by \(.*\) # [\1](https://github.com/\1)#
+s/^ //
+s#  \#\([0-9]*\)# [\#\1](https://github.com/hyperledger/aries-cloudagent-python/pull/\1) #
+s/  / /g
+/^Version/d
+/tasks done/d
+s/^/- /
+```
+
+- Navigate in your browser to the paged list of PRs merged since the last
+  release (using in the GitHub UI a filter such as `is:pr is:merged sort:updated
+  merged:>2022-04-07`) and for each page, highlight, and copy the text
+  of only the list of PRs on the page to use in the following step.
+- For each page, run the command `sed -e :a -e '$!N;s/\n#/ #/;ta' -e 'P;D' <<EOF
+  | sed -f changelog.sed`, paste in the copied text and then type `EOF`.
+  Redirect the output to a file, appending each page of output to the file.
+  - The first `sed` command in the pipeline merges the PR title and PR number
+    plus author lines onto a single line. The commands in the `changelog.sed`
+    file just clean up the data, removing unwanted lines, etc.
+- At the end of that process, you should have a list of all of the PRs in a form you can
+  use in the CHANGELOG.md file.
+- To verify you have right contents, you can do a `wc` of the file and there
+  should be one line per PR. You should scan the file as well, looking for
+  anomalies. It's a pretty ugly process.
+  - Using a `curl` command and the GitHub API is probably a much better and more
+  robust way to do this, but this was quick and dirty...
+
+Once you have the list of PRs:
+
 - Organize the list into suitable categories, update (if necessary) the PR description and add notes to clarify the changes. See previous release entries to understand the style -- a format should help developers.
 - Add a narrative about the release above the PR that highlights what has gone into the release.
 
-4. Update the ReadTheDocs in the `/docs` folder by following the instructions in the `docs/README.md` file. That will likely add a number of new and modified files to the PR. Eliminate all of the errors in the generation process, either by mocking external dependencies or by fixing ACA-Py code. If necessary, create an issue with the errors and assign it to the appropriate developer. Experience has demonstrated to use that documentation generation errors should be fixed in the code.
+4. Update the ReadTheDocs in the `/docs` folder by following the instructions in
+   the `docs/README.md` file. That will likely add a number of new and modified
+   files to the PR. Eliminate all of the errors in the generation process,
+   either by mocking external dependencies or by fixing ACA-Py code. If
+   necessary, create an issue with the errors and assign it to the appropriate
+   developer. Experience has demonstrated to use that documentation generation
+   errors should be fixed in the code.
 
-5. Update the version number listed in [aries_cloudagent/version.py](aries_cloudagent/version.py) and, prefixed with a "v" in [open-api/openapi.json](open-api/openapi.json) (e.g. "0.7.2" in the version.py file and "v0.7.2" in the openapi.json file). The incremented version number should adhere to the [Semantic Versioning Specification](https://semver.org/#semantic-versioning-specification-semver) based on the changes since the last published release. For Release Candidates, the form of the tag is "0.7.2-rc0".
+5. Update the version number listed in
+   [aries_cloudagent/version.py](aries_cloudagent/version.py) and, prefixed with
+   a "v" in [open-api/openapi.json](open-api/openapi.json) (e.g. "0.7.2" in the
+   version.py file and "v0.7.2" in the openapi.json file). The incremented
+   version number should adhere to the [Semantic Versioning
+   Specification](https://semver.org/#semantic-versioning-specification-semver)
+   based on the changes since the last published release. For Release
+   Candidates, the form of the tag is "0.7.2-rc0".
   
-6. An extra search of the repo for the existing tag is recommended to see if there are any other instances of the tag in the repo. If any are found to be required (other than in CHANGELOG.md and the examples in this file, of course), finding a way to not need them is best, but if they are needed, please update this document to note where the tag can be found.
+6. An extra search of the repo for the existing tag is recommended to see if
+   there are any other instances of the tag in the repo. If any are found to be
+   required (other than in CHANGELOG.md and the examples in this file, of
+   course), finding a way to not need them is best, but if they are needed,
+   please update this document to note where the tag can be found.
 
-7. Double check all of these steps above, and then submit a PR from the branch. If there are still further changes to be merged, mark the PR as "Draft", repeat **ALL** of the steps again, and then mark this PR as ready and then wait until it is merged.
+7. Double check all of these steps above, and then submit a PR from the branch.
+   If there are still further changes to be merged, mark the PR as "Draft",
+   repeat **ALL** of the steps again, and then mark this PR as ready and then
+   wait until it is merged.
 
-8. Immediately after it is merged, create a new GitHub tag representing the version. The tag name and title of the release should be the same as the version in [aries_cloudagent/version.py](aries_cloudagent/version.py). Use the "Generate Release Notes" capability to get a sequential listing of the PRs in the release, to complement the manually curated Changelog. Verify on PyPi that the version is published.
+8. Immediately after it is merged, create a new GitHub tag representing the
+   version. The tag name and title of the release should be the same as the
+   version in [aries_cloudagent/version.py](aries_cloudagent/version.py). Use
+   the "Generate Release Notes" capability to get a sequential listing of the
+   PRs in the release, to complement the manually curated Changelog. Verify on
+   PyPi that the version is published.
 
-9. Publish a new docker container on Docker Hub ([bcgovimages/aries-cloudagent](https://hub.docker.com/r/bcgovimages/aries-cloudagent/)) by following the README.md instructions to create a PR for the release in the repository [https://github.com/bcgov/aries-cloudagent-container](https://github.com/bcgov/aries-cloudagent-container). Appropriate permissions are required to publish the image.
+9. Publish a new docker container on Docker Hub
+   ([bcgovimages/aries-cloudagent](https://hub.docker.com/r/bcgovimages/aries-cloudagent/))
+   by following the README.md instructions to create a PR for the release in the
+   repository
+   [https://github.com/bcgov/aries-cloudagent-container](https://github.com/bcgov/aries-cloudagent-container).
+   Appropriate permissions are required to publish the image.
 
-10. Update the ACA-Py Read The Docs site by building the new "latest" (main branch) and activating and building the new release. Appropriate permissions are required to publish the new documentation version.
+10. Update the ACA-Py Read The Docs site by building the new "latest" (main
+    branch) and activating and building the new release. Appropriate permissions
+    are required to publish the new documentation version.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -107,12 +107,20 @@ Once you have the list of PRs:
    PRs in the release, to complement the manually curated Changelog. Verify on
    PyPi that the version is published.
 
-9. Publish a new docker container on Docker Hub
-   ([bcgovimages/aries-cloudagent](https://hub.docker.com/r/bcgovimages/aries-cloudagent/))
-   by following the README.md instructions to create a PR for the release in the
-   repository
-   [https://github.com/bcgov/aries-cloudagent-container](https://github.com/bcgov/aries-cloudagent-container).
-   Appropriate permissions are required to publish the image.
+9. New images for the release are automatically published by the GitHubAction
+   Workflows: [publish.yml] and [publish-indy.yml]. The actions are triggered
+   when a release is tagged, so no manual action is needed. The images are
+   published in the [Hyperledger Package Repository under
+   aries-cloudagent-python](https://github.com/orgs/hyperledger/packages?repo_name=aries-cloudagent-python)
+   and a link to the packages added to the repositories main page (under
+   "Packages").
+
+   Additional information about the container image publication process can be
+   found in the document [Container Images and Github Actions]().
+
+[publish.yml]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/.github/workflows/publish.yml
+[publish-indy.yml]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/.github/workflows/publish-indy.yml
+[Container Images and Github Actions]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/ContainerImagesAndGithubActions.md
 
 10. Update the ACA-Py Read The Docs site by building the new "latest" (main
     branch) and activating and building the new release. Appropriate permissions

--- a/aries_cloudagent/version.py
+++ b/aries_cloudagent/version.py
@@ -1,4 +1,4 @@
 """Library version information."""
 
-__version__ = "1.0.0-rc1"
+__version__ = "0.8.0-rc0"
 RECORD_TYPE_ACAPY_VERSION = "acapy_version"

--- a/docs/generated/aries_cloudagent.wallet.rst
+++ b/docs/generated/aries_cloudagent.wallet.rst
@@ -65,6 +65,14 @@ aries\_cloudagent.wallet.did\_method module
    :undoc-members:
    :show-inheritance:
 
+aries\_cloudagent.wallet.did\_parameters\_validation module
+-----------------------------------------------------------
+
+.. automodule:: aries_cloudagent.wallet.did_parameters_validation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 aries\_cloudagent.wallet.did\_posture module
 --------------------------------------------
 

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -1,7 +1,7 @@
 {
   "swagger" : "2.0",
   "info" : {
-    "version" : "v1.0.0-rc1",
+    "version" : "v0.8.0-rc0",
     "title" : "Aries Cloud Agent"
   },
   "tags" : [ {


### PR DESCRIPTION
Updates necessary to create a 0.8.0-rc0 release. For this release, the CHANGELOG.md has been update to move the categorized list of Pull Requests from the "0.1.0-rc1" to under this release, and then the PRs since 1.0.0-rc1 were added.

My proposal is that after we release 0.8.0 (final), we follow up with a 0.1.0-rc2 release that is the same as 0.8.0 so that those tracking to the 1.0.0 release can use that. As needed, we can do the same for 0.8.1 / 0.9.0 if needed, but ideally we will get 1.0.0 out the door before those are needed.

@WadeBarnes @ianco @dbluhm -- does that make sense?

Also, please review the note I put into the changelog about the container images (do we have link to put into that paragraph), and if what I state is accurate.
