### PR TITLE
Allow any did to be public

### DIFF
--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -10,6 +10,7 @@ from hashlib import sha256
 from typing import List, Sequence, Tuple, Union
 
 from ..indy.issuer import DEFAULT_CRED_DEF_TAG, IndyIssuer, IndyIssuerError
+from ..messaging.valid import IndyDID
 from ..utils import sentinel
 from ..wallet.did_info import DIDInfo
 
@@ -294,6 +295,11 @@ class BaseLedger(ABC, metaclass=ABCMeta):
         public_info = await self.get_wallet_public_did()
         if not public_info:
             raise BadLedgerRequestError("Cannot publish schema without a public DID")
+
+        if not bool(IndyDID.PATTERN.match(public_info.did)):
+            raise BadLedgerRequestError(
+                "Cannot publish schema when public DID is not an IndyDID"
+            )
 
         schema_info = await self.check_existing_schema(
             public_info.did, schema_name, schema_version, attribute_names

--- a/aries_cloudagent/ledger/indy_vdr.py
+++ b/aries_cloudagent/ledger/indy_vdr.py
@@ -18,6 +18,7 @@ from indy_vdr import ledger, open_pool, Pool, Request, VdrError
 
 from ..cache.base import BaseCache
 from ..core.profile import Profile
+from ..messaging.valid import IndyDID
 from ..storage.base import BaseStorage, StorageRecord
 from ..utils import sentinel
 from ..utils.env import storage_path
@@ -605,6 +606,11 @@ class IndyVdrLedger(BaseLedger):
         nym = self.did_to_nym(did)
         public_info = await self.get_wallet_public_did()
         public_did = public_info.did if public_info else None
+
+        # current public_did may be non-indy -> create nym request with empty public did
+        if public_did is not None and not bool(IndyDID.PATTERN.match(public_did)):
+            public_did = None
+
         try:
             nym_req = ledger.build_get_nym_request(public_did, nym)
         except VdrError as err:

--- a/aries_cloudagent/ledger/tests/test_indy_vdr.py
+++ b/aries_cloudagent/ledger/tests/test_indy_vdr.py
@@ -10,8 +10,9 @@ from ...core.in_memory import InMemoryProfile
 from ...indy.issuer import IndyIssuer
 from ...wallet.base import BaseWallet
 from ...wallet.key_type import KeyType, ED25519
-from ...wallet.did_method import SOV, DIDMethods
+from ...wallet.did_method import SOV, DIDMethods, DIDMethod, HolderDefinedDid
 from ...wallet.did_info import DIDInfo
+from ...wallet.did_posture import DIDPosture
 
 from ..endpoint_type import EndpointType
 from ..indy_vdr import (
@@ -25,10 +26,19 @@ from ..indy_vdr import (
     VdrError,
 )
 
+WEB = DIDMethod(
+    name="web",
+    key_types=[ED25519],
+    rotation=True,
+    holder_defined_did=HolderDefinedDid.REQUIRED,
+)
+
 
 @pytest.fixture()
 def ledger():
-    profile = InMemoryProfile.test_profile(bind={DIDMethods: DIDMethods()})
+    did_methods = DIDMethods()
+    did_methods.register(WEB)
+    profile = InMemoryProfile.test_profile(bind={DIDMethods: did_methods})
     ledger = IndyVdrLedger(IndyVdrLedgerPool("test-ledger"), profile)
 
     async def open():
@@ -342,6 +352,28 @@ class TestIndyVdrLedger:
                     )
 
     @pytest.mark.asyncio
+    async def test_send_schema_no_indy_did(
+        self,
+        ledger: IndyVdrLedger,
+    ):
+        wallet = async_mock.MagicMock((await ledger.profile.session()).wallet)
+        wallet.create_public_did.return_value = {
+            "result": {
+                "did": "did:web:doma.in",
+                "verkey": "verkey",
+                "posture": DIDPosture.PUBLIC.moniker,
+                "key_type": ED25519.key_type,
+                "method": WEB.method_name,
+            }
+        }
+        issuer = async_mock.MagicMock(IndyIssuer)
+        async with ledger:
+            with pytest.raises(BadLedgerRequestError):
+                schema_id, schema_def = await ledger.create_and_send_schema(
+                    issuer, "schema_name", "9.1", ["a", "b"]
+                )
+
+    @pytest.mark.asyncio
     async def test_get_schema(
         self,
         ledger: IndyVdrLedger,
@@ -520,6 +552,26 @@ class TestIndyVdrLedger:
         ledger: IndyVdrLedger,
     ):
         async with ledger:
+            ledger.pool_handle.submit_request.return_value = {
+                "data": r'{"verkey": "VK"}',
+            }
+            result = await ledger.get_key_for_did("55GkHamhTU1ZbTbV2ab9DE")
+            assert result == "VK"
+
+    @pytest.mark.asyncio
+    async def test_get_key_for_did_non_sov_public_did(
+        self,
+        ledger: IndyVdrLedger,
+    ):
+        async with ledger:
+            wallet = async_mock.MagicMock((await ledger.profile.session()).wallet)
+            wallet.get_public_did.return_value = DIDInfo(
+                "did:web:doma.in",
+                "verkey",
+                DIDPosture.PUBLIC.metadata,
+                WEB,
+                ED25519,
+            )
             ledger.pool_handle.submit_request.return_value = {
                 "data": r'{"verkey": "VK"}',
             }

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -13,6 +13,7 @@ from ....connections.models.connection_target import ConnectionTarget
 from ....core.error import BaseError
 from ....core.profile import Profile
 from ....messaging.responder import BaseResponder
+from ....messaging.valid import IndyDID
 from ....multitenant.base import BaseMultitenantManager
 from ....storage.error import StorageError, StorageNotFoundError
 from ....transport.inbound.receipt import MessageReceipt
@@ -176,8 +177,12 @@ class ConnectionManager(BaseConnectionManager):
                 )
 
             # FIXME - allow ledger instance to format public DID with prefix?
