### PR TITLE
:art: clarify LedgerError message when TAA is required and not accepted

### DIFF
--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -303,7 +303,8 @@ class BaseLedger(ABC, metaclass=ABCMeta):
         else:
             if await self.is_ledger_read_only():
                 raise LedgerError(
-                    "Error cannot write schema when ledger is in read only mode"
+                    "Error cannot write schema when ledger is in read only mode, "
+                    "or TAA is required and not accepted"
                 )
 
             try:
@@ -497,7 +498,8 @@ class BaseLedger(ABC, metaclass=ABCMeta):
 
             if await self.is_ledger_read_only():
                 raise LedgerError(
-                    "Error cannot write cred def when ledger is in read only mode"
+                    "Error cannot write cred def when ledger is in read only mode, "
+                    "or TAA is required and not accepted"
                 )
 
             cred_def_req = await self._create_credential_definition_request(

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -766,7 +766,8 @@ class IndySdkLedger(BaseLedger):
         if exist_endpoint_of_type != endpoint:
             if await self.is_ledger_read_only():
                 raise LedgerError(
-                    "Error cannot update endpoint when ledger is in read only mode"
+                    "Error cannot update endpoint when ledger is in read only mode, "
+                    "or TAA is required and not accepted"
                 )
 
             nym = self.did_to_nym(did)
@@ -817,7 +818,8 @@ class IndySdkLedger(BaseLedger):
         """
         if await self.is_ledger_read_only():
             raise LedgerError(
-                "Error cannot register nym when ledger is in read only mode"
+                "Error cannot register nym when ledger is in read only mode, "
+                "or TAA is required and not accepted"
             )
 
         public_info = await self.get_wallet_public_did()


### PR DESCRIPTION
Previously:
```py
            if await self.is_ledger_read_only():
                raise LedgerError(
                    "Error cannot write cred def when ledger is in read only mode"
                )
```

`is_ledger_read_only` also checks to see if TAA is required, and if not accepted it will also report the ledger is read-only:
```py
    async def is_ledger_read_only(self) -> bool:
        """Check if ledger is read-only including TAA."""
        if self.read_only:
            return self.read_only
        # if TAA is required and not accepted we should be in read-only mode
        taa = await self.get_txn_author_agreement()
        if taa["taa_required"]:
            taa_acceptance = await self.get_latest_txn_author_acceptance()
            if "mechanism" not in taa_acceptance:
                return True
        return self.read_only
```

To make this clearer to the user, I updated the relevant error messages to say TAA  may also be the cause of the LedgerError.

e.g.:
```py
                raise LedgerError(
                    "Error cannot write cred def when ledger is in read only mode, "
                    "or TAA is required and not accepted"
                )
```