### PR TITLE
:bug: fix wallet_update when only `extra_settings` requested

### DIFF
--- a/aries_cloudagent/multitenant/admin/routes.py
+++ b/aries_cloudagent/multitenant/admin/routes.py
@@ -481,10 +481,17 @@ async def wallet_update(request: web.BaseRequest):
     wallet_dispatch_type = body.get("wallet_dispatch_type")
     label = body.get("label")
     image_url = body.get("image_url")
-    extra_settings = body.get("extra_settings") or {}
+    extra_settings = body.get("extra_settings")
 
     if all(
-        v is None for v in (wallet_webhook_urls, wallet_dispatch_type, label, image_url)
+        v is None
+        for v in (
+            wallet_webhook_urls,
+            wallet_dispatch_type,
+            label,
+            image_url,
+            extra_settings,
+        )
     ):
         raise web.HTTPBadRequest(reason="At least one parameter is required.")
 
@@ -504,7 +511,7 @@ async def wallet_update(request: web.BaseRequest):
         settings["default_label"] = label
     if image_url is not None:
         settings["image_url"] = image_url
-    extra_subwallet_setting = get_extra_settings_dict_per_tenant(extra_settings)
+    extra_subwallet_setting = get_extra_settings_dict_per_tenant(extra_settings or {})
     settings.update(extra_subwallet_setting)
 
     try:


### PR DESCRIPTION
Minor bug fix: `wallet_update` has a condition:

```py
    if all(
        v is None for v in (wallet_webhook_urls, wallet_dispatch_type, label, image_url)
    ):
        raise web.HTTPBadRequest(reason="At least one parameter is required.")
```

This ignores the newly added `extra_settings`, and so trying to update a wallet with only `extra_settings` in the request raises a faulty Bad Request: "At least one parameter is required."

This PR simply adds `extra_settings` to the list of possible parameters.

Edit: I moved the default value of `extra_settings` to be set in the `get_extra_settings_dict_per_tenant` call. If `extra_settings` defaults to `{}` immediately, then the `v is None` check for `extra_settings` is never True.