### PR TITLE
API endpoint to decommission revocation registry

### DIFF
--- a/aries_cloudagent/revocation/error.py
+++ b/aries_cloudagent/revocation/error.py
@@ -13,3 +13,7 @@ class RevocationNotSupportedError(RevocationError):
 
 class RevocationRegistryBadSizeError(RevocationError):
     """Attempted to create registry with maximum credentials too large or too small."""
+
+
+class RevocationInvalidStateValueError(RevocationError):
+    """Invalid Revocation Registry State value."""

--- a/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
+++ b/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
@@ -72,6 +72,17 @@ class IssuerRevRegRecord(BaseRecord):
     STATE_POSTED = "posted"  # definition published
     STATE_ACTIVE = "active"  # initial entry published, possibly subsequent entries
     STATE_FULL = "full"  # includes corrupt
+    STATE_DECOMMISSIONED = "decommissioned"
+
+    STATES = [
+        STATE_INIT,
+        STATE_GENERATED,
+        STATE_POSTED,
+        STATE_ACTIVE,
+        STATE_FULL,
+        STATE_DECOMMISSIONED,
+    ]
+    TERMINAL_STATES = [STATE_FULL, STATE_DECOMMISSIONED]
 
     def __init__(
         self,

--- a/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
+++ b/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
@@ -296,6 +296,7 @@ class IssuerRevRegRecord(BaseRecord):
         if self.state not in (
             IssuerRevRegRecord.STATE_POSTED,
             IssuerRevRegRecord.STATE_ACTIVE,
+            IssuerRevRegRecord.STATE_DECOMMISSIONED,
             IssuerRevRegRecord.STATE_FULL,  # can still publish revocation deltas
         ):
             raise RevocationError(

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -384,7 +384,7 @@ class SetRevRegStateQueryStringSchema(OpenAPISchema):
             [
                 getattr(IssuerRevRegRecord, m)
                 for m in vars(IssuerRevRegRecord)
-                if m.startswith("STATE_")
+                if m.startswith("STATE_") and m != "STATE_DECOMMISSIONED"
             ]
         ),
     )

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -538,18 +538,18 @@ async def clear_pending_revocations(request: web.BaseRequest):
     return web.json_response({"rrid2crid": results})
 
 
-@docs(tags=["revocation"], summary="Decommision revocation registry")
+@docs(tags=["revocation"], summary="Rotate revocation registry")
 @match_info_schema(RevocationCredDefIdMatchInfoSchema())
 @response_schema(RevRegsCreatedSchema(), 200, description="")
-async def decommission_rev_reg(request: web.BaseRequest):
+async def rotate_rev_reg(request: web.BaseRequest):
     """
-    Request handler to decommision the active revocation registries for cred. def.
+    Request handler to rotate the active revocation registries for cred. def.
 
     Args:
         request: aiohttp request object
 
     Returns:
-        200
+        list or revocation registry ids that were rotated out
 
     """
     context: AdminRequestContext = request["context"]
@@ -1601,8 +1601,8 @@ async def register(app: web.Application):
                 allow_head=False,
             ),
             web.post(
-                "/revocation/active-registry/{cred_def_id}/decommission",
-                decommission_rev_reg,
+                "/revocation/active-registry/{cred_def_id}/rotate",
+                rotate_rev_reg,
             ),
             web.get(
                 "/revocation/registry/{rev_reg_id}/issued",

--- a/aries_cloudagent/revocation/tests/test_indy.py
+++ b/aries_cloudagent/revocation/tests/test_indy.py
@@ -172,7 +172,7 @@ class TestIndyRevocation(AsyncTestCase):
         # store the ids to verify they are decommissioned
         rev_reg_ids = [rec.revoc_reg_id for rec in recs if rec.revoc_reg_id]
 
-        # need these to be active so we can decommission
+        # need these to be not init so we can decommission
         async with self.profile.transaction() as txn:
             for rec in recs:
                 registry = await IssuerRevRegRecord.retrieve_by_revoc_reg_id(

--- a/aries_cloudagent/revocation/tests/test_indy.py
+++ b/aries_cloudagent/revocation/tests/test_indy.py
@@ -154,7 +154,7 @@ class TestIndyRevocation(AsyncTestCase):
 
         assert len(await self.revoc.list_issuer_registries()) == 2
 
-    async def test_decommision_issuer_registries(self):
+    async def test_decommission_issuer_registries(self):
         CRED_DEF_ID = [f"{self.test_did}:3:CL:{i}:default" for i in (4321, 8765)]
 
         for cd_id in CRED_DEF_ID:

--- a/docs/GettingStartedAriesDev/CredentialRevocation.md
+++ b/docs/GettingStartedAriesDev/CredentialRevocation.md
@@ -181,3 +181,15 @@ There are several endpoints that must be called, and they must be called in this
 4. Write the tails file `PUT /revocation/registry/{rev_reg_id}/tails-file`
 
    - the tails server will check that the registry definition is already written to the ledger
+
+## Revocation Registry Rotation
+
+From time to time an Issuer may want to issue credentials from a new Revocation Registry. That can be done by changing the Credential Definition, but that could impact verifiers. 
+Revocation Registries go through a series of state changes: `init`, `generated`, `posted`, `active`, `full`, `decommissioned`. When issuing revocable credentials, the work is done with the `active` registry record. There are always 2 `active` registry records: one for tracking revocation until it is full, and the second to act as a "hot swap" in case issuance is done when the primary is full and being replaced. This ensures that there is always an `active` registry. When rotating, all registry records (except records in `init` state) are `decommissioned` and a new pair of `active` registry records are created.  
+  
+Issuers can rotate their Credential Definition Revocation Registry records with a simple call: `POST /revocation/active-registry/{cred_def_id}/rotate`
+
+It is advised that Issuers ensure the active registry is ready by calling `GET /revocation/active-registry/{cred_def_id}` after rotation and before issuance (if possible).
+
+
+


### PR DESCRIPTION
Closes issue #2304 

There are two active registries at a given time, this API endpoint - given a `cred_def_id` - will find and decommission the active revocation registries and will kick off the procedure to create new active registries (same as when a registry is full).

Note that the `pytest` doesn't have a handler to transition the `init` state registries to `active`, so we simulate that before testing the decommission code. 