### PR TITLE
1.0.0-rc2 Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,57 @@
+# 1.0.0-rc2
+
+## April 5, 2023
+
+ACA-Py 1.0.0 will be a breaking update to ACA-Py with the version number
+indicating the maturity of the implementation. The final 1.0.0 release will be
+Aries Interop Profile 2.0-complete, and based on Python 3.9 or higher. The
+decision to start tagging early `1.0.0` releases was probably a bad one given
+the subsequent focus in the community on optimization of what we have vs.
+completing the [to-do list for AIP 2.0](/SupportedRFCs.md#aip-20). However, some
+organizations are using 1.0.0-rc1, so with this release of 1.0.0-rc2, we are
+providing an update that incorporates the many, many enhancements, improvements,
+and fixes that are in releases [0.8.0](#080) and [0.8.1](#081).
+
+### Breaking Changes
+
+See the breaking changes documented in Releases [0.8.1](#081) and [0.8.0](#080).
+There are no breaking changes in the merged pull requested listed below--those
+merged since Release 0.8.1.
+
+### What's Changed Since 1.0.0-rc1
+
+Release 1.0.0-rc1 was tagged soon after 0.7.5. As such, the full changelog
+from Release 1.0.0-rc2 included all of the changes in 0.8.0, 0.8.1 and the
+pull requests [listed below, made since the tagging of Release 0.8.1](#categorized-list-of-pull-requests-since-081).
+
+### Categorized List of Pull Requests Since 0.8.1
+
+- Connections Fixes/Updates
+  - Add support for JsonWebKey2020 for the connection invitations [\#2173](https://github.com/hyperledger/aries-cloudagent-python/pull/2173) [dkulic](https://github.com/dkulic)
+  - fix: only cache completed connection targets [\#2240](https://github.com/hyperledger/aries-cloudagent-python/pull/2240) [dbluhm](https://github.com/dbluhm)
+  - Connection target should not be limited only to indy dids [\#2229](https://github.com/hyperledger/aries-cloudagent-python/pull/2229) [dkulic](https://github.com/dkulic)
+  - Disable webhook trigger on initial response to multi-use connection invitation [\#2223](https://github.com/hyperledger/aries-cloudagent-python/pull/2223) [esune](https://github.com/esune)
+- Credential Exchange (Issue, Present) Updates
+  - Pass document loader to jsonld.expand [\#2175](https://github.com/hyperledger/aries-cloudagent-python/pull/2175) [andrewwhitehead](https://github.com/andrewwhitehead)
+- Multi-tenancy fixes/updates
+  - stand up multiple agents (single and multi) for local development and testing [\#2230](https://github.com/hyperledger/aries-cloudagent-python/pull/2230) [usingtechnology](https://github.com/usingtechnology)
+  - Multi-tenant self-managed mediation verkey lookup [\#2232](https://github.com/hyperledger/aries-cloudagent-python/pull/2232) [usingtechnology](https://github.com/usingtechnology)
+  - fix: route multitenant connectionless oob invitation [\#2243](https://github.com/hyperledger/aries-cloudagent-python/pull/2243) [TimoGlastra](https://github.com/TimoGlastra)
+  - Fix multitenant/mediation in demo [\#2075](https://github.com/hyperledger/aries-cloudagent-python/pull/2075) [ianco](https://github.com/ianco)
+- Other Bug Fixes
+  - ./run_demo performance -c 1 --mediation --timing --trace-log [#2245](https://github.com/hyperledger/aries-cloudagent-python/pull/2245) [usingtechnology](https://github.com/usingtechnology)
+  - Fix formatting and grammatical errors in different readme's [\#2222](https://github.com/hyperledger/aries-cloudagent-python/pull/2222) [ff137](https://github.com/ff137)
+  - Fix broken link in README [\#2221](https://github.com/hyperledger/aries-cloudagent-python/pull/2221) [ff137](https://github.com/ff137)
+  - fix: run only on main, forks ok [\#2166](https://github.com/hyperledger/aries-cloudagent-python/pull/2166) [anwalker293](https://github.com/anwalker293)
+  - Update Alice Wants a JSON-LD Credential to fix invocation [\#2219](https://github.com/hyperledger/aries-cloudagent-python/pull/2219) [swcurran](https://github.com/swcurran)
+- Dependencies and Internal Updates
+  - Bump requests from 2.30.0 to 2.31.0 in /demo/playground/scripts dependenciesPull requests that update a dependency file [\#2238](https://github.com/hyperledger/aries-cloudagent-python/pull/2238) [dependabot bot](https://github.com/dependabot)
+  - Upgrade codegen tools in scripts/generate-open-api-spec and publish Swagger 2.0 and OpenAPI 3.0 specs [\#2246](https://github.com/hyperledger/aries-cloudagent-python/pull/2246) [ff137](https://github.com/ff137)
+- Message Tracing/Timing Updates
+  - Add updated ELK stack for demos. [\#2236](https://github.com/hyperledger/aries-cloudagent-python/pull/2236) [usingtechnology](https://github.com/usingtechnology)
+- Release management pull requests
+  - 1.0.0-rc2 [\#XXXX](https://github.com/hyperledger/aries-cloudagent-python/pull/2207) [swcurran](https://github.com/swcurran)
+
 # 0.8.1
 
 ## April 5, 2023

--- a/aries_cloudagent/commands/default_version_upgrade_config.yml
+++ b/aries_cloudagent/commands/default_version_upgrade_config.yml
@@ -1,3 +1,8 @@
+v1.0.0-rc2:
+  resave_records:
+    base_record_path:
+      - "aries_cloudagent.connections.models.conn_record.ConnRecord"
+  update_existing_records: false
 v0.8.1:
   resave_records:
     base_record_path:

--- a/aries_cloudagent/version.py
+++ b/aries_cloudagent/version.py
@@ -1,4 +1,4 @@
 """Library version information."""
 
-__version__ = "0.8.1"
+__version__ = "1.0.0-rc2"
 RECORD_TYPE_ACAPY_VERSION = "acapy_version"

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -2,7 +2,7 @@
   "openapi" : "3.0.1",
   "info" : {
     "title" : "Aries Cloud Agent",
-    "version" : "v0.8.1"
+    "version" : "v1.0.0-rc2"
   },
   "servers" : [ {
     "url" : "/"

--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger" : "2.0",
   "info" : {
-    "version" : "v0.8.1",
+    "version" : "v1.0.0-rc2",
     "title" : "Aries Cloud Agent"
   },
   "tags" : [ {


### PR DESCRIPTION
@WadeBarnes -- advice needed.

With this PR, we update the "version.py" and "openapi" versions to "1.0.0-rc2", which I don't we want to leave in place.

Here are some things we can do:

- After this PR is merged, add another that changes the "main" branch version to what it usually is -- "0.8.1" (the last released version).  That's the state we are usually in between releases.
   - Side Issue: Should we change this practice and after a release, change the version references in the code to what we expect the next release to be -- e.g. "0.8.2-latest" or something like that.
- Merge this PR into a new branch "1.0.0" and we use that for future "1.0.0-rcX" tags.  As part of making subsequent 1.0.0-rcX tags, we merge main into the 1.0.0 branch.  That means that 1.0.0 is a clone of main for tags, updated with the types of changes that are in this PR.

I kind of lean towards the "1.0.0" branch, but you know this stuff way better than I.

