### PR TITLE
Goal and Goal Code in invitation URL.

### DIFF
--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -362,10 +362,11 @@ class OutOfBandManager(BaseConnectionManager):
                     routing_keys=routing_keys,
                 )
             ]
-            invi_url = invi_msg.to_url()
             if goal and goal_code:
                 invi_msg.goal_code = goal_code
                 invi_msg.goal = goal
+
+            invi_url = invi_msg.to_url()
 
             # Update connection record
             if conn_rec:


### PR DESCRIPTION
Add a unit test to ensure goal/goal code are in the encoded invitation URL.

Fixes #2583 