### PR TITLE
feat(anoncreds): Implement automated setup of revocation

### DIFF
--- a/aries_cloudagent/anoncreds/events.py
+++ b/aries_cloudagent/anoncreds/events.py
@@ -1,0 +1,81 @@
+"""Events fired by AnonCreds interface."""
+
+import re
+from typing import NamedTuple, Optional
+
+from aries_cloudagent.anoncreds.models.anoncreds_revocation import RevRegDef
+from ..core.event_bus import Event
+
+
+CRED_DEF_FINISHED_EVENT = "anoncreds::credential-definition::finished"
+REV_REG_DEF_FINISHED_EVENT = "anoncreds::revocation-registry-definition::finished"
+REV_LIST_FINISHED_EVENT = "anoncreds::revocation-list::finished"
+
+CRED_DEF_FINISHED_PATTERN = re.compile("anoncreds::credential-definition::finished")
+REV_REG_DEF_FINISHED_PATTERN = re.compile(
+    "anoncreds::revocation-registry-definition::finished"
+)
+REV_LIST_FINISHED_PATTERN = re.compile("anoncreds::revocation-list::finished")
+
+
+class CredDefFinishedPayload(NamedTuple):
+    """Payload of cred def finished event."""
+
+    schema_id: str
+    cred_def_id: str
+    issuer_id: str
+    support_revocation: bool
+    novel: bool
+    max_cred_num: int
+    auto_create_rev_reg: bool = False
+    create_pending_rev_reg: bool = False
+
+
+class CredDefFinishedEvent(Event):
+    """Event for cred def finished."""
+
+    def __init__(self, payload: CredDefFinishedPayload):
+        self._topic = CRED_DEF_FINISHED_EVENT
+        self._payload = payload
+
+    @property
+    def payload(self) -> CredDefFinishedPayload:
+        """Return payload."""
+        return self._payload
+
+
+class RevRegDefFinishedPayload(NamedTuple):
+    """Payload of rev reg def finished event."""
+
+    rev_reg_def_id: str
+    rev_reg_def: RevRegDef
+
+
+class RevRegDefFinishedEvent(Event):
+    """Event for rev reg def finished."""
+
+    def __init__(self, payload: RevRegDefFinishedPayload):
+        self._topic = REV_REG_DEF_FINISHED_EVENT
+        self._payload = payload
+
+    @property
+    def payload(self) -> RevRegDefFinishedPayload:
+        """Return payload."""
+        return self._payload
+
+
+class RevListFinishedPayload(NamedTuple):
+    """Payload of rev list finished event."""
+
+
+class RevListFinishedEvent(Event):
+    """Event for rev list finished."""
+
+    def __init__(self, payload: RevListFinishedPayload):
+        self._topic = REV_LIST_FINISHED_EVENT
+        self._payload = payload
+
+    @property
+    def payload(self) -> RevListFinishedPayload:
+        """Return payload."""
+        return self._payload

--- a/aries_cloudagent/anoncreds/events.py
+++ b/aries_cloudagent/anoncreds/events.py
@@ -1,10 +1,10 @@
 """Events fired by AnonCreds interface."""
 
 import re
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
-from aries_cloudagent.anoncreds.models.anoncreds_revocation import RevRegDef
 from ..core.event_bus import Event
+from .models.anoncreds_revocation import RevRegDef
 
 
 CRED_DEF_FINISHED_EVENT = "anoncreds::credential-definition::finished"
@@ -25,18 +25,32 @@ class CredDefFinishedPayload(NamedTuple):
     cred_def_id: str
     issuer_id: str
     support_revocation: bool
-    novel: bool
     max_cred_num: int
-    auto_create_rev_reg: bool = False
-    create_pending_rev_reg: bool = False
 
 
 class CredDefFinishedEvent(Event):
     """Event for cred def finished."""
 
-    def __init__(self, payload: CredDefFinishedPayload):
+    def __init__(
+        self,
+        payload: CredDefFinishedPayload,
+    ):
         self._topic = CRED_DEF_FINISHED_EVENT
         self._payload = payload
+
+    @classmethod
+    def with_payload(
+        cls,
+        schema_id: str,
+        cred_def_id: str,
+        issuer_id: str,
+        support_revocation: bool,
+        max_cred_num: int,
+    ):
+        payload = CredDefFinishedPayload(
+            schema_id, cred_def_id, issuer_id, support_revocation, max_cred_num
+        )
+        return cls(payload)
 
     @property
     def payload(self) -> CredDefFinishedPayload:
