### PR TITLE
feat: add timeout to did resolver resolve method

### DIFF
--- a/aries_cloudagent/resolver/did_resolver.py
+++ b/aries_cloudagent/resolver/did_resolver.py
@@ -30,6 +30,8 @@ LOGGER = logging.getLogger(__name__)
 class DIDResolver:
     """did resolver singleton."""
 
+    DEFAULT_TIMEOUT = 30
+
     def __init__(self, resolvers: Optional[List[BaseDIDResolver]] = None):
         """Create DID Resolver."""
         self.resolvers = resolvers or []
@@ -64,7 +66,7 @@ class DIDResolver:
                         did,
                         service_accept,
                     ),
-                    timeout if timeout is not None else 30,
+                    timeout if timeout is not None else self.DEFAULT_TIMEOUT,
                 )
                 return resolver, document
             except DIDNotFound:

--- a/aries_cloudagent/resolver/did_resolver.py
+++ b/aries_cloudagent/resolver/did_resolver.py
@@ -4,6 +4,7 @@ responsible for keeping track of all resolvers. more importantly
 retrieving did's from different sources provided by the method type.
 """
 
+import asyncio
 from datetime import datetime
 from itertools import chain
 import logging
@@ -42,9 +43,14 @@ class DIDResolver:
         profile: Profile,
         did: Union[str, DID],
         service_accept: Optional[Sequence[Text]] = None,
+        *,
+        timeout: Optional[int] = None,
     ) -> Tuple[BaseDIDResolver, dict]:
-        """Retrieve doc and return with resolver."""
-        # TODO Cache results
+        """Retrieve doc and return with resolver.
+
+        This private method enables the public resolve and resolve_with_metadata
+        methods to share the same logic.
+        """
         if isinstance(did, DID):
             did = str(did)
         else:
@@ -52,10 +58,13 @@ class DIDResolver:
         for resolver in await self._match_did_to_resolver(profile, did):
             try:
                 LOGGER.debug("Resolving DID %s with %s", did, resolver)
-                document = await resolver.resolve(
-                    profile,
-                    did,
-                    service_accept,
+                document = await asyncio.wait_for(
+                    resolver.resolve(
+                        profile,
+                        did,
+                        service_accept,
+                    ),
+                    timeout if timeout is not None else 30,
                 )
                 return resolver, document
             except DIDNotFound:
@@ -68,18 +77,20 @@ class DIDResolver:
         profile: Profile,
         did: Union[str, DID],
         service_accept: Optional[Sequence[Text]] = None,
+        *,
+        timeout: Optional[int] = None,
     ) -> dict:
         """Resolve a DID."""
-        _, doc = await self._resolve(profile, did, service_accept)
+        _, doc = await self._resolve(profile, did, service_accept, timeout=timeout)
         return doc
 
     async def resolve_with_metadata(
-        self, profile: Profile, did: Union[str, DID]
+        self, profile: Profile, did: Union[str, DID], *, timeout: Optional[int] = None
     ) -> ResolutionResult:
         """Resolve a DID and return the ResolutionResult."""
         resolution_start_time = datetime.utcnow()
 
-        resolver, doc = await self._resolve(profile, did)
+        resolver, doc = await self._resolve(profile, did, timeout=timeout)
 
         time_now = datetime.utcnow()
         duration = int((time_now - resolution_start_time).total_seconds() * 1000)
@@ -120,7 +131,6 @@ class DIDResolver:
         document: Optional[BaseDIDDocument] = None,
     ) -> Resource:
         """Dereference a DID URL to its corresponding DID Doc object."""
-        # TODO Use cached DID Docs when possible
         try:
             parsed = DIDUrl.parse(did_url)
             if not parsed.did:


### PR DESCRIPTION
This PR adds a `timeout` parameter to the DID Resolver interface, defaulting to 30 seconds. Without it, a poorly behaved resolver plugin can "resolve" documents that aren't actually DID Docs and cause ACA-Py to run out of memory.

There's space for additional tuning on the timeout default. Some DID Methods are, in my experience, quite slow (did:btcr and did:ion resolvers can be pretty slow sometimes). 30 seconds might be overly charitable.