### PR TITLE
chore!: drop python 3.6 support

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -14,9 +14,6 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        include:
-          - os: "ubuntu-20.04"
-            python-version: "3.6"
     uses: ./.github/workflows/tests.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -30,9 +27,6 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        include:
-          - os: "ubuntu-20.04"
-            python-version: "3.6"
     uses: ./.github/workflows/tests-indy.yml
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
     uses: ./.github/workflows/tests.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
     uses: ./.github/workflows/tests-indy.yml
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -8,13 +8,13 @@ jobs:
     name: Tests
     uses: ./.github/workflows/tests.yml
     with:
-      python-version: "3.6"
-      os: "ubuntu-20.04"
+      python-version: "3.9"
+      os: "ubuntu-latest"
 
   tests-indy:
     name: Tests (Indy)
     uses: ./.github/workflows/tests-indy.yml
     with:
-      python-version: "3.6"
+      python-version: "3.9"
       indy-version: "1.16.0"
-      os: "ubuntu-20.04"
+      os: "ubuntu-latest"

--- a/.github/workflows/publish-indy.yml
+++ b/.github/workflows/publish-indy.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.9']
+        python-version: ['3.9']
 
     name: Publish ACA-Py Image (Indy)
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.9']
+        python-version: ['3.9']
 
     name: Publish ACA-Py Image
     runs-on: ubuntu-latest

--- a/ContainerImagesAndGithubActions.md
+++ b/ContainerImagesAndGithubActions.md
@@ -47,12 +47,8 @@ Below is a table of all generated images and their tags:
 
 Tag                     | Variant  | Example                  | Description                                                                                     |
 ------------------------|----------|--------------------------|-------------------------------------------------------------------------------------------------|
-py3.7-X.Y.Z             | Standard | py3.7-0.7.4              | Standard image variant built on Python 3.7 for ACA-Py version X.Y.Z                             |
-py3.8-X.Y.Z             | Standard | py3.8-0.7.4              | Standard image variant built on Python 3.8 for ACA-Py version X.Y.Z                             |
 py3.9-X.Y.Z             | Standard | py3.9-0.7.4              | Standard image variant built on Python 3.9 for ACA-Py version X.Y.Z                             |
 py3.10-X.Y.Z            | Standard | py3.10-0.7.4             | Standard image variant built on Python 3.10 for ACA-Py version X.Y.Z                            |
-py3.7-indy-A.B.C-X.Y.Z  | Indy     | py3.7-indy-1.16.0-0.7.4  | Standard image variant built on Python 3.7 for ACA-Py version X.Y.Z and Indy SDK Version A.B.C  |
-py3.8-indy-A.B.C-X.Y.Z  | Indy     | py3.8-indy-1.16.0-0.7.4  | Standard image variant built on Python 3.8 for ACA-Py version X.Y.Z and Indy SDK Version A.B.C  |
 py3.9-indy-A.B.C-X.Y.Z  | Indy     | py3.9-indy-1.16.0-0.7.4  | Standard image variant built on Python 3.9 for ACA-Py version X.Y.Z and Indy SDK Version A.B.C  |
 py3.10-indy-A.B.C-X.Y.Z | Indy     | py3.10-indy-1.16.0-0.7.4 | Standard image variant built on Python 3.10 for ACA-Py version X.Y.Z and Indy SDK Version A.B.C |
 

--- a/ContainerImagesAndGithubActions.md
+++ b/ContainerImagesAndGithubActions.md
@@ -47,7 +47,6 @@ Below is a table of all generated images and their tags:
 
 Tag                     | Variant  | Example                  | Description                                                                                     |
 ------------------------|----------|--------------------------|-------------------------------------------------------------------------------------------------|
-py3.6-X.Y.Z             | Standard | py3.6-0.7.4              | Standard image variant built on Python 3.6 for ACA-Py version X.Y.Z                             |
 py3.7-X.Y.Z             | Standard | py3.7-0.7.4              | Standard image variant built on Python 3.7 for ACA-Py version X.Y.Z                             |
 py3.8-X.Y.Z             | Standard | py3.8-0.7.4              | Standard image variant built on Python 3.8 for ACA-Py version X.Y.Z                             |
 py3.9-X.Y.Z             | Standard | py3.9-0.7.4              | Standard image variant built on Python 3.9 for ACA-Py version X.Y.Z                             |

--- a/demo/docker-agent/Dockerfile.acapy
+++ b/demo/docker-agent/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM bcgovimages/aries-cloudagent:py36-1.16-1_1.0.0-rc0
+FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-indy-1.16.0-0.8.1
 
 USER root
 

--- a/demo/docker-test/docker-compose-agent.yml
+++ b/demo/docker-test/docker-compose-agent.yml
@@ -1,7 +1,6 @@
 version: "3"
 services:
   vcr-agent:
-    #image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.5
     build:
       context: ../../
       dockerfile: docker/Dockerfile.run

--- a/demo/multi-demo/Dockerfile.acapy
+++ b/demo/multi-demo/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-indy-1.16.0-0.8.1
+FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-indy-1.16.0-0.8.1
 
 USER root
 

--- a/demo/multi-demo/Dockerfile.acapy
+++ b/demo/multi-demo/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM bcgovimages/aries-cloudagent:py36-1.16-1_1.0.0-rc0
+FROM FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-indy-1.16.0-0.8.1
 
 USER root
 

--- a/demo/run_bdd
+++ b/demo/run_bdd
@@ -126,6 +126,7 @@ AGENT_PORT=8020
 AGENT_PORT_RANGE=8020-8079
 
 echo "Preparing agent image..."
+docker build -q -t indy-base -f ../docker/Dockerfile.indy --target=indy-base .. || exit 1
 docker build -q -t faber-alice-demo -f ../docker/Dockerfile.demo .. || exit 1
 docker build -q -t aries-bdd-image -f ../docker/Dockerfile.bdd .. || exit 1
 

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -1,4 +1,4 @@
-FROM bcgovimages/von-image:py36-1.15-1
+FROM indy-base
 
 ENV ENABLE_PTVSD 0
 ENV ENABLE_PYDEVD_PYCHARM 0

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,4 +1,4 @@
-ARG python_version=3.6.13
+ARG python_version=3.9.16
 FROM python:${python_version}-slim-buster
 
 RUN apt-get update -y && \

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,5 +1,5 @@
 ARG python_version=3.9.16
-FROM python:${python_version}-slim-buster
+FROM python:${python_version}-slim-bullseye
 
 RUN apt-get update -y && \
 	apt-get install -y --no-install-recommends \

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
             "bbs": parse_requirements("requirements.bbs.txt"),
             "uvloop": {"uvloop": "^=0.14.0"},
         },
-        python_requires=">=3.6.3",
+        python_requires=">=3.9",
         classifiers=[
             "Programming Language :: Python :: 3",
             "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Update setup.py minimum python version requirement.
Update workflows to use Python 3.9 by default.
Update container image docs.

@swcurran @WadeBarnes I believe these are the relevant changes in workflows and setup files in order to officially drop Python 3.6. I think once we've made the transition, there are a number of dependencies that ought to be updated. I think those updates are best suited to a follow up PR.

closes: #2244 