@@ -57,6 +71,15 @@ class RevRegDefFinishedEvent(Event):
     def __init__(self, payload: RevRegDefFinishedPayload):
         self._topic = REV_REG_DEF_FINISHED_EVENT
         self._payload = payload
+
+    @classmethod
+    def with_payload(
+        cls,
+        rev_reg_def_id: str,
+        rev_reg_def: RevRegDef,
+    ):
+        payload = RevRegDefFinishedPayload(rev_reg_def_id, rev_reg_def)
+        return cls(payload)
 
     @property
     def payload(self) -> RevRegDefFinishedPayload:

--- a/aries_cloudagent/anoncreds/revocation_setup.py
+++ b/aries_cloudagent/anoncreds/revocation_setup.py
@@ -1,0 +1,138 @@
+"""Automated setup process for AnonCreds credential definitions with revocation."""
+
+import re
+
+from ..anoncreds.revocation import AnonCredsRevocation
+from ..core.profile import Profile
+from ..core.event_bus import Event, EventBus
+from .events import (
+    CRED_DEF_FINISHED_PATTERN,
+    REV_REG_DEF_FINISHED_PATTERN,
+    REV_LIST_FINISHED_PATTERN,
+    CredDefFinishedEvent,
+    RevRegDefFinishedEvent,
+    RevListFinishedEvent,
+)
+
+REGISTRY_TYPE = "CL_ACCUM"
+DEFAULT_TAG = "default"
+
+
+class AnonCredsRevocationSetupManager:
+    """Manager for automated setup of revocation support."""
+
+    def __init__(self):
+        """Init manager."""
+
+    async def setup(self, profile: Profile):
+        """Register event listeners."""
+        bus = profile.inject(EventBus)
+        bus.subscribe(re.compile(CRED_DEF_FINISHED_PATTERN), self.on_cred_def)
+        bus.subscribe(re.compile(REV_REG_DEF_FINISHED_PATTERN), self.on_rev_reg_def)
+        bus.subscribe(re.compile(REV_LIST_FINISHED_PATTERN), self.on_rev_list)
+
+    async def on_cred_def(self, profile: Profile, event: CredDefFinishedEvent):
+        """Handle cred def finished."""
+        payload = event.payload
+        if payload.support_revocation and payload.novel and payload.auto_create_rev_reg:
+            # this kicks off the revocation registry creation process, which is 3 steps:
+            # 1 - create revocation registry (ledger transaction may require endorsement)
+            # 2 - upload tails file
+            # 3 - create revocation entry (ledger transaction may require endorsement)
+            # For a cred def we also automatically create a second "pending" revocation
+            # registry, so when the first one fills up we can continue to issue credentials
+            # without a delay
+            revoc = AnonCredsRevocation(profile)
+            await revoc.create_and_register_revocation_registry_definition(
+                issuer_id=payload.issuer_id,
+                cred_def_id=payload.cred_def_id,
+                registry_type=REGISTRY_TYPE,
+                max_cred_num=payload.max_cred_num,
+                tag=DEFAULT_TAG,
+            )
+
+    async def on_rev_reg_def(self, profile: Profile, event: RevRegDefFinishedEvent):
+        """Handle rev reg def finished."""
+        revoc = AnonCredsRevocation(profile)
+        await revoc.upload_tails_file(event.payload.rev_reg_def)
+        await revoc.create_and_register_revocation_list(event.payload.rev_reg_def_id)
+
+        # Generate the registry and upload the tails file
+        async def generate(rr_record: IssuerRevRegRecord) -> dict:
+            await rr_record.generate_registry(profile)
+            public_uri = (
+                tails_base_url.rstrip("/") + f"/{registry_record.revoc_reg_id}"
+            )  # TODO: update to include /hash
+            await rr_record.set_tails_file_public_uri(profile, public_uri)
+            rev_reg_resp = await rr_record.send_def(
+                profile,
+                write_ledger=write_ledger,
+                endorser_did=endorser_did,
+            )
+            if write_ledger:
+                # Upload the tails file
+                await rr_record.upload_tails_file(profile)
+
+                # Post the initial revocation entry
+                await notify_revocation_entry_event(profile, record_id, meta_data)
+            else:
+                transaction_manager = TransactionManager(profile)
+                try:
+                    revo_transaction = await transaction_manager.create_record(
+                        messages_attach=rev_reg_resp["result"],
+                        connection_id=connection.connection_id,
+                        meta_data=event.payload,
+                    )
+                except StorageError as err:
+                    raise TransactionManagerError(reason=err.roll_up) from err
+
+                # if auto-request, send the request to the endorser
+                if profile.settings.get_value("endorser.auto_request"):
+                    try:
+                        (
+                            revo_transaction,
+                            revo_transaction_request,
+                        ) = await transaction_manager.create_request(
+                            transaction=revo_transaction,
+                            # TODO see if we need to parameterize these params
+                            # expires_time=expires_time,
+                            # endorser_write_txn=endorser_write_txn,
+                        )
+                    except (StorageError, TransactionManagerError) as err:
+                        raise TransactionManagerError(reason=err.roll_up) from err
+
+                    responder = profile.inject_or(BaseResponder)
+                    if responder:
+                        await responder.send(
+                            revo_transaction_request,
+                            connection_id=connection.connection_id,
+                        )
+                    else:
+                        LOGGER.warning(
+                            "Configuration has no BaseResponder: cannot update "
+                            "revocation on registry ID: %s",
+                            record_id,
+                        )
+
+        record_id = meta_data["context"]["issuer_rev_id"]
+        async with profile.session() as session:
+            registry_record = await IssuerRevRegRecord.retrieve_by_id(
+                session, record_id
+            )
+        await shield(generate(registry_record))
+
+        create_pending_rev_reg = meta_data["processing"].get(
+            "create_pending_rev_reg", False
+        )
+        if write_ledger and create_pending_rev_reg:
+            revoc = AnonCredsRevocation(profile)
+            await revoc.init_issuer_registry(
+                registry_record.issuer_id,
+                registry_record.cred_def_id,
+                registry_record.max_cred_num,
+                registry_record.revoc_def_type,
+                endorser_connection_id=endorser_connection_id,
+            )
+
+    async def on_rev_list(self, profile: Profile, event: RevListFinishedEvent):
+        """Handle rev list finished."""

