### PR TITLE
Anoncreds API BDD Tests

### DIFF
--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -168,7 +168,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
                     issuer_id=schema["id"].split(":")[0],
                     attr_names=schema["attrNames"],
                     name=schema["name"],
-                    version=schema["ver"],
+                    version=schema["version"],
                 )
                 result = GetSchemaResult(
                     schema=anonscreds_schema,

--- a/aries_cloudagent/askar/profile.py
+++ b/aries_cloudagent/askar/profile.py
@@ -16,6 +16,8 @@ from ..config.injection_context import InjectionContext
 from ..config.provider import ClassProvider
 from ..core.error import ProfileError
 from ..core.profile import Profile, ProfileManager, ProfileSession
+from ..indy.holder import IndyHolder
+from ..indy.issuer import IndyIssuer
 from ..ledger.base import BaseLedger
 from ..ledger.indy_vdr import IndyVdrLedger, IndyVdrLedgerPool
 from ..storage.base import BaseStorage, BaseStorageSearch
@@ -101,6 +103,19 @@ class AskarProfile(Profile):
             ClassProvider(
                 "aries_cloudagent.storage.vc_holder.askar.AskarVCHolder",
                 ref(self),
+            ),
+        )
+        injector.bind_provider(
+            IndyHolder,
+            ClassProvider(
+                "aries_cloudagent.indy.credx.holder.IndyCredxHolder",
+                ref(self),
+            ),
+        )
+        injector.bind_provider(
+            IndyIssuer,
+            ClassProvider(
+                "aries_cloudagent.indy.credx.issuer.IndyCredxIssuer", ref(self)
             ),
         )
         if self.ledger_pool:

--- a/demo/features/0453-issue-credential.feature
+++ b/demo/features/0453-issue-credential.feature
@@ -1,6 +1,41 @@
 @RFC0453
 Feature: RFC 0453 Aries agent issue credential
 
+  @T004-RFC0453 @GHA-Anoncreds-break @GHA
+  Scenario Outline: Using anoncreds, Issue a credential with revocation, with the Issuer beginning with an offer, and then revoking the credential
+    Given we have "2" agents
+      | name  | role    | capabilities        |
+      | Acme  | issuer  | <Acme_capabilities> |
+      | Bob   | holder  | <Bob_capabilities>  |
+    And "Acme" and "Bob" have an existing connection
+    And Using anoncreds, "Bob" has an issued <Schema_name> credential <Credential_data> from "Acme"
+    Then Using anoncreds, "Acme" revokes the credential
+    And "Bob" has the credential issued
+
+    Examples:
+       | Acme_capabilities                        | Bob_capabilities  | Schema_name    | Credential_data          |
+       | --revocation --cred-type anoncreds --public-did |            | anoncreds-testing | Data_AC_NormalizedValues |
+       | --revocation --cred-type anoncreds --public-did --did-exchange | --did-exchange| anoncreds-testing | Data_AC_NormalizedValues |
+       | --revocation --cred-type anoncreds --public-did --multitenant  | --multitenant | anoncreds-testing | Data_AC_NormalizedValues |
+
+  @T003-RFC0453 @GHA-Anoncreds-break @GHA
+  Scenario Outline: Using anoncreds, Issue a credential with the Issuer beginning with an offer
+    Given we have "2" agents
+      | name  | role    | capabilities        |
+      | Acme  | issuer  | <Acme_capabilities> |
+      | Bob   | holder  | <Bob_capabilities>  |
+    And "Acme" and "Bob" have an existing connection
+    And Using anoncreds, "Acme" is ready to issue a credential for <Schema_name>
+    When "Acme" offers a credential with data <Credential_data>
+    Then "Bob" has the credential issued
+
+    Examples:
+       | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
+       | --public-did --cred-type anoncreds     |                           | anoncreds-testing | Data_AC_NormalizedValues |
+       | --public-did --cred-type anoncreds --did-exchange | --did-exchange | anoncreds-testing | Data_AC_NormalizedValues |
+       | --public-did --cred-type anoncreds --mediation | --mediation       | anoncreds-testing | Data_AC_NormalizedValues |
+       | --public-did --cred-type anoncreds --multitenant | --multitenant   | anoncreds-testing | Data_AC_NormalizedValues |
+
   @T003-RFC0453 @GHA-Anoncreds-break
   Scenario Outline: Issue a credential with the Issuer beginning with an offer
     Given we have "2" agents

