### PR TITLE
Add ConnectionProblemReport handler

### DIFF
--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -542,7 +542,7 @@ class ConnRecord(BaseRecord):
 
     async def abandon(self, session: ProfileSession, *, reason: Optional[str] = None):
         """Set state to abandoned."""
-        reason = reason or "Connectin abandoned"
+        reason = reason or "Connection abandoned"
         self.state = ConnRecord.State.ABANDONED.rfc160
         self.error_msg = reason
         await self.save(session, reason=reason)

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/connection_invitation_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/connection_invitation_handler.py
@@ -5,7 +5,6 @@ from .....messaging.base_handler import (
     BaseResponder,
     RequestContext,
 )
-
 from ..messages.connection_invitation import ConnectionInvitation
 from ..messages.problem_report import ConnectionProblemReport, ProblemReportReason
 
@@ -25,8 +24,12 @@ class ConnectionInvitationHandler(BaseHandler):
         assert isinstance(context.message, ConnectionInvitation)
 
         report = ConnectionProblemReport(
-            problem_code=ProblemReportReason.INVITATION_NOT_ACCEPTED,
-            explain="Connection invitations cannot be submitted via agent messaging",
+            description={
+                "code": ProblemReportReason.INVITATION_NOT_ACCEPTED.value,
+                "en": (
+                    "Connection invitations cannot be submitted via agent messaging"
+                ),
+            }
         )
         # client likely needs to be using direct responses to receive the problem report
         await responder.send_reply(report)

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/connection_request_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/connection_request_handler.py
@@ -63,6 +63,8 @@ class ConnectionRequestHandler(BaseHandler):
                             "Error parsing DIDDoc for problem report"
                         )
                 await responder.send_reply(
-                    ConnectionProblemReport(problem_code=e.error_code, explain=str(e)),
+                    ConnectionProblemReport(
+                        description={"en": e.message, "code": e.error_code}
+                    ),
                     target_list=targets,
                 )

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/connection_response_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/connection_response_handler.py
@@ -6,7 +6,6 @@ from .....messaging.base_handler import (
     RequestContext,
 )
 from .....protocols.trustping.v1_0.messages.ping import Ping
-
 from ..manager import ConnectionManager, ConnectionManagerError
 from ..messages.connection_response import ConnectionResponse
 from ..messages.problem_report import ConnectionProblemReport
@@ -46,7 +45,9 @@ class ConnectionResponseHandler(BaseHandler):
                             "Error parsing DIDDoc for problem report"
                         )
                 await responder.send_reply(
-                    ConnectionProblemReport(problem_code=e.error_code, explain=str(e)),
+                    ConnectionProblemReport(
+                        description={"en": e.message, "code": e.error_code}
+                    ),
                     target_list=targets,
                 )
             return

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/problem_report_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/problem_report_handler.py
@@ -1,0 +1,35 @@
+"""Problem report handler for Connection Protocol."""
+
+from .....messaging.base_handler import (
+    BaseHandler,
+    BaseResponder,
+    HandlerException,
+    RequestContext,
+)
+from ..manager import ConnectionManager, ConnectionManagerError
+from ..messages.problem_report import ConnectionProblemReport
+
+
+class ConnectionProblemReportHandler(BaseHandler):
+    """Handler class for Connection problem report messages."""
+
+    async def handle(self, context: RequestContext, responder: BaseResponder):
+        """Handle problem report message."""
+        self._logger.debug(
+            f"ConnectionProblemReportHandler called with context {context}"
+        )
+        assert isinstance(context.message, ConnectionProblemReport)
+
+        self._logger.info(f"Received problem report: {context.message.problem_code}")
+        profile = context.profile
+        mgr = ConnectionManager(profile)
+        try:
+            if context.connection_record:
+                await mgr.receive_problem_report(
+                    context.connection_record, context.message
+                )
+            else:
+                raise HandlerException("No connection established for problem report")
+        except ConnectionManagerError:
+            # Unrecognized problem report code
+            self._logger.exception("Error receiving Connection problem report")

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/tests/test_invitation_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/tests/test_invitation_handler.py
@@ -3,7 +3,6 @@ import pytest
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
 from ......transport.inbound.receipt import MessageReceipt
-
 from ...handlers.connection_invitation_handler import ConnectionInvitationHandler
 from ...messages.connection_invitation import ConnectionInvitation
 from ...messages.problem_report import ConnectionProblemReport, ProblemReportReason
