### PR TITLE
fix: clean up requests and invites

### DIFF
--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -522,13 +522,23 @@ class ConnRecord(BaseRecord):
         """
         await super().delete_record(session)
 
+        storage = session.inject(BaseStorage)
         # Delete metadata
         if self.connection_id:
-            storage = session.inject(BaseStorage)
             await storage.delete_all_records(
                 self.RECORD_TYPE_METADATA,
                 {"connection_id": self.connection_id},
             )
+
+        # Delete attached messages
+        await storage.delete_all_records(
+            self.RECORD_TYPE_REQUEST,
+            {"connection_id": self.connection_id},
+        )
+        await storage.delete_all_records(
+            self.RECORD_TYPE_INVITATION,
+            {"connection_id": self.connection_id},
+        )
 
     async def abandon(self, session: ProfileSession, *, reason: Optional[str] = None):
         """Set state to abandoned."""


### PR DESCRIPTION
On connection deletion, all records strongly associated with the connection should be deleted. These records include connection metadata, connection requests, and connection invitations.

Records referencing the connection ID such as mediation or routing records are not "strongly" associated with the connection; there are other mechanisms in place to enable deletion of these records through the Admin API. The records for metadata, requests, and invitations, on the other hand, cannot be cleaned up any other way.

This PR makes sure these records are deleted when the connection is deleted.

It might be a good idea for us to look at other records that ought to be cleaned up automatically. Those can be addressed in future work.