--- a/demo/features/0454-present-proof.feature
+++ b/demo/features/0454-present-proof.feature
@@ -16,7 +16,7 @@ Feature: RFC 0454 Aries agent present proof
          | issuer | Acme_capabilities                      | Bob_capabilities          | Schema_name       | Credential_data   | Proof_request     |
          | Faber  | --public-did --cred-type anoncreds                           |                           | anoncreds-testing | Data_AC_NormalizedValues | AC_age_over_40 |
          | Faber  | --public-did --cred-type anoncreds --did-exchange            | --did-exchange            | anoncreds-testing | Data_AC_NormalizedValues | AC_age_over_40 |
-
+         | Faber  | --public-did --cred-type anoncreds                           |                           | anoncreds-testing | Data_AC_NormalizedValues | AC_age_over_40_schema |
 
    @T002-RFC0454 @GHA-Anoncreds-break @GHA
    Scenario Outline: Using anoncreds, Present Proof where the issuer revokes the credential and the proof fails

--- a/demo/features/0454-present-proof.feature
+++ b/demo/features/0454-present-proof.feature
@@ -1,5 +1,41 @@
 Feature: RFC 0454 Aries agent present proof
 
+   @T001-RFC0454 @GHA-Anoncreds-break @GHA
+   Scenario Outline: Using anoncreds, Present Proof where the prover does not propose a presentation of the proof and is acknowledged
+      Given we have "2" agents
+         | name  | role     | capabilities        |
+         | Faber | verifier | <Acme_capabilities> |
+         | Bob   | prover   | <Bob_capabilities>  |
+      And "<issuer>" and "Bob" have an existing connection
+      And Using anoncreds, "Bob" has an issued <Schema_name> credential <Credential_data> from "<issuer>"
+      And "Faber" and "Bob" have an existing connection
+      When "Faber" sends a request for proof presentation <Proof_request> to "Bob"
+      Then "Faber" has the proof verified
+
+      Examples:
+         | issuer | Acme_capabilities                      | Bob_capabilities          | Schema_name       | Credential_data   | Proof_request     |
+         | Faber  | --public-did --cred-type anoncreds                           |                           | anoncreds-testing | Data_AC_NormalizedValues | AC_age_over_40 |
+         | Faber  | --public-did --cred-type anoncreds --did-exchange            | --did-exchange            | anoncreds-testing | Data_AC_NormalizedValues | AC_age_over_40 |
+
+
+   @T002-RFC0454 @GHA-Anoncreds-break @GHA
+   Scenario Outline: Using anoncreds, Present Proof where the issuer revokes the credential and the proof fails
+      Given we have "2" agents
+         | name  | role     | capabilities        |
+         | Faber | verifier | <Acme_capabilities> |
+         | Bob   | prover   | <Bob_capabilities>  |
+      And "<issuer>" and "Bob" have an existing connection
+      And Using anoncreds, "Bob" has an issued <Schema_name> credential <Credential_data> from "<issuer>"
+      And Using anoncreds, "<issuer>" revokes the credential
+      And "Faber" and "Bob" have an existing connection
+      When "Faber" sends a request for proof presentation <Proof_request> to "Bob"
+      Then "Faber" has the proof verification fail
+
+      Examples:
+         | issuer | Acme_capabilities                          | Bob_capabilities | Schema_name       | Credential_data   | Proof_request     |
+         | Faber  | --revocation --public-did --cred-type anoncreds                  |                  | anoncreds-testing | Data_AC_NormalizedValues | AC_age_over_40 |
+         | Faber  | --revocation --public-did --did-exchange --cred-type anoncreds   | --did-exchange   | anoncreds-testing | Data_AC_NormalizedValues | AC_age_over_40 |
+
    @T001-RFC0454 @GHA-Anoncreds-break
    Scenario Outline: Present Proof where the prover does not propose a presentation of the proof and is acknowledged
       Given we have "2" agents

