### PR TITLE
Update the ReadTheDocs config in case we do another 0.10.x release

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,3 +8,7 @@ build:
 sphinx:
   builder: dirhtml
   configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
This file has not been updated for the last two releases, and as such, the ReadTheDocs deployments have not worked. Not the end of the world, but adding this file now in case we do another release, and I forget again. If we don't do another deploy -- no harm done.
