### PR TITLE
Fix routing in set public did

### DIFF
--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -498,9 +498,12 @@ async def wallet_set_public_did(request: web.BaseRequest):
     )
     routing_keys = None
     mediator_endpoint = None
-    if mediation_record:
-        routing_keys = mediation_record.routing_keys
-        mediator_endpoint = mediation_record.endpoint
+
+    routing_keys, mediator_endpoint = await route_manager.routing_info(
+        profile,
+        mediator_endpoint,
+        mediation_record,
+    )
 
     try:
         info, attrib_def = await promote_wallet_public_did(

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import List
+from typing import List, cast
 
 from aiohttp import web
 from aiohttp_apispec import docs, querystring_schema, request_schema, response_schema
@@ -496,12 +496,10 @@ async def wallet_set_public_did(request: web.BaseRequest):
     mediation_record = await route_manager.mediation_record_if_id(
         profile=profile, mediation_id=mediation_id, or_default=True
     )
-    routing_keys = None
-    mediator_endpoint = None
 
     routing_keys, mediator_endpoint = await route_manager.routing_info(
         profile,
-        mediator_endpoint,
+        cast(str, profile.settings.get("default_endpoint")),
         mediation_record,
     )
 

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import List, cast
+from typing import List
 
 from aiohttp import web
 from aiohttp_apispec import docs, querystring_schema, request_schema, response_schema
@@ -499,7 +499,7 @@ async def wallet_set_public_did(request: web.BaseRequest):
 
     routing_keys, mediator_endpoint = await route_manager.routing_info(
         profile,
-        cast(str, profile.settings.get("default_endpoint")),
+        None,
         mediation_record,
     )
 

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -674,7 +674,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             return_value=None
         )
         mock_route_manager.routing_info = async_mock.AsyncMock(
-            return_value=([], default_endpoint)
+            return_value=(None, default_endpoint)
         )
         mock_route_manager.__aenter__ = async_mock.AsyncMock(
             return_value=mock_route_manager

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -674,7 +674,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             return_value=None
         )
         mock_route_manager.routing_info = async_mock.AsyncMock(
-            return_value=(None, default_endpoint)
+            return_value=(None, None)
         )
         mock_route_manager.__aenter__ = async_mock.AsyncMock(
             return_value=mock_route_manager

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -42,6 +42,11 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         self.did_methods = DIDMethods()
         self.context.injector.bind_instance(DIDMethods, self.did_methods)
 
+        self.test_mediator_routing_keys = [
+            "3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRR"
+        ]
+        self.test_mediator_endpoint = "http://mediator.example.com"
+
     async def test_missing_wallet(self):
         self.session_inject[BaseWallet] = None
 
@@ -440,6 +445,9 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         mock_route_manager = async_mock.MagicMock()
         mock_route_manager.route_verkey = async_mock.AsyncMock()
         mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.routing_info = async_mock.AsyncMock(
+            return_value=(self.test_mediator_routing_keys, self.test_mediator_endpoint)
+        )
         mock_route_manager.__aenter__ = async_mock.AsyncMock(
             return_value=mock_route_manager
         )
@@ -477,6 +485,9 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
     async def test_set_public_did_no_ledger(self):
         mock_route_manager = async_mock.MagicMock()
         mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.routing_info = async_mock.AsyncMock(
+            return_value=(self.test_mediator_routing_keys, self.test_mediator_endpoint)
+        )
         mock_route_manager.__aenter__ = async_mock.AsyncMock(
             return_value=mock_route_manager
         )
@@ -497,6 +508,9 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
 
         mock_route_manager = async_mock.MagicMock()
         mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.routing_info = async_mock.AsyncMock(
+            return_value=(self.test_mediator_routing_keys, self.test_mediator_endpoint)
+        )
         mock_route_manager.__aenter__ = async_mock.AsyncMock(
             return_value=mock_route_manager
         )
@@ -516,6 +530,9 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
 
         mock_route_manager = async_mock.MagicMock()
         mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.routing_info = async_mock.AsyncMock(
+            return_value=(self.test_mediator_routing_keys, self.test_mediator_endpoint)
+        )
         mock_route_manager.__aenter__ = async_mock.AsyncMock(
             return_value=mock_route_manager
         )
@@ -537,6 +554,9 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
 
         mock_route_manager = async_mock.MagicMock()
         mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.routing_info = async_mock.AsyncMock(
+            return_value=(self.test_mediator_routing_keys, self.test_mediator_endpoint)
+        )
         mock_route_manager.__aenter__ = async_mock.AsyncMock(
             return_value=mock_route_manager
         )
@@ -568,6 +588,9 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
 
         mock_route_manager = async_mock.MagicMock()
         mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.routing_info = async_mock.AsyncMock(
+            return_value=(self.test_mediator_routing_keys, self.test_mediator_endpoint)
+        )
         mock_route_manager.__aenter__ = async_mock.AsyncMock(
             return_value=mock_route_manager
         )
@@ -600,6 +623,9 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         mock_route_manager = async_mock.MagicMock()
         mock_route_manager.route_verkey = async_mock.AsyncMock()
         mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.routing_info = async_mock.AsyncMock(
+            return_value=(self.test_mediator_routing_keys, self.test_mediator_endpoint)
+        )
         mock_route_manager.__aenter__ = async_mock.AsyncMock(
             return_value=mock_route_manager
         )
@@ -611,7 +637,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             self.wallet.set_public_did.return_value = DIDInfo(
                 self.test_did,
                 self.test_verkey,
-                {**DIDPosture.PUBLIC.metadata, "endpoint": "https://endpoint.com"},
+                {**DIDPosture.PUBLIC.metadata, "endpoint": self.test_mediator_endpoint},
                 SOV,
                 ED25519,
             )
@@ -632,9 +658,8 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
 
     async def test_set_public_did_update_endpoint_use_default_update_in_wallet(self):
         self.request.query = {"did": self.test_did}
-        self.context.update_settings(
-            {"default_endpoint": "https://default_endpoint.com"}
-        )
+        default_endpoint = "https://default_endpoint.com"
+        self.context.update_settings({"default_endpoint": default_endpoint})
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
@@ -647,6 +672,9 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         mock_route_manager.route_verkey = async_mock.AsyncMock()
         mock_route_manager.mediation_record_if_id = async_mock.AsyncMock(
             return_value=None
+        )
+        mock_route_manager.routing_info = async_mock.AsyncMock(
+            return_value=([], default_endpoint)
         )
         mock_route_manager.__aenter__ = async_mock.AsyncMock(
             return_value=mock_route_manager


### PR DESCRIPTION
Having a multitenancy mode and a base wallet mediator, when a DID was being promoted to public the base wallet mediator was not taken into consideration - the returned mediation record was always None. As a result, the agent's endpoint is written to ledger instead of the mediator's.

This PR fixes this issue.