### PR TITLE
Create .readthedocs.yaml file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,8 @@ version: 2
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "3.8"
+    python: "3.9"
 
 sphinx:
+  builder: dirhtml
   configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.8"
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
Add readthedocs YAML file as required by RTD.  Per this [blog post](https://blog.readthedocs.com/migrate-configuration-v2/), this file is now required for publishing the type of documentation we generate to the RTD sites. For those not aware, here is the link to the RTD site for ACA-Py -- https://aries-cloud-agent-python.readthedocs.io

Here is the link to the version of the docs generated from this branch with this new file: https://aries-cloud-agent-python.readthedocs.io/en/swcurran-add-rtd/. LGTM!