### PR TITLE
Remove Indy tests from workflows

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -18,17 +18,3 @@ jobs:
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
-
-  tests-indy:
-    if: github.repository == 'hyperledger/aries-cloudagent-python' || github.event_name == 'workflow_dispatch'
-    name: Tests (Indy)
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.9", "3.10"]
-    uses: ./.github/workflows/tests-indy.yml
-    with:
-      python-version: ${{ matrix.python-version }}
-      os: ${{ matrix.os }}
-      indy-version: "1.16.0"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -14,11 +14,3 @@ jobs:
     with:
       python-version: "3.9"
       os: "ubuntu-latest"
-
-  tests-indy:
-    name: Tests (Indy)
-    uses: ./.github/workflows/tests-indy.yml
-    with:
-      python-version: "3.9"
-      indy-version: "1.16.0"
-      os: "ubuntu-latest"

--- a/demo/docker-agent/Dockerfile.acapy
+++ b/demo/docker-agent/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-indy-1.16.0-0.8.1
+FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.9.0
 
 USER root
 

--- a/demo/docker-agent/docker-compose.yml
+++ b/demo/docker-agent/docker-compose.yml
@@ -29,7 +29,7 @@ services:
         ./ngrok-wait.sh"
       ]
     volumes:
-      - ./ngrok-wait.sh:/home/indy/ngrok-wait.sh
+      - ./ngrok-wait.sh:/home/aries/ngrok-wait.sh
 
   wallet-db:
     image: postgres:12

--- a/demo/docker-agent/ngrok-wait.sh
+++ b/demo/docker-agent/ngrok-wait.sh
@@ -32,7 +32,7 @@ exec aca-py start \
     --auto-ping-connection \
     --monitor-ping \
     --public-invites \
-    --wallet-type "indy" \
+    --wallet-type "askar" \
     --wallet-name "test_author" \
     --wallet-key "secret_key" \
     --wallet-storage-type "postgres_storage" \

--- a/demo/docker/docker-compose.yml
+++ b/demo/docker/docker-compose.yml
@@ -51,7 +51,7 @@ services:
         --log-level 'info' ",
       ]
     volumes:
-      - ./ledgers.yaml:/home/indy/ledgers.yaml
+      - ./ledgers.yaml:/home/aries/ledgers.yaml
     networks:
       - tails-network
 

--- a/demo/multi-demo/Dockerfile.acapy
+++ b/demo/multi-demo/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-indy-1.16.0-0.8.1
+FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.9.0
 
 USER root
 

--- a/demo/multi-demo/docker-compose.yml
+++ b/demo/multi-demo/docker-compose.yml
@@ -52,7 +52,7 @@ services:
         ./ngrok-wait.sh"
       ]
     volumes:
-      - ./ngrok-wait.sh:/home/indy/ngrok-wait.sh
+      - ./ngrok-wait.sh:/home/aries/ngrok-wait.sh
     networks:
       - app-network
       - elk-network

--- a/demo/run_bdd
+++ b/demo/run_bdd
@@ -126,7 +126,8 @@ AGENT_PORT=8020
 AGENT_PORT_RANGE=8020-8079
 
 echo "Preparing agent image..."
-docker build -q -t faber-alice-demo -f ../docker/Dockerfile.demo .. || exit 1
+docker build -q -t acapy-base -f ../docker/Dockerfile .. || exit 1
+docker build -q -t faber-alice-demo -f ../docker/Dockerfile.demo --build-arg from_image=acapy-base .. || exit 1
 docker build -q -t aries-bdd-image -f ../docker/Dockerfile.bdd .. || exit 1
 
 if [ ! -z "$DOCKERHOST" ]; then

--- a/demo/run_bdd
+++ b/demo/run_bdd
@@ -126,7 +126,6 @@ AGENT_PORT=8020
 AGENT_PORT_RANGE=8020-8079
 
 echo "Preparing agent image..."
-docker build -q -t indy-base -f ../docker/Dockerfile.indy --target=indy-base .. || exit 1
 docker build -q -t faber-alice-demo -f ../docker/Dockerfile.demo .. || exit 1
 docker build -q -t aries-bdd-image -f ../docker/Dockerfile.bdd .. || exit 1
 
