### PR TITLE
Cancel in-progress workflows when PR is updated

### DIFF
--- a/.github/workflows/integrationtests.yml
+++ b/.github/workflows/integrationtests.yml
@@ -1,12 +1,19 @@
 name: acapy-integration-tests
+
 on:
   workflow_dispatch:
   pull_request:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -3,6 +3,10 @@ name: PR Tests
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Tests

--- a/requirements.askar.txt
+++ b/requirements.askar.txt
@@ -1,3 +1,3 @@
 aries-askar~=0.2.5
-indy-credx~=0.3
+indy-credx~=0.3.3
 indy-vdr~=0.3.3


### PR DESCRIPTION
This is meant to cancel in-progress unit tests and integration tests which are no longer valid, and only consuming resources.