+            public_did_did = public_did.did
+            if bool(IndyDID.PATTERN.match(public_did_did)):
+                public_did_did = f"did:sov:{public_did.did}"
+
             invitation = ConnectionInvitation(
-                label=my_label, did=f"did:sov:{public_did.did}", image_url=image_url
+                label=my_label, did=public_did_did, image_url=image_url
             )
 
             connection = ConnRecord(  # create connection record

--- a/aries_cloudagent/protocols/connections/v1_0/messages/connection_invitation.py
+++ b/aries_cloudagent/protocols/connections/v1_0/messages/connection_invitation.py
@@ -6,7 +6,7 @@ from urllib.parse import parse_qs, urljoin, urlparse
 from marshmallow import EXCLUDE, fields, validates_schema, ValidationError
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
-from .....messaging.valid import INDY_DID, INDY_RAW_PUBLIC_KEY
+from .....messaging.valid import GENERIC_DID, INDY_RAW_PUBLIC_KEY
 from .....wallet.util import b64_to_bytes, bytes_to_b64
 
 from ..message_types import CONNECTION_INVITATION, PROTOCOL_PACKAGE
@@ -106,7 +106,7 @@ class ConnectionInvitationSchema(AgentMessageSchema):
         example="Bob",
     )
     did = fields.Str(
-        required=False, description="DID for connection invitation", **INDY_DID
+        required=False, description="DID for connection invitation", **GENERIC_DID
     )
     recipient_keys = fields.List(
         fields.Str(description="Recipient public key", **INDY_RAW_PUBLIC_KEY),

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -17,6 +17,7 @@ from ....core.oob_processor import OobMessageProcessor
 from ....core.profile import Profile
 from ....did.did_key import DIDKey
 from ....messaging.responder import BaseResponder
+from ....messaging.valid import IndyDID
 from ....storage.error import StorageNotFoundError
 from ....transport.inbound.receipt import MessageReceipt
 from ....wallet.base import BaseWallet
@@ -220,12 +221,16 @@ class OutOfBandManager(BaseConnectionManager):
                     "Cannot create public invitation with no public DID"
                 )
 
