### PR TITLE
feat: Proof Negotiation

### DIFF
--- a/aries_cloudagent/protocols/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/manager.py
@@ -212,6 +212,33 @@ class PresentationManager:
 
         return presentation_exchange_record
 
+    async def create_request_as_response(
+        self,
+        presentation_exchange_record: V10PresentationExchange,
+        presentation_request_message: PresentationRequest,
+    ):
+        """
+        Create a presentation exchange record for input presentation request.
+
+        Args:
+            presentation_exchange_record: Presentation exchange record for which
+                to add presentation request
+            presentation_request_message: Presentation request to use in exchange record
+
+        Returns:
+            Presentation exchange record, updated
+
+        """
+        presentation_exchange_record.state = V10PresentationExchange.STATE_REQUEST_SENT
+        presentation_exchange_record.presentation_request = presentation_request_message.indy_proof_request()
+        presentation_exchange_record.presentation_request_dict = presentation_request_message
+        async with self._profile.session() as session:
+            await presentation_exchange_record.save(
+                session, reason="create presentation request in response to a proposal"
+            )
+
+        return presentation_exchange_record
+
     async def receive_request(
         self, presentation_exchange_record: V10PresentationExchange
     ):

--- a/aries_cloudagent/protocols/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/manager.py
@@ -230,8 +230,12 @@ class PresentationManager:
 
         """
         presentation_exchange_record.state = V10PresentationExchange.STATE_REQUEST_SENT
-        presentation_exchange_record.presentation_request = presentation_request_message.indy_proof_request()
-        presentation_exchange_record.presentation_request_dict = presentation_request_message
+        presentation_exchange_record.presentation_request = (
+            presentation_request_message.indy_proof_request()
+        )
+        presentation_exchange_record.presentation_request_dict = (
+            presentation_request_message
+        )
         async with self._profile.session() as session:
             await presentation_exchange_record.save(
                 session, reason="create presentation request in response to a proposal"

--- a/aries_cloudagent/protocols/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/routes.py
@@ -767,7 +767,7 @@ async def presentation_exchange_send_bound_request(request: web.BaseRequest):
                 )
             ],
         )
-        
+
         try:
             presentation_manager = PresentationManager(profile)
             pres_ex_record = await presentation_manager.create_request_as_response(

--- a/aries_cloudagent/protocols/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/routes.py
@@ -197,33 +197,10 @@ class V10PresentationSendRequestRequestSchema(
     )
 
 
-class V10PresentationSendRequestToProposalSchema(AdminAPIMessageTracingSchema):
+class V10PresentationSendRequestToProposalSchema(
+    V10PresentationCreateRequestRequestSchema
+):
     """Request schema for sending a proof request bound to a proposal."""
-
-    auto_verify = fields.Bool(
-        required=False,
-        metadata={
-            "description": "Verifier choice to auto-verify proof presentation",
-            "example": False,
-        },
-    )
-    auto_remove = fields.Bool(
-        required=False,
-        dump_default=False,
-        metadata={
-            "description": (
-                "Whether to remove the presentation exchange record on completion"
-                " (overrides --preserve-exchange-records configuration setting)"
-            )
-        },
-    )
-    trace = fields.Bool(
-        required=False,
-        metadata={
-            "description": "Whether to trace event (default false)",
-            "example": False,
-        },
-    )
 
 
 class CredentialsFetchQueryStringSchema(OpenAPISchema):
@@ -755,25 +732,61 @@ async def presentation_exchange_send_bound_request(request: web.BaseRequest):
     )
     pres_ex_record.auto_remove = body.get("auto_remove")
 
-    try:
-        presentation_manager = PresentationManager(profile)
-        (
-            pres_ex_record,
-            presentation_request_message,
-        ) = await presentation_manager.create_bound_request(pres_ex_record)
-        result = pres_ex_record.serialize()
-    except (BaseModelError, LedgerError, StorageError) as err:
-        if pres_ex_record:
-            async with profile.session() as session:
-                await pres_ex_record.save_error_state(session, reason=err.roll_up)
-        # other party cares that we cannot continue protocol
-        await report_problem(
-            err,
-            ProblemReportReason.ABANDONED.value,
-            web.HTTPBadRequest,
-            pres_ex_record,
-            outbound_handler,
+    if not body.get("proof_request"):
+        try:
+            presentation_manager = PresentationManager(profile)
+            (
+                pres_ex_record,
+                presentation_request_message,
+            ) = await presentation_manager.create_bound_request(pres_ex_record)
+            result = pres_ex_record.serialize()
+        except (BaseModelError, LedgerError, StorageError) as err:
+            if pres_ex_record:
+                async with profile.session() as session:
+                    await pres_ex_record.save_error_state(session, reason=err.roll_up)
+            # other party cares that we cannot continue protocol
+            await report_problem(
+                err,
+                ProblemReportReason.ABANDONED.value,
+                web.HTTPBadRequest,
+                pres_ex_record,
+                outbound_handler,
+            )
+    else:
+        comment = body.get("comment")
+        indy_proof_request = body.get("proof_request")
+        if not indy_proof_request.get("nonce"):
+            indy_proof_request["nonce"] = await generate_pr_nonce()
+
+        presentation_request_message = PresentationRequest(
+            comment=comment,
+            request_presentations_attach=[
+                AttachDecorator.data_base64(
+                    mapping=indy_proof_request,
+                    ident=ATTACH_DECO_IDS[PRESENTATION_REQUEST],
+                )
+            ],
         )
+        
+        try:
+            presentation_manager = PresentationManager(profile)
+            pres_ex_record = await presentation_manager.create_request_as_response(
+                presentation_request_message=presentation_request_message,
+                presentation_exchange_record=pres_ex_record,
+            )
+            result = pres_ex_record.serialize()
+        except (BaseModelError, StorageError) as err:
+            if pres_ex_record:
+                async with profile.session() as session:
+                    await pres_ex_record.save_error_state(session, reason=err.roll_up)
+            # other party cares that we cannot continue protocol
+            await report_problem(
+                err,
+                ProblemReportReason.ABANDONED.value,
+                web.HTTPBadRequest,
+                pres_ex_record,
+                outbound_handler,
+            )
 
     trace_msg = body.get("trace")
     presentation_request_message.assign_trace_decorator(

--- a/aries_cloudagent/protocols/present_proof/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/tests/test_routes.py
@@ -788,7 +788,6 @@ class TestProofRoutes(AsyncTestCase):
             "models.presentation_exchange.V10PresentationExchange",
             autospec=True,
         ) as mock_presentation_exchange:
-
             # Since we are mocking import
             importlib.reload(test_module)
 

--- a/aries_cloudagent/protocols/present_proof/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/tests/test_routes.py
@@ -746,6 +746,83 @@ class TestProofRoutes(AsyncTestCase):
                     mock_presentation_exchange.serialize.return_value
                 )
 
+    async def test_presentation_exchange_send_updated_bound_request(self):
+        self.request.json = async_mock.CoroutineMock(return_value={"trace": False})
+        self.request.match_info = {
+            "pres_ex_id": "dummy",
+            "proof_request": {},
+        }
+
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            async_mock.MagicMock(
+                __aenter__=async_mock.CoroutineMock(),
+                __aexit__=async_mock.CoroutineMock(),
+            ),
+        )
+        self.profile.context.injector.bind_instance(
+            IndyVerifier,
+            async_mock.MagicMock(
+                verify_presentation=async_mock.CoroutineMock(),
+            ),
+        )
+
+        with async_mock.patch(
+            "aries_cloudagent.connections.models.conn_record.ConnRecord",
+            autospec=True,
+        ) as mock_connection_record, async_mock.patch(
+            "aries_cloudagent.protocols.present_proof.v1_0.manager.PresentationManager",
+            autospec=True,
+        ) as mock_presentation_manager, async_mock.patch(
+            "aries_cloudagent.indy.util.generate_pr_nonce",
+            autospec=True,
+        ) as mock_generate_nonce, async_mock.patch.object(
+            test_module, "IndyPresPreview", autospec=True
+        ) as mock_presentation_proposal, async_mock.patch.object(
+            test_module, "PresentationRequest", autospec=True
+        ) as mock_presentation_request, async_mock.patch(
+            "aries_cloudagent.messaging.decorators.attach_decorator.AttachDecorator",
+            autospec=True,
+        ) as mock_attach_decorator, async_mock.patch(
+            "aries_cloudagent.protocols.present_proof.v1_0."
+            "models.presentation_exchange.V10PresentationExchange",
+            autospec=True,
+        ) as mock_presentation_exchange:
+
+            # Since we are mocking import
+            importlib.reload(test_module)
+
+            mock_presentation_exchange.connection_id = "dummy"
+            mock_presentation_exchange.state = (
+                test_module.V10PresentationExchange.STATE_PROPOSAL_RECEIVED
+            )
+            mock_presentation_exchange.retrieve_by_id = async_mock.CoroutineMock(
+                return_value=mock_presentation_exchange
+            )
+            mock_presentation_exchange.serialize = async_mock.MagicMock()
+            mock_presentation_exchange.serialize.return_value = {
+                "thread_id": "sample-thread-id"
+            }
+            mock_connection_record.is_ready = True
+            mock_connection_record.retrieve_by_id = async_mock.CoroutineMock(
+                return_value=mock_connection_record
+            )
+
+            mock_mgr = async_mock.MagicMock(
+                create_bound_request=async_mock.CoroutineMock(
+                    return_value=(mock_presentation_exchange, mock_presentation_request)
+                )
+            )
+            mock_presentation_manager.return_value = mock_mgr
+
+            with async_mock.patch.object(
+                test_module.web, "json_response"
+            ) as mock_response:
+                await test_module.presentation_exchange_send_bound_request(self.request)
+                mock_response.assert_called_once_with(
+                    mock_presentation_exchange.serialize.return_value
+                )
+
     async def test_presentation_exchange_send_bound_request_not_found(self):
         self.request.json = async_mock.CoroutineMock(return_value={"trace": False})
         self.request.match_info = {"pres_ex_id": "dummy"}

--- a/aries_cloudagent/protocols/present_proof/v2_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/manager.py
@@ -207,6 +207,32 @@ class V20PresManager:
 
         return pres_ex_record
 
+    async def create_request_as_response(
+        self,
+        pres_ex_record: V20PresExRecord,
+        pres_request_message: V20PresRequest,
+    ):
+        """
+        Create a presentation exchange record for input presentation request.
+
+        Args:
+            pres_ex_record: Presentation exchange record for which to add presentation request
+            pres_request_message: Presentation request to use in exchange record
+
+        Returns:
+            Presentation exchange record, updated
+
+        """
+        pres_ex_record.state = V20PresExRecord.STATE_REQUEST_SENT
+        pres_ex_record.presentation_request = pres_request_message.indy_proof_request()
+        pres_ex_record.presentation_request_dict = pres_request_message
+        async with self._profile.session() as session:
+            await pres_ex_record.save(
+                session, reason="create v2.0 presentation request in response to a proposal"
+            )
+
+        return pres_ex_record
+
     async def receive_pres_request(self, pres_ex_record: V20PresExRecord):
         """
         Receive a presentation request.

