### PR TITLE
Send Problem report when CredEx not found

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_request_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/handlers/credential_request_handler.py
@@ -7,7 +7,7 @@ from .....messaging.base_handler import BaseHandler, HandlerException
 from .....messaging.models.base import BaseModelError
 from .....messaging.request_context import RequestContext
 from .....messaging.responder import BaseResponder
-from .....storage.error import StorageError
+from .....storage.error import StorageError, StorageNotFoundError
 from .....utils.tracing import trace_event, get_timer
 
 from .. import problem_report_for_record
@@ -53,10 +53,21 @@ class CredentialRequestHandler(BaseHandler):
             )
 
         credential_manager = CredentialManager(profile)
-        cred_ex_record = await credential_manager.receive_request(
-            context.message, context.connection_record, oob_record
-        )  # mgr only finds, saves record: on exception, saving state null is hopeless
-
+        try:
+            cred_ex_record = await credential_manager.receive_request(
+                context.message, context.connection_record, oob_record
+            )  # mgr only finds, saves record: on exception, saving state null is hopeless
+        except StorageNotFoundError:
+            # issue a problem report...
+            cred_ex_record = None
+            thread_id = context.message._thread_id
+            await responder.send_reply(
+                problem_report_for_record(
+                    None,
+                    ProblemReportReason.RECORD_NOT_FOUND.value,
+                    thread_id=thread_id,
+                )
+            )
         r_time = trace_event(
             context.settings,
             context.message,

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -536,10 +536,12 @@ class CredentialManager:
                         )
                     )
                 )
-            except StorageNotFoundError:
-                raise CredentialManagerError(
-                    "Indy issue credential format can't start from credential request"
-                ) from None
+            except StorageNotFoundError as ex:
+                LOGGER.error(
+                    f"Credential Exchange (thread id = {message._thread_id}) not found." 
+                    " Indy issue credential format can't start from credential request.",
+                )
+                raise ex
             if cred_ex_record.state != V10CredentialExchange.STATE_OFFER_SENT:
                 LOGGER.error(
                     "Skipping credential request; exchange state is %s (id=%s)",

--- a/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
@@ -538,7 +538,7 @@ class CredentialManager:
                 )
             except StorageNotFoundError as ex:
                 LOGGER.error(
-                    f"Credential Exchange (thread id = {message._thread_id}) not found." 
+                    f"Credential Exchange (thread id = {message._thread_id}) not found."
                     " Indy issue credential format can't start from credential request.",
                 )
                 raise ex

--- a/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/tests/test_manager.py
@@ -847,7 +847,7 @@ class TestCredentialManager(IsolatedAsyncioTestCase):
             mock.CoroutineMock(),
         ) as mock_retrieve:
             mock_retrieve.side_effect = (StorageNotFoundError(),)