--- a/aries_cloudagent/anoncreds/revocation_setup.py
+++ b/aries_cloudagent/anoncreds/revocation_setup.py
@@ -1,10 +1,9 @@
 """Automated setup process for AnonCreds credential definitions with revocation."""
 
-import re
-
+from abc import ABC, abstractmethod
 from ..anoncreds.revocation import AnonCredsRevocation
 from ..core.profile import Profile
-from ..core.event_bus import Event, EventBus
+from ..core.event_bus import EventBus
 from .events import (
     CRED_DEF_FINISHED_PATTERN,
     REV_REG_DEF_FINISHED_PATTERN,
@@ -14,42 +13,63 @@ from .events import (
     RevListFinishedEvent,
 )
 
-REGISTRY_TYPE = "CL_ACCUM"
-DEFAULT_TAG = "default"
+
+class AnonCredsRevocationSetupManager(ABC):
+    """Base class for automated setup of revocation."""
+
+    @abstractmethod
+    def register_events(self, event_bus: EventBus):
+        """Setup the manager."""
 
 
-class AnonCredsRevocationSetupManager:
-    """Manager for automated setup of revocation support."""
+class DefaultRevocationSetup(AnonCredsRevocationSetupManager):
+    """Manager for automated setup of revocation support.
+
+    This manager models a state machine for the revocation setup process where
+    the transitions are triggered by the `finished` event of the previous
+    artifact. The state machine is as follows:
+
+    [*] --> Cred Def
+    Cred Def --> Rev Reg Def
+    Rev Reg Def --> Rev List
+    Rev List --> [*]
+
+    This implementation of an AnonCredsRevocationSetupManager will create two
+    revocation registries for each credential definition supporting revocation;
+    one that is active and one that is pending. When the active registry fills,
+    the pending registry will be activated and a new pending registry will be
+    created. This will continue indefinitely.
+
+    This hot-swap approach to revocation registry management allows for
+    issuance operations to be performed without a delay for registry
+    creation.
+    """
+
+    REGISTRY_TYPE = "CL_ACCUM"
+    INITIAL_REGISTRY_COUNT = 2
 
     def __init__(self):
         """Init manager."""
 
-    async def setup(self, profile: Profile):
+    def register_events(self, event_bus: EventBus):
         """Register event listeners."""
-        bus = profile.inject(EventBus)
-        bus.subscribe(re.compile(CRED_DEF_FINISHED_PATTERN), self.on_cred_def)
-        bus.subscribe(re.compile(REV_REG_DEF_FINISHED_PATTERN), self.on_rev_reg_def)
-        bus.subscribe(re.compile(REV_LIST_FINISHED_PATTERN), self.on_rev_list)
+        event_bus.subscribe(CRED_DEF_FINISHED_PATTERN, self.on_cred_def)
+        event_bus.subscribe(REV_REG_DEF_FINISHED_PATTERN, self.on_rev_reg_def)
+        event_bus.subscribe(REV_LIST_FINISHED_PATTERN, self.on_rev_list)
 
     async def on_cred_def(self, profile: Profile, event: CredDefFinishedEvent):
         """Handle cred def finished."""
         payload = event.payload
-        if payload.support_revocation and payload.novel and payload.auto_create_rev_reg:
-            # this kicks off the revocation registry creation process, which is 3 steps:
-            # 1 - create revocation registry (ledger transaction may require endorsement)
-            # 2 - upload tails file
-            # 3 - create revocation entry (ledger transaction may require endorsement)
-            # For a cred def we also automatically create a second "pending" revocation
-            # registry, so when the first one fills up we can continue to issue credentials
-            # without a delay
+        if payload.support_revocation:
             revoc = AnonCredsRevocation(profile)
-            await revoc.create_and_register_revocation_registry_definition(
-                issuer_id=payload.issuer_id,
-                cred_def_id=payload.cred_def_id,
-                registry_type=REGISTRY_TYPE,
-                max_cred_num=payload.max_cred_num,
-                tag=DEFAULT_TAG,
-            )
+            for registry_count in range(self.INITIAL_REGISTRY_COUNT):
+                await revoc.create_and_register_revocation_registry_definition(
+                    issuer_id=payload.issuer_id,
+                    cred_def_id=payload.cred_def_id,
+                    registry_type=self.REGISTRY_TYPE,
+                    max_cred_num=payload.max_cred_num,
+                    tag=str(registry_count),
+                )
 
     async def on_rev_reg_def(self, profile: Profile, event: RevRegDefFinishedEvent):
         """Handle rev reg def finished."""
@@ -57,82 +77,9 @@ class AnonCredsRevocationSetupManager:
         await revoc.upload_tails_file(event.payload.rev_reg_def)
         await revoc.create_and_register_revocation_list(event.payload.rev_reg_def_id)
 
-        # Generate the registry and upload the tails file
-        async def generate(rr_record: IssuerRevRegRecord) -> dict:
-            await rr_record.generate_registry(profile)
-            public_uri = (
-                tails_base_url.rstrip("/") + f"/{registry_record.revoc_reg_id}"
-            )  # TODO: update to include /hash
-            await rr_record.set_tails_file_public_uri(profile, public_uri)
-            rev_reg_resp = await rr_record.send_def(
-                profile,
-                write_ledger=write_ledger,
-                endorser_did=endorser_did,
-            )
-            if write_ledger:
-                # Upload the tails file
-                await rr_record.upload_tails_file(profile)
-
-                # Post the initial revocation entry
-                await notify_revocation_entry_event(profile, record_id, meta_data)
-            else:
-                transaction_manager = TransactionManager(profile)
-                try:
-                    revo_transaction = await transaction_manager.create_record(
-                        messages_attach=rev_reg_resp["result"],
-                        connection_id=connection.connection_id,
-                        meta_data=event.payload,
-                    )
-                except StorageError as err:
-                    raise TransactionManagerError(reason=err.roll_up) from err
-
-                # if auto-request, send the request to the endorser
-                if profile.settings.get_value("endorser.auto_request"):
-                    try:
-                        (
-                            revo_transaction,
-                            revo_transaction_request,
-                        ) = await transaction_manager.create_request(
-                            transaction=revo_transaction,
-                            # TODO see if we need to parameterize these params
-                            # expires_time=expires_time,
-                            # endorser_write_txn=endorser_write_txn,
-                        )
-                    except (StorageError, TransactionManagerError) as err:
-                        raise TransactionManagerError(reason=err.roll_up) from err
-
-                    responder = profile.inject_or(BaseResponder)
-                    if responder:
-                        await responder.send(
-                            revo_transaction_request,
-                            connection_id=connection.connection_id,
-                        )
-                    else:
-                        LOGGER.warning(
-                            "Configuration has no BaseResponder: cannot update "
-                            "revocation on registry ID: %s",
-                            record_id,
-                        )
-
-        record_id = meta_data["context"]["issuer_rev_id"]
-        async with profile.session() as session:
-            registry_record = await IssuerRevRegRecord.retrieve_by_id(
-                session, record_id
-            )
-        await shield(generate(registry_record))
-
-        create_pending_rev_reg = meta_data["processing"].get(
-            "create_pending_rev_reg", False
-        )
-        if write_ledger and create_pending_rev_reg:
-            revoc = AnonCredsRevocation(profile)
-            await revoc.init_issuer_registry(
-                registry_record.issuer_id,
-                registry_record.cred_def_id,
-                registry_record.max_cred_num,
-                registry_record.revoc_def_type,
-                endorser_connection_id=endorser_connection_id,
-            )
+        if event.payload.rev_reg_def.tag == str(0):
+            # Mark the first registry as active
+            await revoc.set_active_registry(event.payload.rev_reg_def_id)
 
     async def on_rev_list(self, profile: Profile, event: RevListFinishedEvent):
         """Handle rev list finished."""

--- a/aries_cloudagent/anoncreds/routes.py
+++ b/aries_cloudagent/anoncreds/routes.py
@@ -14,6 +14,7 @@ from marshmallow import fields
 
 from ..admin.request_context import AdminRequestContext
 from ..askar.profile import AskarProfile
+from ..core.event_bus import EventBus
 from ..messaging.models.openapi import OpenAPISchema
 from ..messaging.valid import UUIDFour
 from ..revocation.error import RevocationError, RevocationNotSupportedError
@@ -37,6 +38,7 @@ from .models.anoncreds_schema import (
 )
 from .registry import AnonCredsRegistry
 from .revocation import AnonCredsRevocation, AnonCredsRevocationError
+from .revocation_setup import DefaultRevocationSetup
 
 LOGGER = logging.getLogger(__name__)
 
@@ -591,6 +593,13 @@ async def register(app: web.Application):
             web.post("/anoncreds/publish-revocations", publish_revocations),
         ]
     )
