### PR TITLE
fix: additional tweaks for did:web and other methods as public DIDs

### DIFF
--- a/aries_cloudagent/messaging/responder.py
+++ b/aries_cloudagent/messaging/responder.py
@@ -8,7 +8,7 @@ import asyncio
 import json
 
 from abc import ABC, abstractmethod
-from typing import Sequence, Union, Optional, Tuple
+from typing import List, Sequence, Union, Optional, Tuple
 
 from ..cache.base import BaseCache
 from ..connections.models.connection_target import ConnectionTarget
@@ -208,7 +208,9 @@ class MockResponder(BaseResponder):
 
     def __init__(self):
         """Initialize the mock responder."""
-        self.messages = []
+        self.messages: List[
+            Tuple[Union[BaseMessage, str, bytes, OutboundMessage], Optional[dict]]
+        ] = []
 
     async def send(
         self, message: Union[BaseMessage, str, bytes], **kwargs

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -231,7 +231,7 @@ class DIDXManager(BaseConnectionManager):
             mediation_id=mediation_id,
             goal_code=goal_code,
             goal=goal,
-            public_did=bool(my_public_info),
+            use_public_did=bool(my_public_info),
         )
         conn_rec.request_id = request._id
         conn_rec.state = ConnRecord.State.REQUEST.rfc23
@@ -251,7 +251,7 @@ class DIDXManager(BaseConnectionManager):
         mediation_id: Optional[str] = None,
         goal_code: Optional[str] = None,
         goal: Optional[str] = None,
-        public_did: bool = False,
+        use_public_did: bool = False,
     ) -> DIDXRequest:
         """
         Create a new connection request for a previously-received invitation.
@@ -264,6 +264,8 @@ class DIDXManager(BaseConnectionManager):
                 service endpoint
             goal_code: Optional self-attested code for sharing intent of connection
             goal: Optional self-attested string for sharing intent of connection
+            use_public_did: Flag whether to use public DID and omit DID Doc
+                attachment on request
         Returns:
             A new `DIDXRequest` message to send to the other agent
 
@@ -315,7 +317,7 @@ class DIDXManager(BaseConnectionManager):
                 my_endpoints.append(default_endpoint)
             my_endpoints.extend(self.profile.settings.get("additional_endpoints", []))
 
-        if public_did:
+        if use_public_did:
             # Omit DID Doc attachment if we're using a public DID
             did_doc = None
             attach = None

--- a/aries_cloudagent/protocols/didexchange/v1_0/messages/request.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/messages/request.py
@@ -1,5 +1,6 @@
 """Represents a DID exchange request message under RFC 23."""
 
+from typing import Optional
 from marshmallow import EXCLUDE, fields
 
 from .....messaging.agent_message import AgentMessage, AgentMessageSchema
@@ -27,11 +28,11 @@ class DIDXRequest(AgentMessage):
     def __init__(
         self,
         *,
-        label: str = None,
-        did: str = None,
-        did_doc_attach: AttachDecorator = None,
-        goal_code: str = None,
-        goal: str = None,
+        label: Optional[str] = None,
+        did: Optional[str] = None,
+        did_doc_attach: Optional[AttachDecorator] = None,
+        goal_code: Optional[str] = None,
+        goal: Optional[str] = None,
         **kwargs,
     ):
         """

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -309,6 +309,10 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             )
 
             assert info_public.did == conn_rec.my_did
+            assert self.responder.messages
+            request, kwargs = self.responder.messages[0]
+            assert isinstance(request, test_module.DIDXRequest)
+            assert request.did_doc_attach is None
 
     async def test_create_request_implicit_no_public_did(self):
         with self.assertRaises(WalletError) as context:
@@ -470,6 +474,24 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
                 my_endpoint="http://testendpoint.com/endpoint",
             )
             assert didx_req
+
+    async def test_create_request_public_did(self):
+        mock_conn_rec = async_mock.MagicMock(
+            connection_id="dummy",
+            my_did=self.did_info.did,
+            their_did=TestConfig.test_target_did,
+            their_role=ConnRecord.Role.RESPONDER.rfc23,
+            state=ConnRecord.State.REQUEST.rfc23,
+            retrieve_invitation=async_mock.CoroutineMock(
+                return_value=async_mock.MagicMock(
+                    services=[TestConfig.test_target_did],
+                )
+            ),
+            save=async_mock.CoroutineMock(),
+        )
+
+        request = await self.manager.create_request(mock_conn_rec, public_did=True)
+        assert request.did_doc_attach is None
 
     async def test_receive_request_explicit_public_did(self):
         async with self.profile.session() as session:

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -490,7 +490,7 @@ class TestDidExchangeManager(AsyncTestCase, TestConfig):
             save=async_mock.CoroutineMock(),
         )
 
-        request = await self.manager.create_request(mock_conn_rec, public_did=True)
+        request = await self.manager.create_request(mock_conn_rec, use_public_did=True)
         assert request.did_doc_attach is None
 
     async def test_receive_request_explicit_public_did(self):

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import List
+from typing import List, Optional, Tuple
 
 from aiohttp import web
 from aiohttp_apispec import docs, querystring_schema, request_schema, response_schema
@@ -187,7 +187,7 @@ class DIDListQueryStringSchema(OpenAPISchema):
 class DIDQueryStringSchema(OpenAPISchema):
     """Parameters and validators for set public DID request query string."""
 
-    did = fields.Str(description="DID of interest", required=True, **INDY_DID)
+    did = fields.Str(description="DID of interest", required=True, **GENERIC_DID)
 
 
 class DIDCreateOptionsSchema(OpenAPISchema):
@@ -601,7 +601,7 @@ async def promote_wallet_public_did(
     connection_id: str = None,
     routing_keys: List[str] = None,
     mediator_endpoint: str = None,
-) -> DIDInfo:
+) -> Tuple[DIDInfo, Optional[dict]]:
     """Promote supplied DID to the wallet public DID."""
     info: DIDInfo = None
     endorser_did = None


### PR DESCRIPTION
This PR adjusts the request schema for the set public DID endpoint to permit `GENERIC_DID`s. It seems that the work to support a generic DID in this endpoint was already done and just the request schema was missed by mistake (or perhaps it's a merge artifact :man_shrugging:).

Additionally, this PR adjusts the behavior of DID Exchange requests so that if we're using a public DID, no DID Doc attachment is included in the request. This enables us to form connections using a did:web or other DID that is resolvable without worrying about ACA-Py's DID Doc creation process not being quite up to snuff on multi-method support.

And some minor type hint corrections.