### PR TITLE
feat: add legacy peer did resolver

### DIFF
--- a/aries_cloudagent/cache/base.py
+++ b/aries_cloudagent/cache/base.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from abc import ABC, abstractmethod
-from typing import Any, Sequence, Text, Union
+from typing import Any, Optional, Sequence, Text, Union
 
 from ..core.error import BaseError
 
@@ -32,7 +32,9 @@ class BaseCache(ABC):
         """
 
     @abstractmethod
-    async def set(self, keys: Union[Text, Sequence[Text]], value: Any, ttl: int = None):
+    async def set(
+        self, keys: Union[Text, Sequence[Text]], value: Any, ttl: Optional[int] = None
+    ):
         """
         Add an item to the cache with an optional ttl.
 
@@ -125,7 +127,7 @@ class CacheKeyLock:
         if result:
             self._future.set_result(fut.result())
 
-    async def set_result(self, value: Any, ttl: int = None):
+    async def set_result(self, value: Any, ttl: Optional[int] = None):
         """Set the result, updating the cache and any waiters."""
         if self.done and value:
             raise CacheError("Result already set")

--- a/aries_cloudagent/resolver/__init__.py
+++ b/aries_cloudagent/resolver/__init__.py
@@ -17,6 +17,12 @@ async def setup(context: InjectionContext):
         LOGGER.warning("No DID Resolver instance found in context")
         return
 
+    legacy_resolver = ClassProvider(
+        "aries_cloudagent.resolver.default.legacy_peer.LegacyPeerDIDResolver"
+    ).provide(context.settings, context.injector)
+    await legacy_resolver.setup(context)
+    registry.register_resolver(legacy_resolver)
+
     key_resolver = ClassProvider(
         "aries_cloudagent.resolver.default.key.KeyDIDResolver"
     ).provide(context.settings, context.injector)

