### PR TITLE
Update webhook message to terse form by default, added startup flag --debug-webhooks for full form

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -272,6 +272,15 @@ class DebugGroup(ArgumentGroup):
             ),
         )
         parser.add_argument(
+            "--debug-webhooks",
+            action="store_true",
+            env_var="ACAPY_DEBUG_WEBHOOKS",
+            help=(
+                "Emit protocol state object as webhook. "
+                "Default: false."
+            ),
+        )
+        parser.add_argument(
             "--invite",
             action="store_true",
             env_var="ACAPY_INVITE",
@@ -424,6 +433,8 @@ class DebugGroup(ArgumentGroup):
             settings["debug.credentials"] = True
         if args.debug_presentations:
             settings["debug.presentations"] = True
+        if args.debug_webhooks:
+            settings["debug.webhooks"] = True
         if args.debug_seed:
             settings["debug.seed"] = args.debug_seed
         if args.invite:

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -275,10 +275,7 @@ class DebugGroup(ArgumentGroup):
             "--debug-webhooks",
             action="store_true",
             env_var="ACAPY_DEBUG_WEBHOOKS",
-            help=(
-                "Emit protocol state object as webhook. "
-                "Default: false."
-            ),
+            help=("Emit protocol state object as webhook. " "Default: false."),
         )
         parser.add_argument(
             "--invite",

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -1321,12 +1321,6 @@ class TransportGroup(ArgumentGroup):
             help="Set the maximum size in bytes for inbound agent messages.",
         )
         parser.add_argument(
-            "--light-weight-webhook",
-            action="store_true",
-            env_var="ACAPY_LIGHT_WEIGHT_WEBHOOK",
-            help="omitted client's info from issue-credential related webhook",
-        )
-        parser.add_argument(
             "--enable-undelivered-queue",
             action="store_true",
             env_var="ACAPY_ENABLE_UNDELIVERED_QUEUE",
@@ -1389,8 +1383,6 @@ class TransportGroup(ArgumentGroup):
             settings["image_url"] = args.image_url
         if args.max_message_size:
             settings["transport.max_message_size"] = args.max_message_size
-        if args.light_weight_webhook:
-            settings["transport.light_weight_webhook"] = True
         if args.max_outbound_retry:
             settings["transport.max_outbound_retry"] = args.max_outbound_retry
         if args.ws_heartbeat_interval:

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_exchange_webhook.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_exchange_webhook.py
@@ -1,7 +1,7 @@
-"""v1.0 credential exchange light weight webhook."""
+"""v1.0 credential exchange webhook."""
 
 
-class LightWeightV10CredentialExchangeWebhook:
+class V10CredentialExchangeWebhook:
     """Class representing a state only credential exchange webhook."""
 
     __acceptable_keys_list = [

--- a/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_exchange_webhook.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/messages/credential_exchange_webhook.py
@@ -27,6 +27,8 @@ class LightWeightV10CredentialExchangeWebhook:
         "public_did",
         "cred_id_stored",
         "conn_id",
+        "created_at",
+        "updated_at",
     ]
 
     def __init__(

--- a/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
@@ -18,7 +18,7 @@ from .....storage.base import StorageError
 from ..messages.credential_proposal import CredentialProposal, CredentialProposalSchema
 from ..messages.credential_offer import CredentialOffer, CredentialOfferSchema
 from ..messages.credential_exchange_webhook import (
-    LightWeightV10CredentialExchangeWebhook,
+    V10CredentialExchangeWebhook,
 )
 
 from . import UNENCRYPTED_TAGS
@@ -246,7 +246,7 @@ class V10CredentialExchange(BaseExchangeRecord):
             if not payload:
                 payload = self.serialize()
         else:
-            payload = LightWeightV10CredentialExchangeWebhook(**self.__dict__)
+            payload = V10CredentialExchangeWebhook(**self.__dict__)
             payload = payload.__dict__
 
         await session.profile.notify(topic, payload)

--- a/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
@@ -242,10 +242,10 @@ class V10CredentialExchange(BaseExchangeRecord):
         else:
             topic = f"{self.EVENT_NAMESPACE}::{self.RECORD_TOPIC}"
 
-        if not payload:
-            payload = self.serialize()
-
-        if session.profile.settings.get("transport.light_weight_webhook"):
+        if session.profile.settings.get("debug.webhooks"):
+            if not payload:
+                payload = self.serialize()
+        else:
             payload = LightWeightV10CredentialExchangeWebhook(**self.__dict__)
             payload = payload.__dict__
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_ex_record_webhook.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_ex_record_webhook.py
@@ -1,7 +1,7 @@
-"""v2.0 credential exchange light weight webhook."""
+"""v2.0 credential exchange webhook."""
 
 
-class LightWeightV20CredExRecordWebhook:
+class V20CredExRecordWebhook:
     """Class representing a state only credential exchange webhook."""
 
     __acceptable_keys_list = [

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_ex_record_webhook.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_ex_record_webhook.py
@@ -27,6 +27,8 @@ class LightWeightV20CredExRecordWebhook:
         "public_did",
         "cred_id_stored",
         "conn_id",
+        "created_at",
+        "updated_at",
     ]
 
     def __init__(

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
@@ -17,7 +17,7 @@ from ..messages.cred_proposal import V20CredProposal, V20CredProposalSchema
 from ..messages.cred_offer import V20CredOffer, V20CredOfferSchema
 from ..messages.cred_request import V20CredRequest, V20CredRequestSchema
 from ..messages.inner.cred_preview import V20CredPreviewSchema
-from ..messages.cred_ex_record_webhook import LightWeightV20CredExRecordWebhook
+from ..messages.cred_ex_record_webhook import V20CredExRecordWebhook
 
 from . import UNENCRYPTED_TAGS
 
@@ -206,7 +206,7 @@ class V20CredExRecord(BaseExchangeRecord):
             if not payload:
                 payload = self.serialize()
         else:
-            payload = LightWeightV20CredExRecordWebhook(**self.__dict__)
+            payload = V20CredExRecordWebhook(**self.__dict__)
             payload = payload.__dict__
 
         await session.profile.notify(topic, payload)

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
@@ -202,10 +202,10 @@ class V20CredExRecord(BaseExchangeRecord):
         else:
             topic = f"{self.EVENT_NAMESPACE}::{self.RECORD_TOPIC}"
 
-        if not payload:
-            payload = self.serialize()
-
-        if session.profile.settings.get("transport.light_weight_webhook"):
+        if session.profile.settings.get("debug.webhooks"):
+            if not payload:
+                payload = self.serialize()
+        else:
             payload = LightWeightV20CredExRecordWebhook(**self.__dict__)
             payload = payload.__dict__
 

--- a/aries_cloudagent/protocols/present_proof/v1_0/messages/presentation_webhook.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/messages/presentation_webhook.py
@@ -1,0 +1,39 @@
+"""v1.0 presentation exchange information webhook."""
+
+
+class LightWeightV10PresentationExchangeWebhook:
+    """Class representing a state only presentation exchange webhook."""
+
+    __acceptable_keys_list = [
+        "connection_id",
+        "presentation_exchange_id",
+        "role",
+        "initiator",
+        "auto_present",
+        "auto_verify",
+        "error_msg",
+        "state",
+        "thread_id",
+        "trace",
+        "verified",
+        "verified_msgs",
+        "created_at",
+        "updated_at",
+    ]
+
+    def __init__(
+        self,
+        **kwargs,
+    ):
+        """
+        Initialize webhook object from V10PresentationExchange.
+
+        from a list of accepted attributes.
+        """
+        [
+            self.__setattr__(key, kwargs.get(key))
+            for key in self.__acceptable_keys_list
+            if kwargs.get(key) is not None
+        ]
+        if kwargs.get("_id") is not None:
+            self.presentation_exchange_id = kwargs.get("_id")

--- a/aries_cloudagent/protocols/present_proof/v1_0/messages/presentation_webhook.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/messages/presentation_webhook.py
@@ -1,7 +1,7 @@
 """v1.0 presentation exchange information webhook."""
 
 
-class LightWeightV10PresentationExchangeWebhook:
+class V10PresentationExchangeWebhook:
     """Class representing a state only presentation exchange webhook."""
 
     __acceptable_keys_list = [

--- a/aries_cloudagent/protocols/present_proof/v1_0/models/presentation_exchange.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/models/presentation_exchange.py
@@ -214,10 +214,10 @@ class V10PresentationExchange(BaseExchangeRecord):
         else:
             topic = f"{self.EVENT_NAMESPACE}::{self.RECORD_TOPIC}"
 
-        if not payload:
-            payload = self.serialize()
-
-        if session.profile.settings.get("transport.light_weight_webhook"):
+        if session.profile.settings.get("debug.webhooks"):
+            if not payload:
+                payload = self.serialize()
+        else:
             payload = LightWeightV10PresentationExchangeWebhook(**self.__dict__)
             payload = payload.__dict__
 

--- a/aries_cloudagent/protocols/present_proof/v1_0/models/presentation_exchange.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/models/presentation_exchange.py
@@ -21,7 +21,7 @@ from ..messages.presentation_request import (
     PresentationRequest,
     PresentationRequestSchema,
 )
-from ..messages.presentation_webhook import LightWeightV10PresentationExchangeWebhook
+from ..messages.presentation_webhook import V10PresentationExchangeWebhook
 
 from . import UNENCRYPTED_TAGS
 
@@ -218,7 +218,7 @@ class V10PresentationExchange(BaseExchangeRecord):
             if not payload:
                 payload = self.serialize()
         else:
-            payload = LightWeightV10PresentationExchangeWebhook(**self.__dict__)
+            payload = V10PresentationExchangeWebhook(**self.__dict__)
             payload = payload.__dict__
 
         await session.profile.notify(topic, payload)

--- a/aries_cloudagent/protocols/present_proof/v1_0/models/presentation_exchange.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/models/presentation_exchange.py
@@ -21,6 +21,7 @@ from ..messages.presentation_request import (
     PresentationRequest,
     PresentationRequestSchema,
 )
+from ..messages.presentation_webhook import LightWeightV10PresentationExchangeWebhook
 
 from . import UNENCRYPTED_TAGS
 
@@ -194,6 +195,33 @@ class V10PresentationExchange(BaseExchangeRecord):
             )
         except StorageError as err:
             LOGGER.exception(err)
+
+    # Override
+    async def emit_event(self, session: ProfileSession, payload: Any = None):
+        """
+        Emit an event.
+
+        Args:
+            session: The profile session to use
+            payload: The event payload
+        """
+
+        if not self.RECORD_TOPIC:
+            return
+
+        if self.state:
+            topic = f"{self.EVENT_NAMESPACE}::{self.RECORD_TOPIC}::{self.state}"
+        else:
+            topic = f"{self.EVENT_NAMESPACE}::{self.RECORD_TOPIC}"
+
+        if not payload:
+            payload = self.serialize()
+
+        if session.profile.settings.get("transport.light_weight_webhook"):
+            payload = LightWeightV10PresentationExchangeWebhook(**self.__dict__)
+            payload = payload.__dict__
+
+        await session.profile.notify(topic, payload)
 
     @property
     def record_value(self) -> Mapping:

--- a/aries_cloudagent/protocols/present_proof/v2_0/messages/pres_webhook.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/messages/pres_webhook.py
@@ -1,7 +1,7 @@
 """v2.0 Presentation exchange record webhook."""
 
 
-class LightWeightV20PresExRecordWebhook:
+class V20PresExRecordWebhook:
     """Class representing a state only Presentation exchange record webhook."""
 
     __acceptable_keys_list = [

--- a/aries_cloudagent/protocols/present_proof/v2_0/messages/pres_webhook.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/messages/pres_webhook.py
@@ -1,0 +1,39 @@
+"""v2.0 Presentation exchange record webhook."""
+
+
+class LightWeightV20PresExRecordWebhook:
+    """Class representing a state only Presentation exchange record webhook."""
+
+    __acceptable_keys_list = [
+        "connection_id",
+        "pres_ex_id",
+        "role",
+        "initiator",
+        "auto_present",
+        "auto_verify",
+        "error_msg",
+        "thread_id",
+        "state",
+        "trace",
+        "verified",
+        "verified_msgs",
+        "created_at",
+        "updated_at",
+    ]
+
+    def __init__(
+        self,
+        **kwargs,
+    ):
+        """
+        Initialize webhook object from V20PresExRecord.
+
+        from a list of accepted attributes.
+        """
+        [
+            self.__setattr__(key, kwargs.get(key))
+            for key in self.__acceptable_keys_list
+            if kwargs.get(key) is not None
+        ]
+        if kwargs.get("_id") is not None:
+            self.pres_ex_id = kwargs.get("_id")

--- a/aries_cloudagent/protocols/present_proof/v2_0/models/pres_exchange.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/models/pres_exchange.py
@@ -15,7 +15,7 @@ from ..messages.pres import V20Pres, V20PresSchema
 from ..messages.pres_format import V20PresFormat
 from ..messages.pres_proposal import V20PresProposal, V20PresProposalSchema
 from ..messages.pres_request import V20PresRequest, V20PresRequestSchema
-from ..messages.pres_webhook import LightWeightV20PresExRecordWebhook
+from ..messages.pres_webhook import V20PresExRecordWebhook
 
 from . import UNENCRYPTED_TAGS
 
@@ -204,7 +204,7 @@ class V20PresExRecord(BaseExchangeRecord):
             if not payload:
                 payload = self.serialize()
         else:
-            payload = LightWeightV20PresExRecordWebhook(**self.__dict__)
+            payload = V20PresExRecordWebhook(**self.__dict__)
             payload = payload.__dict__
 
         await session.profile.notify(topic, payload)

--- a/aries_cloudagent/protocols/present_proof/v2_0/models/pres_exchange.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/models/pres_exchange.py
@@ -200,10 +200,10 @@ class V20PresExRecord(BaseExchangeRecord):
         else:
             topic = f"{self.EVENT_NAMESPACE}::{self.RECORD_TOPIC}"
 
-        if not payload:
-            payload = self.serialize()
-
-        if session.profile.settings.get("transport.light_weight_webhook"):
+        if session.profile.settings.get("debug.webhooks"):
+            if not payload:
+                payload = self.serialize()
+        else:
             payload = LightWeightV20PresExRecordWebhook(**self.__dict__)
             payload = payload.__dict__
 

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -3,6 +3,7 @@ FROM bcgovimages/von-image:py36-1.15-1
 ENV ENABLE_PTVSD 0
 ENV ENABLE_PYDEVD_PYCHARM 0
 ENV PYDEVD_PYCHARM_HOST "host.docker.internal"
+ENV ACAPY_DEBUG_WEBHOOKS 1
 
 RUN mkdir bin && curl -L -o bin/jq \
 	https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \


### PR DESCRIPTION
Related PR #1941  
Addresses Issue #2136 

Presentation Exchange now has dedicated webhook object.

added --debug-webhooks flag to toggle full Protocol State Object for development purpose.

removed --light-weight-webhook as it is now obsolete and refactored.

Signed-off-by: Victor Lee [victorlee0505@gmail.com](mailto:victorlee0505@gmail.com)