### PR TITLE
Issue #2488 KeyError raised when Subject ID is not a URI

### DIFF
--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -750,10 +750,10 @@ class CredentialSubject(Validator):
             if "id" in subject:
                 uri_validator = Uri()
                 try:
-                    uri_validator(value["id"])
+                    uri_validator(subject["id"])
                 except ValidationError:
                     raise ValidationError(
-                        f"credential subject id {value[0]} must be URI"
+                        f'credential subject id {subject["id"]} must be URI'
                     ) from None
 
         return value


### PR DESCRIPTION
Changed from `value`, which may or may not be a list, to `subject`, derived from `subjects` which is always a list.