### PR TITLE
fix: nightly runs only on main

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,12 +2,13 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '08 19 * * *'
   push:
     branches:
       - main
-
-if: github.event.repository.default_branch == github.ref
+      
+if: github.repository_owner == 'anwalker293'
+#if: github.event.repository.default_branch == github.ref
 
 jobs:
   tests:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,7 +2,7 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '08 19 * * *'
+    - cron: '09 19 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -3,7 +3,11 @@ name: Nightly Tests
 on:
   schedule:
     - cron: '0 0 * * *'
-  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+if: github.event.repository.default_branch == github.ref
 
 jobs:
   tests:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,7 +2,7 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '28 18 * * *'
+    - cron: '34 18 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,7 +2,7 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '00 18 * * *'
+    - cron: '13 18 * * *'
   push:
     branches:
       - main
@@ -13,8 +13,7 @@ env:
 
 jobs:
   tests:
-    if: env.RUN_NIGHTLY_TESTS == "true"
-    if: github.repository_owner == 'anwalker293'
+    if: env.RUN_NIGHTLY_TESTS == "true" && github.repository_owner == "anwalker293"
     name: Tests
     strategy:
       fail-fast: false
@@ -30,8 +29,7 @@ jobs:
       os: ${{ matrix.os }}
 
   tests-indy:
-    if: env.RUN_NIGHTLY_TESTS == "true"
-    if: github.repository_owner == 'anwalker293'
+    if: env.RUN_NIGHTLY_TESTS == "true" && github.repository_owner == "anwalker293"
     name: Tests (Indy)
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,7 +2,7 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '09 19 * * *'
+    - cron: '14 19 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -7,12 +7,9 @@ on:
     branches:
       - main
 
-env:
-  RUN_NIGHTLY_TESTS: true
-
 jobs:
   tests:
-    if: RUN_NIGHTLY_TESTS
+    if: github.event.repository.owner.id == github.event.sender.id && github.event.ref == 'refs/heads/main'
     name: Tests
     strategy:
       fail-fast: false
@@ -28,7 +25,7 @@ jobs:
       os: ${{ matrix.os }}
 
   tests-indy:
-    if: RUN_NIGHTLY_TESTS
+    if: github.event.repository.owner.id == github.event.sender.id && github.event.ref == 'refs/heads/main'
     name: Tests (Indy)
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,7 +2,7 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '39 18 * * *'
+    - cron: '0 0 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,7 +2,7 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '15 18 * * *'
+    - cron: '19 18 * * *'
   push:
     branches:
       - main
@@ -12,7 +12,7 @@ env:
 
 jobs:
   tests:
-    if: github.repository_owner == "anwalker293" && env.RUN_NIGHTLY_TESTS == "true"
+    if: env.RUN_NIGHTLY_TESTS == "true"
     name: Tests
     strategy:
       fail-fast: false
@@ -28,7 +28,7 @@ jobs:
       os: ${{ matrix.os }}
 
   tests-indy:
-    if: github.repository_owner == "anwalker293" && env.RUN_NIGHTLY_TESTS == "true"
+    if: env.RUN_NIGHTLY_TESTS == "true"
     name: Tests (Indy)
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -7,9 +7,10 @@ on:
     branches:
       - main
       
-if: github.repository_owner == 'anwalker293'
+
 #if: github.event.repository.default_branch == github.ref
 
+if: github.repository_owner == 'anwalker293'
 jobs:
   tests:
     name: Tests

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,14 +2,14 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '34 18 * * *'
+    - cron: '39 18 * * *'
   push:
     branches:
       - main
 
 jobs:
   tests:
-    if: github.event.repository.owner.id == github.event.sender.id && github.event.ref == 'refs/heads/main'
+    if: github.event.ref == 'refs/heads/main'
     name: Tests
     strategy:
       fail-fast: false
@@ -25,7 +25,7 @@ jobs:
       os: ${{ matrix.os }}
 
   tests-indy:
-    if: github.event.repository.owner.id == github.event.sender.id && github.event.ref == 'refs/heads/main'
+    if: github.event.ref == 'refs/heads/main'
     name: Tests (Indy)
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,17 +2,17 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '19 18 * * *'
+    - cron: '24 18 * * *'
   push:
     branches:
       - main
 
 env:
-  RUN_NIGHTLY_TESTS: "true"
+  RUN_NIGHTLY_TESTS: true
 
 jobs:
   tests:
-    if: env.RUN_NIGHTLY_TESTS == "true"
+    if: env.RUN_NIGHTLY_TESTS == true
     name: Tests
     strategy:
       fail-fast: false
@@ -28,7 +28,7 @@ jobs:
       os: ${{ matrix.os }}
 
   tests-indy:
