### PR TITLE
Issue #2419 InvalidClientTaaAcceptanceError time too precise error if container timezone is not UTC

### DIFF
--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -981,7 +981,11 @@ class IndySdkLedger(BaseLedger):
 
         Anything more accurate is a privacy concern.
         """
-        return int(datetime.combine(date.today(), datetime.min.time()).timestamp())
+        return int(
+            datetime.combine(
+                date.today(), datetime.min.time(), datetime.timezone.utc
+            ).timestamp()
+        )
 
     async def accept_txn_author_agreement(
         self, taa_record: dict, mechanism: str, accept_time: int = None

--- a/aries_cloudagent/ledger/indy_vdr.py
+++ b/aries_cloudagent/ledger/indy_vdr.py
@@ -921,7 +921,11 @@ class IndyVdrLedger(BaseLedger):
 
         Anything more accurate is a privacy concern.
         """
-        return int(datetime.combine(date.today(), datetime.min.time()).timestamp())
+        return int(
+            datetime.combine(
+                date.today(), datetime.min.time(), datetime.timezone.utc
+            ).timestamp()
+        )
 
     async def accept_txn_author_agreement(
         self, taa_record: dict, mechanism: str, accept_time: int = None


### PR DESCRIPTION
Adds timezone.utc to datetime.combine to ensure time will be midnight in UTC regardless of the default timezone