### PR TITLE
Slight improvement to credx proof validation error message

### DIFF
--- a/aries_cloudagent/indy/credx/verifier.py
+++ b/aries_cloudagent/indy/credx/verifier.py
@@ -62,7 +62,8 @@ class IndyCredxVerifier(IndyVerifier):
             msgs.append(f"{PresVerifyMsg.PRES_VALUE_ERROR.value}::{s}")
             LOGGER.error(
                 f"Presentation on nonce={pres_req['nonce']} "
-                f"cannot be validated: {str(err)}"
+                f"cannot be validated (presentation will be marked as Invalid)"
+                f": {str(err)}"
             )
             return (False, msgs)
 


### PR DESCRIPTION
Slight improvement to an error message.  (This confused me as it logged a stack trace during integration testing but didn't report a failed test.  Reason = it's not an error, just a proof validation failure.)