-    if: env.RUN_NIGHTLY_TESTS == "true"
+    if: env.RUN_NIGHTLY_TESTS == true
     name: Tests (Indy)
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,7 +2,7 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '14 19 * * *'
+    - cron: '17 19 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,17 +2,14 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '17 19 * * *'
+    - cron: '19 19 * * *'
   push:
     branches:
       - main
-      
-
-#if: github.event.repository.default_branch == github.ref
 
 jobs:
-  if: [github.repository_owner == 'anwalker293']
   tests:
+    if: github.repository_owner == 'anwalker293'
     name: Tests
     strategy:
       fail-fast: false
@@ -28,6 +25,7 @@ jobs:
       os: ${{ matrix.os }}
 
   tests-indy:
+    if: github.repository_owner == 'anwalker293'
     name: Tests (Indy)
     strategy:
       fail-fast: false
@@ -37,7 +35,6 @@ jobs:
         include:
           - os: "ubuntu-20.04"
             python-version: "3.6"
-
     uses: ./.github/workflows/tests-indy.yml
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,13 +2,18 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '19 19 * * *'
+    - cron: '00 18 * * *'
   push:
     branches:
       - main
+      
+env:
+  RUN_NIGHTLY_TESTS: "true"
+
 
 jobs:
   tests:
+    if: env.RUN_NIGHTLY_TESTS == "true"
     if: github.repository_owner == 'anwalker293'
     name: Tests
     strategy:
@@ -25,6 +30,7 @@ jobs:
       os: ${{ matrix.os }}
 
   tests-indy:
+    if: env.RUN_NIGHTLY_TESTS == "true"
     if: github.repository_owner == 'anwalker293'
     name: Tests (Indy)
     strategy:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -10,8 +10,8 @@ on:
 
 #if: github.event.repository.default_branch == github.ref
 
-if: github.repository_owner == 'anwalker293'
 jobs:
+  if: [github.repository_owner == 'anwalker293']
   tests:
     name: Tests
     strategy:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,7 +2,7 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '24 18 * * *'
+    - cron: '27 18 * * *'
   push:
     branches:
       - main
@@ -12,7 +12,7 @@ env:
 
 jobs:
   tests:
-    if: env.RUN_NIGHTLY_TESTS == true
+    if: env.RUN_NIGHTLY_TESTS
     name: Tests
     strategy:
       fail-fast: false
@@ -28,7 +28,7 @@ jobs:
       os: ${{ matrix.os }}
 
   tests-indy:
-    if: env.RUN_NIGHTLY_TESTS == true
+    if: env.RUN_NIGHTLY_TESTS
     name: Tests (Indy)
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,18 +2,17 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '13 18 * * *'
+    - cron: '15 18 * * *'
   push:
     branches:
       - main
-      
+
 env:
   RUN_NIGHTLY_TESTS: "true"
 
-
 jobs:
   tests:
-    if: env.RUN_NIGHTLY_TESTS == "true" && github.repository_owner == "anwalker293"
+    if: github.repository_owner == "anwalker293" && env.RUN_NIGHTLY_TESTS == "true"
     name: Tests
     strategy:
       fail-fast: false
@@ -29,7 +28,7 @@ jobs:
       os: ${{ matrix.os }}
 
   tests-indy:
-    if: env.RUN_NIGHTLY_TESTS == "true" && github.repository_owner == "anwalker293"
+    if: github.repository_owner == "anwalker293" && env.RUN_NIGHTLY_TESTS == "true"
     name: Tests (Indy)
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,7 +2,7 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: '27 18 * * *'
+    - cron: '28 18 * * *'
   push:
     branches:
       - main
@@ -12,7 +12,7 @@ env:
 
 jobs:
   tests:
-    if: env.RUN_NIGHTLY_TESTS
+    if: RUN_NIGHTLY_TESTS
     name: Tests
     strategy:
       fail-fast: false
@@ -28,7 +28,7 @@ jobs:
       os: ${{ matrix.os }}
 
   tests-indy:
-    if: env.RUN_NIGHTLY_TESTS
+    if: RUN_NIGHTLY_TESTS
     name: Tests (Indy)
     strategy:
       fail-fast: false


### PR DESCRIPTION
Changes the nightly runs to only run on main, including on forked versions of this repo.

Every time I tried to put an environment variable within the workflow and referenced it, GitHub didn't seem to like this. (I think there's a work around, *but* you would need this to be in the .env file, which we might not want.) Although, by default, actions are disabled when you fork a repo, so I think this should be okay. (It doesn't seem that bad to just make this if statement false manually?) 

Let me know if there's any fixes you would like me to make to this!

Re: Issue #2152 (https://github.com/hyperledger/aries-cloudagent-python/issues/2152)