### PR TITLE
Connection and DIDX Problem Reports

### DIFF
--- a/aries_cloudagent/messaging/responder.py
+++ b/aries_cloudagent/messaging/responder.py
@@ -5,26 +5,26 @@ in response to the message being handled.
 """
 import asyncio
 import json
-
 from abc import ABC, abstractmethod
-from typing import List, Sequence, Union, Optional, Tuple
+from typing import List, Optional, Sequence, Tuple, Union
 
 from ..cache.base import BaseCache
-from ..connections.models.connection_target import ConnectionTarget
 from ..connections.models.conn_record import ConnRecord
+from ..connections.models.connection_target import ConnectionTarget
 from ..core.error import BaseError
 from ..core.profile import Profile
 from ..transport.outbound.message import OutboundMessage
-
-from .base_message import BaseMessage
 from ..transport.outbound.status import OutboundSendStatus
+from .base_message import BaseMessage
 
 SKIP_ACTIVE_CONN_CHECK_MSG_TYPES = [
     "didexchange/1.0/request",
     "didexchange/1.0/response",
+    "didexchange/1.0/problem_report",
     "connections/1.0/invitation",
     "connections/1.0/request",
     "connections/1.0/response",
+    "connections/1.0/problem_report",
 ]
 
 

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/connection_invitation_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/connection_invitation_handler.py
@@ -31,5 +31,6 @@ class ConnectionInvitationHandler(BaseHandler):
                 ),
             }
         )
+        report.assign_thread_from(context.message)
         # client likely needs to be using direct responses to receive the problem report
         await responder.send_reply(report)

--- a/aries_cloudagent/protocols/connections/v1_0/handlers/connection_request_handler.py
+++ b/aries_cloudagent/protocols/connections/v1_0/handlers/connection_request_handler.py
@@ -5,7 +5,6 @@ from .....messaging.base_handler import BaseHandler, BaseResponder, RequestConte
 from ....coordinate_mediation.v1_0.manager import MediationManager
 from ..manager import ConnectionManager, ConnectionManagerError
 from ..messages.connection_request import ConnectionRequest
-from ..messages.problem_report import ConnectionProblemReport
 
 
 class ConnectionRequestHandler(BaseHandler):
@@ -49,22 +48,11 @@ class ConnectionRequestHandler(BaseHandler):
             else:
                 self._logger.debug("Connection request will await acceptance")
         except ConnectionManagerError as e:
-            self._logger.exception("Error receiving connection request")
-            if e.error_code:
-                targets = None
-                if context.message.connection and context.message.connection.did_doc:
-                    try:
-                        targets = mgr.diddoc_connection_targets(
-                            context.message.connection.did_doc,
-                            context.message_receipt.recipient_verkey,
-                        )
-                    except ConnectionManagerError:
-                        self._logger.exception(
-                            "Error parsing DIDDoc for problem report"
-                        )
+            report, targets = mgr.manager_error_to_problem_report(
+                e, context.message, context.message_receipt
+            )
+            if report and targets:
                 await responder.send_reply(
-                    ConnectionProblemReport(
-                        description={"en": e.message, "code": e.error_code}
-                    ),
+                    message=report,
                     target_list=targets,
                 )

--- a/aries_cloudagent/protocols/didexchange/v1_0/handlers/invitation_handler.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/handlers/invitation_handler.py
@@ -5,9 +5,7 @@ from .....messaging.base_handler import (
     BaseResponder,
     RequestContext,
 )
-
 from ....out_of_band.v1_0.messages.invitation import InvitationMessage
-
 from ..messages.problem_report import DIDXProblemReport, ProblemReportReason
 
 
@@ -34,6 +32,6 @@ class InvitationHandler(BaseHandler):
                 ),
             }
         )
-
+        report.assign_thread_from(context.message)
         # client likely needs to be using direct responses to receive the problem report
         await responder.send_reply(report)

--- a/aries_cloudagent/protocols/didexchange/v1_0/handlers/problem_report_handler.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/handlers/problem_report_handler.py
@@ -1,11 +1,13 @@
 """Problem report handler for DID Exchange."""
 
+from .....connections.models.conn_record import ConnRecord
 from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     HandlerException,
     RequestContext,
 )
+from .....storage.error import StorageNotFoundError
 from ..manager import DIDXManager, DIDXManagerError
 from ..messages.problem_report import DIDXProblemReport
 
@@ -22,10 +24,19 @@ class DIDXProblemReportHandler(BaseHandler):
         profile = context.profile
         mgr = DIDXManager(profile)
         try:
-            if context.connection_record:
-                await mgr.receive_problem_report(
-                    context.connection_record, context.message
-                )
+            conn_rec = context.connection_record
+            if not conn_rec:
+                # try to find connection by thread_id/request_id
+                try:
+                    async with profile.session() as session:
+                        conn_rec = await ConnRecord.retrieve_by_request_id(
+                            session, context.message._thread_id
+                        )
+                except StorageNotFoundError:
+                    pass
+
+            if conn_rec:
+                await mgr.receive_problem_report(conn_rec, context.message)
             else:
                 raise HandlerException("No connection established for problem report")
         except DIDXManagerError:

--- a/aries_cloudagent/protocols/didexchange/v1_0/handlers/request_handler.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/handlers/request_handler.py
@@ -1,8 +1,6 @@
 """Connection request handler under RFC 23 (DID exchange)."""
 
-from aries_cloudagent.protocols.didexchange.v1_0.messages.problem_report import (
-    DIDXProblemReport,
-)
+
 from .....connections.models.conn_record import ConnRecord
 from .....messaging.base_handler import BaseHandler, BaseResponder, RequestContext
 from ....coordinate_mediation.v1_0.manager import MediationManager
@@ -45,7 +43,6 @@ class DIDXRequestHandler(BaseHandler):
                     else context.message_receipt.recipient_verkey
                 ),
             )
-
             # Auto respond
             if conn_rec.accept == ConnRecord.ACCEPT_AUTO:
                 response = await mgr.create_response(
@@ -62,22 +59,11 @@ class DIDXRequestHandler(BaseHandler):
                 self._logger.debug("DID exchange request will await acceptance")
 
         except DIDXManagerError as e:
-            self._logger.exception("Error receiving RFC 23 connection request")
-            if e.error_code:
-                targets = None
-                if context.message.did_doc_attach:
-                    try:
-                        targets = mgr.diddoc_connection_targets(
-                            context.message.did_doc_attach,
-                            context.message_receipt.recipient_verkey,
-                        )
-                    except DIDXManagerError:
-                        self._logger.exception(
-                            "Error parsing DIDDoc for problem report"
-                        )
+            report, targets = await mgr.manager_error_to_problem_report(
+                e, context.message, context.message_receipt
+            )
+            if report and targets:
                 await responder.send_reply(
-                    DIDXProblemReport(
-                        description={"en": e.message, "code": e.error_code}
-                    ),
+                    message=report,
                     target_list=targets,
                 )

--- a/aries_cloudagent/protocols/didexchange/v1_0/handlers/response_handler.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/handlers/response_handler.py
@@ -1,16 +1,12 @@
 """DID exchange response handler under RFC 23."""
 
-from aries_cloudagent.protocols.didexchange.v1_0.messages.problem_report import (
-    DIDXProblemReport,
-)
+
 from .....messaging.base_handler import (
     BaseHandler,
     BaseResponder,
     RequestContext,
 )
-
 from ....trustping.v1_0.messages.ping import Ping
-
 from ..manager import DIDXManager, DIDXManagerError
 from ..messages.response import DIDXResponse
 
@@ -35,23 +31,12 @@ class DIDXResponseHandler(BaseHandler):
                 context.message, context.message_receipt
             )
         except DIDXManagerError as e:
-            self._logger.exception("Error receiving DID exchange response")
-            if e.error_code:
-                targets = None
-                if context.message.did_doc_attach:
-                    try:
-                        targets = mgr.diddoc_connection_targets(
-                            context.message.did_doc_attach,
-                            context.message_receipt.recipient_verkey,
-                        )
-                    except DIDXManagerError:
-                        self._logger.exception(
-                            "Error parsing DIDDoc for problem report"
-                        )
+            report, targets = await mgr.manager_error_to_problem_report(
+                e, context.message, context.message_receipt
+            )
+            if report and targets:
                 await responder.send_reply(
-                    DIDXProblemReport(
-                        description={"en": e.message, "code": e.error_code}
-                    ),
+                    message=report,
                     target_list=targets,
                 )
             return

--- a/aries_cloudagent/protocols/didexchange/v1_0/message_types.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/message_types.py
@@ -21,5 +21,8 @@ MESSAGE_TYPES = DIDCommPrefix.qualify_all(
         DIDX_REQUEST: f"{PROTOCOL_PACKAGE}.messages.request.DIDXRequest",
         DIDX_RESPONSE: f"{PROTOCOL_PACKAGE}.messages.response.DIDXResponse",
         DIDX_COMPLETE: f"{PROTOCOL_PACKAGE}.messages.complete.DIDXComplete",
+        PROBLEM_REPORT: (
+            f"{PROTOCOL_PACKAGE}.messages.problem_report.DIDXProblemReport"
+        ),
     }
 )

--- a/aries_cloudagent/protocols/didexchange/v1_0/messages/problem_report.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/messages/problem_report.py
@@ -1,17 +1,16 @@
 """DID Exchange problem report and reasons."""
 
-from enum import Enum
 import logging
+from enum import Enum
 
 from marshmallow import EXCLUDE, ValidationError, validates_schema
 
 from ....problem_report.v1_0.message import ProblemReport, ProblemReportSchema
 from ..message_types import PROBLEM_REPORT
 
-
 HANDLER_CLASS = (
     "aries_cloudagent.protocols.didexchange.v1_0.handlers."
-    "problem_report_handler.ProblemReportHandler"
+    "problem_report_handler.DIDXProblemReportHandler"
 )
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
- add current message thread to problem report messages to identify which message/thread encountered the problem.
- problem report handlers will find connections based on thread/request id
- register didx problem report so handler will be active and deal with didx problem reports
- update tests to match new handler logic

fixes #2650 
fixes #2598

A lot of underlying issues uncovered (and now addressed) arising from #2530 investigation. 

Synopsis is the implemented logic for sending/handling connection (and didx) problem reports that require a fully working connection. This prevented us from notifying if the problem arose during the request or early response stages. That is addressed by allowing the problem report message types to skip the active check in the responder. Then the next issue was the agent receiving the problem report could not match up their connection, so the sender adds the failing message's thread to the problem report message before delivery, the receiver can then look up connections by a known thread id. Then the DIDX problem report code was always failing when trying to determine the messages targets, so that code was updated to handle diddoc attach conversion to diddoc and then resolve the targets. Then uncovered the fact that the DIDX problem reports (and handler) were not registered in the protocol message registry so those wouldn't get handled when we finally parsed the targets.

Sigh, lots of stuff that just never worked... 🤷 ...hoping that these fixes will be of use when there are issues in the early stages of connecting agents.
