### PR TITLE
chore: correct type hints on base record

### DIFF
--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -506,8 +506,8 @@ class BaseExchangeRecord(BaseRecord):
 
     def __init__(
         self,
-        id: str = None,
-        state: str = None,
+        id: Optional[str] = None,
+        state: Optional[str] = None,
         *,
         trace: bool = False,
         **kwargs,

--- a/aries_cloudagent/messaging/util.py
+++ b/aries_cloudagent/messaging/util.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 I32_BOUND = 2**31
 
 
-def datetime_to_str(dt: Union[str, datetime]) -> str:
+def datetime_to_str(dt: Union[str, datetime, None]) -> Union[str, None]:
     """Convert a datetime object to an indy-standard datetime string.
 
     Args:

--- a/aries_cloudagent/storage/record.py
+++ b/aries_cloudagent/storage/record.py
@@ -1,6 +1,7 @@
 """Record instance stored and searchable by BaseStorage implementation."""
 
 from collections import namedtuple
+from typing import Optional
 from uuid import uuid4
 
 
@@ -9,7 +10,9 @@ class StorageRecord(namedtuple("StorageRecord", "type value tags id")):
 
     __slots__ = ()
 
-    def __new__(cls, type, value, tags: dict = None, id: str = None):
+    def __new__(
+        cls, type, value, tags: Optional[dict] = None, id: Optional[str] = None
+    ):
         """Initialize some defaults on record."""
         if not id:
             id = uuid4().hex


### PR DESCRIPTION
This is a small tweak to correct the type hints on base record and related base classes. These are base classes used widely both within ACA-Py and in plugins. Having these types corrected will solve a cascade of static type checking errors.

These aren't strictly necessary errors to fix but they sure make my life as a developer easier.