### PR TITLE
Fix: Ensure event/webhook is emitted for multi-use invitations

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -525,8 +525,12 @@ class ConnectionManager(BaseConnectionManager):
             connection.their_did = request.connection.did
             connection.state = ConnRecord.State.REQUEST.rfc160
             async with self.profile.session() as session:
+                # force emitting event that would be ignored for multi-use invitations
+                # since the record is not new, and the state was not updated
                 await connection.save(
-                    session, reason="Received connection request from invitation"
+                    session,
+                    reason="Received connection request from invitation",
+                    event=True,
                 )
         elif not self.profile.settings.get("public_invites"):
             raise ConnectionManagerError("Public invitations are not enabled")


### PR DESCRIPTION
As a consequence of the fix in #2223, events/webhooks for new connections created responding to multi-use invitations were not being emitted. This happened because events are emitted, unless specified with the appropriate flag, only when the connection record being saved is new OR the state has changed.

Neither of those conditions is true for a multi-use invitation since the record is "cloned" and contextually set to state `request`  (see #2099). 

The fix ensures an event (and webhook) is always emitted when a new connection transitions to the `request` state.
Resolves #2406 