### PR TITLE
fix: keylist update response race condition

### DIFF
--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -296,7 +296,10 @@ class DIDXManager(BaseConnectionManager):
                     method=SOV,
                     key_type=ED25519,
                 )
-            conn_rec.my_did = my_info.did
+                conn_rec.my_did = my_info.did
+                await conn_rec.save(
+                    session, reason="New DID associated with connection."
+                )
 
         # Idempotent; if routing has already been set up, no action taken
         await self._route_manager.route_connection_as_invitee(

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -297,16 +297,6 @@ class DIDXManager(BaseConnectionManager):
                     key_type=ED25519,
                 )
                 conn_rec.my_did = my_info.did
-                # We must save to correlate routing key sent to mediator back
-                # to a connection.
-                await conn_rec.save(
-                    session, reason="New DID associated with connection."
-                )
-
-        # Idempotent; if routing has already been set up, no action taken
-        await self._route_manager.route_connection_as_invitee(
-            self.profile, conn_rec, mediation_record
-        )
 
         # Create connection request message
         if my_endpoint:
@@ -351,6 +341,11 @@ class DIDXManager(BaseConnectionManager):
         conn_rec.state = ConnRecord.State.REQUEST.rfc23
         async with self.profile.session() as session:
             await conn_rec.save(session, reason="Created connection request")
+
+        # Idempotent; if routing has already been set up, no action taken
+        await self._route_manager.route_connection_as_invitee(
+            self.profile, conn_rec, mediation_record
+        )
 
         return request
 

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -297,6 +297,8 @@ class DIDXManager(BaseConnectionManager):
                     key_type=ED25519,
                 )
                 conn_rec.my_did = my_info.did
+                # We must save to correlate routing key sent to mediator back
+                # to a connection.
                 await conn_rec.save(
                     session, reason="New DID associated with connection."
                 )


### PR DESCRIPTION
When receiving an OOB invitation and automatically accepting by sending a DID Exchange request, it is possible to send a keylist update to the mediator and receive a response back before the connection is saved. This resulted in errors like:

```
Traceback (most recent call last):
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/protocols/coordinate_mediation/v1_0/route_manager.py", line 273, in connection_from_recipient_key
    conn = await ConnRecord.retrieve_by_tag_filter(
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/messaging/models/base_record.py", line 284, in retrieve_by_tag_filter
    raise StorageNotFoundError(
aries_cloudagent.storage.error.StorageNotFoundError: ConnRecord record not found for {'invitation_key': 'qHFoiMYB58Y25wRkFfYajhFLSUvJFZZbJStiaKL1LvW'}

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/protocols/coordinate_mediation/v1_0/handlers/keylist_update_response_handler.py", line 45, in notify_keylist_updated
    key_to_connection = {
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/protocols/coordinate_mediation/v1_0/handlers/keylist_update_response_handler.py", line 46, in <dictcomp>
    updated.recipient_key: await route_manager.connection_from_recipient_key(
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/protocols/coordinate_mediation/v1_0/route_manager.py", line 280, in connection_from_recipient_key
    conn = await ConnRecord.retrieve_by_did(session, my_did=did_info.did)
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/connections/models/conn_record.py", line 313, in retrieve_by_did
    return await cls.retrieve_by_tag_filter(session, tag_filter, post_filter)
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/messaging/models/base_record.py", line 284, in retrieve_by_tag_filter
    raise StorageNotFoundError(
aries_cloudagent.storage.error.StorageNotFoundError: ConnRecord record not found for {'my_did': '2XamEWAbXkzx4eKW24PmSY'}

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/asyncio/tasks.py", line 256, in __step
    result = coro.send(None)
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/core/dispatcher.py", line 269, in handle_message
    await handler(context, responder)
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/protocols/coordinate_mediation/v1_0/handlers/keylist_update_response_handler.py", line 31, in handle
    await self.notify_keylist_updated(
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/protocols/coordinate_mediation/v1_0/handlers/keylist_update_response_handler.py", line 52, in notify_keylist_updated
    raise HandlerException(
aries_cloudagent.messaging.base_handler.HandlerException: Unknown recipient key received in keylist update response
```

Under this condition, this makes it impossible for the keylist update response event emitter to know what connection the updated key was associated with. This PR addresses this by ensuring the DID is associated with the connection record before emitting a keylist update to the mediator.

~~There is a side effect to this change: one additional connection webhook will be emitted where the only change from the previous webhook will be a value for `my_did`; the state will not change from `invitation-received`. It's possible a controller might not like this -- though I think that would be a sign of other issues.~~ Nevermind, I solved this issue.