### PR TITLE
fix: update broken demo dependency

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,4 +1,4 @@
-asyncpg~=0.25.0
+asyncpg~=0.26.0
 prompt_toolkit~=2.0.9
 web.py~=0.62
 pygments~=2.10


### PR DESCRIPTION
Couldn't proceed with further local testing on my host. Probably due to differences in python versions. 

```
    self.proc = await asyncio.wait_for(future, 20, loop=loop)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: wait_for() got an unexpected keyword argument 'loop'
```

But pip install works fine now.