--- a/demo/features/data/cred_data_schema_anoncreds-testing.json
+++ b/demo/features/data/cred_data_schema_anoncreds-testing.json
@@ -1,0 +1,15 @@
+{
+    "Data_AC_NormalizedValues":{
+        "attributes":[
+            {
+               "name":"name",
+               "value":"Bob"
+            },
+            {
+               "name":"age",
+               "value":"42"
+            }
+         ]
+   
+    }
+}

--- a/demo/features/data/proof_request_AC_age_over_40.json
+++ b/demo/features/data/proof_request_AC_age_over_40.json
@@ -1,0 +1,27 @@
+{
+    "presentation_proposal": {
+       "requested_attributes": {
+          "cred_def_restriction": {
+             "name": "name",
+             "restrictions": [
+                {
+                   "cred_def_id": "change-me"
+                }
+             ]
+          }
+       },
+       "requested_predicates": {
+          "cred_def_predicate": {
+             "name": "age",
+             "p_type": ">",
+             "p_value": 40,
+             "restrictions": [
+                {
+                    "cred_def_id": "change-me"
+                }
+             ]
+          }
+       },
+       "version": "0.1.0"
+    }
+ }

--- a/demo/features/data/schema_anoncreds-testing.json
+++ b/demo/features/data/schema_anoncreds-testing.json
@@ -1,0 +1,9 @@
+{
+    "schema": {
+        "attrNames": ["name", "age"],
+        "issuerId": "",
+        "name": "anoncreds-testing",
+        "version": "0.1"
+    },
+    "options": {}
+}

--- a/demo/features/steps/0453-issue-credential.py
+++ b/demo/features/steps/0453-issue-credential.py
@@ -45,7 +45,32 @@ def step_impl(context, issuer, schema_name):
     # confirm the cred def was actually created
     async_sleep(2.0)
     cred_def_saved = agent_container_GET(
-        agent["agent"], "/credential-definitions/" + cred_def_id
+        agent["agent"], "/credential-definition/" + cred_def_id
+    )
+    assert cred_def_saved
+
+    context.schema_name = schema_name
+    context.cred_def_id = cred_def_id
+
+
+@given('Using anoncreds, "{issuer}" is ready to issue a credential for {schema_name}')
+@then('Using anoncreds, "{issuer}" is ready to issue a credential for {schema_name}')
+def step_impl(context, issuer, schema_name):
+    agent = context.active_agents[issuer]
+
+    schema_info = read_schema_data(schema_name)
+
+    cred_def_id = aries_container_create_schema_cred_def(
+        agent["agent"],
+        schema_info["schema"]["name"],
+        schema_info["schema"]["attrNames"],
+        version=schema_info["schema"]["version"],
+    )
+
+    # confirm the cred def was actually created
+    async_sleep(2.0)
+    cred_def_saved = agent_container_GET(
+        agent["agent"], f"/anoncreds/credential-definition/{cred_def_id}"
     )
     assert cred_def_saved
 
@@ -111,6 +136,59 @@ def step_impl(context, holder):
 
     # pause for a few seconds
     async_sleep(3.0)
