### PR TITLE
Update demo to issue multiple credentials

### DIFF
--- a/demo/bdd_support/agent_backchannel_client.py
+++ b/demo/bdd_support/agent_backchannel_client.py
@@ -115,13 +115,37 @@ def aries_container_issue_credential(
     )
 
 
+def aries_container_issue_credentials(
+    the_container: AgentContainer,
+    cred_def_id: str,
+    cred_attrs: dict,
+):
+    return run_coroutine(
+        the_container.issue_multiple_credentials,
+        cred_def_id,
+        cred_attrs,
+    )
+
+
 def aries_container_receive_credential(
+    the_container: AgentContainer,
+    cred_def_id: str,
+    creds_attrs: dict,
+):
+    return run_coroutine(
+        the_container.receive_credential,
+        cred_def_id,
+        creds_attrs,
+    )
+
+
+def aries_container_receive_credentials(
     the_container: AgentContainer,
     cred_def_id: str,
     cred_attrs: list,
 ):
     return run_coroutine(
-        the_container.receive_credential,
+        the_container.receive_credentials,
         cred_def_id,
         cred_attrs,
     )
@@ -173,6 +197,19 @@ def read_credential_data(schema_name: str, cred_scenario_name: str):
         if attr["value"] == "@uuid":
             attr["value"] = str(uuid.uuid4())
     return cred_data["attributes"]
+
+
+def read_credentials_data(schema_name: str, creds_scenario_name: str):
+    schema_creds_data = read_json_data("cred_data_schema_" + schema_name + ".json")
+    creds_data = schema_creds_data[creds_scenario_name]
+    # attrs are in a dictionary indexed by "indy-{i}"
+    i = 0
+    while f"indy-{i}" in creds_data["attributes"]:
+        for attr in creds_data["attributes"][f"indy-{i}"]:
+            if attr["value"] == "@uuid":
+                attr["value"] = str(uuid.uuid4())
+        i += 1
+    return creds_data["attributes"]
 
 
 def read_proof_req_data(proof_req_name: str):

--- a/demo/features/0453-issue-credential.feature
+++ b/demo/features/0453-issue-credential.feature
@@ -71,3 +71,18 @@ Feature: RFC 0453 Aries agent issue credential
     Examples:
        | Acme_capabilities                        | Bob_capabilities  | Schema_name    | Credential_data          |
        | --revocation --public-did --mediation    | --mediation       | driverslicense | Data_DL_NormalizedValues |
+
+  @T005-RFC453
+  Scenario Outline: Issue multiple credentials (no revocation, beginning with an offer) and holder accepts all credentials
+    Given we have "2" agents
+      | name  | role    | capabilities        |
+      | Acme  | issuer  | <Acme_capabilities> |
+      | Bob   | holder  | <Bob_capabilities>  |
+    And "Acme" and "Bob" have an existing connection
+    And "Acme" is ready to issue a credential for <Schema_name>
+    When "Acme" offers multiple credentials with data <Multi_Credential_data>
+    And "Bob" has the credential issued
+
+    Examples:
+       | Acme_capabilities                      | Bob_capabilities  | Schema_name    | Multi_Credential_data          |
+       | --public-did                           |                   | driverslicense | Data_DL_Multi_NormalizedValues |

--- a/demo/features/data/cred_data_schema_driverslicense.json
+++ b/demo/features/data/cred_data_schema_driverslicense.json
@@ -79,5 +79,56 @@
             "value":"20"
          }
       ]
+   },
+   "Data_DL_Multi_NormalizedValues":{
+      "cred_name":"Data_DriversLicense_MinValues",
+      "schema_name":"Schema_DriversLicense",
+      "schema_version":"1.0.1",
+      "attributes": {
+         "indy-0": [
+            {
+               "name":"id",
+               "value":"@uuid"
+            },
+            {
+               "name":"address",
+               "value":"9"
+            },
+            {
+               "name":"DL_number",
+               "value":"0"
+            },
+            {
+               "name":"expiry",
+               "value":"10/12/2022"
+            },
+            {
+               "name":"age",
+               "value":"20"
+            }
+         ],
+         "indy-1": [
+            {
+               "name":"id",
+               "value":"@uuid"
+            },
+            {
+               "name":"address",
+               "value":"99"
+            },
+            {
+               "name":"DL_number",
+               "value":"90"
+            },
+            {
+               "name":"expiry",
+               "value":"9/19/2022"
+            },
+            {
+               "name":"age",
+               "value":"19"
+            }
+         ]
+      }
    }
 }

--- a/demo/runners/alice.py
+++ b/demo/runners/alice.py
@@ -103,6 +103,15 @@ async def input_invitation(agent_container):
         connection = await agent_container.input_invitation(details, wait=True)
 
 
+async def fetch_credentials(agent_container):
+    indy_creds = await agent_container.admin_GET("/credentials")
+    jsonld_creds = await agent_container.admin_POST("/credentials/w3c", data={})
+    return {
+        "indy": indy_creds["results"],
+        "json-ld": jsonld_creds["results"],
+    }
+
+
 async def main(args):
     alice_agent = await create_agent_with_args(args, ident="alice")
 
@@ -137,7 +146,11 @@ async def main(args):
         log_status("#9 Input faber.py invitation details")
         await input_invitation(alice_agent)
 
-        options = "    (3) Send Message\n" "    (4) Input New Invitation\n"
+        options = (
+            "    (3) Send Message\n"
+            "    (4) Input New Invitation\n"
+            "    (5) View Received Credentials\n"
+        )
         if alice_agent.endorser_role and alice_agent.endorser_role == "author":
             options += "    (D) Set Endorser's DID\n"
         if alice_agent.multitenant:
@@ -190,6 +203,11 @@ async def main(args):
                 # handle new invitation
                 log_status("Input new invitation details")
                 await input_invitation(alice_agent)
+
+            elif option == "5":
+                # display all credentials
+                creds = await fetch_credentials(alice_agent)
+                log_msg(json.dumps(creds))
 
         if alice_agent.show_timing:
             timing = await alice_agent.agent.fetch_timing()


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

@swcurran / @shaangill025  this adds an option to the demo ("1m") to issue multiple creds, in either indy or json-ld format.

It includes all creds in one offer, rather than the verbose request/response protocol.

Let me know if there are other additions to the demo you would like.

(There is also a new integration test - it doesn't work yet but @swcurran said last week to not worry about integration tests yet ...)
