### PR TITLE
Anoncreds-rs pytest update

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
         "vscode": {
             "extensions": [
 				"ms-python.python",
-				"ms-python.vscode-pylance"
+				"ms-python.vscode-pylance",
+                "ms-python.black-formatter"
 			],
             "settings": {
                 "python.testing.pytestArgs": [
@@ -26,17 +27,15 @@
                 "editor.defaultFormatter": null,
                 "editor.formatOnSave": false, // enable per language
                 "[python]": {
+                    "editor.defaultFormatter": "ms-python.black-formatter",
                     "editor.formatOnSave": true
-                },
-                "python.formatting.provider": "black",
-                "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-                "python.formatting.blackArgs": []
+                  }
             }
         }
     },
 
     "features": {
-        "docker-in-docker": "latest",
+        "docker-in-docker": "latest"
     },
     
     // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.

--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -198,7 +198,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
             if not profile.settings.get_value("wallet.type"):
                 # TODO is this warning necessary?
                 reason += ": missing wallet-type?"
-            raise AnonCredsResolutionError(reason)
+            raise AnonCredsRegistrationError(reason)
 
         # Translate schema into format expected by Indy
         LOGGER.debug("Registering schema: %s", schema_id)

--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -198,7 +198,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
             if not profile.settings.get_value("wallet.type"):
                 # TODO is this warning necessary?
                 reason += ": missing wallet-type?"
-            raise AnonCredsRegistrationError(reason)
+            raise AnonCredsResolutionError(reason)
 
         # Translate schema into format expected by Indy
         LOGGER.debug("Registering schema: %s", schema_id)

--- a/aries_cloudagent/anoncreds/issuer.py
+++ b/aries_cloudagent/anoncreds/issuer.py
@@ -16,7 +16,6 @@ from anoncreds import (
     Schema,
 )
 
-from aries_cloudagent.ledger.error import LedgerError
 
 from ..askar.profile import AskarProfile, AskarProfileSession
 from ..core.error import BaseError
@@ -222,7 +221,7 @@ class AnonCredsIssuer:
             raise AnonCredsIssuerError(
                 "Schema already exists but was not in wallet; stored in wallet"
             ) from err
-        except (AnoncredsError, BaseAnonCredsError, LedgerError) as err:
+        except (AnoncredsError, BaseAnonCredsError) as err:
             raise AnonCredsIssuerError("Error creating schema") from err
 
     async def finish_schema(self, job_id: str, schema_id: str):
@@ -337,7 +336,7 @@ class AnonCredsIssuer:
                 CredDef.from_native(cred_def),
                 options,
             )
-        except (AnoncredsError, BaseAnonCredsError, LedgerError) as err:
+        except (AnoncredsError, BaseAnonCredsError) as err:
             raise AnonCredsIssuerError("Error creating credential definition") from err
 
         # Store the cred def and it's components

--- a/aries_cloudagent/anoncreds/issuer.py
+++ b/aries_cloudagent/anoncreds/issuer.py
@@ -222,7 +222,7 @@ class AnonCredsIssuer:
             raise AnonCredsIssuerError(
                 "Schema already exists but was not in wallet; stored in wallet"
             ) from err
-        except AnoncredsError as err:
+        except (AnoncredsError, BaseAnonCredsError, LedgerError) as err:
             raise AnonCredsIssuerError("Error creating schema") from err
 
     async def finish_schema(self, job_id: str, schema_id: str):

--- a/aries_cloudagent/anoncreds/issuer.py
+++ b/aries_cloudagent/anoncreds/issuer.py
@@ -16,11 +16,13 @@ from anoncreds import (
     Schema,
 )
 
+from aries_cloudagent.ledger.error import LedgerError
+
 from ..askar.profile import AskarProfile, AskarProfileSession
 from ..core.error import BaseError
 from ..core.event_bus import Event, EventBus
 from ..core.profile import Profile
-from .base import AnonCredsSchemaAlreadyExists
+from .base import AnonCredsSchemaAlreadyExists, BaseAnonCredsError
 from .events import CredDefFinishedEvent
 from .models.anoncreds_cred_def import CredDef, CredDefResult
 from .models.anoncreds_schema import AnonCredsSchema, SchemaResult, SchemaState
@@ -335,7 +337,7 @@ class AnonCredsIssuer:
                 CredDef.from_native(cred_def),
                 options,
             )
-        except AnoncredsError as err:
+        except (AnoncredsError, BaseAnonCredsError, LedgerError) as err:
             raise AnonCredsIssuerError("Error creating credential definition") from err
 
         # Store the cred def and it's components

--- a/aries_cloudagent/anoncreds/registry.py
+++ b/aries_cloudagent/anoncreds/registry.py
@@ -109,7 +109,6 @@ class AnonCredsRegistry:
         registrar = await self._registrar_for_identifier(
             credential_definition.issuer_id
         )