+
+
+@given('Using anoncreds, "{holder}" revokes the credential')
+@when('Using anoncreds, "{holder}" revokes the credential')
+@then('Using anoncreds, "{holder}" revokes the credential')
+def step_impl(context, holder):
+    agent = context.active_agents[holder]
+
+    # get the required revocation info from the last credential exchange
+    cred_exchange = context.cred_exchange
+    cred_ex_id = (
+        cred_exchange["cred_ex_id"]
+        if "cred_ex_id" in cred_exchange
+        else cred_exchange["cred_ex_record"]["cred_ex_id"]
+    )
+    # refresh it...
+    cred_exchange = agent_container_GET(
+        agent["agent"], "/issue-credential-2.0/records/" + cred_ex_id
+    )
+    context.cred_exchange = cred_exchange
+    print("cred_exchange:", json.dumps(cred_exchange))
+    # we need the connection id...
+    connection_id = (
+        cred_exchange["connection_id"]
+        if "connection_id" in cred_exchange
+        else cred_exchange["cred_ex_record"]["connection_id"]
+    )
+
+    cred_exchange = agent_container_POST(
+        agent["agent"],
+        "/anoncreds/revoke",
+        data={
+            "cred_ex_id": cred_ex_id,
+            "connection_id": connection_id,
+            "notify": True,
+        },
+    )
+    async_sleep(3.0)
+    # publish the revocations
+    publish_response = agent_container_POST(
+        agent["agent"],
+        "/anoncreds/publish-revocations",
+        data={},
+    )
+    print("publish_response:", json.dumps(publish_response))
+    # pause for a few seconds
+    async_sleep(3.0)
+    # refresh it...
+    cred_exchange = agent_container_GET(
+        agent["agent"], "/issue-credential-2.0/records/" + cred_ex_id
+    )
+    context.cred_exchange = cred_exchange
+    # print("cred_exchange:", json.dumps(cred_exchange))
 
 
 @given('"{holder}" successfully revoked the credential')
@@ -341,6 +419,56 @@ def step_impl(context, issuer, holder, credential_data):
     pass
 
 
+@when(
+    '"{issuer}" offers "{holder}" an anoncreds credential with data {credential_data}'
+)
+def step_impl(context, issuer, holder, credential_data):
+    # initiate a cred exchange with an anoncreds credential
+    agent = context.active_agents[issuer]
+    holder_agent = context.active_agents[holder]
+
+    offer_request = {
+        "connection_id": agent["agent"].agent.connection_id,
+        "filter": {
+            "ld_proof": {
+                "credential": {
+                    "@context": [
+                        "https://www.w3.org/2018/credentials/v1",
+                        "https://w3id.org/citizenship/v1",
+                    ],
+                    "type": [
+                        "VerifiableCredential",
+                        "PermanentResident",
+                    ],
+                    "id": "https://credential.example.com/residents/1234567890",
+                    "issuer": agent["agent"].agent.did,
+                    "issuanceDate": "2020-01-01T12:00:00Z",
+                    "credentialSubject": {
+                        "type": ["PermanentResident"],
+                        # let the holder set this
+                        # "id": holder_agent["agent"].agent.did,
+                        "givenName": "ALICE",
+                        "familyName": "SMITH",
+                        "gender": "Female",
+                        "birthCountry": "Bahamas",
+                        "birthDate": "1958-07-17",
+                    },
+                },
+                "options": {"proofType": SIG_TYPE_BLS},
+            }
+        },
+    }
+
+    agent_container_POST(
+        agent["agent"],
+        "/issue-credential-2.0/send-offer",
+        offer_request,
+    )
+
+    # TODO test for goodness
+    pass
+
+
 @then('"{holder}" has the json-ld credential issued')
 def step_impl(context, holder):
     # verify the holder has a w3c credential
