### PR TITLE
fix: ignore duplicate record errors on add key

### DIFF
--- a/aries_cloudagent/connections/base_manager.py
+++ b/aries_cloudagent/connections/base_manager.py
@@ -40,7 +40,7 @@ from ..protocols.out_of_band.v1_0.messages.invitation import InvitationMessage
 from ..resolver.base import ResolverError
 from ..resolver.did_resolver import DIDResolver
 from ..storage.base import BaseStorage
-from ..storage.error import StorageError, StorageNotFoundError
+from ..storage.error import StorageDuplicateError, StorageError, StorageNotFoundError
 from ..storage.record import StorageRecord
 from ..transport.inbound.receipt import MessageReceipt
 from ..wallet.base import BaseWallet
@@ -226,6 +226,12 @@ class BaseConnectionManager:
                 await storage.find_record(self.RECORD_TYPE_DID_KEY, {"key": key})
             except StorageNotFoundError:
                 await storage.add_record(record)
+            except StorageDuplicateError:
+                self._logger.warning(
+                    "Key already associated with DID: %s; this is likely caused by "
+                    "routing keys being erroneously stored in the past",
+                    key,
+                )
 
     async def find_did_for_key(self, key: str) -> str:
         """Find the DID previously associated with a key.


### PR DESCRIPTION
This is a bandaid solution to prevent routing keys from being stored for multiple DIDs. It would be nice to correct behavior of the DIDDoc class to not turn routing keys into values in the publicKey list and then claiming that the DID is the controller (with no evidence). However, given the impending replacement of this behavior with did:peer, it doesn't seem worth it to go through that effort right now.

cc @swcurran @WadeBarnes and others