-            with self.assertRaises(CredentialManagerError):
+            with self.assertRaises(StorageNotFoundError):
                 cx_rec = await self.manager.receive_request(request, mock_conn, None)
 
                 mock_retrieve.assert_called_once_with(

--- a/aries_cloudagent/protocols/issue_credential/v2_0/__init__.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/__init__.py
@@ -10,6 +10,7 @@ from .models.cred_ex_record import V20CredExRecord
 def problem_report_for_record(
     record: Union[ConnRecord, V20CredExRecord],
     desc_en: str,
+    thread_id: str = None,
 ) -> V20CredProblemReport:
     """Create problem report for record.
 
@@ -24,10 +25,11 @@ def problem_report_for_record(
             "code": ProblemReportReason.ISSUANCE_ABANDONED.value,
         },
     )
-    if record:
+    thid = thread_id
+    if record and not thread_id:
         thid = getattr(record, "thread_id", None)
-        if thid:
-            result.assign_thread_id(thid)
+    if thid:
+        result.assign_thread_id(thid)
 
     return result
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/handler.py
@@ -102,6 +102,12 @@ class V20CredFormatHandler(ABC):
     ) -> None:
         """Receive format specific credential request message."""
 
+    def can_receive_request_without_offer(
+        self,
+    ) -> bool:
+        """Can this handler receive credential request without an offer?"""
+        return False
+
     @abstractmethod
     async def issue_credential(
         self, cred_ex_record: V20CredExRecord, retries: int = 5

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
@@ -470,6 +470,12 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
 
         return self.get_format_data(CRED_20_REQUEST, detail.serialize())
 
+    def can_receive_request_without_offer(
+        self,
+    ) -> bool:
+        """Can this handler receive credential request without an offer?"""
+        return True
+
     async def receive_request(
         self, cred_ex_record: V20CredExRecord, cred_request_message: V20CredRequest
     ) -> None:

--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -418,7 +418,8 @@ class V20CredManager:
             if (handler := V20CredFormat.Format.get(format.format))
         ]
         handlers_without_offer = [
-            handler for handler in handlers
+            handler
+            for handler in handlers
             if handler.can_receive_request_without_offer()
         ]
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -413,9 +413,9 @@ class V20CredManager:
         connection_id = None if oob_record else connection_record.connection_id
 
         handlers = [
-            handler(self.profile)
+            f.handler(self.profile)
             for format in cred_request_message.formats
-            if (handler := V20CredFormat.Format.get(format.format))
+            if (f := V20CredFormat.Format.get(format.format))
         ]
         handlers_without_offer = [
             handler
@@ -454,8 +454,8 @@ class V20CredManager:
         if connection_record:
             cred_ex_record.connection_id = connection_record.connection_id
 
-        for cred_format in handlers:
-            await cred_format.handler(self.profile).receive_request(
+        for handler in handlers:
+            await handler.receive_request(
                 cred_ex_record, cred_request_message
             )
 

--- a/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/manager.py
@@ -455,9 +455,7 @@ class V20CredManager:
             cred_ex_record.connection_id = connection_record.connection_id
 
         for handler in handlers:
-            await handler.receive_request(
-                cred_ex_record, cred_request_message
-            )
+            await handler.receive_request(cred_ex_record, cred_request_message)
 
         cred_ex_record.cred_request = cred_request_message
         cred_ex_record.state = V20CredExRecord.STATE_REQUEST_RECEIVED

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_problem_report.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_problem_report.py
@@ -21,6 +21,7 @@ class ProblemReportReason(Enum):
     """Supported reason codes."""
 
     ISSUANCE_ABANDONED = "issuance-abandoned"
+    RECORD_NOT_FOUND = "record-not-found"
 
 
 class V20CredProblemReport(ProblemReport):

--- a/demo/bdd_support/agent_backchannel_client.py
+++ b/demo/bdd_support/agent_backchannel_client.py
@@ -249,3 +249,19 @@ def agent_container_PUT(
         text=text,
         params=params,
     )
+
+
+def agent_container_DELETE(
+    the_container: AgentContainer,
+    path: str,
+    data: dict = None,
+    text: bool = False,
+    params: dict = None,
+) -> dict:
+    return run_coroutine(
+        the_container.admin_DELETE,
+        path,
+        data=data,
+        text=text,
+        params=params,
+    )

--- a/demo/features/0453-issue-credential.feature
+++ b/demo/features/0453-issue-credential.feature
@@ -38,7 +38,7 @@ Feature: RFC 0453 Aries agent issue credential
        #| --public-did --multitenant             | --multitenant             | driverslicense | Data_DL_NormalizedValues |
 
   @T003-RFC0453 @GHA
-  Scenario Outline: Issue a credential with the holder beginning with a requset
+  Scenario Outline: Issue a credential with the holder sending a request
     Given we have "2" agents
       | name  | role    | capabilities        |
       | Acme  | issuer  | <Acme_capabilities> |

--- a/demo/features/0453-issue-credential.feature
+++ b/demo/features/0453-issue-credential.feature
@@ -19,6 +19,61 @@ Feature: RFC 0453 Aries agent issue credential
        #| --public-did --mediation               | --mediation               | driverslicense | Data_DL_NormalizedValues |
        #| --public-did --multitenant             | --multitenant             | driverslicense | Data_DL_NormalizedValues |
 
+  @T003-RFC0453 @GHA
+  Scenario Outline: Holder accepts a deleted credential offer
+    Given we have "2" agents
+      | name  | role    | capabilities        |
+      | Acme  | issuer  | <Acme_capabilities> |
+      | Bob   | holder  | <Bob_capabilities>  |
+    And "Acme" and "Bob" have an existing connection
+    And "Acme" is ready to issue a credential for <Schema_name>
+    And "Acme" offers and deletes a credential with data <Credential_data>
+    Then "Bob" has the exchange abandoned
+
+    Examples:
+       | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
+       | --public-did                           |                           | driverslicense | Data_DL_NormalizedValues |
+       #| --public-did --did-exchange            | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
+       #| --public-did --mediation               | --mediation               | driverslicense | Data_DL_NormalizedValues |
+       #| --public-did --multitenant             | --multitenant             | driverslicense | Data_DL_NormalizedValues |
+
+  @T003-RFC0453 @GHA
+  Scenario Outline: Issue a credential with the holder beginning with a requset
+    Given we have "2" agents
+      | name  | role    | capabilities        |
+      | Acme  | issuer  | <Acme_capabilities> |
+      | Bob   | holder  | <Bob_capabilities>  |
+    And "Acme" and "Bob" have an existing connection
+    And "Acme" is ready to issue a credential for <Schema_name>
+    When "Bob" requests a credential with data <Credential_data> from "Acme" it fails
+
+    Examples:
+       | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
+       | --public-did                           |                           | driverslicense | Data_DL_NormalizedValues |
+       #| --public-did --did-exchange            | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
+       #| --public-did --mediation               | --mediation               | driverslicense | Data_DL_NormalizedValues |
+       #| --public-did --multitenant             | --multitenant             | driverslicense | Data_DL_NormalizedValues |
+
+
+  @T003.1-RFC0453 @GHA
+  Scenario Outline: Holder accepts a deleted json-ld credential offer
+    Given we have "2" agents
+      | name  | role    | capabilities        |
+      | Acme  | issuer  | <Acme_capabilities> |
+      | Bob   | holder  | <Bob_capabilities>  |
+    And "Acme" and "Bob" have an existing connection
+    And "Acme" is ready to issue a json-ld credential for <Schema_name>
+    And "Bob" is ready to receive a json-ld credential
+    When "Acme" offers and deletes "Bob" a json-ld credential with data <Credential_data>
+    Then "Bob" has the json-ld credential issued
+    And "Acme" has the exchange completed
+
+    Examples:
+       | Acme_capabilities                                   | Bob_capabilities          | Schema_name    | Credential_data          |
+       | --public-did --cred-type json-ld                    |                           | driverslicense | Data_DL_NormalizedValues |
+       # | --public-did --cred-type json-ld --did-exchange     | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
+       # | --public-did --cred-type json-ld --mediation        | --mediation               | driverslicense | Data_DL_NormalizedValues |
+       # | --public-did --cred-type json-ld --multitenant      | --multitenant             | driverslicense | Data_DL_NormalizedValues |
 
   @T003.1-RFC0453 @GHA
   Scenario Outline: Issue a json-ld credential with the Issuer beginning with an offer
@@ -30,6 +85,26 @@ Feature: RFC 0453 Aries agent issue credential
     And "Acme" is ready to issue a json-ld credential for <Schema_name>
     And "Bob" is ready to receive a json-ld credential
     When "Acme" offers "Bob" a json-ld credential with data <Credential_data>
+    Then "Bob" has the json-ld credential issued
+
+    Examples:
+       | Acme_capabilities                                   | Bob_capabilities          | Schema_name    | Credential_data          |
+       | --public-did --cred-type json-ld                    |                           | driverslicense | Data_DL_NormalizedValues |
+       | --public-did --cred-type json-ld --did-exchange     | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
+       | --public-did --cred-type json-ld --mediation        | --mediation               | driverslicense | Data_DL_NormalizedValues |
+       | --public-did --cred-type json-ld --multitenant      | --multitenant             | driverslicense | Data_DL_NormalizedValues |
+
+
+  @T003.1-RFC0453 @GHA
+  Scenario Outline: Issue a json-ld credential with the holder beginning with a request
+    Given we have "2" agents
+      | name  | role    | capabilities        |
+      | Acme  | issuer  | <Acme_capabilities> |
+      | Bob   | holder  | <Bob_capabilities>  |
+    And "Acme" and "Bob" have an existing connection
+    And "Acme" is ready to issue a json-ld credential for <Schema_name>
+    And "Bob" is ready to receive a json-ld credential
+    When "Bob" requests a json-ld credential with data <Credential_data> from "Acme"
     Then "Bob" has the json-ld credential issued
 
     Examples:

--- a/demo/features/steps/0453-issue-credential.py
+++ b/demo/features/steps/0453-issue-credential.py
@@ -1,4 +1,3 @@
-from aiohttp import ClientError, ClientResponseError
 from behave import given, when, then
 import json
 from time import sleep
@@ -145,7 +144,7 @@ def step_impl(context, issuer, holder, credential_data):
             "/issue-credential-2.0/send-request",
             data,
         )
-    except ClientError as err:
+    except Exception as err:
         # this is not allowed, unprocessable
         assert err
 

--- a/demo/features/steps/0453-issue-credential.py
+++ b/demo/features/steps/0453-issue-credential.py
@@ -1,9 +1,11 @@
+from aiohttp import ClientError, ClientResponseError
 from behave import given, when, then
 import json
 from time import sleep
 import time
 
 from bdd_support.agent_backchannel_client import (
+    agent_container_DELETE,
     aries_container_create_schema_cred_def,
     aries_container_issue_credential,
     aries_container_receive_credential,
@@ -72,6 +74,80 @@ def step_impl(context, issuer, credential_data):
 
     # TODO Check the state of the holder after issuers call of send-offer
     # assert expected_agent_state(context.holder_url, "issue-credential", context.cred_thread_id, "offer-received")
+
+
+@given('"{issuer}" offers and deletes a credential with data {credential_data}')
+@when('"{issuer}" offers and deletes a credential with data {credential_data}')
+def step_impl(context, issuer, credential_data):
+    agent = context.active_agents[issuer]
+
+    cred_attrs = read_credential_data(context.schema_name, credential_data)
+    cred_exchange = aries_container_issue_credential(
+        agent["agent"],
+        context.cred_def_id,
+        cred_attrs,
+    )
+
+    context.cred_attrs = cred_attrs
+    context.cred_exchange = cred_exchange
+
+    # delete this immediately, hopefully this is committed before the holder "accepts" it
+    resp = agent_container_DELETE(
+        agent["agent"],
+        f"/issue-credential-2.0/records/{cred_exchange['cred_ex_id']}",
+    )
+
+    # TODO Check the issuers State
+    # assert resp_json["state"] == "offer-sent"
+
+    # TODO Check the state of the holder after issuers call of send-offer
+    # assert expected_agent_state(context.holder_url, "issue-credential", context.cred_thread_id, "abandoned")
+
+
+@then('"{holder}" has the exchange abandoned')
+def step_impl(context, holder):
+    agent = context.active_agents[holder]
+
+    # give time for the exchange to complete (as abandoned)
+    async_sleep(5.0)
+    resp = agent_container_GET(
+        agent["agent"],
+        "/issue-credential-2.0/records",
+    )
+    assert len(resp["results"]) == 1
+    assert resp["results"][0]["cred_ex_record"]["state"] == "abandoned"
+
+
+@when(
+    '"{holder}" requests a credential with data {credential_data} from "{issuer}" it fails'
+)
+def step_impl(context, issuer, holder, credential_data):
+    issuer_agent = context.active_agents[issuer]
+    holder_agent = context.active_agents[holder]
+
+    cred_attrs = read_credential_data(context.schema_name, credential_data)
+
+    cred_preview = {
+        "@type": "https://didcomm.org/issue-credential/2.0/credential-preview",
+        "attributes": cred_attrs,
+    }
+    data = {
+        "connection_id": holder_agent["agent"].agent.connection_id,
+        "comment": f"Offer on cred def id {context.cred_def_id}",
+        "auto_remove": False,
+        "credential_preview": cred_preview,
+        "filter": {"indy": {"cred_def_id": context.cred_def_id}},
+    }
+
+    try:
+        resp = agent_container_POST(
+            holder_agent["agent"],
+            "/issue-credential-2.0/send-request",
+            data,
+        )
+    except ClientError as err:
+        # this is not allowed, unprocessable
+        assert err
 
 
 @given('"{holder}" revokes the credential')
@@ -339,6 +415,150 @@ def step_impl(context, issuer, holder, credential_data):
 
     # TODO test for goodness
     pass
+
+
+@when(
+    '"{issuer}" offers and deletes "{holder}" a json-ld credential with data {credential_data}'
+)
+def step_impl(context, issuer, holder, credential_data):
+    # initiate a cred exchange with a json-ld credential
+    agent = context.active_agents[issuer]
+    holder_agent = context.active_agents[holder]
+
+    # holder and issuer have no records...
+    resp = agent_container_GET(
+        agent["agent"],
+        "/issue-credential-2.0/records",
+    )
+    assert len(resp["results"]) == 0
+
+    resp = agent_container_GET(
+        holder_agent["agent"],
+        "/issue-credential-2.0/records",
+    )
+    assert len(resp["results"]) == 0
+
+    offer_request = {
+        "connection_id": agent["agent"].agent.connection_id,
+        "filter": {
+            "ld_proof": {
+                "credential": {
+                    "@context": [
+                        "https://www.w3.org/2018/credentials/v1",
+                        "https://w3id.org/citizenship/v1",
+                    ],
+                    "type": [
+                        "VerifiableCredential",
+                        "PermanentResident",
+                    ],
+                    "id": "https://credential.example.com/residents/1234567890",
+                    "issuer": agent["agent"].agent.did,
+                    "issuanceDate": "2020-01-01T12:00:00Z",
+                    "credentialSubject": {
+                        "type": ["PermanentResident"],
+                        # let the holder set this
+                        # "id": holder_agent["agent"].agent.did,
+                        "givenName": "ALICE",
+                        "familyName": "SMITH",
+                        "gender": "Female",
+                        "birthCountry": "Bahamas",
+                        "birthDate": "1958-07-17",
+                    },
+                },
+                "options": {"proofType": SIG_TYPE_BLS},
+            }
+        },
+    }
+
+    resp = agent_container_POST(
+        agent["agent"],
+        "/issue-credential-2.0/send-offer",
+        offer_request,
+    )
+    cred_ex_id = resp["cred_ex_id"]
+
+    # issuer has one record
+    resp = agent_container_GET(
+        agent["agent"],
+        "/issue-credential-2.0/records",
+    )
+    assert len(resp["results"]) == 1
+
+    # delete this immediately, hopefully this is committed before the holder "accepts" it
+    # for json-ld this should turn into a request from the holder
+    resp = agent_container_DELETE(
+        agent["agent"],
+        f"/issue-credential-2.0/records/{cred_ex_id}",
+    )
+
+    # now issuer has no records
+    resp = agent_container_GET(
+        agent["agent"],
+        "/issue-credential-2.0/records",
+    )
+    assert len(resp["results"]) == 0
+
+
+@given('"{issuer}" has the exchange completed')
+@then('"{issuer}" has the exchange completed')
+def step_impl(context, issuer):
+    agent = context.active_agents[issuer]
+
+    # new exchange is initiated by the holder, so issuer has one record
+    async_sleep(5.0)
+    resp = agent_container_GET(
+        agent["agent"],
+        "/issue-credential-2.0/records",
+    )
+    assert len(resp["results"]) == 1
+    assert resp["results"][0]["cred_ex_record"]["state"] == "done"
+
+
+@when(
+    '"{holder}" requests a json-ld credential with data {credential_data} from "{issuer}"'
+)
+def step_impl(context, issuer, holder, credential_data):
+    issuer_agent = context.active_agents[issuer]
+    holder_agent = context.active_agents[holder]
+    data = {
+        "auto_remove": False,
+        "comment": "I would like this credential please",
+        "connection_id": holder_agent["agent"].agent.connection_id,
+        "filter": {
+            "ld_proof": {
+                "credential": {
+                    "@context": [
+                        "https://www.w3.org/2018/credentials/v1",
+                        "https://w3id.org/citizenship/v1",
+                    ],
+                    "type": [
+                        "VerifiableCredential",
+                        "PermanentResident",
+                    ],
+                    "id": "https://credential.example.com/residents/1234567890",
+                    "issuer": issuer_agent["agent"].agent.did,
+                    "issuanceDate": "2020-01-01T12:00:00Z",
+                    "credentialSubject": {
+                        "type": ["PermanentResident"],
+                        "id": holder_agent["agent"].agent.did,
+                        "givenName": "ALICE",
+                        "familyName": "SMITH",
+                        "gender": "Female",
+                        "birthCountry": "Bahamas",
+                        "birthDate": "1958-07-17",
+                    },
+                },
+                "options": {"proofType": SIG_TYPE_BLS},
+            }
+        },
+    }
+
+    resp = agent_container_POST(
+        holder_agent["agent"],
+        "/issue-credential-2.0/send-request",
+        data,
+    )
+    assert resp["state"] == "request-sent"
 
 
 @then('"{holder}" has the json-ld credential issued')

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -239,6 +239,7 @@ class AriesAgent(DemoAgent):
         if prev_state == state:
             return  # ignore
         self.cred_state[cred_ex_id] = state
+        self.cred_state[message["thread_id"]] = state
 
         self.log(f"Credential: state = {state}, cred_ex_id = {cred_ex_id}")
 
@@ -1128,6 +1129,17 @@ class AgentContainer:
         params = any additional parameters to pass with the request
         """
         return await self.agent.admin_PUT(path, data=data, text=text, params=params)
+
+    async def admin_DELETE(self, path, data=None, text=False, params=None) -> dict:
+        """
+        Execute an admin DELETE request in the context of the current wallet.
+
+        path = /path/of/request
+        data = payload to post with the request
+        text = True if the expected response is text, False if json data
+        params = any additional parameters to pass with the request
+        """
+        return await self.agent.admin_DELETE(path, data=data, text=text, params=params)
 
     async def agency_admin_GET(self, path, text=False, params=None) -> dict:
         """

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -1036,6 +1036,34 @@ class DemoAgent:
             self.log(f"Error during PUT {path}: {str(e)}")
             raise
 
+    async def admin_DELETE(
+        self, path, data=None, text=False, params=None, headers=None
+    ) -> ClientResponse:
+        try:
+            EVENT_LOGGER.debug(
+                "Controller DELETE %s request to Agent%s",
+                path,
+                (" with data: \n{}".format(repr_json(data)) if data else ""),
+            )
+            if self.multitenant:
+                if not headers:
+                    headers = {}
+                headers["Authorization"] = (
+                    "Bearer " + self.managed_wallet_params["token"]
+                )
+            response = await self.admin_request(
+                "DELETE", path, data, text, params, headers=headers
+            )
+            EVENT_LOGGER.debug(
+                "Response from DELETE %s received: \n%s",
+                path,
+                repr_json(response),
+            )
+            return response
+        except ClientError as e:
+            self.log(f"Error during DELETE {path}: {str(e)}")
+            raise
+
     async def admin_GET_FILE(self, path, params=None, headers=None) -> bytes:
         try:
             if self.multitenant:


### PR DESCRIPTION
See #2549 

Address the situation when an issuer sends an offer and then deletes that offer (credential exchange) before the holder accepts it. When this is an `indy` credential exchange, a Problem Report is sent; when this is a `json-ld` exchange, the holder's accept actually becomes an unbound request for the credential and the flow carries on.

A discussion is warranted to see if we want to implement something more global? Seems like at any point in any protocol one side may not find their record and the other side should be notified of the abandonment. Maybe it is already done and this was just a gap...

Added BDD tests to address the deletion and followup acceptance for `indy` and `json-ld` and also the holder sending a request for credential to issuer. Again, `indy` is not allowed, `json-ld` can flow into a credential issuance.