@@ -395,6 +523,29 @@ def step_impl(context, holder, schema_name, credential_data, issuer):
     context.execute_steps(
         '''
         Given "'''
+        + issuer
+        + """" is ready to issue a credential for """
+        + schema_name
+        + '''
+        When "'''
+        + issuer
+        + """" offers a credential with data """
+        + credential_data
+        + '''
+        Then "'''
+        + holder
+        + """" has the credential issued
+    """
+    )
+
+
+@given(
+    'Using anoncreds, "{holder}" has an issued {schema_name} credential {credential_data} from "{issuer}"'
+)
+def step_impl(context, holder, schema_name, credential_data, issuer):
+    context.execute_steps(
+        '''
+        Given Using anoncreds, "'''
         + issuer
         + """" is ready to issue a credential for """
         + schema_name

--- a/demo/features/steps/0454-present-proof.py
+++ b/demo/features/steps/0454-present-proof.py
@@ -37,6 +37,20 @@ def step_impl(context, verifier, request_for_proof, prover):
 
     proof_request_info = read_proof_req_data(request_for_proof)
 
+    # replace any restrictions that need the cred def id...
+    cred_def_id = context.cred_def_id
+    cred_def_restrictions = [{"cred_def_id": cred_def_id}]
+
+    if "cred_def_restriction" in proof_request_info["requested_attributes"]:
+        proof_request_info["requested_attributes"]["cred_def_restriction"][
+            "restrictions"
+        ] = cred_def_restrictions
+
+    if "cred_def_predicate" in proof_request_info["requested_predicates"]:
+        proof_request_info["requested_predicates"]["cred_def_predicate"][
+            "restrictions"
+        ] = cred_def_restrictions
+
     proof_exchange = aries_container_request_proof(agent["agent"], proof_request_info)
 
     context.proof_request = proof_request_info

--- a/demo/run_bdd
+++ b/demo/run_bdd
@@ -126,8 +126,9 @@ AGENT_PORT=8020
 AGENT_PORT_RANGE=8020-8079
 
 echo "Preparing agent image..."
-docker build --platform linux/amd64 -q -t faber-alice-demo -f ../docker/Dockerfile.demo .. || exit 1
-docker build --platform linux/amd64 -q -t aries-bdd-image -f ../docker/Dockerfile.bdd .. || exit 1
+docker build -q -t indy-base -f ../docker/Dockerfile.indy --target=indy-base .. || exit 1
+docker build -q -t faber-alice-demo -f ../docker/Dockerfile.demo .. || exit 1
+docker build -q -t aries-bdd-image -f ../docker/Dockerfile.bdd .. || exit 1
 
 if [ ! -z "$DOCKERHOST" ]; then
   # provided via APPLICATION_URL environment variable
@@ -233,7 +234,6 @@ fi
 DOCKER=${DOCKER:-docker}
 
 $DOCKER run --name $AGENT --rm ${DOCKER_OPTS} \
-  --platform linux/amd64 \
   --network=${DOCKER_NET} \
   -p 0.0.0.0:$AGENT_PORT_RANGE:$AGENT_PORT_RANGE \
   -v "/$(pwd)/../logs:/home/indy/logs" \

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -67,6 +67,7 @@ elif RUN_MODE == "pwd":
 
 CRED_FORMAT_INDY = "indy"
 CRED_FORMAT_JSON_LD = "json-ld"
+CRED_FORMAT_ANONCREDS = "anoncreds"
 DID_METHOD_SOV = "sov"
 DID_METHOD_KEY = "key"
 KEY_TYPE_ED255 = "ed25519"
@@ -256,6 +257,37 @@ class DemoAgent:
         support_revocation: bool = False,
         revocation_registry_size: int = None,
         tag=None,
+        cred_type=CRED_FORMAT_INDY,
+    ):
+        if cred_type == CRED_FORMAT_INDY:
+            return await self.register_schema_and_creddef_indy(
+                schema_name,
+                version,
+                schema_attrs,
+                support_revocation=support_revocation,
+                revocation_registry_size=revocation_registry_size,
+                tag=tag,
+            )
+        elif cred_type == CRED_FORMAT_ANONCREDS:
+            return await self.register_schema_and_creddef_anoncreds(
+                schema_name,
+                version,
+                schema_attrs,
+                support_revocation=support_revocation,
+                revocation_registry_size=revocation_registry_size,
+                tag=tag,
+            )
+        else:
+            return None, None
+
+    async def register_schema_and_creddef_indy(
+        self,
+        schema_name,
+        version,
+        schema_attrs,
+        support_revocation: bool = False,
+        revocation_registry_size: int = None,
+        tag=None,
     ):
         # Create a schema
         schema_body = {
@@ -313,6 +345,93 @@ class DemoAgent:
             ):
                 credential_definition_response = await self.admin_GET(
                     "/credential-definitions/created"
+                )
+                if 0 == len(
+                    credential_definition_response["credential_definition_ids"]
+                ):
+                    await asyncio.sleep(1.0)
+                    attempts = attempts - 1
+            credential_definition_id = credential_definition_response[
+                "credential_definition_ids"
+            ][0]
+        log_msg("Cred def ID:", credential_definition_id)
+        return schema_id, credential_definition_id
+
+    async def register_schema_and_creddef_anoncreds(
+        self,
+        schema_name,
+        version,
+        schema_attrs,
+        support_revocation: bool = False,
+        revocation_registry_size: int = None,
+        tag=None,
+    ):
+        # Create a schema
+        schema_body = {
+            "schema": {
+                "attrNames": schema_attrs,
+                "issuerId": self.did,
+                "name": schema_name,
+                "version": version,
+            },
+            "options": {},
+        }
+        schema_response = await self.admin_POST("/anoncreds/schema", schema_body)
+        log_json(json.dumps(schema_response), label="Schema:")
+        await asyncio.sleep(2.0)
+        if "schema_id" in schema_response["schema_state"]:
+            # schema is created directly
+            schema_id = schema_response["schema_state"]["schema_id"]
+        else:
+            # need to wait for the endorser process
+            schema_response = {"schema_ids": []}
+            attempts = 3
+            while 0 < attempts and 0 == len(schema_response["schema_ids"]):
+                schema_response = await self.admin_GET("/anoncreds/schemas")
+                if 0 == len(schema_response["schema_ids"]):
+                    await asyncio.sleep(1.0)
+                    attempts = attempts - 1
+            schema_id = schema_response["schema_ids"][0]
+        log_msg("Schema ID:", schema_id)
+
+        # Create a cred def for the schema
+        cred_def_tag = (
+            tag if tag else (self.ident + "." + schema_name).replace(" ", "_")
+        )
+        max_cred_num = revocation_registry_size if revocation_registry_size else 0
+        credential_definition_body = {
+            "credential_definition": {
+                "tag": cred_def_tag,
+                "schemaId": schema_id,
+                "issuerId": self.did,
+            },
+            "options": {
+                "support_revocation": support_revocation,
+                "max_cred_num": max_cred_num,
+            },
+        }
+        credential_definition_response = await self.admin_POST(
+            "/anoncreds/credential-definition", credential_definition_body
+        )
+        log_json(json.dumps(credential_definition_response), label="Cred Def:")
+        await asyncio.sleep(2.0)
+        if (
+            "credential_definition_id"
+            in credential_definition_response["credential_definition_state"]
+        ):
+            # cred def is created directly
+            credential_definition_id = credential_definition_response[
+                "credential_definition_state"
+            ]["credential_definition_id"]
+        else:
+            # need to wait for the endorser process
+            credential_definition_response = {"credential_definition_ids": []}
+            attempts = 3
+            while 0 < attempts and 0 == len(
+                credential_definition_response["credential_definition_ids"]
+            ):
+                credential_definition_response = await self.admin_GET(
+                    "/anoncreds/credential-definitions"
                 )
                 if 0 == len(
                     credential_definition_response["credential_definition_ids"]
@@ -481,7 +600,7 @@ class DemoAgent:
         role: str = "TRUST_ANCHOR",
         cred_type: str = CRED_FORMAT_INDY,
     ):
-        if cred_type == CRED_FORMAT_INDY:
+        if cred_type in [CRED_FORMAT_INDY, CRED_FORMAT_ANONCREDS]:
             # if registering a did for issuing indy credentials, publish the did on the ledger
             self.log(f"Registering {self.ident} ...")
             if not ledger_url:

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -1,4 +1,4 @@
-FROM bcgovimages/von-image:py36-1.15-1
+FROM indy-base
 
 ENV ENABLE_PTVSD 0
 ENV ENABLE_PYDEVD_PYCHARM 0


### PR DESCRIPTION
Add BDD tests for issue v2 and proof presentation v2.
The tests include create schema, create cred def and revocation through the new `/anoncreds` API.

Note that I encountered some weirdness running the tests in the devcontainer... some messages didn't appear to be fully fleshed out (see comments about "by_format"). Running using the `run_bdd` script was fine.

Also, on proof presentation, I could not get it working using restriction with "schema_name" and "schema_version" like other presentations. I used restrictions by `cred_def_id` to pass the tests.  Not sure if that is something that needs to be looked at further as it would impact migrations to `anoncreds` if current presentation requests don't work.