+            public_did_did = public_did.did
+            if bool(IndyDID.PATTERN.match(public_did.did)):
+                public_did_did = f"did:sov:{public_did.did}"
+
             invi_msg = InvitationMessage(  # create invitation message
                 _id=invitation_message_id,
                 label=my_label or self.profile.settings.get("default_label"),
                 handshake_protocols=handshake_protocols,
                 requests_attach=message_attachments,
-                services=[f"did:sov:{public_did.did}"],
+                services=[public_did_did],
                 accept=service_accept if protocol_version != "1.0" else None,
                 version=protocol_version or DEFAULT_VERSION,
                 image_url=image_url,
@@ -440,7 +445,10 @@ class OutOfBandManager(BaseConnectionManager):
         # Get the DID public did, if any
         public_did = None
         if isinstance(oob_service_item, str):
-            public_did = oob_service_item.split(":")[-1]
+            if bool(IndyDID.PATTERN.match(oob_service_item)):
+                public_did = oob_service_item.split(":")[-1]
+            else:
+                public_did = oob_service_item
 
         conn_rec = None
 

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -25,6 +25,7 @@ from ..messaging.valid import (
     INDY_DID,
     INDY_RAW_PUBLIC_KEY,
     GENERIC_DID,
+    IndyDID,
 )
 from ..protocols.coordinate_mediation.v1_0.route_manager import RouteManager
 from ..protocols.endorse_transaction.v1_0.manager import (
@@ -565,53 +566,60 @@ async def promote_wallet_public_did(
     """Promote supplied DID to the wallet public DID."""
     info: DIDInfo = None
     endorser_did = None
+
+    is_indy_did = bool(IndyDID.PATTERN.match(did))
+    # write only Indy DID
+    write_ledger = is_indy_did and write_ledger
+
     ledger = profile.inject_or(BaseLedger)
-    if not ledger:
-        reason = "No ledger available"
-        if not context.settings.get_value("wallet.type"):
-            reason += ": missing wallet-type?"
-        raise PermissionError(reason)
 
-    async with ledger:
-        if not await ledger.get_key_for_did(did):
-            raise LookupError(f"DID {did} is not posted to the ledger")
+    if is_indy_did:
+        if not ledger:
+            reason = "No ledger available"
+            if not context.settings.get_value("wallet.type"):
+                reason += ": missing wallet-type?"
+            raise PermissionError(reason)
 
-    # check if we need to endorse
-    if is_author_role(profile):
-        # authors cannot write to the ledger
-        write_ledger = False
+        async with ledger:
+            if not await ledger.get_key_for_did(did):
+                raise LookupError(f"DID {did} is not posted to the ledger")
 
-        # author has not provided a connection id, so determine which to use
-        if not connection_id:
-            connection_id = await get_endorser_connection_id(profile)
-        if not connection_id:
-            raise web.HTTPBadRequest(reason="No endorser connection found")
-    if not write_ledger:
-        try:
+        # check if we need to endorse
+        if is_author_role(profile):
+            # authors cannot write to the ledger
+            write_ledger = False
+
+            # author has not provided a connection id, so determine which to use
+            if not connection_id:
+                connection_id = await get_endorser_connection_id(profile)
+            if not connection_id:
+                raise web.HTTPBadRequest(reason="No endorser connection found")
+        if not write_ledger:
+            try:
+                async with profile.session() as session:
+                    connection_record = await ConnRecord.retrieve_by_id(
+                        session, connection_id
+                    )
+            except StorageNotFoundError as err:
+                raise web.HTTPNotFound(reason=err.roll_up) from err
+            except BaseModelError as err:
+                raise web.HTTPBadRequest(reason=err.roll_up) from err
+
             async with profile.session() as session:
-                connection_record = await ConnRecord.retrieve_by_id(
-                    session, connection_id
+                endorser_info = await connection_record.metadata_get(
+                    session, "endorser_info"
                 )
-        except StorageNotFoundError as err:
-            raise web.HTTPNotFound(reason=err.roll_up) from err
-        except BaseModelError as err:
-            raise web.HTTPBadRequest(reason=err.roll_up) from err
-
-        async with profile.session() as session:
-            endorser_info = await connection_record.metadata_get(
-                session, "endorser_info"
-            )
-        if not endorser_info:
-            raise web.HTTPForbidden(
-                reason="Endorser Info is not set up in "
-                "connection metadata for this connection record"
-            )
-        if "endorser_did" not in endorser_info.keys():
-            raise web.HTTPForbidden(
-                reason=' "endorser_did" is not set in "endorser_info"'
-                " in connection metadata for this connection record"
-            )
-        endorser_did = endorser_info["endorser_did"]
+            if not endorser_info:
+                raise web.HTTPForbidden(
+                    reason="Endorser Info is not set up in "
+                    "connection metadata for this connection record"
+                )
+            if "endorser_did" not in endorser_info.keys():
+                raise web.HTTPForbidden(
+                    reason=' "endorser_did" is not set in "endorser_info"'
+                    " in connection metadata for this connection record"
+                )
+            endorser_did = endorser_info["endorser_did"]
 
     did_info: DIDInfo = None
     attrib_def = None
@@ -624,7 +632,7 @@ async def promote_wallet_public_did(
         # Publish endpoint if necessary
         endpoint = did_info.metadata.get("endpoint")
 
-        if not endpoint:
+        if is_indy_did and not endpoint:
             async with session_fn() as session:
                 wallet = session.inject_or(BaseWallet)
                 endpoint = mediator_endpoint or context.settings.get("default_endpoint")

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -14,6 +14,13 @@ from ..base import BaseWallet
 from ..did_info import DIDInfo
 from ..did_posture import DIDPosture
 
+WEB = DIDMethod(
+    name="web",
+    key_types=[ED25519],
+    rotation=True,
+    holder_defined_did=HolderDefinedDid.REQUIRED,
+)
+
 
 class TestWalletRoutes(IsolatedAsyncioTestCase):
     def setUp(self):
@@ -36,10 +43,13 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         )
 
         self.test_did = "did"
+        self.test_did_sov = "WgWxqztrNooG92RXvxSTWv"
+        self.test_did_web = "did:web:doma.in"
         self.test_verkey = "verkey"
         self.test_posted_did = "posted-did"
         self.test_posted_verkey = "posted-verkey"
         self.did_methods = DIDMethods()
+        self.did_methods.register(WEB)
         self.context.injector.bind_instance(DIDMethods, self.did_methods)
 
         self.test_mediator_routing_keys = [
@@ -492,13 +502,13 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             return_value=mock_route_manager
         )
         self.profile.context.injector.bind_instance(RouteManager, mock_route_manager)
-        self.request.query = {"did": self.test_did}
+        self.request.query = {"did": self.test_did_sov}
 
         with self.assertRaises(test_module.web.HTTPForbidden):
             await test_module.wallet_set_public_did(self.request)
 
     async def test_set_public_did_not_public(self):
-        self.request.query = {"did": self.test_did}
+        self.request.query = {"did": self.test_did_sov}
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
@@ -520,7 +530,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             await test_module.wallet_set_public_did(self.request)
 
     async def test_set_public_did_not_found(self):
-        self.request.query = {"did": self.test_did}
+        self.request.query = {"did": self.test_did_sov}
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
@@ -543,7 +553,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             await test_module.wallet_set_public_did(self.request)
 
     async def test_set_public_did_x(self):
-        self.request.query = {"did": self.test_did}
+        self.request.query = {"did": self.test_did_sov}
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
@@ -566,7 +576,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             test_module.web, "json_response", async_mock.Mock()
         ) as json_response:
             self.wallet.get_public_did.return_value = DIDInfo(
-                self.test_did,
+                self.test_did_sov,
                 self.test_verkey,
                 DIDPosture.PUBLIC.metadata,
                 SOV,
@@ -577,7 +587,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 await test_module.wallet_set_public_did(self.request)
 
     async def test_set_public_did_no_wallet_did(self):
-        self.request.query = {"did": self.test_did}
+        self.request.query = {"did": self.test_did_sov}
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
@@ -600,7 +610,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             test_module.web, "json_response", async_mock.Mock()
         ) as json_response:
             self.wallet.get_public_did.return_value = DIDInfo(
-                self.test_did,
+                self.test_did_sov,
                 self.test_verkey,
                 DIDPosture.PUBLIC.metadata,
                 SOV,
@@ -611,7 +621,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
                 await test_module.wallet_set_public_did(self.request)
 
     async def test_set_public_did_update_endpoint(self):
-        self.request.query = {"did": self.test_did}
+        self.request.query = {"did": self.test_did_sov}
 
         Ledger = async_mock.MagicMock()
         ledger = Ledger()
@@ -635,7 +645,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             test_module.web, "json_response", async_mock.Mock()
         ) as json_response:
             self.wallet.set_public_did.return_value = DIDInfo(
-                self.test_did,
+                self.test_did_sov,
                 self.test_verkey,
                 {**DIDPosture.PUBLIC.metadata, "endpoint": self.test_mediator_endpoint},
                 SOV,
@@ -646,7 +656,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             json_response.assert_called_once_with(
                 {
                     "result": {
-                        "did": self.test_did,
+                        "did": self.test_did_sov,
                         "verkey": self.test_verkey,
                         "posture": DIDPosture.PUBLIC.moniker,
                         "key_type": ED25519.key_type,
@@ -657,7 +667,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             assert result is json_response.return_value
 
     async def test_set_public_did_update_endpoint_use_default_update_in_wallet(self):
-        self.request.query = {"did": self.test_did}
+        self.request.query = {"did": self.test_did_sov}
         default_endpoint = "https://default_endpoint.com"
         self.context.update_settings({"default_endpoint": default_endpoint})
 
@@ -685,7 +695,7 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             test_module.web, "json_response", async_mock.Mock()
         ) as json_response:
             did_info = DIDInfo(
-                self.test_did,
+                self.test_did_sov,
                 self.test_verkey,
                 DIDPosture.PUBLIC.metadata,
                 SOV,
@@ -706,11 +716,52 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
             json_response.assert_called_once_with(
                 {
                     "result": {
-                        "did": self.test_did,
+                        "did": self.test_did_sov,
                         "verkey": self.test_verkey,
                         "posture": DIDPosture.PUBLIC.moniker,
                         "key_type": ED25519.key_type,
                         "method": SOV.method_name,
+                    }
+                }
+            )
+            assert result is json_response.return_value
+
+    async def test_set_public_did_with_non_sov_did(self):
+        self.request.query = {"did": self.test_did_web}
+
+        mock_route_manager = async_mock.MagicMock()
+        mock_route_manager.route_verkey = async_mock.AsyncMock()
+        mock_route_manager.mediation_record_if_id = async_mock.AsyncMock()
+        mock_route_manager.routing_info = async_mock.AsyncMock(
+            return_value=(self.test_mediator_routing_keys, self.test_mediator_endpoint)
+        )
+        mock_route_manager.__aenter__ = async_mock.AsyncMock(
+            return_value=mock_route_manager
+        )
+        self.profile.context.injector.bind_instance(RouteManager, mock_route_manager)
+
+        with async_mock.patch.object(
+            test_module.web, "json_response", async_mock.Mock()
+        ) as json_response:
+            self.wallet.set_public_did.return_value = DIDInfo(
+                self.test_did_web,
+                self.test_verkey,
+                DIDPosture.PUBLIC.metadata,
+                WEB,
+                ED25519,
+            )
+            result = await test_module.wallet_set_public_did(self.request)
+            self.wallet.set_public_did.assert_awaited_once()
+            self.wallet.set_did_endpoint.assert_not_called()
+
+            json_response.assert_called_once_with(
+                {
+                    "result": {
+                        "did": self.test_did_web,
+                        "verkey": self.test_verkey,
+                        "posture": DIDPosture.PUBLIC.moniker,
+                        "key_type": ED25519.key_type,
+                        "method": WEB.method_name,
                     }
                 }
             )


### PR DESCRIPTION
Having a universal resolver set in the configuration, I want to be able to create and receive invitations containing a public DID other than did:sov (Indy DID). In order to do that I must promote the DID to public after it has been created in the wallet.

This PR adds checks of the DID format to associate ledger operations to the did:sov only in the said operation, thus allowing any DID format to be set as public.