### PR TITLE
Assign ~thread.thid with thread_id value

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -309,7 +309,7 @@ class CredentialManager:
             offers_attach=[CredentialOffer.wrap_indy_offer(credential_offer)],
         )
 
-        credential_offer_message._thread = {"thid": cred_ex_record.thread_id}
+        credential_offer_message._thread = {"thid": credential_offer_message._thread_id}
         credential_offer_message.assign_trace_decorator(
             self._profile.settings, cred_ex_record.trace
         )

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -20,4 +20,3 @@ ptvsd==4.3.2
 pydevd==1.5.1
 
 pydevd-pycharm~=193.6015.39
-random-word==1.0.11; python_version >= "3"

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -20,3 +20,4 @@ ptvsd==4.3.2
 pydevd==1.5.1
 
 pydevd-pycharm~=193.6015.39
+random-word==1.0.11; python_version >= "3"


### PR DESCRIPTION
The previous assignment used a value from a field that had not been assigned yet. So, use the correct `thread_id` value for the `thid`.

Fixes #2259 

The fix originally discussed in #2259 is too aggressive and after reviewing the code it is clear that there can be empty `~thread` and they are expected to be dealt with by the receiver.  In this case, we were attempting to set the `thid` but just using an unassigned value.