--- a/aries_cloudagent/protocols/present_proof/v2_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/manager.py
@@ -216,7 +216,8 @@ class V20PresManager:
         Create a presentation exchange record for input presentation request.
 
         Args:
-            pres_ex_record: Presentation exchange record for which to add presentation request
+            pres_ex_record: Presentation exchange record for which to add
+                presentation request
             pres_request_message: Presentation request to use in exchange record
 
         Returns:
@@ -228,7 +229,8 @@ class V20PresManager:
         pres_ex_record.presentation_request_dict = pres_request_message
         async with self._profile.session() as session:
             await pres_ex_record.save(
-                session, reason="create v2.0 presentation request in response to a proposal"
+                session,
+                reason="create v2.0 presentation request in response to a proposal",
             )
 
         return pres_ex_record

--- a/aries_cloudagent/protocols/present_proof/v2_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/routes.py
@@ -1126,7 +1126,9 @@ async def present_proof_send_bound_request(request: web.BaseRequest):
         pres_request_message = V20PresRequest(
             comment=comment,
             will_confirm=True,
-            **_formats_attach(pres_request_spec, PRES_20_REQUEST, "request_presentations"),
+            **_formats_attach(
+                pres_request_spec, PRES_20_REQUEST, "request_presentations"
+            ),
         )
 
         try:


### PR DESCRIPTION
This is a rebased version of #2033. Thank you for your contributions, @Przytua!

I think these changes are likely to be better suited to a new endpoint (i.e. `POST /present-proof/{pres_ex_id}/counter-request` or something) rather than changing the behavior of `POST /present-proof/{pres_ex_id}/request`. I'll open this as a draft for now and look at making these changes when I can.