### PR TITLE
Feature Suggestion: Include a Reason When Constraints Cannot Be Applied

### DIFF
--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -1450,7 +1450,7 @@ class DIFPresExchHandler:
             if is_limit_disclosure:
                 field = await self.get_updated_field(field, cred_dict)
             if not await self.filter_by_field(field, credential):
-                return f'Credential is not applicable for field "{field}"'
+                return f'Credential is not applicable for field {field.id} with paths {field.paths}'
             field_paths = field_paths + (
                 await self.restrict_field_paths_one_of_filter(
                     field_paths=field.paths, cred_dict=cred_dict

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -1441,7 +1441,7 @@ class DIFPresExchHandler:
         self, constraint: Constraints, cred_dict: dict
     ) -> str:
         """Evaluate constraint from the request against received credential."""
-        """If successful, returns None, else returns string with failure reason"""
+        """If successful, returns None, otherwise returns string with reason for failure"""
         fields = constraint._fields
         field_paths = []
         credential = self.create_vcrecord(cred_dict)
@@ -1450,7 +1450,7 @@ class DIFPresExchHandler:
             if is_limit_disclosure:
                 field = await self.get_updated_field(field, cred_dict)
             if not await self.filter_by_field(field, credential):
-                return 'Credential is not applicable for field "{field}"'
+                return f'Credential is not applicable for field "{field}"'
             field_paths = field_paths + (
                 await self.restrict_field_paths_one_of_filter(
                     field_paths=field.paths, cred_dict=cred_dict
@@ -1509,7 +1509,7 @@ class DIFPresExchHandler:
         self, extracted_dict: dict, nested_attr_values: dict
     ) -> str:
         """Check if keys of extracted_dict exists in nested_attr_values."""
-        """If successful, returns None, else returns string with failure reason"""
+        """If successful, returns None, otherwise returns string with reason for failure"""
         for attrs in extracted_dict.keys():
             if attrs not in nested_attr_values:
                 return f'{"at least one of " if isinstance(attrs, list) else ""}{attrs} not in field paths'

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -1486,7 +1486,7 @@ class DIFPresExchHandler:
 
             for attrs in cred_dict.keys():
                 if attrs not in field_paths:
-                    return f'{"at least one of " if isinstance(attrs, list) else ""}{attrs} not in field paths'
+                    return f'No field in constraints for {"at least one of " if isinstance(attrs, list) else ""}{attrs}'
             for nested_attr_key in nested_field_paths:
                 nested_attr_values = nested_field_paths[nested_attr_key]
                 extracted = self.nested_get(cred_dict, nested_attr_key)
@@ -1512,7 +1512,7 @@ class DIFPresExchHandler:
         """If successful, returns None, otherwise returns string with reason for failure"""
         for attrs in extracted_dict.keys():
             if attrs not in nested_attr_values:
-                return f'{"at least one of " if isinstance(attrs, list) else ""}{attrs} not in field paths'
+                return f'No field in constraints for {"at least one of " if isinstance(attrs, list) else ""}{attrs}'
         return None
 
     def get_dict_keys_from_path(self, derived_cred_dict: dict, path: str) -> List:

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
@@ -3296,7 +3296,7 @@ class TestPresExchHandler:
             mock_jsonld_expand.return_value = EXPANDED_CRED_FHIR_TYPE_1
             assert await dif_pres_exch_handler.apply_constraint_received_cred(
                 constraint=constraint, cred_dict=cred_dict
-            )
+            ) == None
 
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
@@ -3330,9 +3330,9 @@ class TestPresExchHandler:
             test_module.jsonld, "expand", mock.MagicMock()
         ) as mock_jsonld_expand:
             mock_jsonld_expand.return_value = EXPANDED_CRED_FHIR_TYPE_1
-            assert not await dif_pres_exch_handler.apply_constraint_received_cred(
+            assert await dif_pres_exch_handler.apply_constraint_received_cred(
                 constraint=constraint, cred_dict=cred_dict
-            )
+            ) != None
 
         constraint = {
             "limit_disclosure": "required",
@@ -3348,9 +3348,9 @@ class TestPresExchHandler:
             test_module.jsonld, "expand", mock.MagicMock()
         ) as mock_jsonld_expand:
             mock_jsonld_expand.return_value = EXPANDED_CRED_FHIR_TYPE_1
