### PR TITLE
Playground needs optionally external network

### DIFF
--- a/demo/playground/docker-compose.yml
+++ b/demo/playground/docker-compose.yml
@@ -4,7 +4,7 @@
 # and restart the docker containers without losing your wallet data
 # If you want to delete your wallet data just run `docker volume ls -q | xargs docker volume rm`
 #
-# If you want to enable tracing, see elk-stack. Ensure elk-stack is running, uncomment the ACAPY_TRACE environement variables and run `docker compose up`
+# If you want to enable tracing, see elk-stack. Ensure elk-stack is running, uncomment the ACAPY_TRACE environment variables and run `docker compose up`
 version: "3"
 
 
@@ -12,9 +12,11 @@ networks:
   app-network:
     name: ${APP_NETWORK_NAME:-playgroundnet}
     driver: bridge
+    external: ${APP_NETWORK_EXTERNAL:-false}
   elk-network:
      name: ${ELK_NETWORK_NAME:-elknet}
      driver: bridge
+     external: true
 
 services:
   ngrok-faber-alice:


### PR DESCRIPTION
Sigh... when documenting aries-mediator-service / redid-pq-demo and running through the instructions, I needed to make the playground network external. 

Unclear why it worked fine with the base mediator service and it's network but regardless, this is needed to allow the mediator service with redis demo to work.

Note that the `ELK_NETWORK_NAME` will always be an external network so adding that notation to always be `true`.