--- a/aries_cloudagent/resolver/default/legacy_peer.py
+++ b/aries_cloudagent/resolver/default/legacy_peer.py
@@ -40,7 +40,7 @@ P = ParamSpec("P")
 class LegacyDocCorrections:
     """Legacy peer DID document corrections.
 
-    These correctionsto align the document with updated DID spec and DIDComm
+    These corrections align the document with updated DID spec and DIDComm
     conventions. This also helps with consistent processing of DID Docs.
 
     Input example:

--- a/aries_cloudagent/resolver/default/legacy_peer.py
+++ b/aries_cloudagent/resolver/default/legacy_peer.py
@@ -1,0 +1,272 @@
+"""Resolve legacy peer DIDs.
+
+Resolution is performed by looking up a stored DID Document.
+"""
+
+from collections.abc import Awaitable
+from copy import deepcopy
+from dataclasses import asdict, dataclass
+import functools
+import logging
+from typing import Callable, Optional, Sequence, Text, TypeVar
+from typing_extensions import ParamSpec
+
+from ...cache.base import BaseCache
+from ...config.injection_context import InjectionContext
+from ...connections.base_manager import BaseConnectionManager
+from ...core.profile import Profile
+from ...did.did_key import DIDKey
+from ...messaging.valid import IndyDID
+from ...storage.error import StorageNotFoundError
+from ...wallet.key_type import ED25519
+from ..base import BaseDIDResolver, DIDNotFound, ResolverType
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class RetrieveResult:
+    """Entry in the peer DID cache."""
+
+    is_local: bool
+    doc: Optional[dict] = None
+
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+class LegacyDocCorrections:
+    """Legacy peer DID document corrections.
+
+    These correctionsto align the document with updated DID spec and DIDComm
+    conventions. This also helps with consistent processing of DID Docs.
+
+    Input example:
+    {
+      "@context": "https://w3id.org/did/v1",
+      "id": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ",
+      "publicKey": [
+        {
+          "id": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ#1",
+          "type": "Ed25519VerificationKey2018",
+          "controller": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ",
+          "publicKeyBase58": "AU2FFjtkVzjFuirgWieqGGqtNrAZWS9LDuB8TDp6EUrG"
+        }
+      ],
+      "authentication": [
+        {
+          "type": "Ed25519SignatureAuthentication2018",
+          "publicKey": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ#1"
+        }
+      ],
+      "service": [
+        {
+          "id": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ;indy",
+          "type": "IndyAgent",
+          "priority": 0,
+          "recipientKeys": [
+            "AU2FFjtkVzjFuirgWieqGGqtNrAZWS9LDuB8TDp6EUrG"
+          ],
+          "routingKeys": ["9NnKFUZoYcCqYC2PcaXH3cnaGsoRfyGgyEHbvbLJYh8j"],
+          "serviceEndpoint": "http://bob:3000"
+        }
+      ]
+    }
+
+    Output example:
+    {
+      "@context": "https://w3id.org/did/v1",
+      "id": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ",
+      "verificationMethod": [
+        {
+          "id": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ#1",
+          "type": "Ed25519VerificationKey2018",
+          "controller": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ",
+          "publicKeyBase58": "AU2FFjtkVzjFuirgWieqGGqtNrAZWS9LDuB8TDp6EUrG"
+        }
+      ],
+      "authentication": ["did:sov:JNKL9kJxQi5pNCfA8QBXdJ#1"],
+      "service": [
+        {
+          "id": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ#didcomm",
+          "type": "did-communication",
+          "priority": 0,
+          "recipientKeys": ["did:sov:JNKL9kJxQi5pNCfA8QBXdJ#1"],
+          "routingKeys": ["9NnKFUZoYcCqYC2PcaXH3cnaGsoRfyGgyEHbvbLJYh8j"],
+          "serviceEndpoint": "http://bob:3000"
+        }
+      ]
+    }
+    """
+
+    @staticmethod
+    def public_key_is_verification_method(value: dict) -> dict:
+        """Replace publicKey with verificationMethod."""
+        if "publicKey" in value:
+            value["verificationMethod"] = value.pop("publicKey")
+        return value
+
+    @staticmethod
+    def authentication_is_list_of_verification_methods_and_refs(value: dict) -> dict:
+        """Update authentication to be a list of methods and references."""
+        if "authentication" in value:
+            modified = []
+            for authn in value["authentication"]:
+                if isinstance(authn, dict) and "publicKey" in authn:
+                    modified.append(authn["publicKey"])
+                else:
+                    modified.append(authn)
+                # TODO more checks?
+            value["authentication"] = modified
+        return value
+
+    @staticmethod
+    def didcomm_services_use_updated_conventions(value: dict) -> dict:
+        """Update DIDComm services to use updated conventions."""
+        if "service" in value:
+            for service in value["service"]:
+                if "type" in service and service["type"] == "IndyAgent":
+                    service["type"] = "did-communication"
+                    service["id"] = service["id"].replace(";indy", "#didcomm")
+        return value
+
+    @staticmethod
+    def didcomm_services_recip_keys_are_refs_routing_keys_are_did_key(
+        value: dict,
+    ) -> dict:
+        """Update DIDComm service recips to use refs and routingKeys to use did:key."""
+        if "service" in value:
+            for service in value["service"]:
+                if "type" in service and service["type"] == "did-communication":
+                    service["recipientKeys"] = [f"{value['id']}#1"]
+                if "routingKeys" in service:
+                    service["routingKeys"] = [
+                        DIDKey.from_public_key_b58(key, ED25519).key_id
+                        for key in service["routingKeys"]
+                    ]
+        return value
+
+    @classmethod
+    def apply(cls, value: dict) -> dict:
+        """Apply all corrections to the given DID document."""
+        value = deepcopy(value)
+        for correction in (
+            cls.public_key_is_verification_method,
+            cls.authentication_is_list_of_verification_methods_and_refs,
+            cls.didcomm_services_use_updated_conventions,
+            cls.didcomm_services_recip_keys_are_refs_routing_keys_are_did_key,
+        ):
+            value = correction(value)
+
+        return value
+
+
+class LegacyPeerDIDResolver(BaseDIDResolver):
+    """Resolve legacy peer DIDs."""
+
+    def __init__(self):
+        """Initialize the resolver instance."""
+        super().__init__(ResolverType.NATIVE)
+
+    async def setup(self, context: InjectionContext):
+        """Perform required setup for the resolver."""
+
+    def _cached_resource(
+        self,
+        profile: Profile,
+        key: str,
+        retrieve: Callable[P, Awaitable[RetrieveResult]],
+        ttl: Optional[int] = None,
+    ) -> Callable[P, Awaitable[RetrieveResult]]:
+        """Get a cached resource."""
+
+        @functools.wraps(retrieve)
+        async def _wrapped(*args: P.args, **kwargs: P.kwargs):
+            cache = profile.inject_or(BaseCache)
+            if cache:
+                async with cache.acquire(key) as entry:
+                    if entry.result:
+                        value = RetrieveResult(**entry.result)
+                    else:
+                        value = await retrieve(*args, **kwargs)
+                        await entry.set_result(asdict(value), ttl)
+            else:
+                value = await retrieve(*args, **kwargs)
+
+            return value
+
+        return _wrapped
+
+    async def _fetch_did_document(self, profile: Profile, did: str):
+        """Fetch DID from wallet if available.
+
+        This is the method to be used with _cached_resource to enable caching.
+        """
+        conn_mgr = BaseConnectionManager(profile)
+        if did.startswith("did:sov:"):
+            did = did[8:]
+        try:
+            doc, _ = await conn_mgr.fetch_did_document(did)
+            LOGGER.debug("Fetched doc %s", doc)
+            to_cache = RetrieveResult(True, doc=doc.serialize())
+        except StorageNotFoundError:
+            LOGGER.debug("Failed to fetch doc for did %s", did)
+            to_cache = RetrieveResult(False)
+
+        return to_cache
+
+    async def fetch_did_document(self, profile: Profile, did: str):
+        """Fetch DID from wallet if available.
+
+        Return value is cached.
+        """
+        cache_key = f"legacy_peer_did_resolver::{did}"
+        return await self._cached_resource(
+            profile, cache_key, self._fetch_did_document, ttl=3600
+        )(profile, did)
+
+    async def supports(self, profile: Profile, did: str) -> bool:
+        """Return whether this resolver supports the given DID.
+
+        This resolver resolves unqualified DIDs and dids prefixed with
+        `did:sov:`.
+
+        These DIDs have the unfortunate characteristic of overlapping with what
+        ACA-Py uses for DIDs written to Indy ledgers. This means that we will
+        need to attempt to resolve but defer to the Indy resolver if we don't
+        find anything locally. This has the side effect that this resolver will
+        never raise DIDNotFound since it won't even be selected for resolution
+        unless we have the DID in our wallet.
+
+        This will check if the DID matches the IndyDID regex. If it does,
+        attempt a lookup in the wallet for a document. If found, return True.
+        Else, return False.
+        """
+        LOGGER.debug("Checking if resolver supports DID %s", did)
+        if IndyDID.PATTERN.match(did):
+            LOGGER.debug("DID is valid IndyDID %s", did)
+            result = await self.fetch_did_document(profile, did)
+            return result.is_local
+        else:
+            return False
+
+    async def _resolve(
+        self,
+        profile: Profile,
+        did: str,
+        service_accept: Optional[Sequence[Text]] = None,
+    ) -> dict:
+        """Resolve Legacy Peer DID to a DID document by fetching from the wallet.
+
+        By the time this resolver is selected, it should be impossible for it
+        to raise a DIDNotFound.
+        """
+        result = await self.fetch_did_document(profile, did)
+        if result.is_local:
+            assert result.doc
+            return LegacyDocCorrections.apply(result.doc)
+        else:
+            # This should be impossible because of the checks in supports
+            raise DIDNotFound(f"DID not found: {did}")

--- a/aries_cloudagent/resolver/default/tests/test_indy.py
+++ b/aries_cloudagent/resolver/default/tests/test_indy.py
@@ -3,7 +3,6 @@
 import pytest
 
 from asynctest import mock as async_mock
-from pydid.verification_method import VerificationMethod
 
 from ....core.in_memory import InMemoryProfile
 from ....core.profile import Profile

--- a/aries_cloudagent/resolver/default/tests/test_legacy_peer.py
+++ b/aries_cloudagent/resolver/default/tests/test_legacy_peer.py
@@ -86,7 +86,7 @@ class TestLegacyPeerDIDResolver:
         ) as mock_mgr, async_mock.patch.object(
             test_module, "LegacyDocCorrections"
         ) as mock_corrections:
-            doc = object
+            doc = object()
             mock_corrections.apply = async_mock.MagicMock(return_value=doc)
             mock_mgr.return_value = async_mock.MagicMock(
                 fetch_did_document=async_mock.CoroutineMock(

--- a/aries_cloudagent/resolver/default/tests/test_legacy_peer.py
+++ b/aries_cloudagent/resolver/default/tests/test_legacy_peer.py
@@ -1,0 +1,180 @@
+"""Test LegacyPeerDIDResolver."""
+
+from asynctest import mock as async_mock
+import pytest
+
+from .. import legacy_peer as test_module
+from ....cache.base import BaseCache
+from ....cache.in_memory import InMemoryCache
+from ....connections.models.diddoc.diddoc import DIDDoc
+from ....core.in_memory import InMemoryProfile
+from ....core.profile import Profile
+from ....storage.error import StorageNotFoundError
+from ..legacy_peer import LegacyPeerDIDResolver
+
+
+TEST_DID0 = "did:sov:WgWxqztrNooG92RXvxSTWv"
+TEST_DID1 = "did:example:abc123"
+TEST_DID2 = "did:sov:5No7f9KvpsfSqd6xsGxABh"
+
+
+@pytest.fixture
+def resolver():
+    """Resolver fixture."""
+    yield LegacyPeerDIDResolver()
+
+
+@pytest.fixture
+def profile():
+    """Profile fixture."""
+    profile = InMemoryProfile.test_profile()
+    profile.context.injector.bind_instance(BaseCache, InMemoryCache())
+    yield profile
+
+
+class TestLegacyPeerDIDResolver:
+    @pytest.mark.asyncio
+    async def test_supports(self, resolver: LegacyPeerDIDResolver, profile: Profile):
+        """Test supports."""
+        with async_mock.patch.object(test_module, "BaseConnectionManager") as mock_mgr:
+            mock_mgr.return_value = async_mock.MagicMock(
+                fetch_did_document=async_mock.CoroutineMock(
+                    return_value=(DIDDoc(TEST_DID0), None)
+                )
+            )
+            assert await resolver.supports(profile, TEST_DID0)
+
+    @pytest.mark.asyncio
+    async def test_supports_no_cache(
+        self, resolver: LegacyPeerDIDResolver, profile: Profile
+    ):
+        """Test supports."""
+        profile.context.injector.clear_binding(BaseCache)
+        with async_mock.patch.object(test_module, "BaseConnectionManager") as mock_mgr:
+            mock_mgr.return_value = async_mock.MagicMock(
+                fetch_did_document=async_mock.CoroutineMock(
+                    return_value=(DIDDoc(TEST_DID0), None)
+                )
+            )
+            assert await resolver.supports(profile, TEST_DID0)
+
+    @pytest.mark.asyncio
+    async def test_supports_x_not_legacy_did(
+        self, resolver: LegacyPeerDIDResolver, profile: Profile
+    ):
+        """Test supports returns false for DID not matching legacy."""
+        assert not await resolver.supports(profile, TEST_DID1)
+
+    @pytest.mark.asyncio
+    async def test_supports_x_unknown_did(
+        self, resolver: LegacyPeerDIDResolver, profile: Profile
+    ):
+        """Test supports returns false for unknown DID."""
+        with async_mock.patch.object(test_module, "BaseConnectionManager") as mock_mgr:
+            mock_mgr.return_value = async_mock.MagicMock(
+                fetch_did_document=async_mock.CoroutineMock(
+                    side_effect=StorageNotFoundError
+                )
+            )
+            assert not await resolver.supports(profile, TEST_DID2)
+
+    @pytest.mark.asyncio
+    async def test_resolve(self, resolver: LegacyPeerDIDResolver, profile: Profile):
+        """Test resolve."""
+        with async_mock.patch.object(
+            test_module, "BaseConnectionManager"
+        ) as mock_mgr, async_mock.patch.object(
+            test_module, "LegacyDocCorrections"
+        ) as mock_corrections:
+            doc = object
+            mock_corrections.apply = async_mock.MagicMock(return_value=doc)
+            mock_mgr.return_value = async_mock.MagicMock(
+                fetch_did_document=async_mock.CoroutineMock(
+                    return_value=(DIDDoc(TEST_DID0), None)
+                )
+            )
+            result = await resolver.resolve(profile, TEST_DID0)
+            assert result == doc
+
+    @pytest.mark.asyncio
+    async def test_resolve_x_not_found(
+        self, resolver: LegacyPeerDIDResolver, profile: Profile
+    ):
+        """Test resolve with not found.
+
+        This should be impossible in practice but still.
+        """
+        with async_mock.patch.object(
+            test_module, "BaseConnectionManager"
+        ) as mock_mgr, async_mock.patch.object(
+            test_module, "LegacyDocCorrections"
+        ) as mock_corrections, pytest.raises(
+            test_module.DIDNotFound
+        ):
+            doc = object
+            mock_corrections.apply = async_mock.MagicMock(return_value=doc)
+            mock_mgr.return_value = async_mock.MagicMock(
+                fetch_did_document=async_mock.CoroutineMock(
+                    side_effect=StorageNotFoundError
+                )
+            )
+            resolver.supports = async_mock.CoroutineMock(return_value=True)
+            result = await resolver.resolve(profile, TEST_DID0)
+            assert result == doc
+
+    def test_corrections_examples(self):
+        input_doc = {
+            "@context": "https://w3id.org/did/v1",
+            "id": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ",
+            "publicKey": [
+                {
+                    "id": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ#1",
+                    "type": "Ed25519VerificationKey2018",
+                    "controller": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ",
+                    "publicKeyBase58": "AU2FFjtkVzjFuirgWieqGGqtNrAZWS9LDuB8TDp6EUrG",
+                }
+            ],
+            "authentication": [
+                {
+                    "type": "Ed25519SignatureAuthentication2018",
+                    "publicKey": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ#1",
+                }
+            ],
+            "service": [
+                {
+                    "id": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ;indy",
+                    "type": "IndyAgent",
+                    "priority": 0,
+                    "recipientKeys": ["AU2FFjtkVzjFuirgWieqGGqtNrAZWS9LDuB8TDp6EUrG"],
+                    "routingKeys": ["9NnKFUZoYcCqYC2PcaXH3cnaGsoRfyGgyEHbvbLJYh8j"],
+                    "serviceEndpoint": "http://bob:3000",
+                }
+            ],
+        }
+        expected = {
+            "@context": "https://w3id.org/did/v1",
+            "id": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ",
+            "verificationMethod": [
+                {
+                    "id": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ#1",
+                    "type": "Ed25519VerificationKey2018",
+                    "controller": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ",
+                    "publicKeyBase58": "AU2FFjtkVzjFuirgWieqGGqtNrAZWS9LDuB8TDp6EUrG",
+                }
+            ],
+            "authentication": ["did:sov:JNKL9kJxQi5pNCfA8QBXdJ#1"],
+            "service": [
+                {
+                    "id": "did:sov:JNKL9kJxQi5pNCfA8QBXdJ#didcomm",
+                    "type": "did-communication",
+                    "priority": 0,
+                    "recipientKeys": ["did:sov:JNKL9kJxQi5pNCfA8QBXdJ#1"],
+                    "routingKeys": [
+                        "did:key:z6Mknq3MqipEt9hJegs6J9V7tiLa6T5H5rX3fFCXksJKTuv7#z6Mknq3MqipEt9hJegs6J9V7tiLa6T5H5rX3fFCXksJKTuv7"
+                    ],
+                    "serviceEndpoint": "http://bob:3000",
+                }
+            ],
+        }
+        actual = test_module.LegacyDocCorrections.apply(input_doc)
+        assert actual == expected

--- a/aries_cloudagent/resolver/did_resolver.py
+++ b/aries_cloudagent/resolver/did_resolver.py
@@ -103,6 +103,7 @@ class DIDResolver:
             for resolver in self.resolvers
             if await resolver.supports(profile, did)
         ]
+        LOGGER.debug("Valid resolvers for DID %s: %s", did, valid_resolvers)
         native_resolvers = filter(lambda resolver: resolver.native, valid_resolvers)
         non_native_resolvers = filter(
             lambda resolver: not resolver.native, valid_resolvers


### PR DESCRIPTION
This PR adds support for resolving legacy peer DIDs to DID Documents previously stored in our wallet.

This is one part of some additional changes I have in mind; using these changes, I'd like to make "resolving" connection targets for a DID consistent regardless of whether the DID we're resolving is did:web, did:indy, did:sov, unqualified local did, did:peer, etc. I'm hopeful those changes will also help ease the transition to proper peer DIDs. I'm still fleshing out those changes but I think this resolver is useful regardless of the outcome.

As noted in the docstrings of the methods in the resolver, due to the nature of ACA-Py's use of did:sov and unqualified DIDs for both public (posted to a ledger) and pairwise/peer DIDs, this resolver requires a bit of trial and error. If the DID has a doc associated with it in the wallet, it will report that it supports resolving the DID. The cache is employed to help make this check slightly more efficient but there's still some open questions. For instance, how long should the cache be considered valid?

As implemented, this resolver will only return the DID Documents we've received through the Connections or DID Exchange protocols. In other words, we can only resolve the DID of the remote party, or "their DID." We could also store the docs for our own DIDs, making them resolvable as well. I'm not sure if this is valuable or not yet.

For Indy "style" DIDs that are created outside of the context of a connection, such as Public DIDs, there is no DID Document associated with it stored in our wallet. This means that this resolver will not be selected and the document for the DID will be resolved by the `IndyDIDResolver`, as usual.

In the interest of that consistent connection target goal I mentioned above, I currently have this resolver configured to transform documents retrieved from our wallet to be better aligned with updates to DIDComm/DID Document conventions.

Resolves #2161. I think. lol