### PR TITLE
chore: relax connections filter DID format

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -28,6 +28,7 @@ from ....messaging.valid import (
     INDY_RAW_PUBLIC_KEY_VALIDATE,
     UUID4_EXAMPLE,
     UUID4_VALIDATE,
+    GENERIC_DID_VALIDATE,
 )
 from ....storage.error import StorageError, StorageNotFoundError
 from ....wallet.error import WalletError
@@ -248,7 +249,7 @@ class ConnectionsListQueryStringSchema(OpenAPISchema):
     )
     my_did = fields.Str(
         required=False,
-        validate=INDY_DID_VALIDATE,
+        validate=GENERIC_DID_VALIDATE,
         metadata={"description": "My DID", "example": INDY_DID_EXAMPLE},
     )
     state = fields.Str(
@@ -260,12 +261,12 @@ class ConnectionsListQueryStringSchema(OpenAPISchema):
     )
     their_did = fields.Str(
         required=False,
-        validate=INDY_DID_VALIDATE,
+        validate=GENERIC_DID_VALIDATE,
         metadata={"description": "Their DID", "example": INDY_DID_EXAMPLE},
     )
     their_public_did = fields.Str(
         required=False,
-        validate=INDY_DID_VALIDATE,
+        validate=GENERIC_DID_VALIDATE,
         metadata={"description": "Their Public DID", "example": INDY_DID_EXAMPLE},
     )
     their_role = fields.Str(


### PR DESCRIPTION
Relax the connection filter on `my_did`, `their_did` and `their_public_did` fields of the `/connections` endpoints.

These values were restricted to `did:sov` and are now open to the generic DID format.