### PR TITLE
fix: version should be set by pyproject.toml

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -100,7 +100,7 @@ Once you have the list of PRs:
    errors should be fixed in the code.
 
 5. Update the version number listed in
-   [aries_cloudagent/version.py](aries_cloudagent/version.py) and, prefixed with
+   [pyproject.toml](pyproject.toml) and, prefixed with
    a "v" in [open-api/openapi.json](open-api/openapi.json) and
    [open-api/swagger.json](open-api/swagger.json) (e.g. "0.7.2" in the
    version.py file and "v0.7.2" in the openapi.json file). The incremented
@@ -126,7 +126,7 @@ Once you have the list of PRs:
 
 9. Immediately after it is merged, create a new GitHub tag representing the
    version. The tag name and title of the release should be the same as the
-   version in [aries_cloudagent/version.py](aries_cloudagent/version.py). Use
+   version in [pyproject.toml](pyproject.toml). Use
    the "Generate Release Notes" capability to get a sequential listing of the
    PRs in the release, to complement the manually curated Changelog. Verify on
    PyPi that the version is published.

--- a/aries_cloudagent/version.py
+++ b/aries_cloudagent/version.py
@@ -1,4 +1,6 @@
 """Library version information."""
 
-__version__ = "0.10.1"
+from importlib import metadata
+
+__version__ = metadata.version("aries-cloudagent")
 RECORD_TYPE_ACAPY_VERSION = "acapy_version"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "aries_cloudagent"
-version = "0.10.0-rc0"
-description = ""
+version = "0.10.1"
+description = "Hyperledger Aries Cloud Agent Python (ACA-Py) is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 authors = ["Hyperledger Aries <aries@lists.hyperledger.org>"]
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
`aries_cloudagent.version.__version__` was out of sync with the version listed in the pyproject.toml file. The pyproject.toml file should be the source of truth as it will be used when publishing using poetry. However, `__version__` is used in code for some operations. To ensure that the pyproject file and the `__version__` can't get out of sync, `aries_cloudagent.version` will now be read from the package metadata.

Update: I was previously trying to read from pyproject.toml. This was a naive approach that wouldn't have worked after installing ACA-Py as a pip package. The better solution is the one I've switched to, just reading the package metadata.