+
+
+def register_events(event_bus: EventBus):
+    """Register events."""
+    # TODO Make this pluggable?
+    setup_manager = DefaultRevocationSetup()
+    setup_manager.register_events(event_bus)
 
 
 def post_process_routes(app: web.Application):


### PR DESCRIPTION
This PR implements automated setup of revocation by introducing an `AnonCredsRevocationSetupManager` base class and `DefaultRevocationSetup` concrete class and adding the appropriate hooks to the artifact registration steps.

Overall, I'm very pleased with the simplicity of this setup manager as compared to our original mechanism. It works in more or less the same way, listening for events and triggering the next step in the flow; however, all the event listeners are defined in one place (rather than across 2 or 3 modules) and the event objects themselves have been formalized to make accessing the information in the event simpler. Additionally, encapsulation of the anoncreds interface is better than what we had previously so the event listeners themselves are fewer lines with significantly more straightforward logic.

I've left the door open for enabling plugins to implement their own `AnonCredsRevocationSetupManager` if there is ever a need to customize the setup behavior. I'm considering moving the `handle_full_registry` logic to this same component for the same reason -- giving plugin authors the ability to customize if needed -- but I'm not sure how likely it is anyone will actually need or want to do customizations.

This PR invalidates the following temporary endpoints we added for testing:

- `POST /anoncreds/revocation-registry-definition`
- `PUT /anoncreds/registry/{rev_reg_def_id}/tails-file`
- `PUT /anoncreds/registry/{rev_reg_def_id}/active`
- `POST /anoncreds/revocation-list`

I haven't removed these endpoints just yet in this PR though.

This PR adds `max_cred_num` to the expected options of the `POST /anoncreds/credential-definition` endpoint.