### PR TITLE
fix: run tests script copying local env

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ test-reports
 .python-version
 docker
 env
+.venv

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -12,8 +12,9 @@ WORKDIR /usr/src/app
 RUN pip install --no-cache-dir poetry
 
 ADD ./README.md pyproject.toml ./poetry.lock ./
+RUN mkdir aries_cloudagent && touch aries_cloudagent/__init__.py
 
-RUN poetry install --no-root --no-directory -E "askar bbs"
+RUN poetry install --no-directory -E "askar bbs" --with=dev
 
 ADD . .
 


### PR DESCRIPTION
This PR fixes the scripts/run_tests script and its dockerfiles to make sure it doesn't copy local .venv directories into the container image. This was causing the script to fail.