### PR TITLE
Multi-tenant self-managed mediation verkey lookup

### DIFF
--- a/aries_cloudagent/multitenant/route_manager.py
+++ b/aries_cloudagent/multitenant/route_manager.py
@@ -81,8 +81,17 @@ class MultitenantRouteManager(RouteManager):
                 keylist_updates = await mediation_mgr.remove_key(
                     replace_key, keylist_updates
                 )
-
-            responder = self.root_profile.inject(BaseResponder)
+            # in order to locate the correct verkey for message packing we need
+            # to use the correct profile.
+            # if we are using default/base mediation then we need
+            # the root_profile to create the responder.
+            # if sub-wallets are configuring their own mediation, then
+            # we need the sub-wallet (profile) to create the responder.
+            responder = (
+                self.root_profile.inject(BaseResponder)
+                if base_mediation_record
+                else profile.inject(BaseResponder)
+            )
             await responder.send(
                 keylist_updates, connection_id=mediation_record.connection_id
             )


### PR DESCRIPTION
fixes #2231 

There are two ways to setup mediation for multitenancy. One is to have the base wallet mediate for all tenants, and the second is for each tenant to manage their own. In the second case, there was a bug when locating the verkey and packing the outbound message.

This PR checks if the base wallet is mediating and decides which responder to use. If the tenant is managing their own mediation then we need the sub-wallet profile to create the responder NOT the base wallet profile.