### PR TITLE
Allow awaiting in verification key strategy

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
@@ -275,7 +275,7 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
         verkey_id_strategy = self.profile.context.inject(BaseVerificationKeyStrategy)
         verification_method = (
             verification_method
-            or verkey_id_strategy.get_verification_method_id_for_did(
+            or await verkey_id_strategy.get_verification_method_id_for_did(
                 issuer_id, proof_purpose="assertionMethod"
             )
         )

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -120,8 +120,10 @@ class DIFPresExchHandler:
         """Get signature suite for signing presentation."""
         did_info = await self._did_info_for_did(issuer_id)
         verkey_id_strategy = self.profile.context.inject(BaseVerificationKeyStrategy)
-        verification_method = verkey_id_strategy.get_verification_method_id_for_did(
-            issuer_id, proof_purpose="assertionMethod"
+        verification_method = (
+            await verkey_id_strategy.get_verification_method_id_for_did(
+                issuer_id, proof_purpose="assertionMethod"
+            )
         )
 
         if verification_method is None:

--- a/aries_cloudagent/wallet/default_verification_key_strategy.py
+++ b/aries_cloudagent/wallet/default_verification_key_strategy.py
@@ -11,7 +11,7 @@ class BaseVerificationKeyStrategy(ABC):
     """Base class for defining which verification method is in use."""
 
     @abstractmethod
-    def get_verification_method_id_for_did(
+    async def get_verification_method_id_for_did(
         self,
         did: str,
         allowed_verification_method_types: Optional[List[KeyType]] = None,
@@ -35,7 +35,7 @@ class DefaultVerificationKeyStrategy(BaseVerificationKeyStrategy):
     Supports did:key: and did:sov only.
     """
 
-    def get_verification_method_id_for_did(
+    async def get_verification_method_id_for_did(
         self,
         did: str,
         allowed_verification_method_types: Optional[List[KeyType]] = None,

--- a/aries_cloudagent/wallet/tests/test_default_verification_key_strategy.py
+++ b/aries_cloudagent/wallet/tests/test_default_verification_key_strategy.py
@@ -11,20 +11,22 @@ TEST_DID_KEY = "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL"
 
 
 class TestDefaultVerificationKeyStrategy(TestCase):
-    def test_with_did_sov(self):
+    async def test_with_did_sov(self):
         strategy = DefaultVerificationKeyStrategy()
         assert (
-            strategy.get_verification_method_id_for_did(TEST_DID_SOV)
+            await strategy.get_verification_method_id_for_did(TEST_DID_SOV)
             == TEST_DID_SOV + "#key-1"
         )
 
-    def test_with_did_key(self):
+    async def test_with_did_key(self):
         strategy = DefaultVerificationKeyStrategy()
         assert (
-            strategy.get_verification_method_id_for_did(TEST_DID_KEY)
+            await strategy.get_verification_method_id_for_did(TEST_DID_KEY)
             == DIDKey.from_did(TEST_DID_KEY).key_id
         )
 
-    def test_unsupported_did_method(self):
+    async def test_unsupported_did_method(self):
         strategy = DefaultVerificationKeyStrategy()
-        assert strategy.get_verification_method_id_for_did("did:test:test") is None
+        assert (
+            await strategy.get_verification_method_id_for_did("did:test:test") is None
+        )


### PR DESCRIPTION
PR #2235 has just been merged, but I realized that having a non-async function could be too restrictive. For example, accessing storage with the current function's signature is hard. 

This PR fixes this.