### PR TITLE
Hardcode version due to poetry modifying version metadata containing `-`

### DIFF
--- a/aries_cloudagent/version.py
+++ b/aries_cloudagent/version.py
@@ -2,5 +2,5 @@
 
 from importlib import metadata
 
-__version__ = metadata.version("aries-cloudagent")
+__version__ = "0.11.0-rc1"
 RECORD_TYPE_ACAPY_VERSION = "acapy_version"

--- a/aries_cloudagent/version.py
+++ b/aries_cloudagent/version.py
@@ -1,6 +1,4 @@
 """Library version information."""
 
-from importlib import metadata
-
 __version__ = "0.11.0-rc1"
 RECORD_TYPE_ACAPY_VERSION = "acapy_version"


### PR DESCRIPTION
This resolves #2579

The issue originates at commit 492091ec250e1ec5e66c792f67aebfa2ef177756 on September 6th

```diff
--- a/aries_cloudagent/version.py
+++ b/aries_cloudagent/version.py
@@ -1,4 +1,6 @@
 """Library version information."""
 
-__version__ = "0.10.1"
+from importlib import metadata
+
+__version__ = metadata.version("aries-cloudagent")
 RECORD_TYPE_ACAPY_VERSION = "acapy_version"
 --- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "aries_cloudagent"
-version = "0.10.0-rc0"
-description = ""
+version = "0.10.1"
+description = "Hyperledger Aries Cloud Agent Python (ACA-Py) is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 authors = ["Hyperledger Aries <aries@lists.hyperledger.org>"]
 license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "aries_cloudagent"}]
 classifiers = [
             "Programming Language :: Python :: 3",
             "License :: OSI Approved :: Apache Software License",
 	    "Operating System :: OS Independent",
```

Which syncs the version with the metadata version

This worked as expected until the latest rc where a `-` was introduced in commit 82385d8c18d9a2f9bac6aa00bfcd8f36d73e548c and 08d5a4be938527f8eb9d310e56cf0fead2d0bc63 which both occurred on october 30th 

```diff
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "aries_cloudagent"
-version = "0.11.0-rc0"
+version = "0.11.0-rc1"
 description = "Hyperledger Aries Cloud Agent Python (ACA-Py) is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 authors = ["Hyperledger Aries <aries@lists.hyperledger.org>"]
 license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "aries_cloudagent"}]
 classifiers = [
             "Programming Language :: Python :: 3",
             "License :: OSI Approved :: Apache Software License",
 	    "Operating System :: OS Independent",
```

While this will not automatically track with the version in `pyproject.toml` it is the best known option for restoring the `-` in release candidate versions.