### PR TITLE
chore: update PyYAML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ pynacl~=1.5.0
 python-dateutil~=2.8.1
 python-json-logger~=2.0.7
 pytz~=2021.1
-pyyaml~=5.4.0
+pyyaml~=6.0.1
 requests~=2.25.0
 rlp==1.2.0
 unflatten~=0.1


### PR DESCRIPTION
The older version seems to be causing errors in builds downstream for plugins and deployments after the recent 6.0.1 release.