### PR TITLE
Temporarily disable multi-architecture image builds

### DIFF
--- a/.github/workflows/publish-indy.yml
+++ b/.github/workflows/publish-indy.yml
@@ -20,6 +20,10 @@ on:
         required: true
         default: linux/amd64
         type: string
+      ref:
+        description: 'Optional - The branch, tag or SHA to checkout.'
+        required: false
+        type: string
 
 # Note:
 # - ACA-Py with Indy SDK image builds do not include support for the linux/arm64 platform.
@@ -48,6 +52,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Gather image info
         id: info

--- a/.github/workflows/publish-indy.yml
+++ b/.github/workflows/publish-indy.yml
@@ -15,6 +15,11 @@ on:
         description: 'Image tag'
         required: true
         type: string
+      platforms:
+        description: 'Platforms - Comma separated list of the platforms to support.'
+        required: true
+        default: linux/amd64
+        type: string
 
 # Note:
 # - ACA-Py with Indy SDK image builds do not include support for the linux/arm64 platform.
@@ -22,6 +27,14 @@ on:
 
 env:
   INDY_VERSION: ${{ inputs.indy_version || '1.16.0' }}
+
+  # Images do not include support for the linux/arm64 platform due to a known issue compiling the postgres plugin
+  # - https://github.com/hyperledger/indy-sdk/issues/2445
+  # There is a pending PR to fix this issue here; https://github.com/hyperledger/indy-sdk/pull/2453
+  #
+  # linux/386 platform support has been disabled pending a permanent fix for https://github.com/hyperledger/aries-cloudagent-python/issues/2124
+  # PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/386' }}
+  PLATFORMS: ${{ inputs.platforms || 'linux/amd64' }}
 
 jobs:
   publish-image:
@@ -83,10 +96,7 @@ jobs:
             acapy_version=${{ inputs.tag || github.event.release.tag_name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          # Images do not include support for the linux/arm64 platform due to a known issue compiling the postgres plugin
-          # - https://github.com/hyperledger/indy-sdk/issues/2445
-          # There is a pending PR to fix this issue here; https://github.com/hyperledger/indy-sdk/pull/2453
-          platforms: linux/amd64,linux/386
+          platforms: ${{ env.PLATFORMS }}
 
       # Temp fix
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,16 @@ on:
         description: 'Image tag'
         required: true
         type: string
+      platforms:
+        description: 'Platforms - Comma separated list of the platforms to support.'
+        required: true
+        default: linux/amd64
+        type: string
+
+env:
+  # linux/386 platform support has been disabled pending a permanent fix for https://github.com/hyperledger/aries-cloudagent-python/issues/2124
+  # PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64,linux/386' }}
+  PLATFORMS: ${{ inputs.platforms || 'linux/amd64' }}
 
 jobs:
   publish-image:
@@ -70,7 +80,7 @@ jobs:
             acapy_version=${{ inputs.tag || github.event.release.tag_name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          platforms: linux/amd64,linux/arm64,linux/386
+          platforms: ${{ env.PLATFORMS }}
 
       # Temp fix
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,10 @@ on:
         required: true
         default: linux/amd64
         type: string
+      ref:
+        description: 'Optional - The branch, tag or SHA to checkout.'
+        required: false
+        type: string
 
 env:
   # linux/386 platform support has been disabled pending a permanent fix for https://github.com/hyperledger/aries-cloudagent-python/issues/2124
@@ -33,6 +37,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Gather image info
         id: info


### PR DESCRIPTION
- Temporarily disable multi-architecture image builds until the required dependencies publish compatible packages.
- Details here; https://github.com/hyperledger/aries-cloudagent-python/issues/2124

- Add support for defining the image platforms when running the image publishing workflows manually.
- Add support for building off a git ref when running the image publishing workflows manually.