### PR TITLE
Add symlink to /home/indy/.indy_client for backwards compatibility

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,6 +86,10 @@ RUN mkdir -p \
 RUN chown -R $user:root $HOME/.indy_client $HOME/.aries_cloudagent && \
     chmod -R ug+rw $HOME/log $HOME/ledger $HOME/.aries_cloudagent $HOME/.cache $HOME/.indy_client
 
+# Create /home/indy and symlink .indy_client folder for backwards compatibility with artifacts created on older indy-based images.
+RUN mkdir -p /home/indy
+RUN ln -s /home/aries/.indy_client /home/indy/.indy_client
+
 # Install ACA-py from the wheel as $user,
 # and ensure the permissions on the python 'site-packages' and $HOME/.local folders are set correctly.
 USER $user


### PR DESCRIPTION
This should resolve an issue happening when migrating an indy-based agent to an askar-only image: the home directories will change, however the database will contain references to previously created artifacts (specifically tails files in the case that triggered this fix) that will not be resolvable anymore.

Creating a symlink for `/home/indy/.indy-client/` pointing to `/home/aries/.indy_client` should resolve issues with path resolution without needing to update path references stored in the database.

We could potentially create a symlink between `/home/indy` and `/home/aries`, but I don't like the idea of symlinking home directories.