### PR TITLE
fix: response type on delete-tails-files endpoint

### DIFF
--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -1494,7 +1494,14 @@ async def on_revocation_registry_endorsed_event(profile: Profile, event: Event):
         )
 
 
+class TailsDeleteResponseSchema(OpenAPISchema):
+    """Return schema for tails failes deletion."""
+
+    message = fields.Str()
+
+
 @querystring_schema(RevRegId())
+@response_schema(TailsDeleteResponseSchema())
 @docs(tags=["revocation"], summary="Delete the tail files")
 async def delete_tails(request: web.BaseRequest) -> json:
     """Delete Tails Files."""


### PR DESCRIPTION
Add a return schema to `delete_tails` in order to get a valid openapi specification.