### PR TITLE
chore: point to official sd-jwt lib release

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -938,19 +938,19 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
-version = "3.12.4"
+version = "3.13.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.12.4-py3-none-any.whl", hash = "sha256:08c21d87ded6e2b9da6728c3dff51baf1dcecf973b768ef35bcbc3447edb9ad4"},
-    {file = "filelock-3.12.4.tar.gz", hash = "sha256:2e6f249f1f3654291606e046b09f1fd5eac39b360664c27f5aad072012f8bcbd"},
+    {file = "filelock-3.13.1-py3-none-any.whl", hash = "sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c"},
+    {file = "filelock-3.13.1.tar.gz", hash = "sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.7.26)", "sphinx (>=7.1.2)", "sphinx-autodoc-typehints (>=1.24)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.3)", "diff-cover (>=7.7)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)", "pytest-timeout (>=2.1)"]
-typing = ["typing-extensions (>=4.7.1)"]
+docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.24)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
+typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
 name = "frozendict"
@@ -1070,13 +1070,13 @@ files = [
 
 [[package]]
 name = "identify"
-version = "2.5.30"
+version = "2.5.31"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "identify-2.5.30-py2.py3-none-any.whl", hash = "sha256:afe67f26ae29bab007ec21b03d4114f41316ab9dd15aa8736a167481e108da54"},
-    {file = "identify-2.5.30.tar.gz", hash = "sha256:f302a4256a15c849b91cfcdcec052a8ce914634b2f77ae87dad29cd749f2d88d"},
+    {file = "identify-2.5.31-py2.py3-none-any.whl", hash = "sha256:90199cb9e7bd3c5407a9b7e81b4abec4bb9d249991c79439ec8af740afc6293d"},
+    {file = "identify-2.5.31.tar.gz", hash = "sha256:7736b3c7a28233637e3c36550646fc6389bedd74ae84cb788200cc8e2dd60b75"},
 ]
 
 [package.extras]
@@ -1866,13 +1866,13 @@ files = [
 
 [[package]]
 name = "pydid"
-version = "0.3.10"
+version = "0.3.11"
 description = "Python library for validating, constructing, and representing DIDs and DID Documents"
 optional = false
 python-versions = ">=3.6.9,<4.0.0"
 files = [
-    {file = "pydid-0.3.10-py3-none-any.whl", hash = "sha256:60b7a38976d0af0026cedeb78c777a3cc173e17a443ee8c45a755ecef972288d"},
-    {file = "pydid-0.3.10.tar.gz", hash = "sha256:b472c2a035f8f4df1ea101445e5fb8fd692b59a194769e766ff1138e77eda91c"},
+    {file = "pydid-0.3.11-py3-none-any.whl", hash = "sha256:ce102d47bf8d0748ad2d754a5f9f8574f59d0b32c26ee015a85f058f9d9e101a"},
+    {file = "pydid-0.3.11.tar.gz", hash = "sha256:f14063700648b16e418b44eb4782cf45c9ce86c82e9dc2bfb72e680967c52f6b"},
 ]
 
 [package.dependencies]
@@ -2245,22 +2245,18 @@ files = [
 
 [[package]]
 name = "sd-jwt"
-version = "0.9.1"
+version = "0.10.3"
 description = "The reference implementation of the IETF SD-JWT specification."
 optional = false
-python-versions = "^3.8"
-files = []
-develop = false
+python-versions = ">=3.8,<4.0"
+files = [
+    {file = "sd_jwt-0.10.3-py3-none-any.whl", hash = "sha256:de5d8296a977c758cefcc153a1bfab12de3087fbf4a38bf589165ab31c7a41f7"},
+    {file = "sd_jwt-0.10.3.tar.gz", hash = "sha256:c9307ed1cb9597c532f19d5eb3e040a77ff264214354b2ed0533db83c05a3a8e"},
+]
 
 [package.dependencies]
 jwcrypto = ">=1.3.1"
 pyyaml = ">=5.4"
-
-[package.source]
-type = "git"
-url = "https://github.com/openwallet-foundation-labs/sd-jwt-python.git"
-reference = "HEAD"
-resolved_reference = "23f9d1d872612180d7b5a160adebcf2838fbe504"
 
 [[package]]
 name = "setuptools"
@@ -2793,4 +2789,4 @@ indy = ["python3-indy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "2be14ad5c4160104421c2d4447aa5fda080347ae4206c36b278b6f93fd65fb0d"
+content-hash = "cf4d8725d084b0d9381758933b34911e60092e75f25e2d3ff1b992bb65963ed2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ qrcode = {version = ">=6.1,<7.0", extras = ["pil"]}
 requests="~2.31.0"
 rlp="1.2.0"
 unflatten="~0.1"
-sd_jwt = {git = "https://github.com/openwallet-foundation-labs/sd-jwt-python.git"}
+sd-jwt = "^0.10.3"
 did-peer-2 = "^0.1.2"
 
 # askar


### PR DESCRIPTION
This PR adjusts the version of sd-jwt pulled to be the official release now published to PyPI: https://pypi.org/project/sd-jwt/