### PR TITLE
feat: add verification method to issue-credentials-2.0/send endpoint

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
@@ -268,7 +268,10 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
         )
 
         did_info = await self._did_info_for_did(issuer_id)
-        verification_method = self._get_verification_method(issuer_id)
+        verification_method = (
+            detail.options.verification_method
+            or self._get_verification_method(issuer_id)
+        )
 
         suite = await self._get_suite(
             proof_type=proof_type,

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/models/cred_detail_options.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/models/cred_detail_options.py
@@ -23,6 +23,7 @@ class LDProofVCDetailOptions(BaseModel):
         domain: Optional[str] = None,
         challenge: Optional[str] = None,
         credential_status: Optional[dict] = None,
+        verification_method: Optional[str] = None,
     ) -> None:
         """Initialize the LDProofVCDetailOptions instance."""
 
@@ -32,6 +33,7 @@ class LDProofVCDetailOptions(BaseModel):
         self.domain = domain
         self.challenge = challenge
         self.credential_status = credential_status
+        self.verification_method = verification_method
 
     def __eq__(self, o: object) -> bool:
         """Check equalness."""
@@ -43,6 +45,7 @@ class LDProofVCDetailOptions(BaseModel):
                 and self.domain == o.domain
                 and self.challenge == o.challenge
                 and self.credential_status == o.credential_status
+                and self.verification_method == o.verification_method
             )
 
         return False
@@ -128,4 +131,11 @@ class LDProofVCDetailOptionsSchema(BaseModelSchema):
             " Omitting the property indicates the issued credential"
             " will not include a credential status"
         ),
+    )
+
+    verification_method = fields.Str(
+        required=False,
+        default=None,
+        allow_none=True,
+        description="Verification method used to sign, as identified in the DIDDocument",
     )


### PR DESCRIPTION
Accomodate credential sending for did methods that are not did:sov or did:key by adding an optional `verification_method` parameter to the send endpoint options.