### PR TITLE
Allow direct reading of pyproject.toml version when package not installed

### DIFF
--- a/aries_cloudagent/version.py
+++ b/aries_cloudagent/version.py
@@ -1,6 +1,31 @@
 """Library version information."""
 
-from importlib import metadata
+from contextlib import suppress
+import importlib.metadata
+from pathlib import Path
 
-__version__ = metadata.version("aries-cloudagent")
+
+def extract_version() -> str:
+    """Return package version.
+
+    Returns version of the installed package or the one found in nearby pyproject.toml
+    for cases when package is not installed (ie. local development and testing).
+    """
+    try:
+        return importlib.metadata.version("aries-cloudagent")
+    except importlib.metadata.PackageNotFoundError:
+        with suppress(FileNotFoundError, StopIteration):
+            with open(
+                (Path(__file__).parent.parent) / "pyproject.toml",
+                encoding="utf-8",
+            ) as pyproject_toml:
+                version = (
+                    next(line for line in pyproject_toml if line.startswith("version"))
+                    .split("=")[1]
+                    .strip("'\"\n ")
+                )
+                return f"{version}"
+
+
+__version__ = extract_version()
 RECORD_TYPE_ACAPY_VERSION = "acapy_version"


### PR DESCRIPTION
Slight tweak to the package version read. See #2471 

When running locally, without `poetry` (ie `devcontainer`), the pytests need to read the version but the `aries-cloudagent` package is not installed. This will read the value from the `pyproject.toml` directly if package not found.

Built images will read from the installed package metadata, but pytests (run locally) read from pyproject.toml.