### PR TITLE
Adds the upgrade command YML file to the PyPi Release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include aries_cloudagent/config/default_logging_config.ini
+include aries_cloudagent/commands/default_version_upgrade_config.yml
 include requirements.txt
 include requirements.dev.txt
 include requirements.indy.txt


### PR DESCRIPTION
@andrewwhitehead -- can you please test the packaging of this to verify that the next release that goes to PyPi will include the added [YML File](https://github.com/hyperledger/aries-cloudagent-python/blob/main/aries_cloudagent/commands/default_version_upgrade_config.yml).

@ianco -- I don't think you need to do anything on this.

Addresses issue #2178 