### PR TITLE
Add replacement_id to API.

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -57,6 +57,7 @@ class V20CredManager:
         cred_proposal: V20CredProposal,
         verification_method: Optional[str] = None,
         auto_remove: bool = None,
+        replacement_id: str = None,
     ) -> Tuple[V20CredExRecord, V20CredOffer]:
         """
         Set up a new credential exchange record for an automated send.
@@ -66,6 +67,7 @@ class V20CredManager:
             cred_proposal: credential proposal with preview
             verification_method: an optional verification method to be used when issuing
             auto_remove: flag to remove the record automatically on completion
+            replacement_id: identifier to help coordinate credential replacement
 
         Returns:
             A tuple of the new credential exchange record and credential offer message
@@ -87,6 +89,7 @@ class V20CredManager:
             cred_ex_record=cred_ex_record,
             counter_proposal=None,
             comment="create automated v2.0 credential exchange record",
+            replacement_id=replacement_id,
         )
 
     async def create_proposal(

--- a/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
@@ -210,6 +210,13 @@ class V20IssueCredSchemaCore(AdminAPIMessageTracingSchema):
 
     credential_preview = fields.Nested(V20CredPreviewSchema, required=False)
 
+    replacement_id = fields.Str(
+        description="Optional identifier used to manage credential replacement",
+        required=False,
+        allow_none=True,
+        example=UUIDFour.EXAMPLE,
+    )
+
     @validates_schema
     def validate(self, data, **kwargs):
         """Make sure preview is present when indy format is present."""
@@ -642,6 +649,7 @@ async def credential_exchange_send(request: web.BaseRequest):
         raise web.HTTPBadRequest(reason="Missing filter")
     preview_spec = body.get("credential_preview")
     auto_remove = body.get("auto_remove")
+    replacement_id = body.get("replacement_id")
     trace_msg = body.get("trace")
 
     conn_record = None
@@ -680,6 +688,7 @@ async def credential_exchange_send(request: web.BaseRequest):
             verification_method=verification_method,
             cred_proposal=cred_proposal,
             auto_remove=auto_remove,
+            replacement_id=replacement_id,
         )
         result = cred_ex_record.serialize()
 
@@ -809,6 +818,7 @@ async def _create_free_offer(
     connection_id: str = None,
     auto_issue: bool = False,
     auto_remove: bool = False,
+    replacement_id: str = None,
     preview_spec: dict = None,
     comment: str = None,
     trace_msg: bool = None,
@@ -840,6 +850,7 @@ async def _create_free_offer(
     (cred_ex_record, cred_offer_message) = await cred_manager.create_offer(
         cred_ex_record,
         comment=comment,
+        replacement_id=replacement_id,
     )
 
     return (cred_ex_record, cred_offer_message)
@@ -876,6 +887,7 @@ async def credential_exchange_create_free_offer(request: web.BaseRequest):
         "auto_issue", context.settings.get("debug.auto_respond_credential_request")
     )
     auto_remove = body.get("auto_remove")
+    replacement_id = body.get("replacement_id")
     comment = body.get("comment")
     preview_spec = body.get("credential_preview")
     filt_spec = body.get("filter")
@@ -889,6 +901,7 @@ async def credential_exchange_create_free_offer(request: web.BaseRequest):
             filt_spec=filt_spec,
             auto_issue=auto_issue,
             auto_remove=auto_remove,
+            replacement_id=replacement_id,
             preview_spec=preview_spec,
             comment=comment,
             trace_msg=trace_msg,
@@ -950,6 +963,7 @@ async def credential_exchange_send_free_offer(request: web.BaseRequest):
         "auto_issue", context.settings.get("debug.auto_respond_credential_request")
     )
     auto_remove = body.get("auto_remove")
+    replacement_id = body.get("replacement_id")
     comment = body.get("comment")
     preview_spec = body.get("credential_preview")
     trace_msg = body.get("trace")
@@ -971,6 +985,7 @@ async def credential_exchange_send_free_offer(request: web.BaseRequest):
             preview_spec=preview_spec,
             comment=comment,
             trace_msg=trace_msg,
+            replacement_id=replacement_id,
         )
         result = cred_ex_record.serialize()
 


### PR DESCRIPTION
create/create-offer, send/send-offer now have replacement_id in the POST body to set the id

Addresses #2218

`replacement_id` for [RFC-0453](https://github.com/hyperledger/aries-rfcs/tree/main/features/0453-issue-credential-v2) was half implemented, just needed to expose it to the API for the issuer to set the value.