### PR TITLE
Avoid multiple open wallet connections

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
@@ -303,9 +303,6 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
         did_info: DIDInfo = None,
     ):
         """Get signature suite for issuance of verification."""
-        session = await self.profile.session()
-        wallet = session.inject(BaseWallet)
-
         # Get signature class based on proof type
         SignatureClass = PROOF_TYPE_SIGNATURE_SUITE_MAPPING[proof_type]
 
@@ -314,7 +311,7 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
             verification_method=verification_method,
             proof=proof,
             key_pair=WalletKeyPair(
-                wallet=wallet,
+                profile=self.profile,
                 key_type=SIGNATURE_SUITE_KEY_TYPE_MAPPING[SignatureClass],
                 public_key_base58=did_info.verkey if did_info else None,
             ),

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
@@ -396,7 +396,7 @@ class TestDIFFormatHandler(AsyncTestCase):
             self.handler.validate_fields(PRES_20, incorrect_pres)
 
     async def test_get_all_suites(self):
-        suites = await self.handler._get_all_suites(self.wallet)
+        suites = await self.handler._get_all_suites()
         assert len(suites) == 4
         types = [
             Ed25519Signature2018,

--- a/aries_cloudagent/vc/ld_proofs/crypto/tests/test_wallet_key_pair.py
+++ b/aries_cloudagent/vc/ld_proofs/crypto/tests/test_wallet_key_pair.py
@@ -2,7 +2,8 @@ from asynctest import TestCase, mock as async_mock
 
 from aries_cloudagent.wallet.key_type import ED25519
 
-
+from .....core.in_memory import InMemoryProfile
+from .....wallet.in_memory import InMemoryWallet
 from ...error import LinkedDataProofException
 
 from ..wallet_key_pair import WalletKeyPair
@@ -10,10 +11,10 @@ from ..wallet_key_pair import WalletKeyPair
 
 class TestWalletKeyPair(TestCase):
     async def setUp(self):
-        self.wallet = async_mock.MagicMock()
+        self.profile = InMemoryProfile.test_profile()
 
     async def test_sign_x_no_public_key(self):
-        key_pair = WalletKeyPair(wallet=self.wallet, key_type=ED25519)
+        key_pair = WalletKeyPair(profile=self.profile, key_type=ED25519)
 
         with self.assertRaises(LinkedDataProofException) as context:
             await key_pair.sign(b"Message")
@@ -22,23 +23,26 @@ class TestWalletKeyPair(TestCase):
     async def test_sign(self):
         public_key_base58 = "verkey"
         key_pair = WalletKeyPair(
-            wallet=self.wallet,
+            profile=self.profile,
             key_type=ED25519,
             public_key_base58=public_key_base58,
         )
         signed = async_mock.MagicMock()
 
-        self.wallet.sign_message = async_mock.CoroutineMock(return_value=signed)
+        with async_mock.patch.object(
+            InMemoryWallet,
+            "sign_message",
+            async_mock.CoroutineMock(return_value=signed),
+        ) as sign_message:
+            singed_ret = await key_pair.sign(b"Message")
 
-        singed_ret = await key_pair.sign(b"Message")
-
-        assert signed == singed_ret
-        self.wallet.sign_message.assert_called_once_with(
-            message=b"Message", from_verkey=public_key_base58
-        )
+            assert signed == singed_ret
+            sign_message.assert_called_once_with(
+                message=b"Message", from_verkey=public_key_base58
+            )
 
     async def test_verify_x_no_public_key(self):
-        key_pair = WalletKeyPair(wallet=self.wallet, key_type=ED25519)
+        key_pair = WalletKeyPair(profile=self.profile, key_type=ED25519)
 
         with self.assertRaises(LinkedDataProofException) as context:
             await key_pair.verify(b"Message", b"signature")
@@ -47,24 +51,28 @@ class TestWalletKeyPair(TestCase):
     async def test_verify(self):
         public_key_base58 = "verkey"
         key_pair = WalletKeyPair(
-            wallet=self.wallet,
+            profile=self.profile,
             key_type=ED25519,
             public_key_base58=public_key_base58,
         )
-        self.wallet.verify_message = async_mock.CoroutineMock(return_value=True)
 
-        verified = await key_pair.verify(b"Message", b"signature")
+        with async_mock.patch.object(
+            InMemoryWallet,
+            "verify_message",
+            async_mock.CoroutineMock(return_value=True),
+        ) as verify_message:
+            verified = await key_pair.verify(b"Message", b"signature")
 
-        assert verified
-        self.wallet.verify_message.assert_called_once_with(
-            message=b"Message",
-            signature=b"signature",
-            from_verkey=public_key_base58,
-            key_type=ED25519,
-        )
+            assert verified
+            verify_message.assert_called_once_with(
+                message=b"Message",
+                signature=b"signature",
+                from_verkey=public_key_base58,
+                key_type=ED25519,
+            )
 
     async def test_from_verification_method_x_no_public_key_base58(self):
-        key_pair = WalletKeyPair(wallet=self.wallet, key_type=ED25519)
+        key_pair = WalletKeyPair(profile=self.profile, key_type=ED25519)
 
         with self.assertRaises(LinkedDataProofException) as context:
             key_pair.from_verification_method({})

--- a/aries_cloudagent/vc/ld_proofs/suites/tests/test_bbs_bls_signature_2020.py
+++ b/aries_cloudagent/vc/ld_proofs/suites/tests/test_bbs_bls_signature_2020.py
@@ -3,9 +3,9 @@ import pytest
 
 from aries_cloudagent.wallet.key_type import BLS12381G2
 
+from .....core.in_memory import InMemoryProfile
 from .....did.did_key import DIDKey
 from .....wallet.in_memory import InMemoryWallet
-from .....core.in_memory import InMemoryProfile
 from ....tests.document_loader import custom_document_loader
 from ....tests.data import (
     TEST_LD_DOCUMENT,
@@ -38,11 +38,11 @@ class TestBbsBlsSignature2020(TestCase):
         ).key_id
 
         self.sign_key_pair = WalletKeyPair(
-            wallet=self.wallet,
+            profile=self.profile,
             key_type=BLS12381G2,
             public_key_base58=self.key.verkey,
         )
-        self.verify_key_pair = WalletKeyPair(wallet=self.wallet, key_type=BLS12381G2)
+        self.verify_key_pair = WalletKeyPair(profile=self.profile, key_type=BLS12381G2)
 
     async def test_sign_ld_proofs(self):
         signed = await sign(

--- a/aries_cloudagent/vc/ld_proofs/suites/tests/test_bbs_bls_signature_proof_2020.py
+++ b/aries_cloudagent/vc/ld_proofs/suites/tests/test_bbs_bls_signature_proof_2020.py
@@ -3,9 +3,9 @@ import pytest
 
 from aries_cloudagent.wallet.key_type import BLS12381G2
 
+from .....core.in_memory import InMemoryProfile
 from .....did.did_key import DIDKey
 from .....wallet.in_memory import InMemoryWallet
-from .....core.in_memory import InMemoryProfile
 from ....tests.document_loader import custom_document_loader
 from ....tests.data import (
     TEST_LD_DOCUMENT_SIGNED_BBS,
@@ -46,7 +46,7 @@ class TestBbsBlsSignatureProof2020(TestCase):
             self.key.verkey, BLS12381G2
         ).key_id
 
-        self.key_pair = WalletKeyPair(wallet=self.wallet, key_type=BLS12381G2)
+        self.key_pair = WalletKeyPair(profile=self.profile, key_type=BLS12381G2)
 
     async def test_derive_ld_proofs(self):
         derived = await derive(

--- a/aries_cloudagent/vc/ld_proofs/suites/tests/test_ed25519_signature_2018.py
+++ b/aries_cloudagent/vc/ld_proofs/suites/tests/test_ed25519_signature_2018.py
@@ -37,11 +37,11 @@ class TestEd25519Signature2018(TestCase):
         ).key_id
 
         self.sign_key_pair = WalletKeyPair(
-            wallet=self.wallet,
+            profile=self.profile,
             key_type=ED25519,
             public_key_base58=self.key.verkey,
         )
-        self.verify_key_pair = WalletKeyPair(wallet=self.wallet, key_type=ED25519)
+        self.verify_key_pair = WalletKeyPair(profile=self.profile, key_type=ED25519)
 
     async def test_sign_ld_proofs(self):
         signed = await sign(

--- a/aries_cloudagent/vc/ld_proofs/suites/tests/test_ed25519_signature_2020.py
+++ b/aries_cloudagent/vc/ld_proofs/suites/tests/test_ed25519_signature_2020.py
@@ -32,11 +32,11 @@ class TestEd25519Signature2020(TestCase):
         ).key_id
 
         self.sign_key_pair = WalletKeyPair(
-            wallet=self.wallet,
+            profile=self.profile,
             key_type=ED25519,
             public_key_base58=self.key.verkey,
         )
-        self.verify_key_pair = WalletKeyPair(wallet=self.wallet, key_type=ED25519)
+        self.verify_key_pair = WalletKeyPair(profile=self.profile, key_type=ED25519)
 
     async def test_sign_ld_proofs(self):
         signed = await sign(

--- a/aries_cloudagent/vc/ld_proofs/tests/test_ld_proofs.py
+++ b/aries_cloudagent/vc/ld_proofs/tests/test_ld_proofs.py
@@ -65,7 +65,7 @@ class TestLDProofs(TestCase):
         suite = Ed25519Signature2018(
             verification_method=self.ed25519_verification_method,
             key_pair=WalletKeyPair(
-                wallet=self.wallet,
+                profile=self.profile,
                 key_type=ED25519,
                 public_key_base58=self.ed25519_key_info.verkey,
             ),
@@ -87,7 +87,7 @@ class TestLDProofs(TestCase):
         suite = Ed25519Signature2020(
             verification_method=self.ed25519_verification_method,
             key_pair=WalletKeyPair(
-                wallet=self.wallet,
+                profile=self.profile,
                 key_type=ED25519,
                 public_key_base58=self.ed25519_key_info.verkey,
             ),
@@ -105,7 +105,7 @@ class TestLDProofs(TestCase):
     async def test_verify_Ed25519Signature2018(self):
         # Verification requires lot less input parameters
         suite = Ed25519Signature2018(
-            key_pair=WalletKeyPair(wallet=self.wallet, key_type=ED25519),
+            key_pair=WalletKeyPair(profile=self.profile, key_type=ED25519),
         )
 
         result = await verify(
@@ -120,7 +120,7 @@ class TestLDProofs(TestCase):
     async def test_verify_Ed25519Signature2020(self):
         # Verification requires lot less input parameters
         suite = Ed25519Signature2020(
-            key_pair=WalletKeyPair(wallet=self.wallet, key_type=ED25519),
+            key_pair=WalletKeyPair(profile=self.profile, key_type=ED25519),
         )
 
         result = await verify(
@@ -140,7 +140,7 @@ class TestLDProofs(TestCase):
         suite = BbsBlsSignature2020(
             verification_method=self.bls12381g2_verification_method,
             key_pair=WalletKeyPair(
-                wallet=self.wallet,
+                profile=self.profile,
                 key_type=BLS12381G2,
                 public_key_base58=self.bls12381g2_key_info.verkey,
             ),
@@ -169,7 +169,7 @@ class TestLDProofs(TestCase):
     async def test_verify_BbsBlsSignature2020(self):
         # Verification requires lot less input parameters
         suite = BbsBlsSignature2020(
-            key_pair=WalletKeyPair(wallet=self.wallet, key_type=BLS12381G2),
+            key_pair=WalletKeyPair(profile=self.profile, key_type=BLS12381G2),
         )
 
         result = await verify(
@@ -185,7 +185,7 @@ class TestLDProofs(TestCase):
     async def test_derive_BbsBlsSignatureProof2020(self):
         # Verification requires lot less input parameters
         suite = BbsBlsSignatureProof2020(
-            key_pair=WalletKeyPair(wallet=self.wallet, key_type=BLS12381G2),
+            key_pair=WalletKeyPair(profile=self.profile, key_type=BLS12381G2),
         )
 
         result = await derive(
@@ -201,7 +201,7 @@ class TestLDProofs(TestCase):
     async def test_verify_BbsBlsSignatureProof2020(self):
         # Verification requires lot less input parameters
         suite = BbsBlsSignatureProof2020(
-            key_pair=WalletKeyPair(wallet=self.wallet, key_type=BLS12381G2),
+            key_pair=WalletKeyPair(profile=self.profile, key_type=BLS12381G2),
         )
 
         result = await verify(

--- a/aries_cloudagent/vc/tests/test_bbs_mattr_interop.py
+++ b/aries_cloudagent/vc/tests/test_bbs_mattr_interop.py
@@ -51,17 +51,17 @@ class TestBbsMattrInterop(TestCase):
         self.signature_issuer_suite = BbsBlsSignature2020(
             verification_method="did:example:489398593#test",
             key_pair=WalletKeyPair(
-                wallet=self.wallet,
+                profile=self.profile,
                 key_type=BLS12381G2,
                 public_key_base58=public_key_base58,
             ),
         )
 
         self.signature_suite = BbsBlsSignature2020(
-            key_pair=WalletKeyPair(wallet=self.wallet, key_type=BLS12381G2),
+            key_pair=WalletKeyPair(profile=self.profile, key_type=BLS12381G2),
         )
         self.proof_suite = BbsBlsSignatureProof2020(
-            key_pair=WalletKeyPair(wallet=self.wallet, key_type=BLS12381G2)
+            key_pair=WalletKeyPair(profile=self.profile, key_type=BLS12381G2)
         )
 
     async def test_sign_bbs_vc_mattr(self):

--- a/aries_cloudagent/vc/vc_ld/tests/test_vc_ld.py
+++ b/aries_cloudagent/vc/vc_ld/tests/test_vc_ld.py
@@ -68,7 +68,7 @@ class TestLinkedDataVerifiableCredential(TestCase):
         suite = Ed25519Signature2018(
             verification_method=self.ed25519_verification_method,
             key_pair=WalletKeyPair(
-                wallet=self.wallet,
+                profile=self.profile,
                 key_type=ED25519,
                 public_key_base58=self.ed25519_key_info.verkey,
             ),
@@ -90,7 +90,7 @@ class TestLinkedDataVerifiableCredential(TestCase):
         suite = Ed25519Signature2020(
             verification_method=self.ed25519_verification_method,
             key_pair=WalletKeyPair(
-                wallet=self.wallet,
+                profile=self.profile,
                 key_type=ED25519,
                 public_key_base58=self.ed25519_key_info.verkey,
             ),
@@ -133,7 +133,7 @@ class TestLinkedDataVerifiableCredential(TestCase):
     async def test_verify_Ed25519Signature2018(self):
         # Verification requires lot less input parameters
         suite = Ed25519Signature2018(
-            key_pair=WalletKeyPair(wallet=self.wallet, key_type=ED25519),
+            key_pair=WalletKeyPair(profile=self.profile, key_type=ED25519),
         )
         verified = await verify_credential(
             credential=CREDENTIAL_ISSUED,
@@ -146,7 +146,7 @@ class TestLinkedDataVerifiableCredential(TestCase):
     async def test_verify_Ed25519Signature2020(self):
         # Verification requires lot less input parameters
         suite = Ed25519Signature2020(
-            key_pair=WalletKeyPair(wallet=self.wallet, key_type=ED25519),
+            key_pair=WalletKeyPair(profile=self.profile, key_type=ED25519),
         )
         verified = await verify_credential(
             credential=CREDENTIAL_ISSUED_2020,
@@ -177,7 +177,7 @@ class TestLinkedDataVerifiableCredential(TestCase):
         suite = BbsBlsSignature2020(
             verification_method=self.bls12381g2_verification_method,
             key_pair=WalletKeyPair(
-                wallet=self.wallet,
+                profile=self.profile,
                 key_type=BLS12381G2,
                 public_key_base58=self.bls12381g2_key_info.verkey,
             ),
@@ -201,7 +201,7 @@ class TestLinkedDataVerifiableCredential(TestCase):
     async def test_verify_BbsBlsSignature2020(self):
         # Verification requires lot less input parameters
         suite = BbsBlsSignature2020(
-            key_pair=WalletKeyPair(wallet=self.wallet, key_type=BLS12381G2),
+            key_pair=WalletKeyPair(profile=self.profile, key_type=BLS12381G2),
         )
         result = await verify_credential(
             credential=CREDENTIAL_ISSUED_BBS,
@@ -227,7 +227,7 @@ class TestLinkedDataVerifiableCredential(TestCase):
         suite = Ed25519Signature2018(
             verification_method=self.ed25519_verification_method,
             key_pair=WalletKeyPair(
-                wallet=self.wallet,
+                profile=self.profile,
                 key_type=ED25519,
                 public_key_base58=self.ed25519_key_info.verkey,
             ),
@@ -260,7 +260,7 @@ class TestLinkedDataVerifiableCredential(TestCase):
         suite = BbsBlsSignature2020(
             verification_method=self.bls12381g2_verification_method,
             key_pair=WalletKeyPair(
-                wallet=self.wallet,
+                profile=self.profile,
                 key_type=BLS12381G2,
                 public_key_base58=self.bls12381g2_key_info.verkey,
             ),
@@ -269,7 +269,7 @@ class TestLinkedDataVerifiableCredential(TestCase):
 
         assert unsigned_presentation == PRESENTATION_UNSIGNED
         unsigned_presentation["@context"].append("https://w3id.org/security/bbs/v1")
-        presentation = await sign_presentation(
+        _ = await sign_presentation(
             presentation=unsigned_presentation,
             suite=suite,
             document_loader=custom_document_loader,
@@ -278,7 +278,7 @@ class TestLinkedDataVerifiableCredential(TestCase):
 
     async def test_verify_presentation(self):
         suite = Ed25519Signature2018(
-            key_pair=WalletKeyPair(wallet=self.wallet, key_type=ED25519),
+            key_pair=WalletKeyPair(profile=self.profile, key_type=ED25519),
         )
         verification_result = await verify_presentation(
             presentation=PRESENTATION_SIGNED,


### PR DESCRIPTION
Fixes issues with timeouts during integration tests when the maximum number of connections is low.