### PR TITLE
Improve faber agent with ngrok selection and invitation_url output

### DIFF
--- a/demo/run_demo
+++ b/demo/run_demo
@@ -178,7 +178,7 @@ if [ -z "$AGENT_ENDPOINT" ] && [ "$RUNMODE" == "docker" ]; then
   echo "Trying to detect ngrok service endpoint"
   JQ=${JQ:-`which jq`}
   if [ -x "$JQ" ]; then
-    NGROK_ENDPOINT=$(curl --silent localhost:4040/api/tunnels | $JQ -r '.tunnels[0].public_url')
+    NGROK_ENDPOINT=$(curl --silent localhost:4040/api/tunnels | $JQ -r ".tunnels[] | select(.config.addr | endswith(\"$AGENT_PORT\")) | .public_url")
     if [ -z "$NGROK_ENDPOINT" ] || [ "$NGROK_ENDPOINT" = "null" ]; then
       echo "ngrok not detected for agent endpoint"
     else

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -591,6 +591,7 @@ class AriesAgent(DemoAgent):
                 json.dumps(invi_rec["invitation"]), label="Invitation Data:", color=None
             )
             qr.print_ascii(invert=True)
+            log_msg(invi_rec["invitation_url"], label="Invitation URL:", color=None)
 
         if wait:
             log_msg("Waiting for connection...")


### PR DESCRIPTION
- Update NGROK_ENDPOINT to select the tunnel with the specified AGENT_PORT
- Add output of invitation_url using log_msg function