@@ -236,6 +235,6 @@ DOCKER=${DOCKER:-docker}
 $DOCKER run --name $AGENT --rm ${DOCKER_OPTS} \
   --network=${DOCKER_NET} \
   -p 0.0.0.0:$AGENT_PORT_RANGE:$AGENT_PORT_RANGE \
-  -v "/$(pwd)/../logs:/home/indy/logs" \
+  -v "/$(pwd)/../logs:/home/aries/logs" \
   $DOCKER_ENV \
   aries-bdd-image $ARGS

--- a/demo/run_demo
+++ b/demo/run_demo
@@ -149,7 +149,8 @@ else
 fi
 
 echo "Preparing agent image..."
-docker build -q -t faber-alice-demo -f ../docker/Dockerfile.demo .. || exit 1
+docker build -q -t acapy-base -f ../docker/Dockerfile .. || exit 1
+docker build -q -t faber-alice-demo -f ../docker/Dockerfile.demo --build-arg from_image=acapy-base .. || exit 1
 
 if [ ! -z "$DOCKERHOST" ]; then
   # provided via APPLICATION_URL environment variable

--- a/demo/run_demo
+++ b/demo/run_demo
@@ -85,7 +85,7 @@ do
       echo "For example, to create the directory and then set the permissions use: 'mkdir ../logs; chmod uga+rws ../logs'"
       exit 1
     fi
-    DOCKER_VOL="${DOCKER_VOL} -v /$(pwd)/../logs:/home/indy/logs"
+    DOCKER_VOL="${DOCKER_VOL} -v /$(pwd)/../logs:/home/aries/logs"
     continue
   ;;
   --bg)
@@ -149,7 +149,6 @@ else
 fi
 
 echo "Preparing agent image..."
-docker build -q -t indy-base -f ../docker/Dockerfile.indy --target=indy-base .. || exit 1
 docker build -q -t faber-alice-demo -f ../docker/Dockerfile.demo .. || exit 1
 
 if [ ! -z "$DOCKERHOST" ]; then

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -1,12 +1,12 @@
-ARG python_version=3.9.16
-FROM python:${python_version}-slim-bullseye
+ARG from_image=ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.9.0
+FROM ${from_image}
 
 ENV ENABLE_PTVSD 0
 ENV ENABLE_PYDEVD_PYCHARM 0
 ENV PYDEVD_PYCHARM_HOST "host.docker.internal"
 ENV ACAPY_DEBUG_WEBHOOKS 1
 
-RUN mkdir bin && curl -L -o bin/jq \
+RUN mkdir -p bin && curl -L -o bin/jq \
 	https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
 	chmod ug+x bin/jq
 

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -1,4 +1,5 @@
-FROM indy-base
+ARG python_version=3.9.16
+FROM python:${python_version}-slim-bullseye
 
 ENV ENABLE_PTVSD 0
 ENV ENABLE_PYDEVD_PYCHARM 0
@@ -26,7 +27,7 @@ ADD setup.py ./
 
 RUN pip3 install --no-cache-dir -e .
 
-RUN mkdir demo logs && chown -R indy:indy demo logs && chmod -R ug+rw demo logs
+RUN mkdir demo logs && chown -R aries:aries demo logs && chmod -R ug+rw demo logs
 
 # Add and install demo code
 ADD demo/requirements.txt ./demo/requirements.txt

--- a/docker/Dockerfile.run
+++ b/docker/Dockerfile.run
@@ -2,6 +2,8 @@ FROM python:3.9-slim-bullseye
 
 ENV ENABLE_PTVSD 0
 
+# For consistency with base images, include curl for healthchecks
+RUN apt-get update && apt-get install -y curl && apt-get clean
 ADD requirements*.txt ./
 
 RUN pip3 install --no-cache-dir \


### PR DESCRIPTION
As discussed recently and captured in #2402, this PR removes Indy specific tests from PR test runs. This also adjusts other images and examples in the demo folder to use the non-indy variant of images.