-            assert not await dif_pres_exch_handler.apply_constraint_received_cred(
+            assert await dif_pres_exch_handler.apply_constraint_received_cred(
                 constraint=constraint, cred_dict=cred_dict
-            )
+            ) != None
 
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
@@ -3376,7 +3376,7 @@ class TestPresExchHandler:
             mock_jsonld_expand.return_value = EXPANDED_CRED_FHIR_TYPE_1
             assert await dif_pres_exch_handler.apply_constraint_received_cred(
                 constraint=constraint, cred_dict=cred_dict
-            )
+            ) == None
 
         constraint = {
             "limit_disclosure": "required",
@@ -3394,7 +3394,7 @@ class TestPresExchHandler:
             mock_jsonld_expand.return_value = EXPANDED_CRED_FHIR_TYPE_1
             assert await dif_pres_exch_handler.apply_constraint_received_cred(
                 constraint=constraint, cred_dict=cred_dict
-            )
+            ) == None
 
         cred_dict["credentialSubject"]["Patient"]["address"] = [
             {
@@ -3422,7 +3422,7 @@ class TestPresExchHandler:
             mock_jsonld_expand.return_value = EXPANDED_CRED_FHIR_TYPE_1
             assert await dif_pres_exch_handler.apply_constraint_received_cred(
                 constraint=constraint, cred_dict=cred_dict
-            )
+            ) == None
 
         cred_dict["credentialSubject"]["Patient"] = [
             {
@@ -3466,7 +3466,7 @@ class TestPresExchHandler:
             mock_jsonld_expand.return_value = EXPANDED_CRED_FHIR_TYPE_2
             assert await dif_pres_exch_handler.apply_constraint_received_cred(
                 constraint=constraint, cred_dict=cred_dict
-            )
+            ) == None
 
         constraint = {
             "limit_disclosure": "required",
@@ -3484,7 +3484,7 @@ class TestPresExchHandler:
             mock_jsonld_expand.return_value = EXPANDED_CRED_FHIR_TYPE_2
             assert await dif_pres_exch_handler.apply_constraint_received_cred(
                 constraint=constraint, cred_dict=cred_dict
-            )
+            ) == None
 
         constraint = {
             "limit_disclosure": "required",
@@ -3502,7 +3502,7 @@ class TestPresExchHandler:
             mock_jsonld_expand.return_value = EXPANDED_CRED_FHIR_TYPE_2
             assert await dif_pres_exch_handler.apply_constraint_received_cred(
                 constraint=constraint, cred_dict=cred_dict
-            )
+            ) == None
 
         constraint = {
             "limit_disclosure": "required",
@@ -3520,7 +3520,7 @@ class TestPresExchHandler:
             mock_jsonld_expand.return_value = EXPANDED_CRED_FHIR_TYPE_2
             assert await dif_pres_exch_handler.apply_constraint_received_cred(
                 constraint=constraint, cred_dict=cred_dict
-            )
+            ) == None
 
     @pytest.mark.asyncio
     @pytest.mark.ursa_bbs_signatures
@@ -3542,9 +3542,9 @@ class TestPresExchHandler:
             test_module.jsonld, "expand", mock.MagicMock()
         ) as mock_jsonld_expand:
             mock_jsonld_expand.return_value = EXPANDED_CRED_FHIR_TYPE_1
-            assert not await dif_pres_exch_handler.apply_constraint_received_cred(
+            assert await dif_pres_exch_handler.apply_constraint_received_cred(
                 constraint=constraint, cred_dict=cred_dict
-            )
+            ) != None
 
     @pytest.mark.asyncio
     async def test_get_updated_path(self, profile):


### PR DESCRIPTION
When the verifier agent is unable to apply a constraint filter, it would be helpful to have a reason why it failed to do so. For example, instead of:

```
Constraint specified for input_descriptor_123 does not apply to the enclosed credential in $.verifiableCredential[0]
```

... the message could include the reason that the constraint could not be applied, with the specific path or item that did not match. For example:

```
Constraint specified for input_descriptor_123 does not apply to the enclosed credential in $.verifiableCredential[0]
Reason: Credential is not applicable for field 11111111-2222-3333-4444-56789abcdef0 with paths ['$.credentialSubject.part1.part2']
```

This indicates that the field indicated in the message was not found in the Reveal Document or the full Credential.

or

```
Constraint specified for input_descriptor_123 does not apply to the enclosed credential in $.verifiableCredential[0]
Reason: No field in constraints for part2 under parent path "$.credentialSubject.part1"
```

This indicates that the "part2" property found in the Reveal Document under "$.credentialSubject.part1" was not found in the list of fields in the constraints.