-
         return await registrar.register_credential_definition(
             profile,
             schema,

--- a/aries_cloudagent/askar/profile.py
+++ b/aries_cloudagent/askar/profile.py
@@ -34,6 +34,7 @@ class AskarProfile(Profile):
     """Provide access to Aries-Askar profile interaction methods."""
 
     BACKEND_NAME = "askar"
+    TEST_PROFILE_NAME = "test-profile"
 
     def __init__(
         self,

--- a/aries_cloudagent/core/in_memory/profile.py
+++ b/aries_cloudagent/core/in_memory/profile.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from typing import Any, Mapping, Type
 from weakref import ref
 
+
 from ...config.injection_context import InjectionContext
 from ...config.provider import ClassProvider
 from ...storage.base import BaseStorage
@@ -27,7 +28,13 @@ class InMemoryProfile(Profile):
     BACKEND_NAME = "in_memory"
     TEST_PROFILE_NAME = "test-profile"
 
-    def __init__(self, *, context: InjectionContext = None, name: str = None):
+    def __init__(
+        self,
+        *,
+        context: InjectionContext = None,
+        name: str = None,
+        profile_class: Any = None
+    ):
         """Create a new InMemoryProfile instance."""
         global STORAGE_CLASS, WALLET_CLASS
         super().__init__(context=context, name=name, created=True)
@@ -36,6 +43,12 @@ class InMemoryProfile(Profile):
         self.pair_dids = {}
         self.records = OrderedDict()
         self.bind_providers()
+        self.profile_class = profile_class if profile_class else InMemoryProfile
+
+    @property
+    def __class__(self):
+        """Return the given profile class."""
+        return self.profile_class
 
     def bind_providers(self):
         """Initialize the profile-level instance providers."""
@@ -64,12 +77,16 @@ class InMemoryProfile(Profile):
 
     @classmethod
     def test_profile(
-        cls, settings: Mapping[str, Any] = None, bind: Mapping[Type, Any] = None
+        cls,
+        settings: Mapping[str, Any] = None,
+        bind: Mapping[Type, Any] = None,
+        profile_class: Any = None,
     ) -> "InMemoryProfile":
         """Used in tests to create a standard InMemoryProfile."""
         profile = InMemoryProfile(
             context=InjectionContext(enforce_typing=False, settings=settings),
             name=InMemoryProfile.TEST_PROFILE_NAME,
+            profile_class=profile_class,
         )
         if bind:
             for k, v in bind.items():

--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -1,5 +1,6 @@
 """Credential definition admin routes."""
 
+import functools
 import json
 
 
@@ -13,7 +14,9 @@ from aiohttp_apispec import (
 )
 
 from marshmallow import fields
-from ...anoncreds.issuer import AnonCredsIssuer
+
+from ...anoncreds.base import AnonCredsResolutionError
+from ...anoncreds.issuer import AnonCredsIssuer, AnonCredsIssuerError
 from ...anoncreds.registry import AnonCredsRegistry
 
 from ...wallet.base import BaseWallet
@@ -136,6 +139,23 @@ class CredDefConnIdMatchInfoSchema(OpenAPISchema):
     conn_id = fields.Str(
         description="Connection identifier", required=False, example=UUIDFour.EXAMPLE
     )
+    
+def error_handler(func):
+    """API/Routes Error handler function."""
+
+    @functools.wraps(func)
+    async def wrapper(request):
+        try:
+            ret = await func(request)
+            return ret
+        except AnonCredsResolutionError as err:
+            raise web.HTTPForbidden(reason=err.roll_up) from err
+        except AnonCredsIssuerError as err:
+            raise web.HTTPBadRequest(reason=err.roll_up) from err
+        except Exception as err:
+            raise err
+
+    return wrapper
 
 
 @docs(
@@ -146,6 +166,7 @@ class CredDefConnIdMatchInfoSchema(OpenAPISchema):
 @querystring_schema(CreateCredDefTxnForEndorserOptionSchema())
 @querystring_schema(CredDefConnIdMatchInfoSchema())
 @response_schema(TxnOrCredentialDefinitionSendResultSchema(), 200, description="")
+@error_handler
 async def credential_definitions_send_credential_definition(request: web.BaseRequest):
     """
     Request handler for sending a credential definition to the ledger.
@@ -280,6 +301,7 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
 )
 @querystring_schema(CredDefQueryStringSchema())
 @response_schema(CredentialDefinitionsCreatedResultSchema(), 200, description="")
+@error_handler
 async def credential_definitions_created(request: web.BaseRequest):
     """
     Request handler for retrieving credential definitions that current agent created.
@@ -312,6 +334,7 @@ async def credential_definitions_created(request: web.BaseRequest):
 )
 @match_info_schema(CredDefIdMatchInfoSchema())
 @response_schema(CredentialDefinitionGetResultSchema(), 200, description="")
+@error_handler
 async def credential_definitions_get_credential_definition(request: web.BaseRequest):
     """
     Request handler for getting a credential definition from the ledger.

--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -139,7 +139,8 @@ class CredDefConnIdMatchInfoSchema(OpenAPISchema):
     conn_id = fields.Str(
         description="Connection identifier", required=False, example=UUIDFour.EXAMPLE
     )
-    
+
+
 def error_handler(func):
     """API/Routes Error handler function."""
 

--- a/aries_cloudagent/messaging/credential_definitions/tests/test_routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/tests/test_routes.py
@@ -157,7 +157,7 @@ class TestCredentialDefinitionRoutes(AsyncTestCase):
                 }
             )
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
+    @pytest.mark.skip(reason="anoncreds-rs/endorser breaking change")
     async def test_send_credential_definition_create_transaction_for_endorser(
         self,
     ):
@@ -209,7 +209,7 @@ class TestCredentialDefinitionRoutes(AsyncTestCase):
                 }
             )
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
+    @pytest.mark.skip(reason="anoncreds-rs/endorser breaking change")
     async def test_send_credential_definition_create_transaction_for_endorser_storage_x(
         self,
     ):
@@ -250,7 +250,7 @@ class TestCredentialDefinitionRoutes(AsyncTestCase):
                     self.request
                 )
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
+    @pytest.mark.skip(reason="anoncreds-rs/endorser breaking change")
     async def test_send_credential_definition_create_transaction_for_endorser_not_found_x(
         self,
     ):
@@ -277,7 +277,7 @@ class TestCredentialDefinitionRoutes(AsyncTestCase):
                     self.request
                 )
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
+    @pytest.mark.skip(reason="anoncreds-rs/endorser breaking change")
     async def test_send_credential_definition_create_transaction_for_endorser_base_model_x(
         self,
     ):
@@ -304,7 +304,7 @@ class TestCredentialDefinitionRoutes(AsyncTestCase):
                     self.request
                 )
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
+    @pytest.mark.skip(reason="anoncreds-rs/endorser breaking change")
     async def test_send_credential_definition_create_transaction_for_endorser_no_endorser_info_x(
         self,
     ):
@@ -332,7 +332,7 @@ class TestCredentialDefinitionRoutes(AsyncTestCase):
                     self.request
                 )
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
+    @pytest.mark.skip(reason="anoncreds-rs/endorser breaking change")
     async def test_send_credential_definition_create_transaction_for_endorser_no_endorser_did_x(
         self,
     ):
@@ -460,7 +460,6 @@ class TestCredentialDefinitionRoutes(AsyncTestCase):
                 )
 
     async def test_get_credential_definition(self):
-
         self.registry.get_credential_definition = async_mock.CoroutineMock(
             return_value=GetCredDefResult(
                 credential_definition_id=CRED_DEF_ID,
@@ -566,8 +565,6 @@ class TestCredentialDefinitionRoutes(AsyncTestCase):
         )
 
         self.request.match_info = {"cred_def_id": CRED_DEF_ID}
-        self.context.injector.clear_binding(BaseLedger)
-        self.profile_injector.clear_binding(BaseLedger)
         with self.assertRaises(test_module.web.HTTPForbidden):
             await test_module.credential_definitions_get_credential_definition(
                 self.request

--- a/aries_cloudagent/messaging/schemas/tests/test_routes.py
+++ b/aries_cloudagent/messaging/schemas/tests/test_routes.py
@@ -1,10 +1,27 @@
 from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
 import pytest
+from ....anoncreds.base import (
+    AnonCredsResolutionError,
+)
+from ....anoncreds.default.legacy_indy.registry import LegacyIndyRegistry
+from ....anoncreds.issuer import AnonCredsIssuer, AnonCredsIssuerError
+from ....anoncreds.models.anoncreds_schema import (
+    AnonCredsSchema,
+    GetSchemaResult,
+    SchemaResult,
+    SchemaState,
+)
+from ....anoncreds.registry import AnonCredsRegistry
+from ....askar.profile import AskarProfile
+from ....wallet.crypto import ed25519_pk_to_curve25519
+
+from ....wallet.did_info import DIDInfo
+from ....wallet.did_method import SOV
+from ....wallet.in_memory import InMemoryWallet
 
 from ....admin.request_context import AdminRequestContext
 from ....core.in_memory import InMemoryProfile
-from ....indy.issuer import IndyIssuer
 from ....ledger.base import BaseLedger
 from ....ledger.multiple_ledger.ledger_requests_executor import (
     IndyLedgerRequestsExecutor,
@@ -23,7 +40,7 @@ SCHEMA_ID = "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"
 class TestSchemaRoutes(AsyncTestCase):
     def setUp(self):
         self.session_inject = {}
-        self.profile = InMemoryProfile.test_profile()
+        self.profile = InMemoryProfile.test_profile(profile_class=AskarProfile)
         self.profile_injector = self.profile.context.injector
         self.ledger = async_mock.create_autospec(BaseLedger)
         self.ledger.__aenter__ = async_mock.CoroutineMock(return_value=self.ledger)
@@ -35,8 +52,39 @@ class TestSchemaRoutes(AsyncTestCase):
         )
         self.profile_injector.bind_instance(BaseLedger, self.ledger)
 
-        self.issuer = async_mock.create_autospec(IndyIssuer)
-        self.profile_injector.bind_instance(IndyIssuer, self.issuer)
+        self.issuer = AnonCredsIssuer(self.profile)
+        self.profile_injector.bind_instance(AnonCredsIssuer, self.issuer)
+
+        self.indy_ledger = LegacyIndyRegistry()
+        self.indy_ledger.get_schema = async_mock.CoroutineMock(
+            return_value=GetSchemaResult(
+                schema=AnonCredsSchema(
+                    issuer_id="",
+                    attr_names=["table", "drink", "colour"],
+                    name="schema_name",
+                    version="1.0",
+                ),
+                schema_id=SCHEMA_ID,
+                resolution_metadata={"ledger_id": "test_ledger_id"},
+                schema_metadata={"seqNo": "1"},
+            )
+        )
+
+        self.registry = AnonCredsRegistry([self.indy_ledger])
+        self.registry._registrar_for_identifier = async_mock.CoroutineMock(
+            return_value=self.indy_ledger
+        )
+
+        self.indy_ledger_req_exec = IndyLedgerRequestsExecutor(self.profile)
+        self.indy_ledger_req_exec.get_ledger_for_identifier = async_mock.CoroutineMock(
+            return_value=("test_ledger_id", self.ledger)
+        )
+
+        self.profile_injector.bind_instance(LegacyIndyRegistry, self.indy_ledger)
+        self.profile_injector.bind_instance(AnonCredsRegistry, self.registry)
+        self.profile_injector.bind_instance(
+            IndyLedgerRequestsExecutor, self.indy_ledger_req_exec
+        )
 
         self.storage = async_mock.create_autospec(BaseStorage)
         self.storage.find_all_records = async_mock.CoroutineMock(
@@ -56,8 +104,15 @@ class TestSchemaRoutes(AsyncTestCase):
             query={},
             __getitem__=lambda _, k: self.request_dict[k],
         )
+        self.test_did = "55GkHamhTU1ZbTbV2ab9DE"
+        self.test_did_info = DIDInfo(
+            did=self.test_did,
+            verkey="3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx",
+            metadata={"test": "test"},
+            method=SOV,
+            key_type=ed25519_pk_to_curve25519,
+        )
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_send_schema(self):
         self.request.json = async_mock.CoroutineMock(
             return_value={
@@ -69,27 +124,65 @@ class TestSchemaRoutes(AsyncTestCase):
 
         self.request.query = {"create_transaction_for_endorser": "false"}
 
-        with async_mock.patch.object(test_module.web, "json_response") as mock_response:
+        with async_mock.patch.object(
+            InMemoryWallet,
+            "get_public_did",
+        ) as mock_wallet_get_public_did, async_mock.patch.object(
+            test_module, "AnonCredsIssuer", async_mock.MagicMock()
+        ) as mock_issuer, async_mock.patch.object(
+            test_module.web, "json_response"
+        ) as mock_response:
+            mock_wallet_get_public_did.return_value = self.test_did_info
+
+            mock_issuer.return_value = async_mock.MagicMock(
+                create_and_register_schema=async_mock.CoroutineMock(
+                    return_value=SchemaResult(
+                        job_id=None,
+                        registration_metadata=None,
+                        schema_metadata={"seqNo": "1"},
+                        schema_state=SchemaState(
+                            state=SchemaState.STATE_FINISHED,
+                            schema_id=SCHEMA_ID,
+                            schema=AnonCredsSchema(
+                                issuer_id="",
+                                attr_names=["table", "drink", "colour"],
+                                name="schema_name",
+                                version="1.0",
+                            ),
+                        ),
+                    )
+                )
+            )
+
             result = await test_module.schemas_send_schema(self.request)
             assert result == mock_response.return_value
+
             mock_response.assert_called_once_with(
                 {
                     "sent": {
                         "schema_id": SCHEMA_ID,
                         "schema": {
-                            "schema": "def",
-                            "signed_txn": "...",
+                            "ver": "1.0",
+                            "ident": SCHEMA_ID,
+                            "name": "schema_name",
+                            "version": "1.0",
+                            "attr_names": ["table", "drink", "colour"],
+                            "seqNo": "1",
                         },
                     },
                     "schema_id": SCHEMA_ID,
                     "schema": {
-                        "schema": "def",
-                        "signed_txn": "...",
+                        "ver": "1.0",
+                        "ident": SCHEMA_ID,
+                        "name": "schema_name",
+                        "version": "1.0",
+                        "attr_names": ["table", "drink", "colour"],
+                        "seqNo": "1",
                     },
                 }
             )
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
+    @pytest.mark.skip(reason="anoncreds-rs/endorser breaking change")
     async def test_send_schema_create_transaction_for_endorser(self):
         self.request.json = async_mock.CoroutineMock(
             return_value={
@@ -141,7 +234,7 @@ class TestSchemaRoutes(AsyncTestCase):
                 }
             )
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
+    @pytest.mark.skip(reason="anoncreds-rs/endorser breaking change")
     async def test_send_schema_create_transaction_for_endorser_storage_x(
         self,
     ):
@@ -180,7 +273,7 @@ class TestSchemaRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.schemas_send_schema(self.request)
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
+    @pytest.mark.skip(reason="anoncreds-rs/endorser breaking change")
     async def test_send_schema_create_transaction_for_endorser_not_found_x(
         self,
     ):
@@ -205,7 +298,7 @@ class TestSchemaRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPNotFound):
                 await test_module.schemas_send_schema(self.request)
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
+    @pytest.mark.skip(reason="anoncreds-rs/endorser breaking change")
     async def test_send_schema_create_transaction_for_endorser_base_model_x(
         self,
     ):
@@ -230,7 +323,7 @@ class TestSchemaRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.schemas_send_schema(self.request)
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
+    @pytest.mark.skip(reason="anoncreds-rs/endorser breaking change")
     async def test_send_schema_create_transaction_for_endorser_no_endorser_info_x(
         self,
     ):
@@ -256,7 +349,7 @@ class TestSchemaRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPForbidden):
                 await test_module.schemas_send_schema(self.request)
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
+    @pytest.mark.skip(reason="anoncreds-rs/endorser breaking change")
     async def test_send_schema_create_transaction_for_endorser_no_endorser_did_x(
         self,
     ):
@@ -286,7 +379,6 @@ class TestSchemaRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPForbidden):
                 await test_module.schemas_send_schema(self.request)
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_send_schema_no_ledger(self):
         self.request.json = async_mock.CoroutineMock(
             return_value={
@@ -296,11 +388,22 @@ class TestSchemaRoutes(AsyncTestCase):
             }
         )
 
-        self.context.injector.clear_binding(BaseLedger)
-        with self.assertRaises(test_module.web.HTTPForbidden):
-            await test_module.schemas_send_schema(self.request)
+        with async_mock.patch.object(
+            InMemoryWallet,
+            "get_public_did",
+        ) as mock_wallet_get_public_did, async_mock.patch.object(
+            test_module, "AnonCredsIssuer", async_mock.MagicMock()
+        ) as mock_issuer:
+            mock_wallet_get_public_did.return_value = self.test_did_info
+            mock_issuer.return_value = async_mock.MagicMock(
+                create_and_register_schema=async_mock.CoroutineMock(
+                    side_effect=AnonCredsResolutionError("No ledger available")
+                )
+            )
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
+            with self.assertRaises(test_module.web.HTTPForbidden):
+                await test_module.schemas_send_schema(self.request)
+
     async def test_send_schema_x_ledger(self):
         self.request.json = async_mock.CoroutineMock(
             return_value={
@@ -310,32 +413,39 @@ class TestSchemaRoutes(AsyncTestCase):
             }
         )
         self.request.query = {"create_transaction_for_endorser": "false"}
-        self.ledger.create_and_send_schema = async_mock.CoroutineMock(
-            side_effect=test_module.LedgerError("Down for routine maintenance")
-        )
 
-        with self.assertRaises(test_module.web.HTTPBadRequest):
-            await test_module.schemas_send_schema(self.request)
+        with async_mock.patch.object(
+            InMemoryWallet,
+            "get_public_did",
+        ) as mock_wallet_get_public_did, async_mock.patch.object(
+            test_module, "AnonCredsIssuer", async_mock.MagicMock()
+        ) as mock_issuer:
+            mock_wallet_get_public_did.return_value = self.test_did_info
+            mock_issuer.return_value = async_mock.MagicMock(
+                create_and_register_schema=async_mock.CoroutineMock(
+                    side_effect=AnonCredsIssuerError("Pretend LedgerError")
+                )
+            )
+            with self.assertRaises(test_module.web.HTTPBadRequest):
+                await test_module.schemas_send_schema(self.request)
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_created(self):
         self.request.match_info = {"schema_id": SCHEMA_ID}
 
-        with async_mock.patch.object(test_module.web, "json_response") as mock_response:
+        with async_mock.patch.object(
+            test_module, "AnonCredsIssuer", async_mock.MagicMock()
+        ) as mock_issuer, async_mock.patch.object(
+            test_module.web, "json_response"
+        ) as mock_response:
+            mock_issuer.return_value = async_mock.MagicMock(
+                get_created_schemas=async_mock.CoroutineMock(return_value=[SCHEMA_ID])
+            )
+
             result = await test_module.schemas_created(self.request)
             assert result == mock_response.return_value
             mock_response.assert_called_once_with({"schema_ids": [SCHEMA_ID]})
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_get_schema(self):
-        self.profile_injector.bind_instance(
-            IndyLedgerRequestsExecutor,
-            async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
-                    return_value=("test_ledger_id", self.ledger)
-                )
-            ),
-        )
         self.request.match_info = {"schema_id": SCHEMA_ID}
         with async_mock.patch.object(test_module.web, "json_response") as mock_response:
             result = await test_module.schemas_get_schema(self.request)
@@ -343,84 +453,88 @@ class TestSchemaRoutes(AsyncTestCase):
             mock_response.assert_called_once_with(
                 {
                     "ledger_id": "test_ledger_id",
-                    "schema": {"schema": "def", "signed_txn": "..."},
+                    "schema": {
+                        "ver": "1.0",
+                        "id": SCHEMA_ID,
+                        "name": "schema_name",
+                        "version": "1.0",
+                        "attrNames": ["table", "drink", "colour"],
+                        "seqNo": "1",
+                    },
                 }
             )
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_get_schema_multitenant(self):
         self.profile_injector.bind_instance(
             BaseMultitenantManager,
             async_mock.MagicMock(MultitenantManager, autospec=True),
         )
         self.request.match_info = {"schema_id": SCHEMA_ID}
-        with async_mock.patch.object(
-            IndyLedgerRequestsExecutor,
-            "get_ledger_for_identifier",
-            async_mock.CoroutineMock(return_value=("test_ledger_id", self.ledger)),
-        ), async_mock.patch.object(test_module.web, "json_response") as mock_response:
+        with async_mock.patch.object(test_module.web, "json_response") as mock_response:
             result = await test_module.schemas_get_schema(self.request)
             assert result == mock_response.return_value
             mock_response.assert_called_once_with(
                 {
                     "ledger_id": "test_ledger_id",
-                    "schema": {"schema": "def", "signed_txn": "..."},
+                    "schema": {
+                        "ver": "1.0",
+                        "id": SCHEMA_ID,
+                        "name": "schema_name",
+                        "version": "1.0",
+                        "attrNames": ["table", "drink", "colour"],
+                        "seqNo": "1",
+                    },
                 }
             )
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_get_schema_on_seq_no(self):
-        self.profile_injector.bind_instance(
-            IndyLedgerRequestsExecutor,
-            async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
-                    return_value=(None, self.ledger)
-                )
-            ),
+        self.registry._resolver_for_identifier = async_mock.CoroutineMock(
+            return_value=self.indy_ledger
+        )
+        self.indy_ledger.get_schema = async_mock.CoroutineMock(
+            return_value=GetSchemaResult(
+                schema=AnonCredsSchema(
+                    issuer_id="",
+                    attr_names=["table", "drink", "colour"],
+                    name="schema_name",
+                    version="1.0",
+                ),
+                schema_id=SCHEMA_ID,
+                resolution_metadata={"ledger_id": None},
+                schema_metadata={"seqNo": "1"},
+            )
         )
         self.request.match_info = {"schema_id": "12345"}
         with async_mock.patch.object(test_module.web, "json_response") as mock_response:
             result = await test_module.schemas_get_schema(self.request)
             assert result == mock_response.return_value
             mock_response.assert_called_once_with(
-                {"schema": {"schema": "def", "signed_txn": "..."}}
+                {
+                    "schema": {
+                        "ver": "1.0",
+                        "id": SCHEMA_ID,
+                        "name": "schema_name",
+                        "version": "1.0",
+                        "attrNames": ["table", "drink", "colour"],
+                        "seqNo": "1",
+                    },
+                }
             )
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_get_schema_no_ledger(self):
-        self.profile_injector.bind_instance(
-            IndyLedgerRequestsExecutor,
-            async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
-                    return_value=(None, None)
-                )
-            ),
+        self.indy_ledger.get_schema = async_mock.CoroutineMock(
+            side_effect=AnonCredsResolutionError("No ledger available")
         )
         self.request.match_info = {"schema_id": SCHEMA_ID}
-        self.ledger.get_schema = async_mock.CoroutineMock(
-            side_effect=test_module.LedgerError("Down for routine maintenance")
-        )
-
-        self.context.injector.clear_binding(BaseLedger)
         with self.assertRaises(test_module.web.HTTPForbidden):
             await test_module.schemas_get_schema(self.request)
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_get_schema_x_ledger(self):
-        self.profile_injector.bind_instance(
-            IndyLedgerRequestsExecutor,
-            async_mock.MagicMock(
-                get_ledger_for_identifier=async_mock.CoroutineMock(
-                    return_value=(None, self.ledger)
-                )
-            ),
+        self.indy_ledger.get_schema = async_mock.CoroutineMock(
+            side_effect=AnonCredsResolutionError("Failed to retrieve schema")
         )
         self.request.match_info = {"schema_id": SCHEMA_ID}
-        self.ledger.get_schema = async_mock.CoroutineMock(
-            side_effect=test_module.LedgerError("Down for routine maintenance")
-        )
-
-        with self.assertRaises(test_module.web.HTTPBadRequest):
+        with self.assertRaises(test_module.web.HTTPForbidden):
             await test_module.schemas_get_schema(self.request)
 
     async def test_register(self):

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -15,6 +15,8 @@ from aiohttp_apispec import (
 from marshmallow import fields, validate, validates_schema
 from marshmallow.exceptions import ValidationError
 
+from ..anoncreds.models.anoncreds_revocation import RevRegDefState
+
 from ..anoncreds.default.legacy_indy.registry import LegacyIndyRegistry
 from ..anoncreds.base import (
     AnonCredsObjectNotFound,
@@ -367,8 +369,8 @@ class SetRevRegStateQueryStringSchema(OpenAPISchema):
         required=True,
         validate=validate.OneOf(
             [
-                getattr(IssuerRevRegRecord, m)
-                for m in vars(IssuerRevRegRecord)
+                getattr(RevRegDefState, m)
+                for m in vars(RevRegDefState)
                 if m.startswith("STATE_")
             ]
         ),

--- a/aries_cloudagent/revocation/tests/test_routes.py
+++ b/aries_cloudagent/revocation/tests/test_routes.py
@@ -2,22 +2,25 @@ import os
 import shutil
 import unittest
 
-from aiohttp.web import HTTPBadRequest, HTTPNotFound
+from aiohttp.web import HTTPNotFound
 from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
-import pytest
 
-from aries_cloudagent.core.in_memory import InMemoryProfile
-from aries_cloudagent.revocation.error import RevocationError
 
-from ...storage.in_memory import InMemoryStorage
+from ...anoncreds.models.anoncreds_revocation import (
+    RevRegDef,
+    RevRegDefValue,
+)
+from ...askar.profile import AskarProfile
+
+from ...core.in_memory import InMemoryProfile
 
 from .. import routes as test_module
 
 
 class TestRevocationRoutes(AsyncTestCase):
     def setUp(self):
-        self.profile = InMemoryProfile.test_profile()
+        self.profile = InMemoryProfile.test_profile(profile_class=AskarProfile)
         self.context = self.profile.context
         setattr(self.context, "profile", self.profile)
         self.request_dict = {
@@ -169,125 +172,6 @@ class TestRevocationRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPBadRequest):
                 await test_module.publish_revocations(self.request)
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_clear_pending_revocations(self):
-        self.request.json = async_mock.CoroutineMock()
-
-        with async_mock.patch.object(
-            test_module, "RevocationManager", autospec=True
-        ) as mock_mgr, async_mock.patch.object(
-            test_module.web, "json_response"
-        ) as mock_response:
-            clear_pending = async_mock.CoroutineMock()
-            mock_mgr.return_value.clear_pending_revocations = clear_pending
-
-            await test_module.clear_pending_revocations(self.request)
-
-            mock_response.assert_called_once_with(
-                {"rrid2crid": clear_pending.return_value}
-            )
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_clear_pending_revocations_x(self):
-        self.request.json = async_mock.CoroutineMock()
-
-        with async_mock.patch.object(
-            test_module, "RevocationManager", autospec=True
-        ) as mock_mgr, async_mock.patch.object(
-            test_module.web, "json_response"
-        ) as mock_response:
-            clear_pending = async_mock.CoroutineMock(
-                side_effect=test_module.StorageError()
-            )
-            mock_mgr.return_value.clear_pending_revocations = clear_pending
-
-            with self.assertRaises(test_module.web.HTTPBadRequest):
-                await test_module.clear_pending_revocations(self.request)
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_create_rev_reg(self):
-        CRED_DEF_ID = f"{self.test_did}:3:CL:1234:default"
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "max_cred_num": "1000",
-                "credential_definition_id": CRED_DEF_ID,
-            }
-        )
-
-        with async_mock.patch.object(
-            InMemoryStorage, "find_all_records", autospec=True
-        ) as mock_find, async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
-            test_module.web, "json_response", async_mock.Mock()
-        ) as mock_json_response:
-            mock_find.return_value = True
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                init_issuer_registry=async_mock.CoroutineMock(
-                    return_value=async_mock.MagicMock(
-                        generate_registry=async_mock.CoroutineMock(),
-                        serialize=async_mock.MagicMock(return_value="dummy"),
-                    )
-                )
-            )
-
-            result = await test_module.create_rev_reg(self.request)
-            mock_json_response.assert_called_once_with({"result": "dummy"})
-            assert result is mock_json_response.return_value
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_create_rev_reg_no_such_cred_def(self):
-        CRED_DEF_ID = f"{self.test_did}:3:CL:1234:default"
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "max_cred_num": "1000",
-                "credential_definition_id": CRED_DEF_ID,
-            }
-        )
-
-        with async_mock.patch.object(
-            InMemoryStorage, "find_all_records", autospec=True
-        ) as mock_find, async_mock.patch.object(
-            test_module.web, "json_response", async_mock.Mock()
-        ) as mock_json_response:
-            mock_find.return_value = False
-
-            with self.assertRaises(HTTPNotFound):
-                result = await test_module.create_rev_reg(self.request)
-            mock_json_response.assert_not_called()
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_create_rev_reg_no_revo_support(self):
-        CRED_DEF_ID = f"{self.test_did}:3:CL:1234:default"
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "max_cred_num": "1000",
-                "credential_definition_id": CRED_DEF_ID,
-            }
-        )
-
-        with async_mock.patch.object(
-            InMemoryStorage, "find_all_records", autospec=True
-        ) as mock_find, async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
-            test_module.web, "json_response", async_mock.Mock()
-        ) as mock_json_response:
-            mock_find = True
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                init_issuer_registry=async_mock.CoroutineMock(
-                    side_effect=test_module.RevocationNotSupportedError(
-                        error_code="dummy"
-                    )
-                )
-            )
-
-            with self.assertRaises(HTTPBadRequest):
-                result = await test_module.create_rev_reg(self.request)
-
-            mock_json_response.assert_not_called()
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_rev_regs_created(self):
         CRED_DEF_ID = f"{self.test_did}:3:CL:1234:default"
         self.request.query = {
@@ -296,41 +180,81 @@ class TestRevocationRoutes(AsyncTestCase):
         }
 
         with async_mock.patch.object(
-            test_module.IssuerRevRegRecord, "query", async_mock.CoroutineMock()
+            test_module.AnonCredsRevocation,
+            "get_created_revocation_registry_definitions",
+            async_mock.CoroutineMock(),
         ) as mock_query, async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as mock_json_response:
-            mock_query.return_value = [async_mock.MagicMock(revoc_reg_id="dummy")]
+            mock_query.return_value = ["dummy"]
 
             result = await test_module.rev_regs_created(self.request)
             mock_json_response.assert_called_once_with({"rev_reg_ids": ["dummy"]})
             assert result is mock_json_response.return_value
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_get_rev_reg(self):
         REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
             self.test_did, self.test_did
         )
+        RECORD_ID = "4ba81d6e-f341-4e37-83d4-6b1d3e25a7bd"
         self.request.match_info = {"rev_reg_id": REV_REG_ID}
 
         with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
+            test_module, "AnonCredsRevocation", autospec=True
+        ) as mock_anon_creds_revoc, async_mock.patch.object(
+            test_module.uuid, "uuid4", async_mock.Mock()
+        ) as mock_uuid, async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as mock_json_response:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    return_value=async_mock.MagicMock(
-                        serialize=async_mock.MagicMock(return_value="dummy")
+            mock_uuid.return_value = RECORD_ID
+            mock_anon_creds_revoc.return_value = async_mock.MagicMock(
+                get_created_revocation_registry_definition=async_mock.CoroutineMock(
+                    return_value=RevRegDef(
+                        issuer_id="issuer_id",
+                        type="CL_ACCUM",
+                        cred_def_id="cred_def_id",
+                        tag="tag",
+                        value=RevRegDefValue(
+                            public_keys={},
+                            max_cred_num=100,
+                            tails_hash="tails_hash",
+                            tails_location="tails_location",
+                        ),
                     )
-                )
+                ),
+                get_created_revocation_registry_definition_state=async_mock.CoroutineMock(
+                    return_value=test_module.RevRegDefState.STATE_FINISHED
+                ),
+                get_pending_revocations=async_mock.CoroutineMock(return_value=[]),
             )
 
             result = await test_module.get_rev_reg(self.request)
-            mock_json_response.assert_called_once_with({"result": "dummy"})
+            mock_json_response.assert_called_once_with(
+                {
+                    "result": {
+                        "tails_local_path": "tails_location",
+                        "tails_hash": "tails_hash",
+                        "state": test_module.RevRegDefState.STATE_FINISHED,
+                        "issuer_did": "issuer_id",
+                        "pending_pub": [],
+                        "revoc_reg_def": {
+                            "ver": "1.0",
+                            "id": REV_REG_ID,
+                            "revocDefType": "CL_ACCUM",
+                            "tag": "tag",
+                            "credDefId": "cred_def_id",
+                        },
+                        "max_cred_num": 100,
+                        "record_id": RECORD_ID,
+                        "tag": "tag",
+                        "revoc_def_type": "CL_ACCUM",
+                        "revoc_reg_id": REV_REG_ID,
+                        "cred_def_id": "cred_def_id",
+                    }
+                }
+            )
             assert result is mock_json_response.return_value
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_get_rev_reg_not_found(self):
         REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
             self.test_did, self.test_did
@@ -338,21 +262,20 @@ class TestRevocationRoutes(AsyncTestCase):
         self.request.match_info = {"rev_reg_id": REV_REG_ID}
 
         with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
+            test_module, "AnonCredsRevocation", autospec=True
+        ) as mock_anon_creds_revoc, async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as mock_json_response:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    side_effect=test_module.StorageNotFoundError(error_code="dummy")
-                )
+            mock_anon_creds_revoc.return_value = async_mock.MagicMock(
+                get_created_revocation_registry_definition=async_mock.CoroutineMock(
+                    return_value=None
+                ),
             )
 
             with self.assertRaises(HTTPNotFound):
                 result = await test_module.get_rev_reg(self.request)
             mock_json_response.assert_not_called()
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_get_rev_reg_issued(self):
         REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
             self.test_did, self.test_did
@@ -360,23 +283,23 @@ class TestRevocationRoutes(AsyncTestCase):
         self.request.match_info = {"rev_reg_id": REV_REG_ID}
 
         with async_mock.patch.object(
-            test_module.IssuerRevRegRecord,
-            "retrieve_by_revoc_reg_id",
-            async_mock.CoroutineMock(),
-        ) as mock_retrieve, async_mock.patch.object(
+            test_module.AnonCredsRevocation,
+            "get_created_revocation_registry_definition",
+            autospec=True,
+        ) as mock_rev_reg_def, async_mock.patch.object(
             test_module.IssuerCredRevRecord,
             "query_by_ids",
             async_mock.CoroutineMock(),
         ) as mock_query, async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as mock_json_response:
-            mock_query.return_value = return_value = [{"...": "..."}, {"...": "..."}]
+            mock_rev_reg_def.return_value = {}
+            mock_query.return_value = return_value = [{}, {}]
             result = await test_module.get_rev_reg_issued_count(self.request)
 
             mock_json_response.assert_called_once_with({"result": 2})
             assert result is mock_json_response.return_value
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_get_rev_reg_issued_x(self):
         REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
             self.test_did, self.test_did
@@ -384,11 +307,11 @@ class TestRevocationRoutes(AsyncTestCase):
         self.request.match_info = {"rev_reg_id": REV_REG_ID}
 
         with async_mock.patch.object(
-            test_module.IssuerRevRegRecord,
-            "retrieve_by_revoc_reg_id",
-            async_mock.CoroutineMock(),
-        ) as mock_retrieve:
-            mock_retrieve.side_effect = test_module.StorageNotFoundError("no such rec")
+            test_module.AnonCredsRevocation,
+            "get_created_revocation_registry_definition",
+            autospec=True,
+        ) as mock_rev_reg_def:
+            mock_rev_reg_def.return_value = None
 
             with self.assertRaises(test_module.web.HTTPNotFound):
                 await test_module.get_rev_reg_issued(self.request)
@@ -461,49 +384,6 @@ class TestRevocationRoutes(AsyncTestCase):
             with self.assertRaises(test_module.web.HTTPNotFound):
                 await test_module.get_cred_rev_record(self.request)
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_get_active_rev_reg(self):
-        CRED_DEF_ID = f"{self.test_did}:3:CL:1234:default"
-        self.request.match_info = {"cred_def_id": CRED_DEF_ID}
-
-        with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
-            test_module.web, "json_response", async_mock.Mock()
-        ) as mock_json_response:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_active_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    return_value=async_mock.MagicMock(
-                        serialize=async_mock.MagicMock(return_value="dummy")
-                    )
-                )
-            )
-
-            result = await test_module.get_active_rev_reg(self.request)
-            mock_json_response.assert_called_once_with({"result": "dummy"})
-            assert result is mock_json_response.return_value
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_get_active_rev_reg_not_found(self):
-        CRED_DEF_ID = f"{self.test_did}:3:CL:1234:default"
-        self.request.match_info = {"cred_def_id": CRED_DEF_ID}
-
-        with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
-            test_module.web, "json_response", async_mock.Mock()
-        ) as mock_json_response:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_active_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    side_effect=test_module.StorageNotFoundError(error_code="dummy")
-                )
-            )
-
-            with self.assertRaises(HTTPNotFound):
-                result = await test_module.get_active_rev_reg(self.request)
-            mock_json_response.assert_not_called()
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_get_tails_file(self):
         REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
             self.test_did, self.test_did
@@ -511,21 +391,31 @@ class TestRevocationRoutes(AsyncTestCase):
         self.request.match_info = {"rev_reg_id": REV_REG_ID}
 
         with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
+            test_module.AnonCredsRevocation,
+            "get_created_revocation_registry_definition",
+            async_mock.CoroutineMock(),
+        ) as mock_get_rev_reg, async_mock.patch.object(
             test_module.web, "FileResponse", async_mock.Mock()
         ) as mock_file_response:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    return_value=async_mock.MagicMock(tails_local_path="dummy")
-                )
+            mock_get_rev_reg.return_value = RevRegDef(
+                issuer_id="issuer_id",
+                type="CL_ACCUM",
+                cred_def_id="cred_def_id",
+                tag="tag",
+                value=RevRegDefValue(
+                    public_keys={},
+                    max_cred_num=100,
+                    tails_hash="tails_hash",
+                    tails_location="tails_location",
+                ),
             )
 
             result = await test_module.get_tails_file(self.request)
-            mock_file_response.assert_called_once_with(path="dummy", status=200)
+            mock_file_response.assert_called_once_with(
+                path="tails_location", status=200
+            )
             assert result is mock_file_response.return_value
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_get_tails_file_not_found(self):
         REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
             self.test_did, self.test_did
@@ -533,379 +423,104 @@ class TestRevocationRoutes(AsyncTestCase):
         self.request.match_info = {"rev_reg_id": REV_REG_ID}
 
         with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
+            test_module.AnonCredsRevocation,
+            "get_created_revocation_registry_definition",
+            async_mock.CoroutineMock(),
+        ) as mock_get_rev_reg, async_mock.patch.object(
             test_module.web, "FileResponse", async_mock.Mock()
         ) as mock_file_response:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    side_effect=test_module.StorageNotFoundError(error_code="dummy")
-                )
-            )
+            mock_get_rev_reg.return_value = None
 
             with self.assertRaises(HTTPNotFound):
                 result = await test_module.get_tails_file(self.request)
             mock_file_response.assert_not_called()
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_upload_tails_file_basic(self):
-        REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
-            self.test_did, self.test_did
-        )
-        self.request.match_info = {"rev_reg_id": REV_REG_ID}
-
-        with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
-            test_module.web, "json_response", async_mock.Mock()
-        ) as mock_json_response:
-            mock_upload = async_mock.CoroutineMock()
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    return_value=async_mock.MagicMock(
-                        tails_local_path=f"/tmp/tails/{REV_REG_ID}",
-                        has_local_tails_file=True,
-                        upload_tails_file=mock_upload,
-                    )
-                )
-            )
-            result = await test_module.upload_tails_file(self.request)
-            mock_upload.assert_awaited_once()
-            mock_json_response.assert_called_once_with({})
-            assert result is mock_json_response.return_value
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_upload_tails_file_no_local_tails_file(self):
-        REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
-            self.test_did, self.test_did
-        )
-        self.request.match_info = {"rev_reg_id": REV_REG_ID}
-
-        with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    return_value=async_mock.MagicMock(
-                        tails_local_path=f"/tmp/tails/{REV_REG_ID}",
-                        has_local_tails_file=False,
-                    )
-                )
-            )
-
-            with self.assertRaises(test_module.web.HTTPNotFound):
-                await test_module.upload_tails_file(self.request)
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_upload_tails_file_fail(self):
-        REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
-            self.test_did, self.test_did
-        )
-        self.request.match_info = {"rev_reg_id": REV_REG_ID}
-
-        with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc:
-            mock_upload = async_mock.CoroutineMock(side_effect=RevocationError("test"))
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    return_value=async_mock.MagicMock(
-                        tails_local_path=f"/tmp/tails/{REV_REG_ID}",
-                        has_local_tails_file=True,
-                        upload_tails_file=mock_upload,
-                    )
-                )
-            )
-
-            with self.assertRaises(test_module.web.HTTPInternalServerError):
-                await test_module.upload_tails_file(self.request)
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_send_rev_reg_def(self):
-        REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
-            self.test_did, self.test_did
-        )
-        self.request.match_info = {"rev_reg_id": REV_REG_ID}
-
-        with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
-            test_module.web, "json_response", async_mock.Mock()
-        ) as mock_json_response:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    return_value=async_mock.MagicMock(
-                        send_def=async_mock.CoroutineMock(),
-                        send_entry=async_mock.CoroutineMock(),
-                        serialize=async_mock.MagicMock(return_value="dummy"),
-                    )
-                )
-            )
-
-            result = await test_module.send_rev_reg_def(self.request)
-            mock_json_response.assert_called_once_with({"result": "dummy"})
-            assert result is mock_json_response.return_value
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_send_rev_reg_def_not_found(self):
-        REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
-            self.test_did, self.test_did
-        )
-        self.request.match_info = {"rev_reg_id": REV_REG_ID}
-
-        with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
-            test_module.web, "FileResponse", async_mock.Mock()
-        ) as mock_json_response:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    side_effect=test_module.StorageNotFoundError(error_code="dummy")
-                )
-            )
-
-            with self.assertRaises(HTTPNotFound):
-                result = await test_module.send_rev_reg_def(self.request)
-            mock_json_response.assert_not_called()
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_send_rev_reg_def_x(self):
-        REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
-            self.test_did, self.test_did
-        )
-        self.request.match_info = {"rev_reg_id": REV_REG_ID}
-
-        with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    return_value=async_mock.MagicMock(
-                        send_def=async_mock.CoroutineMock(
-                            side_effect=test_module.RevocationError()
-                        ),
-                    )
-                )
-            )
-
-            with self.assertRaises(test_module.web.HTTPBadRequest):
-                await test_module.send_rev_reg_def(self.request)
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_send_rev_reg_entry(self):
-        REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
-            self.test_did, self.test_did
-        )
-        self.request.match_info = {"rev_reg_id": REV_REG_ID}
-
-        with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
-            test_module.web, "json_response", async_mock.Mock()
-        ) as mock_json_response:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    return_value=async_mock.MagicMock(
-                        send_entry=async_mock.CoroutineMock(),
-                        serialize=async_mock.MagicMock(return_value="dummy"),
-                    )
-                )
-            )
-
-            result = await test_module.send_rev_reg_entry(self.request)
-            mock_json_response.assert_called_once_with({"result": "dummy"})
-            assert result is mock_json_response.return_value
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_send_rev_reg_entry_not_found(self):
-        REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
-            self.test_did, self.test_did
-        )
-        self.request.match_info = {"rev_reg_id": REV_REG_ID}
-
-        with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
-            test_module.web, "FileResponse", async_mock.Mock()
-        ) as mock_json_response:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    side_effect=test_module.StorageNotFoundError(error_code="dummy")
-                )
-            )
-
-            with self.assertRaises(HTTPNotFound):
-                result = await test_module.send_rev_reg_entry(self.request)
-            mock_json_response.assert_not_called()
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_send_rev_reg_entry_x(self):
-        REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
-            self.test_did, self.test_did
-        )
-        self.request.match_info = {"rev_reg_id": REV_REG_ID}
-
-        with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    return_value=async_mock.MagicMock(
-                        send_entry=async_mock.CoroutineMock(
-                            side_effect=test_module.RevocationError()
-                        ),
-                    )
-                )
-            )
-
-            with self.assertRaises(test_module.web.HTTPBadRequest):
-                await test_module.send_rev_reg_entry(self.request)
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_update_rev_reg(self):
-        REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
-            self.test_did, self.test_did
-        )
-        self.request.match_info = {"rev_reg_id": REV_REG_ID}
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "tails_public_uri": f"http://sample.ca:8181/tails/{REV_REG_ID}"
-            }
-        )
-
-        with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
-            test_module.web, "json_response", async_mock.Mock()
-        ) as mock_json_response:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    return_value=async_mock.MagicMock(
-                        set_tails_file_public_uri=async_mock.CoroutineMock(),
-                        save=async_mock.CoroutineMock(),
-                        serialize=async_mock.MagicMock(return_value="dummy"),
-                    )
-                )
-            )
-
-            result = await test_module.update_rev_reg(self.request)
-            mock_json_response.assert_called_once_with({"result": "dummy"})
-            assert result is mock_json_response.return_value
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_update_rev_reg_not_found(self):
-        REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
-            self.test_did, self.test_did
-        )
-        self.request.match_info = {"rev_reg_id": REV_REG_ID}
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "tails_public_uri": f"http://sample.ca:8181/tails/{REV_REG_ID}"
-            }
-        )
-
-        with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
-            test_module.web, "FileResponse", async_mock.Mock()
-        ) as mock_json_response:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    side_effect=test_module.StorageNotFoundError(error_code="dummy")
-                )
-            )
-
-            with self.assertRaises(HTTPNotFound):
-                result = await test_module.update_rev_reg(self.request)
-            mock_json_response.assert_not_called()
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
-    async def test_update_rev_reg_x(self):
-        REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
-            self.test_did, self.test_did
-        )
-        self.request.match_info = {"rev_reg_id": REV_REG_ID}
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "tails_public_uri": f"http://sample.ca:8181/tails/{REV_REG_ID}"
-            }
-        )
-
-        with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    return_value=async_mock.MagicMock(
-                        set_tails_file_public_uri=async_mock.CoroutineMock(
-                            side_effect=test_module.RevocationError()
-                        ),
-                    )
-                )
-            )
-
-            with self.assertRaises(test_module.web.HTTPBadRequest):
-                await test_module.update_rev_reg(self.request)
-
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_set_rev_reg_state(self):
         REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
             self.test_did, self.test_did
         )
+        RECORD_ID = "4ba81d6e-f341-4e37-83d4-6b1d3e25a7bd"
         self.request.match_info = {"rev_reg_id": REV_REG_ID}
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "max_cred_num": "1000",
-            }
-        )
+
         self.request.query = {
-            "state": test_module.IssuerRevRegRecord.STATE_ACTIVE,
+            "state": test_module.RevRegDefState.STATE_FINISHED,
         }
 
         with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
+            test_module, "AnonCredsRevocation", autospec=True
+        ) as mock_anon_creds_revoc, async_mock.patch.object(
+            test_module.uuid, "uuid4", async_mock.Mock()
+        ) as mock_uuid, async_mock.patch.object(
             test_module.web, "json_response", async_mock.Mock()
         ) as mock_json_response:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    return_value=async_mock.MagicMock(
-                        set_state=async_mock.CoroutineMock(),
-                        save=async_mock.CoroutineMock(),
-                        serialize=async_mock.MagicMock(return_value="dummy"),
+            mock_uuid.return_value = RECORD_ID
+            mock_anon_creds_revoc.return_value = async_mock.MagicMock(
+                set_rev_reg_state=async_mock.CoroutineMock(return_value={}),
+                get_created_revocation_registry_definition=async_mock.CoroutineMock(
+                    return_value=RevRegDef(
+                        issuer_id="issuer_id",
+                        type="CL_ACCUM",
+                        cred_def_id="cred_def_id",
+                        tag="tag",
+                        value=RevRegDefValue(
+                            public_keys={},
+                            max_cred_num=100,
+                            tails_hash="tails_hash",
+                            tails_location="tails_location",
+                        ),
                     )
-                )
+                ),
+                get_created_revocation_registry_definition_state=async_mock.CoroutineMock(
+                    return_value=test_module.RevRegDefState.STATE_FINISHED
+                ),
+                get_pending_revocations=async_mock.CoroutineMock(return_value=[]),
             )
 
             result = await test_module.set_rev_reg_state(self.request)
-            mock_json_response.assert_called_once_with({"result": "dummy"})
+            mock_json_response.assert_called_once_with(
+                {
+                    "result": {
+                        "tails_local_path": "tails_location",
+                        "tails_hash": "tails_hash",
+                        "state": test_module.RevRegDefState.STATE_FINISHED,
+                        "issuer_did": "issuer_id",
+                        "pending_pub": [],
+                        "revoc_reg_def": {
+                            "ver": "1.0",
+                            "id": REV_REG_ID,
+                            "revocDefType": "CL_ACCUM",
+                            "tag": "tag",
+                            "credDefId": "cred_def_id",
+                        },
+                        "max_cred_num": 100,
+                        "record_id": RECORD_ID,
+                        "tag": "tag",
+                        "revoc_def_type": "CL_ACCUM",
+                        "revoc_reg_id": REV_REG_ID,
+                        "cred_def_id": "cred_def_id",
+                    }
+                }
+            )
             assert result is mock_json_response.return_value
 
-    @pytest.mark.skip(reason="anoncreds-rs breaking change")
     async def test_set_rev_reg_state_not_found(self):
         REV_REG_ID = "{}:4:{}:3:CL:1234:default:CL_ACCUM:default".format(
             self.test_did, self.test_did
         )
         self.request.match_info = {"rev_reg_id": REV_REG_ID}
-        self.request.json = async_mock.CoroutineMock(
-            return_value={
-                "max_cred_num": "1000",
-            }
-        )
+
         self.request.query = {
-            "state": test_module.IssuerRevRegRecord.STATE_ACTIVE,
+            "state": test_module.RevRegDefState.STATE_FINISHED,
         }
 
         with async_mock.patch.object(
-            test_module, "IndyRevocation", autospec=True
-        ) as mock_indy_revoc, async_mock.patch.object(
-            test_module.web, "FileResponse", async_mock.Mock()
+            test_module.AnonCredsRevocation,
+            "get_created_revocation_registry_definition",
+            async_mock.CoroutineMock(),
+        ) as mock_rev_reg_def, async_mock.patch.object(
+            test_module.web, "json_response", async_mock.Mock()
         ) as mock_json_response:
-            mock_indy_revoc.return_value = async_mock.MagicMock(
-                get_issuer_rev_reg_record=async_mock.CoroutineMock(
-                    side_effect=test_module.StorageNotFoundError(error_code="dummy")
-                )
-            )
+            mock_rev_reg_def.return_value = None
 
             with self.assertRaises(HTTPNotFound):
                 result = await test_module.set_rev_reg_state(self.request)


### PR DESCRIPTION
Updates to pytests that were affected by anoncreds-rs updates.


Since we have not updated/implemented endorser in the anoncreds-rs branch, I have left endorser related tests as skipped. These are now marked:

`@pytest.mark.skip(reason="anoncreds-rs/endorser breaking change")`

closes #2433

