### PR TITLE
Resolve definitions.py fix

### DIFF
--- a/aries_cloudagent/core/util.py
+++ b/aries_cloudagent/core/util.py
@@ -159,7 +159,6 @@ async def get_version_def_from_msg_class(
     profile: Profile, msg_class: type, major_version: int = 1
 ):
     """Return version_definition of a protocol from msg_class."""
-    print(f"get_version_def_from_msg_class({profile}, {msg_class}, {major_version})")
     cache = profile.inject_or(BaseCache)
     version_definition = None
     if cache:
@@ -169,9 +168,7 @@ async def get_version_def_from_msg_class(
         if version_definition:
             return version_definition
     definition_path = _get_path_from_msg_class(msg_class)
-    print(f"definition_path = {definition_path}")
     version_definition = _get_version_def_from_path(definition_path, major_version)
-    print(f"version_definition = {version_definition}")
     if not version_definition:
         raise ProtocolDefinitionValidationError(
             f"Unable to load protocol version_definition for {str(msg_class)}"


### PR DESCRIPTION
Include searching by the module base package when resolving plugin definitions location.

Fixes #2224 

This still depends on the module package names and file system paths matching up, which is not guaranteed. But without adding additional configuration in the plugin registry, I think this is all we can do.