@@ -28,6 +27,10 @@ class TestInvitationHandler:
         result, target = messages[0]
         assert (
             isinstance(result, ConnectionProblemReport)
-            and result.problem_code == ProblemReportReason.INVITATION_NOT_ACCEPTED
+            and result.description
+            and (
+                result.description["code"]
+                == ProblemReportReason.INVITATION_NOT_ACCEPTED.value
+            )
         )
         assert not target

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/tests/test_request_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/tests/test_request_handler.py
@@ -1,15 +1,16 @@
 import pytest
+
 from aries_cloudagent.tests import mock
 
-from ......core.profile import ProfileSession
 from ......connections.models import connection_target
 from ......connections.models.conn_record import ConnRecord
 from ......connections.models.diddoc import DIDDoc, PublicKey, PublicKeyType, Service
+from ......core.profile import ProfileSession
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
-from ......transport.inbound.receipt import MessageReceipt
 from ......storage.base import BaseStorage
 from ......storage.error import StorageNotFoundError
+from ......transport.inbound.receipt import MessageReceipt
 from ...handlers import connection_request_handler as handler
 from ...manager import ConnectionManagerError
 from ...messages.connection_request import ConnectionRequest
@@ -161,7 +162,7 @@ class TestRequestHandler:
     async def test_problem_report(self, mock_conn_mgr, request_context):
         mock_conn_mgr.return_value.receive_request = mock.CoroutineMock()
         mock_conn_mgr.return_value.receive_request.side_effect = ConnectionManagerError(
-            error_code=ProblemReportReason.REQUEST_NOT_ACCEPTED
+            error_code=ProblemReportReason.REQUEST_NOT_ACCEPTED.value
         )
         request_context.message = ConnectionRequest()
         handler_inst = handler.ConnectionRequestHandler()
@@ -172,7 +173,11 @@ class TestRequestHandler:
         result, target = messages[0]
         assert (
             isinstance(result, ConnectionProblemReport)
-            and result.problem_code == ProblemReportReason.REQUEST_NOT_ACCEPTED
+            and result.description
+            and (
+                result.description["code"]
+                == ProblemReportReason.REQUEST_NOT_ACCEPTED.value
+            )
         )
         assert target == {"target_list": None}
 
