### PR TITLE
1.0.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.0.0-rc3
+
+## July 7, 2023
+
+ACA-Py 1.0.0 will be a breaking update to ACA-Py with the version number indicating the maturity of the implementation. The final 1.0.0 release will be Aries Interop Profile 2.0-complete, and based on Python 3.9 or higher. The decision to start tagging early 1.0.0 releases was probably a bad one given the subsequent focus in the community on optimization of what we have vs. completing the to-do list for AIP 2.0. However, some organizations are using `1.0.0-rc` releases, so with this release of 1.0.0-rc3 we are providing an update that incorporates the many, many enhancements, improvements, and fixes that are in ACA-Py releases 0.8.0, 0.8.1 and 0.8.2.
+
+Release 1.0.0-rc3 is identical in functionality to ACA-Py Release 0.8.2 (changelog entry below). The only differences are the versions in the code/Swagger/Open API files and this changelog entry.
+
 # 0.8.2
 
 ## June 29, 2023

--- a/aries_cloudagent/version.py
+++ b/aries_cloudagent/version.py
@@ -1,4 +1,4 @@
 """Library version information."""
 
-__version__ = "0.8.2"
+__version__ = "1.0.0-rc3"
 RECORD_TYPE_ACAPY_VERSION = "acapy_version"

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -2,7 +2,7 @@
   "openapi" : "3.0.1",
   "info" : {
     "title" : "Aries Cloud Agent",
-    "version" : "v0.8.2"
+    "version" : "v1.0.0-rc3"
   },
   "servers" : [ {
     "url" : "/"

--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger" : "2.0",
   "info" : {
-    "version" : "v0.8.2",
+    "version" : "v1.0.0-rc3",
     "title" : "Aries Cloud Agent"
   },
   "tags" : [ {


### PR DESCRIPTION
PR to enable creating a 1.0.0-rc3 release that matches ACA-Py Release 0.8.2.