### PR TITLE
fix: route multitenant connectionless oob invitation

### DIFF
--- a/aries_cloudagent/multitenant/base.py
+++ b/aries_cloudagent/multitenant/base.py
@@ -199,7 +199,7 @@ class BaseMultitenantManager(ABC):
                 public_did_info = await wallet.get_public_did()
 
             if public_did_info:
-                await profile.inject(RouteManager).route_public_did(
+                await profile.inject(RouteManager).route_verkey(
                     profile, public_did_info.verkey
                 )
         except Exception:

--- a/aries_cloudagent/multitenant/tests/test_base.py
+++ b/aries_cloudagent/multitenant/tests/test_base.py
@@ -210,7 +210,7 @@ class TestBaseMultitenantManager(AsyncTestCase):
 
     async def test_create_wallet_saves_wallet_record_creates_profile(self):
         mock_route_manager = async_mock.MagicMock()
-        mock_route_manager.route_public_did = async_mock.CoroutineMock()
+        mock_route_manager.route_verkey = async_mock.CoroutineMock()
         self.context.injector.bind_instance(RouteManager, mock_route_manager)
 
         with async_mock.patch.object(
@@ -232,7 +232,7 @@ class TestBaseMultitenantManager(AsyncTestCase):
                 {"wallet.key": "test_key"},
                 provision=True,
             )
-            mock_route_manager.route_public_did.assert_not_called()
+            mock_route_manager.route_verkey.assert_not_called()
             assert isinstance(wallet_record, WalletRecord)
             assert wallet_record.wallet_name == "test_wallet"
             assert wallet_record.key_management_mode == WalletRecord.MODE_MANAGED
@@ -248,7 +248,7 @@ class TestBaseMultitenantManager(AsyncTestCase):
         )
 
         mock_route_manager = async_mock.MagicMock()
-        mock_route_manager.route_public_did = async_mock.CoroutineMock()
+        mock_route_manager.route_verkey = async_mock.CoroutineMock()
 
         with async_mock.patch.object(
             WalletRecord, "save"
@@ -267,7 +267,7 @@ class TestBaseMultitenantManager(AsyncTestCase):
                 WalletRecord.MODE_MANAGED,
             )
 
-            mock_route_manager.route_public_did.assert_called_once_with(
+            mock_route_manager.route_verkey.assert_called_once_with(
                 get_wallet_profile.return_value, did_info.verkey
             )
 

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -196,7 +196,7 @@ class ConnectionManager(BaseConnectionManager):
 
             # Add mapping for multitenant relaying.
             # Mediation of public keys is not supported yet
-            await self._route_manager.route_public_did(self.profile, public_did.verkey)
+            await self._route_manager.route_verkey(self.profile, public_did.verkey)
 
         else:
             # Create connection record

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
@@ -146,7 +146,7 @@ class TestConnectionManager(AsyncTestCase):
     async def test_create_invitation_public(self):
         self.context.update_settings({"public_invites": True})
 
-        self.route_manager.route_public_did = async_mock.CoroutineMock()
+        self.route_manager.route_verkey = async_mock.CoroutineMock()
         with async_mock.patch.object(
             InMemoryWallet, "get_public_did", autospec=True
         ) as mock_wallet_get_public_did:
@@ -163,7 +163,7 @@ class TestConnectionManager(AsyncTestCase):
 
             assert connect_record
             assert connect_invite.did.endswith(self.test_did)
-            self.route_manager.route_public_did.assert_called_once_with(
+            self.route_manager.route_verkey.assert_called_once_with(
                 self.profile, self.test_verkey
             )
 

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/route_manager.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/route_manager.py
@@ -197,8 +197,15 @@ class RouteManager(ABC):
 
         raise ValueError("Expected connection to have invitation_key")
 
-    async def route_public_did(self, profile: Profile, verkey: str):
+    async def route_verkey(self, profile: Profile, verkey: str):
         """Establish routing for a public DID."""
+        return await self._route_for_key(profile, verkey, skip_if_exists=True)
+
+    async def route_public_did(self, profile: Profile, verkey: str):
+        """Establish routing for a public DID.
+
+        [DEPRECATED] Establish routing for a public DID. Use route_verkey() instead.
+        """
         return await self._route_for_key(profile, verkey, skip_if_exists=True)
 
     async def route_static(

--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_route_manager.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/tests/test_route_manager.py
@@ -395,6 +395,14 @@ async def test_route_public_did(profile: Profile, route_manager: RouteManager):
 
 
 @pytest.mark.asyncio
+async def test_route_verkey(profile: Profile, route_manager: RouteManager):
+    await route_manager.route_verkey(profile, "test-verkey")
+    route_manager._route_for_key.assert_called_once_with(
+        profile, "test-verkey", skip_if_exists=True
+    )
+
+
+@pytest.mark.asyncio
 async def test_route_static(
     profile: Profile, route_manager: RouteManager, conn_record: ConnRecord
 ):

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -322,6 +322,10 @@ class OutOfBandManager(BaseConnectionManager):
                     endpoint=my_endpoint,
                     routing_keys=routing_keys,
                 ).serialize()
+                # Need to make sure the created key is routed by the base wallet
+                await self._route_manager.route_verkey(
+                    self.profile, connection_key.verkey
+                )
 
             routing_keys = [
                 key
@@ -543,6 +547,11 @@ class OutOfBandManager(BaseConnectionManager):
                         endpoint=self.profile.settings.get("default_endpoint"),
                         routing_keys=[],
                     ).serialize()
+
+                    # Need to make sure the created key is routed by the base wallet
+                    await self._route_manager.route_verkey(
+                        self.profile, connection_key.verkey
+                    )
                     await oob_record.save(session)
 
             await self._process_request_attach(oob_record)

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -632,7 +632,7 @@ async def promote_wallet_public_did(
 
         # Route the public DID
         route_manager = profile.inject(RouteManager)
-        await route_manager.route_public_did(profile, info.verkey)
+        await route_manager.route_verkey(profile, info.verkey)
 
     return info, attrib_def
 

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -427,7 +427,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
 
         mock_route_manager = async_mock.MagicMock()
-        mock_route_manager.route_public_did = async_mock.AsyncMock()
+        mock_route_manager.route_verkey = async_mock.AsyncMock()
         mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
         mock_route_manager.__aenter__ = async_mock.AsyncMock(
             return_value=mock_route_manager
@@ -587,7 +587,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
 
         mock_route_manager = async_mock.MagicMock()
-        mock_route_manager.route_public_did = async_mock.AsyncMock()
+        mock_route_manager.route_verkey = async_mock.AsyncMock()
         mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
         mock_route_manager.__aenter__ = async_mock.AsyncMock(
             return_value=mock_route_manager
@@ -633,7 +633,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         self.profile.context.injector.bind_instance(BaseLedger, ledger)
 
         mock_route_manager = async_mock.MagicMock()
-        mock_route_manager.route_public_did = async_mock.AsyncMock()
+        mock_route_manager.route_verkey = async_mock.AsyncMock()
         mock_route_manager.mediation_record_if_id = async_mock.AsyncMock(
             return_value=None
         )


### PR DESCRIPTION
This addresses an issue where the keys used in connectionless oob invitations were not correctly set-up for routing through the base wallet when multi-tenancy is enabled, which resulted in those invitation not being usable.

cc @lohanspies @ff137