@@ -184,7 +189,7 @@ class TestRequestHandler:
     ):
         mock_conn_mgr.return_value.receive_request = mock.CoroutineMock()
         mock_conn_mgr.return_value.receive_request.side_effect = ConnectionManagerError(
-            error_code=ProblemReportReason.REQUEST_NOT_ACCEPTED
+            error_code=ProblemReportReason.REQUEST_NOT_ACCEPTED.value
         )
         mock_conn_mgr.return_value.diddoc_connection_targets = mock.MagicMock(
             return_value=[mock_conn_target]
@@ -202,7 +207,11 @@ class TestRequestHandler:
         result, target = messages[0]
         assert (
             isinstance(result, ConnectionProblemReport)
-            and result.problem_code == ProblemReportReason.REQUEST_NOT_ACCEPTED
+            and result.description
+            and (
+                result.description["code"]
+                == ProblemReportReason.REQUEST_NOT_ACCEPTED.value
+            )
         )
         assert target == {"target_list": [mock_conn_target]}
 
@@ -214,7 +223,7 @@ class TestRequestHandler:
     ):
         mock_conn_mgr.return_value.receive_request = mock.CoroutineMock()
         mock_conn_mgr.return_value.receive_request.side_effect = ConnectionManagerError(
-            error_code=ProblemReportReason.REQUEST_NOT_ACCEPTED
+            error_code=ProblemReportReason.REQUEST_NOT_ACCEPTED.value
         )
         mock_conn_mgr.return_value.diddoc_connection_targets = mock.MagicMock(
             side_effect=ConnectionManagerError("no targets")
@@ -232,6 +241,10 @@ class TestRequestHandler:
         result, target = messages[0]
         assert (
             isinstance(result, ConnectionProblemReport)
-            and result.problem_code == ProblemReportReason.REQUEST_NOT_ACCEPTED
+            and result.description
+            and (
+                result.description["code"]
+                == ProblemReportReason.REQUEST_NOT_ACCEPTED.value
+            )
         )
         assert target == {"target_list": None}

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/tests/test_response_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/tests/test_response_handler.py
@@ -1,4 +1,5 @@
 import pytest
+
 from aries_cloudagent.tests import mock
 
 from ......connections.models import connection_target
@@ -10,11 +11,8 @@ from ......connections.models.diddoc import (
 )
 from ......messaging.request_context import RequestContext
 from ......messaging.responder import MockResponder
-
 from ......protocols.trustping.v1_0.messages.ping import Ping
-
 from ......transport.inbound.receipt import MessageReceipt
-
 from ...handlers import connection_response_handler as handler
 from ...manager import ConnectionManagerError
 from ...messages.connection_response import ConnectionResponse
@@ -101,7 +99,7 @@ class TestResponseHandler:
     async def test_problem_report(self, mock_conn_mgr, request_context):
         mock_conn_mgr.return_value.accept_response = mock.CoroutineMock()
         mock_conn_mgr.return_value.accept_response.side_effect = ConnectionManagerError(
-            error_code=ProblemReportReason.RESPONSE_NOT_ACCEPTED
+            error_code=ProblemReportReason.RESPONSE_NOT_ACCEPTED.value,
         )
         request_context.message = ConnectionResponse()
         handler_inst = handler.ConnectionResponseHandler()
@@ -112,7 +110,11 @@ class TestResponseHandler:
         result, target = messages[0]
         assert (
             isinstance(result, ConnectionProblemReport)
-            and result.problem_code == ProblemReportReason.RESPONSE_NOT_ACCEPTED
+            and result.description
+            and (
+                result.description["code"]
+                == ProblemReportReason.RESPONSE_NOT_ACCEPTED.value
+            )
         )
         assert target == {"target_list": None}
 
@@ -124,7 +126,7 @@ class TestResponseHandler:
     ):
         mock_conn_mgr.return_value.accept_response = mock.CoroutineMock()
         mock_conn_mgr.return_value.accept_response.side_effect = ConnectionManagerError(
-            error_code=ProblemReportReason.REQUEST_NOT_ACCEPTED
+            error_code=ProblemReportReason.RESPONSE_NOT_ACCEPTED.value,
         )
         mock_conn_mgr.return_value.diddoc_connection_targets = mock.MagicMock(
             return_value=[mock_conn_target]
@@ -140,7 +142,11 @@ class TestResponseHandler:
         result, target = messages[0]
         assert (
             isinstance(result, ConnectionProblemReport)
-            and result.problem_code == ProblemReportReason.REQUEST_NOT_ACCEPTED
+            and result.description
+            and (
+                result.description["code"]
+                == ProblemReportReason.RESPONSE_NOT_ACCEPTED.value
+            )
         )
         assert target == {"target_list": [mock_conn_target]}
 
@@ -152,7 +158,7 @@ class TestResponseHandler:
     ):
         mock_conn_mgr.return_value.accept_response = mock.CoroutineMock()
         mock_conn_mgr.return_value.accept_response.side_effect = ConnectionManagerError(
-            error_code=ProblemReportReason.REQUEST_NOT_ACCEPTED
+            error_code=ProblemReportReason.RESPONSE_NOT_ACCEPTED.value,
         )
         mock_conn_mgr.return_value.diddoc_connection_targets = mock.MagicMock(
             side_effect=ConnectionManagerError("no target")
@@ -168,6 +174,10 @@ class TestResponseHandler:
         result, target = messages[0]
         assert (
             isinstance(result, ConnectionProblemReport)
-            and result.problem_code == ProblemReportReason.REQUEST_NOT_ACCEPTED
+            and result.description
+            and (
+                result.description["code"]
+                == ProblemReportReason.RESPONSE_NOT_ACCEPTED.value
+            )
         )
         assert target == {"target_list": None}

--- a/aries_cloudagent/protocols/connections/v1_0/messages/problem_report.py
+++ b/aries_cloudagent/protocols/connections/v1_0/messages/problem_report.py
@@ -8,7 +8,8 @@ from .....messaging.agent_message import AgentMessage, AgentMessageSchema
 from ..message_types import PROBLEM_REPORT
 
 HANDLER_CLASS = (
-    "aries_cloudagent.protocols.problem_report.v1_0.handler.ProblemReportHandler"
+    "aries_cloudagent.protocols.connections.v1_0.handlers."
+    "problem_report_handler.ConnectionProblemReportHandler"
 )
 
 


### PR DESCRIPTION
fixes #2530 
fixes #2599

Add new problem report handler for connection protocol.

Update the ConnectionManagerError and ConnectionProblemReport to match the same base classes and structure as found in the DIDX protocol. There were issues where the ConnectionManagerErrors were actually failing during marshalling causing problem reports to not get sent. This is addressed by updating the classes and error_codes.


There is still a significant logic gap that I will raise in another issue - ProblemReport delivery requires an existing connection which is means we can't deliver a problem report to indicate the issue is the connection protocol...  but leaving that discussion out of this PR.

