### PR TITLE
Add /rotate to revocation api.

### DIFF
--- a/aries_cloudagent/anoncreds/models/anoncreds_revocation.py
+++ b/aries_cloudagent/anoncreds/models/anoncreds_revocation.py
@@ -135,6 +135,8 @@ class RevRegDefState(BaseModel):
     STATE_FAILED = "failed"
     STATE_ACTION = "action"
     STATE_WAIT = "wait"
+    STATE_DECOMMISSIONED = "decommissioned"
+    STATE_FULL = "full"
 
     class Meta:
         """RevRegDefState metadata."""
@@ -179,6 +181,8 @@ class RevRegDefStateSchema(BaseModelSchema):
                 RevRegDefState.STATE_FAILED,
                 RevRegDefState.STATE_ACTION,
                 RevRegDefState.STATE_WAIT,
+                RevRegDefState.STATE_DECOMMISSIONED,
+                RevRegDefState.STATE_FULL,
             ]
         )
     )

--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -189,7 +189,7 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
     options = {}
     if support_revocation:
         options["support_revocation"] = True
-        options["revocation_registry_size"] = rev_reg_size
+        options["max_cred_num"] = rev_reg_size
     if create_transaction_for_endorser:
         endorser_connection_id = await get_endorser_connection_id(context.profile)
         if not endorser_connection_id:

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -15,6 +15,8 @@ from aiohttp_apispec import (
 from marshmallow import fields, validate, validates_schema
 from marshmallow.exceptions import ValidationError
 
+from ..anoncreds.models.anoncreds_revocation import RevRegDefState
+
 from ..anoncreds.default.legacy_indy.registry import LegacyIndyRegistry
 from ..anoncreds.base import (
     AnonCredsObjectNotFound,
@@ -351,8 +353,8 @@ class RevRegsCreatedQueryStringSchema(OpenAPISchema):
         required=False,
         validate=validate.OneOf(
             [
-                getattr(IssuerRevRegRecord, m)
-                for m in vars(IssuerRevRegRecord)
+                getattr(RevRegDefState, m)
+                for m in vars(RevRegDefState)
                 if m.startswith("STATE_")
             ]
         ),
@@ -622,6 +624,61 @@ async def _get_issuer_rev_reg_record(
         pending_pub=pending_pubs,
     )
     return result
+
+
+@docs(
+    tags=["revocation"],
+    summary="Get current active revocation registry by credential definition id",
+)
+@match_info_schema(RevocationCredDefIdMatchInfoSchema())
+@response_schema(RevRegResultSchema(), 200, description="")
+async def get_active_rev_reg(request: web.BaseRequest):
+    """Request handler to get current active revocation registry by cred def id.
+
+    Args:
+        request: aiohttp request object
+
+    Returns:
+        The revocation registry identifier
+
+    """
+    context: AdminRequestContext = request["context"]
+    profile: AskarProfile = context.profile
+    cred_def_id = request.match_info["cred_def_id"]
+    try:
+        revocation = AnonCredsRevocation(profile)
+        active_reg = await revocation.get_or_create_active_registry(cred_def_id)
+        rev_reg = await _get_issuer_rev_reg_record(profile, active_reg.rev_reg_def_id)
+    except AnonCredsIssuerError as e:
+        raise web.HTTPInternalServerError(reason=str(e)) from e
+
+    return web.json_response({"result": rev_reg.serialize()})
+
+
+@docs(tags=["revocation"], summary="Rotate revocation registry")
+@match_info_schema(RevocationCredDefIdMatchInfoSchema())
+@response_schema(RevRegsCreatedSchema(), 200, description="")
+async def rotate_rev_reg(request: web.BaseRequest):
+    """Request handler to rotate the active revocation registries for cred. def.
+
+    Args:
+        request: aiohttp request object
+
+    Returns:
+        list or revocation registry ids that were rotated out
+
+    """
+    context: AdminRequestContext = request["context"]
+    profile: AskarProfile = context.profile
+    cred_def_id = request.match_info["cred_def_id"]
+
+    try:
+        revocation = AnonCredsRevocation(profile)
+        recs = await revocation.decommission_registry(cred_def_id)
+    except AnonCredsIssuerError as e:
+        raise web.HTTPInternalServerError(reason=str(e)) from e
+
+    return web.json_response({"rev_reg_ids": [rec.name for rec in recs if rec.name]})
 
 
 @docs(
@@ -966,6 +1023,15 @@ async def register(app: web.Application):
                 allow_head=False,
             ),
             web.get("/revocation/registry/{rev_reg_id}", get_rev_reg, allow_head=False),
+            web.get(
+                "/revocation/active-registry/{cred_def_id}",
+                get_active_rev_reg,
+                allow_head=False,
+            ),
+            web.post(
+                "/revocation/active-registry/{cred_def_id}/rotate",
+                rotate_rev_reg,
+            ),
             web.get(
                 "/revocation/registry/{rev_reg_id}/issued",
                 get_rev_reg_issued_count,

--- a/demo/README.md
+++ b/demo/README.md
@@ -229,6 +229,8 @@ Faber will setup support for revocation automatically, and you will see an extra
     (4) Create New Invitation
     (5) Revoke Credential
     (6) Publish Revocations
+    (7) Rotate Revocation Registry
+    (8) List Revocation Registries
     (T) Toggle tracing on credential/proof exchange
     (X) Exit?
   ```
@@ -243,14 +245,18 @@ Faber      | Credential revocation ID: 1
 When you revoke a credential you will need to provide those values:
 
 ```
-[1/2/3/4/5/6/T/X] 5
+[1/2/3/4/5/6/7/8/T/X] 5
 
 Enter revocation registry ID: WGmUNAdH2ZfeGvacFoMVVP:4:WGmUNAdH2ZfeGvacFoMVVP:3:CL:38:Faber.Agent.degree_schema:CL_ACCUM:15ca49ed-1250-4608-9e8f-c0d52d7260c3
 Enter credential revocation ID: 1
 Publish now? [Y/N]: y
 ```
 
-Note that you need to Publish the revocation information to the ledger.  Once you've revoked a credential any proof which uses this credential will fail to verify.
+Note that you need to Publish the revocation information to the ledger.  Once you've revoked a credential any proof which uses this credential will fail to verify.  
+
+Rotating the revocation registry will decommission any "ready" registry records and create 2 new registry records. You can view in the logs as the records are created and transition to 'active'. There should always be 2 'active' revocation registries - one working and one for hot-swap. Note that revocation information can still be published from decommissioned registries.
+
+You can also list the created registries, filtering by current state: 'init', 'generated', 'posted', 'active', 'full', 'decommissioned'.
 
 ### DID Exchange
 

--- a/demo/features/revocation-api.feature
+++ b/demo/features/revocation-api.feature
@@ -68,3 +68,64 @@ Feature: ACA-Py Revocation API
       Examples:
          | issuer | Acme_capabilities                          | Bob_capabilities | Schema_name       | Credential_data   | Proof_request     |
          | Acme   | --revocation --public-did --did-exchange   |                  | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
+
+   @GHA
+   Scenario Outline: Using revocation api, rotate revocation 
+      Given we have "3" agents
+         | name  | role     | capabilities        |
+         | Acme  | issuer   | <Acme_capabilities> |
+         | Faber | verifier | <Acme_capabilities> |
+         | Bob   | prover   | <Bob_capabilities>  |
+      And "<issuer>" and "Bob" have an existing connection
+      And "Bob" has an issued <Schema_name> credential <Credential_data> from "<issuer>"
+      And "<issuer>" lists revocation registries
+      And "<issuer>" rotates revocation registries
+
+      Examples:
+         | issuer | Acme_capabilities                          | Bob_capabilities | Schema_name       | Credential_data   | Proof_request     |
+         | Acme   | --revocation --public-did                  |                  | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
+
+   @GHA
+   Scenario Outline: Using revocation api, fill registry (need to run with "TAILS_FILE_COUNT": "4" env var)
+      Given we have "2" agents
+         | name  | role     | capabilities        |
+         | Acme  | issuer   | <Acme_capabilities> |
+         | Bob   | prover   | <Bob_capabilities>  |
+      And "<issuer>" and "Bob" have an existing connection
+      And "Bob" has an issued <Schema_name> credential <Credential_data> from "<issuer>"
+      And wait 5 seconds
+      And "<issuer>" lists revocation registries 1
+      When "<issuer>" offers a credential with data <Credential_data>
+      Then "Bob" has the credential issued
+      And wait 5 seconds
+      And "<issuer>" lists revocation registries 2
+      When "<issuer>" offers a credential with data <Credential_data>
+      Then "Bob" has the credential issued
+      And wait 5 seconds
+      And "<issuer>" lists revocation registries 3
+      When "<issuer>" offers a credential with data <Credential_data>
+      Then "Bob" has the credential issued
+      And wait 5 seconds
+      And "<issuer>" lists revocation registries 4
+      When "<issuer>" offers a credential with data <Credential_data>
+      Then "Bob" has the credential issued
+      And wait 5 seconds
+      And "<issuer>" lists revocation registries 5
+      When "<issuer>" offers a credential with data <Credential_data>
+      Then "Bob" has the credential issued
+      And wait 5 seconds
+      And "<issuer>" lists revocation registries 6
+      When "<issuer>" offers a credential with data <Credential_data>
+      Then "Bob" has the credential issued
+      And wait 5 seconds
+      And "<issuer>" lists revocation registries 7
+      When "<issuer>" offers a credential with data <Credential_data>
+      Then "Bob" has the credential issued
+      And "<issuer>" lists revocation registries 8
+      When "<issuer>" offers a credential with data <Credential_data>
+      Then "Bob" has the credential issued
+      And wait 5 seconds      
+      
+      Examples:
+         | issuer | Acme_capabilities                          | Bob_capabilities | Schema_name       | Credential_data   | Proof_request     |
+         | Acme   | --revocation --public-did                  |                  | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |

--- a/demo/features/steps/revocation-api.py
+++ b/demo/features/steps/revocation-api.py
@@ -1,0 +1,75 @@
+from behave import given, when, then
+import json
+import os
+
+from bdd_support.agent_backchannel_client import (
+    agent_container_GET,
+    agent_container_POST,
+    async_sleep,
+)
+from runners.agent_container import AgentContainer
+
+
+BDD_EXTRA_AGENT_ARGS = os.getenv("BDD_EXTRA_AGENT_ARGS")
+
+#      And "<issuer>" lists revocation registries
+#      And "<issuer>" rotates revocation registries
+
+@given("wait {count} seconds")
+@then("wait {count} seconds")
+def step_impl(context, count=None):
+    if count:
+        print(f"sleeping for {count} seconds..")
+        async_sleep(int(count))
+
+@given('"{issuer}" lists revocation registries {count}')
+@then('"{issuer}" lists revocation registries {count}')
+def step_impl(context, issuer, count=None):
+    agent = context.active_agents[issuer]
+    async_sleep(5.0)
+    created_response = agent_container_GET(
+        agent["agent"], f"/revocation/registries/created"
+    )
+    full_response = agent_container_GET(
+        agent["agent"], f"/revocation/registries/created", params={"state": "full"}
+    )
+    decommissioned_response = agent_container_GET(
+        agent["agent"], f"/revocation/registries/created", params={"state": "decommissioned"}
+    )
+    finished_response = agent_container_GET(
+        agent["agent"], f"/revocation/registries/created", params={"state": "finished"}
+    )
+    async_sleep(4.0)
+    if count:
+        print(f"\nlists revocation registries ({count} creds) = = = = = = = = = = = = = =")
+    else:
+        print("\nlists revocation registries = = = = = = = = = = = = = = = = = = = = = =")
+    print("\ncreated_response: ", len(created_response["rev_reg_ids"]))
+    print("full_response: ", len(full_response["rev_reg_ids"]))
+    print("decommissioned_response:", len(decommissioned_response["rev_reg_ids"]))
+    print("finished_response: ", len(finished_response["rev_reg_ids"]))
+    async_sleep(1.0)
+
+@given('"{issuer}" rotates revocation registries')
+@then('"{issuer}" rotates revocation registries')
+def step_impl(context, issuer):
+    agent = context.active_agents[issuer]
+    cred_def_id = context.cred_def_id
+    original_active_response = agent_container_GET(
+        agent["agent"], f"/revocation/active-registry/{cred_def_id}"
+    )
+    print("original_active_response:", json.dumps(original_active_response))   
+    
+    rotate_response = agent_container_POST(
+        agent["agent"],
+        f"/revocation/active-registry/{cred_def_id}/rotate",
+        data={},
+    )
+    print("rotate_response:", json.dumps(rotate_response))
+      
+    async_sleep(10.0)
+   
+    active_response = agent_container_GET(
+        agent["agent"], f"/revocation/active-registry/{cred_def_id}"
+    )
+    print("active_response:", json.dumps(active_response))

--- a/demo/runners/faber.py
+++ b/demo/runners/faber.py
@@ -440,14 +440,19 @@ async def main(args):
             "    (4) Create New Invitation\n"
         )
         if faber_agent.revocation:
-            options += "    (5) Revoke Credential\n" "    (6) Publish Revocations\n"
+            options += (
+                "    (5) Revoke Credential\n"
+                "    (6) Publish Revocations\n"
+                "    (7) Rotate Revocation Registry\n"
+                "    (8) List Revocation Registries\n"
+            )
         if faber_agent.endorser_role and faber_agent.endorser_role == "author":
             options += "    (D) Set Endorser's DID\n"
         if faber_agent.multitenant:
             options += "    (W) Create and/or Enable Wallet\n"
         options += "    (T) Toggle tracing on credential/proof exchange\n"
         options += "    (X) Exit?\n[1/2/3/4/{}{}T/X] ".format(
-            "5/6/" if faber_agent.revocation else "",
+            "5/6/7/8/" if faber_agent.revocation else "",
             "W/" if faber_agent.multitenant else "",
         )
         async for option in prompt_loop(options):
@@ -715,7 +720,50 @@ async def main(args):
                     )
                 except ClientError:
                     pass
-
+            elif option == "7" and faber_agent.revocation:
+                try:
+                    resp = await faber_agent.agent.admin_POST(
+                        f"/revocation/active-registry/{faber_agent.cred_def_id}/rotate",
+                        {},
+                    )
+                    faber_agent.agent.log(
+                        "Rotated registries for {}. Decommissioned Registries: {}".format(
+                            faber_agent.cred_def_id,
+                            json.dumps([r for r in resp["rev_reg_ids"]], indent=4),
+                        )
+                    )
+                except ClientError:
+                    pass
+            elif option == "8" and faber_agent.revocation:
+                states = [
+                    "init",
+                    "generated",
+                    "posted",
+                    "active",
+                    "full",
+                    "decommissioned",
+                ]
+                state = (
+                    await prompt(
+                        f"Filter by state: {states}: ",
+                        default="active",
+                    )
+                ).strip()
+                if state not in states:
+                    state = "active"
+                try:
+                    resp = await faber_agent.agent.admin_GET(
+                        "/revocation/registries/created",
+                        params={"state": state},
+                    )
+                    faber_agent.agent.log(
+                        "Registries (state = '{}'): {}".format(
+                            state,
+                            json.dumps([r for r in resp["rev_reg_ids"]], indent=4),
+                        )
+                    )
+                except ClientError:
+                    pass
             elif option == "6" and faber_agent.revocation:
                 try:
                     resp = await faber_agent.agent.admin_POST(


### PR DESCRIPTION
Added in `handle_full_registry` but seems to be some issues with how the counts work.
Cannot set the `next_index` to start at 0 because the credential data is invalid.
And because we don't track the index and current revocation id externally, we can't trigger the `handle_full_registry` until after a credential is created. So for every list/index we lose 1 slot. The only way I could successfully have registries rollover AND create the credentials successfully was triggering 1 slot before the max. cred. num.


