### PR TITLE
Fix: Do not replace public verkey on mediator

### DIFF
--- a/aries_cloudagent/protocols/coordinate_mediation/v1_0/route_manager.py
+++ b/aries_cloudagent/protocols/coordinate_mediation/v1_0/route_manager.py
@@ -144,11 +144,21 @@ class RouteManager(ABC):
         """Set up routing for a new connection when we are the inviter."""
         LOGGER.debug("Routing connection as inviter")
         my_info = await self.get_or_create_my_did(profile, conn_record)
+
+        replace_key = conn_record.invitation_key
+        async with profile.session() as session:
+            wallet = session.inject(BaseWallet)
+            public_did = await wallet.get_public_did()
+
+        # Do not replace key, if it is public
+        if public_did and public_did.verkey == conn_record.invitation_key:
+            replace_key = None
+
         return await self._route_for_key(
             profile,
             my_info.verkey,
             mediation_record,
-            replace_key=conn_record.invitation_key,
+            replace_key=replace_key,
             skip_if_exists=True,
         )
 


### PR DESCRIPTION
This PR fixes a case when public verkey of the mediated agent is removed from the keylists of its mediator during establishing a connection.

Assuming there is mediation established for an agent.
If the DID was promoted to public via POST /wallet/did/public?did={}&mediation_id={non_empty_id} then an ATTRIB 'endpoint' transaction was created on the ledger with the url pointing to the mediator and the respective routing_keys.

Next, the Inviter creates an invitation using the public=true (or use_public_did: true) flag, the communication of the Inviter goes through the mediator as it should. Then in the Inviter's accept-request phase, the public verkey is removed from the keylist of the mediator. 
That prevents any next attempts to answer to the Inviter's invitations with its public DID since the mediator does no longer have the routing key (verkey) associated to the public DID.

In conclusion, the public verkey must remain in the mediator as the routing key.