### PR TITLE
Fix for nightly tests failing on Python 3.10

### DIFF
--- a/.github/workflows/nigthly.yml
+++ b/.github/workflows/nigthly.yml
@@ -38,7 +38,7 @@ jobs:
 
   publish:
     name: Publish
-    needs: [setup_and_check_pub]
+    needs: [tests, setup_and_check_pub]
     if: needs.setup_and_check_pub.outputs.commits_today > 0
     uses: ./.github/workflows/publish.yml
     strategy:

--- a/aries_cloudagent/admin/tests/test_admin_server.py
+++ b/aries_cloudagent/admin/tests/test_admin_server.py
@@ -2,8 +2,7 @@ import json
 
 import pytest
 import mock as async_mock
-from async_case import IsolatedAsyncioTestCase
-
+from unittest import IsolatedAsyncioTestCase
 from aiohttp import ClientSession, DummyCookieJar, TCPConnector, web
 from aiohttp.test_utils import unused_port
 
@@ -303,7 +302,6 @@ class TestAdminServer(IsolatedAsyncioTestCase):
             logs.output
         )
 
-    @pytest.mark.skip(reason="async_case library not compatible with python 3.10")
     async def test_visit_insecure_mode(self):
         settings = {"admin.admin_insecure_mode": True, "task_queue": True}
         server = self.get_admin_server(settings)
@@ -335,7 +333,6 @@ class TestAdminServer(IsolatedAsyncioTestCase):
 
         await server.stop()
 
-    @pytest.mark.skip(reason="async_case library not compatible with python 3.10")
     async def test_visit_secure_mode(self):
         settings = {
             "admin.admin_insecure_mode": False,
@@ -388,7 +385,6 @@ class TestAdminServer(IsolatedAsyncioTestCase):
 
         await server.stop()
 
-    @pytest.mark.skip(reason="async_case library not compatible with python 3.10")
     async def test_query_config(self):
         settings = {
             "admin.admin_insecure_mode": False,

--- a/aries_cloudagent/admin/tests/test_admin_server.py
+++ b/aries_cloudagent/admin/tests/test_admin_server.py
@@ -303,6 +303,7 @@ class TestAdminServer(IsolatedAsyncioTestCase):
             logs.output
         )
 
+    @pytest.mark.skip(reason="async_case library not compatible with python 3.10")
     async def test_visit_insecure_mode(self):
         settings = {"admin.admin_insecure_mode": True, "task_queue": True}
         server = self.get_admin_server(settings)

--- a/aries_cloudagent/core/tests/test_conductor.py
+++ b/aries_cloudagent/core/tests/test_conductor.py
@@ -1,7 +1,7 @@
 from io import StringIO
 
 import mock as async_mock
-from async_case import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase
 
 from ...admin.base_server import BaseAdminServer
 from ...config.base_context import ContextBuilder

--- a/aries_cloudagent/core/tests/test_dispatcher.py
+++ b/aries_cloudagent/core/tests/test_dispatcher.py
@@ -1,6 +1,6 @@
 import json
 
-from async_case import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase
 import mock as async_mock
 import pytest
 

--- a/aries_cloudagent/core/tests/test_util.py
+++ b/aries_cloudagent/core/tests/test_util.py
@@ -1,4 +1,4 @@
-from async_case import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase
 
 from ...cache.base import BaseCache
 from ...cache.in_memory import InMemoryCache

--- a/aries_cloudagent/ledger/tests/test_routes.py
+++ b/aries_cloudagent/ledger/tests/test_routes.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from async_case import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase
 import mock as async_mock
 
 from ...core.in_memory import InMemoryProfile

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -1,7 +1,7 @@
 import mock as async_mock
 import pytest
 from aiohttp.web import HTTPForbidden
-from async_case import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase
 
 from ...admin.request_context import AdminRequestContext
 from ...core.in_memory import InMemoryProfile

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,4 @@
 asynctest==0.13.0
-async-case~=10.1
 pytest~=7.4.0
 pytest-asyncio==0.14.0
 pytest-cov==2.10.1


### PR DESCRIPTION
Before the recent support for nightly release tests for Python 3.10 (see the logs [here](https://github.com/hyperledger/aries-cloudagent-python/actions/runs/5861979241/job/15893033620)) were broken this fix corrected the tests by simply replacing  [async_case](https://pypi.org/project/async-case/) with the original [unittest](https://docs.python.org/3/library/unittest.html) library.

A similar issue was resolved for the same incompatibility in #2187

As [async_case](https://pypi.org/project/async-case/) was simply a backport of functionality included since Python 3.8 and acapy supports Python 3.9+ there is no longer a need for [async_case](https://pypi.org/project/async-case/).

Finally, this means we also restore the functionality of 2 additional tests that were previously skipped in #2187

## Including Tests as a Dependency for Nightly Releases
In addition, the current release does not check that the tests for Python 3.10 were successful before building a nightly release. This PR also adds this as a dependency. 


## Additional context
The current source of the error with Python 3.10 is due to [async_case](https://pypi.org/project/async-case/) using 
```python
            loop.run_until_complete(
                asyncio.gather(*to_cancel, loop=loop, return_exceptions=True))
```
as of Python 3.10 the `loop` keyword has been depreciated in [asyncio.gather](https://docs.python.org/3/library/asyncio-task.html#asyncio.gather). 

This leads to the following exception
![image](https://github.com/hyperledger/aries-cloudagent-python/assets/34443260/f25991be-6e62-4a00-a8ab-25e7661f3c40)