### PR TITLE
Disable webhook trigger on initial response to multi-use connection invitation

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -490,6 +490,7 @@ class ConnectionManager(BaseConnectionManager):
                         reason=(
                             "Received connection request from multi-use invitation DID"
                         ),
+                        event=False
                     )
 
                 # Transfer metadata from multi-use to new connection

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -490,7 +490,7 @@ class ConnectionManager(BaseConnectionManager):
                         reason=(
                             "Received connection request from multi-use invitation DID"
                         ),
-                        event=False
+                        event=False,
                     )
 
                 # Transfer metadata from multi-use to new connection


### PR DESCRIPTION
Disable the webhook emitter when cloning a multi-use connection record, as it is "overhead": the webhook is fired once when the multi-use invitation is created, and subsequent interactions should only fire for subsequent updates of the new (cloned, contact-specific) connection record.

Fixes #2217 