### PR TITLE
Tweak scope of GHA integration tests

### DIFF
--- a/demo/features/0160-connection.feature
+++ b/demo/features/0160-connection.feature
@@ -1,6 +1,6 @@
 Feature: RFC 0160 Aries agent connection functions
 
-   @T001-RFC0160 @GHA
+   @T001-RFC0160
    Scenario Outline: establish a connection between two agents
       Given we have "2" agents
          | name  | role    | capabilities        |
@@ -11,6 +11,7 @@ Feature: RFC 0160 Aries agent connection functions
       Then "Acme" has an active connection
       And "Bob" has an active connection
 
+      @GHA @WalletType_Askar
       Examples:
          | Acme_capabilities                      | Bob_capabilities          |
          | --public-did                           |                           |
@@ -18,6 +19,10 @@ Feature: RFC 0160 Aries agent connection functions
          | --public-did --mediation               | --mediation               |
          | --public-did --multitenant             | --multitenant             |
          | --public-did --mediation --multitenant | --mediation --multitenant |
+
+      @GHA @WalletType_Askar_AnonCreds
+      Examples:
+         | Acme_capabilities                      | Bob_capabilities          |
          | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds |
          | --public-did --wallet-type askar-anoncreds |                               |
          | --public-did                           | --wallet-type askar-anoncreds |

--- a/demo/features/0453-issue-credential.feature
+++ b/demo/features/0453-issue-credential.feature
@@ -1,7 +1,7 @@
 @RFC0453
 Feature: RFC 0453 Aries agent issue credential
 
-  @T003-RFC0453 @GHA
+  @T003-RFC0453
   Scenario Outline: Issue a credential with the Issuer beginning with an offer
     Given we have "2" agents
       | name  | role    | capabilities        |
@@ -12,17 +12,22 @@ Feature: RFC 0453 Aries agent issue credential
     When "Acme" offers a credential with data <Credential_data>
     Then "Bob" has the credential issued
 
+    @GHA @WalletType_Askar
     Examples:
        | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
        | --public-did                           |                           | driverslicense | Data_DL_NormalizedValues |
        | --public-did --did-exchange            | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
        | --public-did --mediation               | --mediation               | driverslicense | Data_DL_NormalizedValues |
        | --public-did --multitenant             | --multitenant             | driverslicense | Data_DL_NormalizedValues |
+
+    @GHA @WalletType_Askar_AnonCreds
+    Examples:
+       | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
        | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
        | --public-did --wallet-type askar-anoncreds |                               | driverslicense | Data_DL_NormalizedValues |
        | --public-did                           | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
 
-  @T003-RFC0453 @GHA
+  @T003-RFC0453
   Scenario Outline: Holder accepts a deleted credential offer
     Given we have "2" agents
       | name  | role    | capabilities        |
@@ -33,15 +38,24 @@ Feature: RFC 0453 Aries agent issue credential
     And "Acme" offers and deletes a credential with data <Credential_data>
     Then "Bob" has the exchange abandoned
 
+    @GHA @WalletType_Askar
     Examples:
        | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
        | --public-did                           |                           | driverslicense | Data_DL_NormalizedValues |
-       | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
-       #| --public-did --did-exchange            | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
-       #| --public-did --mediation               | --mediation               | driverslicense | Data_DL_NormalizedValues |
-       #| --public-did --multitenant             | --multitenant             | driverslicense | Data_DL_NormalizedValues |
 
-  @T003-RFC0453 @GHA
+    @WalletType_Askar_AnonCreds
+    Examples:
+       | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
+       | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
+
+    @WalletType_Askar
+    Examples:
+       | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
+       | --public-did --did-exchange            | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
+       | --public-did --mediation               | --mediation               | driverslicense | Data_DL_NormalizedValues |
+       | --public-did --multitenant             | --multitenant             | driverslicense | Data_DL_NormalizedValues |
+
+  @T003-RFC0453
   Scenario Outline: Issue a credential with the holder sending a request
     Given we have "2" agents
       | name  | role    | capabilities        |
@@ -51,16 +65,25 @@ Feature: RFC 0453 Aries agent issue credential
     And "Acme" is ready to issue a credential for <Schema_name>
     When "Bob" requests a credential with data <Credential_data> from "Acme" it fails
 
+    @GHA @WalletType_Askar
     Examples:
        | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
        | --public-did                           |                           | driverslicense | Data_DL_NormalizedValues |
+
+    @WalletType_Askar_AnonCreds
+    Examples:
+       | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
        | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
-       #| --public-did --did-exchange            | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
-       #| --public-did --mediation               | --mediation               | driverslicense | Data_DL_NormalizedValues |
-       #| --public-did --multitenant             | --multitenant             | driverslicense | Data_DL_NormalizedValues |
+
+    @WalletType_Askar
+    Examples:
+       | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
+       | --public-did --did-exchange            | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
+       | --public-did --mediation               | --mediation               | driverslicense | Data_DL_NormalizedValues |
+       | --public-did --multitenant             | --multitenant             | driverslicense | Data_DL_NormalizedValues |
 
 
-  @T003.1-RFC0453 @GHA
+  @T003.1-RFC0453
   Scenario Outline: Holder accepts a deleted json-ld credential offer
     Given we have "2" agents
       | name  | role    | capabilities        |
@@ -73,15 +96,24 @@ Feature: RFC 0453 Aries agent issue credential
     Then "Bob" has the json-ld credential issued
     And "Acme" has the exchange completed
 
+    @GHA @WalletType_Askar
     Examples:
        | Acme_capabilities                                   | Bob_capabilities          | Schema_name    | Credential_data          |
        | --public-did --cred-type json-ld                    |                           | driverslicense | Data_DL_NormalizedValues |
-       | --public-did --cred-type json-ld --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
-       # | --public-did --cred-type json-ld --did-exchange     | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
-       # | --public-did --cred-type json-ld --mediation        | --mediation               | driverslicense | Data_DL_NormalizedValues |
-       # | --public-did --cred-type json-ld --multitenant      | --multitenant             | driverslicense | Data_DL_NormalizedValues |
 
-  @T003.1-RFC0453 @GHA
+    @WalletType_Askar_AnonCreds
+    Examples:
+       | Acme_capabilities                                   | Bob_capabilities          | Schema_name    | Credential_data          |
+       | --public-did --cred-type json-ld --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
+
+    @WalletType_Askar
+    Examples:
+       | Acme_capabilities                                   | Bob_capabilities          | Schema_name    | Credential_data          |
+       | --public-did --cred-type json-ld --did-exchange     | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
+       | --public-did --cred-type json-ld --mediation        | --mediation               | driverslicense | Data_DL_NormalizedValues |
+       | --public-did --cred-type json-ld --multitenant      | --multitenant             | driverslicense | Data_DL_NormalizedValues |
+
+  @T003.1-RFC0453
   Scenario Outline: Issue a json-ld credential with the Issuer beginning with an offer
     Given we have "2" agents
       | name  | role    | capabilities        |
@@ -93,19 +125,28 @@ Feature: RFC 0453 Aries agent issue credential
     When "Acme" offers "Bob" a json-ld credential with data <Credential_data>
     Then "Bob" has the json-ld credential issued
 
+    @GHA @WalletType_Askar
     Examples:
        | Acme_capabilities                                   | Bob_capabilities          | Schema_name    | Credential_data          |
        | --public-did --cred-type json-ld                    |                           | driverslicense | Data_DL_NormalizedValues |
        | --public-did --cred-type json-ld --did-exchange     | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
        | --public-did --cred-type json-ld --mediation        | --mediation               | driverslicense | Data_DL_NormalizedValues |
        | --public-did --cred-type json-ld --multitenant      | --multitenant             | driverslicense | Data_DL_NormalizedValues |
+
+    @GHA @WalletType_Askar_AnonCreds
+    Examples:
+       | Acme_capabilities                                   | Bob_capabilities          | Schema_name    | Credential_data          |
        | --public-did --cred-type json-ld --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
        | --public-did --cred-type json-ld --did-exchange --wallet-type askar-anoncreds | --did-exchange --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
+
+    @WalletType_Askar_AnonCreds
+    Examples:
+       | Acme_capabilities                                   | Bob_capabilities          | Schema_name    | Credential_data          |
        | --public-did --cred-type json-ld --mediation --wallet-type askar-anoncreds | --mediation --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
        | --public-did --cred-type json-ld --multitenant --wallet-type askar-anoncreds | --multitenant --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
 
 
-  @T003.1-RFC0453 @GHA
+  @T003.1-RFC0453
   Scenario Outline: Issue a json-ld credential with the holder beginning with a request
     Given we have "2" agents
       | name  | role    | capabilities        |
@@ -117,16 +158,21 @@ Feature: RFC 0453 Aries agent issue credential
     When "Bob" requests a json-ld credential with data <Credential_data> from "Acme"
     Then "Bob" has the json-ld credential issued
 
+    @GHA @WalletType_Askar
     Examples:
        | Acme_capabilities                                   | Bob_capabilities          | Schema_name    | Credential_data          |
        | --public-did --cred-type json-ld                    |                           | driverslicense | Data_DL_NormalizedValues |
        | --public-did --cred-type json-ld --did-exchange     | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
        | --public-did --cred-type json-ld --mediation        | --mediation               | driverslicense | Data_DL_NormalizedValues |
        | --public-did --cred-type json-ld --multitenant      | --multitenant             | driverslicense | Data_DL_NormalizedValues |
+
+    @GHA @WalletType_Askar_AnonCreds
+    Examples:
+       | Acme_capabilities                                   | Bob_capabilities          | Schema_name    | Credential_data          |
        | --public-did --cred-type json-ld --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
 
 
-  @T004-RFC0453 @GHA
+  @T004-RFC0453
   Scenario Outline: Issue a credential with revocation, with the Issuer beginning with an offer, and then revoking the credential
     Given we have "2" agents
       | name  | role    | capabilities        |
@@ -137,11 +183,16 @@ Feature: RFC 0453 Aries agent issue credential
     Then "Acme" revokes the credential
     And "Bob" has the credential issued
 
+    @GHA @WalletType_Askar
     Examples:
        | Acme_capabilities                        | Bob_capabilities  | Schema_name    | Credential_data          |
        | --revocation --public-did                |                   | driverslicense | Data_DL_NormalizedValues |
        | --revocation --public-did --did-exchange | --did-exchange    | driverslicense | Data_DL_NormalizedValues |
        | --revocation --public-did --multitenant  | --multitenant     | driverslicense | Data_DL_NormalizedValues |
+
+    @WalletType_Askar_AnonCreds
+    Examples:
+       | Acme_capabilities                        | Bob_capabilities  | Schema_name    | Credential_data          |
        | --revocation --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
 
   @T004.1-RFC0453
@@ -155,7 +206,12 @@ Feature: RFC 0453 Aries agent issue credential
     Then "Acme" revokes the credential
     And "Bob" has the credential issued
 
+    @WalletType_Askar
     Examples:
        | Acme_capabilities                        | Bob_capabilities  | Schema_name    | Credential_data          |
        | --revocation --public-did --mediation    | --mediation       | driverslicense | Data_DL_NormalizedValues |
+
+    @WalletType_Askar_AnonCreds
+    Examples:
+       | Acme_capabilities                        | Bob_capabilities  | Schema_name    | Credential_data          |
        | --revocation --public-did --mediation --wallet-type askar-anoncreds | --mediation --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |

--- a/demo/features/0454-present-proof.feature
+++ b/demo/features/0454-present-proof.feature
@@ -1,6 +1,6 @@
 Feature: RFC 0454 Aries agent present proof
 
-   @T001-RFC0454 @GHA
+   @T001-RFC0454
    Scenario Outline: Present Proof where the prover does not propose a presentation of the proof and is acknowledged
       Given we have "2" agents
          | name  | role     | capabilities        |
@@ -12,10 +12,15 @@ Feature: RFC 0454 Aries agent present proof
       When "Faber" sends a request for proof presentation <Proof_request> to "Bob"
       Then "Faber" has the proof verified
 
+      @GHA @WalletType_Askar
       Examples:
          | issuer | Acme_capabilities                      | Bob_capabilities          | Schema_name       | Credential_data   | Proof_request     |
          | Faber  | --public-did                           |                           | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Faber  | --public-did --did-exchange            | --did-exchange            | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
+
+      @GHA @WalletType_Askar_AnonCreds
+      Examples:
+         | issuer | Acme_capabilities                      | Bob_capabilities          | Schema_name       | Credential_data   | Proof_request     |
          | Faber  | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Faber  | --public-did --wallet-type askar-anoncreds |                               | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Faber  | --public-did                           | --wallet-type askar-anoncreds | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
@@ -34,17 +39,22 @@ Feature: RFC 0454 Aries agent present proof
       When "Faber" sends a request for proof presentation <Proof_request> to "Bob"
       Then "Faber" has the proof verified
 
+      @WalletType_Askar
       Examples:
          | issuer | Acme_capabilities                      | Bob_capabilities          | Schema_name       | Credential_data   | Proof_request     |
          | Acme   | --public-did                           |                           | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Faber  | --public-did                           |                           | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Acme   | --public-did --mediation --multitenant | --mediation --multitenant | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
+
+      @WalletType_Askar_AnonCreds
+      Examples:
+         | issuer | Acme_capabilities                      | Bob_capabilities          | Schema_name       | Credential_data   | Proof_request     |
          | Faber  | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Faber  | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Acme   | --public-did --mediation --multitenant | --mediation --multitenant | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
 
 
-   @T001.2-RFC0454 @GHA
+   @T001.2-RFC0454
    Scenario Outline: Present Proof json-ld where the prover does not propose a presentation of the proof and is acknowledged
       Given we have "3" agents
          | name  | role     | capabilities        |
@@ -57,14 +67,19 @@ Feature: RFC 0454 Aries agent present proof
       When "Faber" sends a request for json-ld proof presentation <Proof_request> to "Bob"
       Then "Faber" has the proof verified
 
+      @GHA @WalletType_Askar
       Examples:
          | issuer | Acme_capabilities                                         | Bob_capabilities          | Schema_name       | Credential_data   | Proof_request     |
          | Acme   | --public-did --cred-type json-ld                          |                           | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Faber  | --public-did --cred-type json-ld --did-exchange           | --did-exchange            | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
+
+      @WalletType_Askar_AnonCreds
+      Examples:
+         | issuer | Acme_capabilities                                         | Bob_capabilities          | Schema_name       | Credential_data   | Proof_request     |
          | Faber  | --public-did --cred-type json-ld --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
 
 
-   @T002-RFC0454 @GHA
+   @T002-RFC0454
    Scenario Outline: Present Proof where the issuer revokes the credential and the proof fails
       Given we have "2" agents
          | name  | role     | capabilities        |
@@ -77,10 +92,15 @@ Feature: RFC 0454 Aries agent present proof
       When "Faber" sends a request for proof presentation <Proof_request> to "Bob"
       Then "Faber" has the proof verification fail
 
+      @GHA @WalletType_Askar
       Examples:
          | issuer | Acme_capabilities                          | Bob_capabilities | Schema_name       | Credential_data   | Proof_request     |
          | Faber  | --revocation --public-did                  |                  | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Faber  | --revocation --public-did --did-exchange   | --did-exchange   | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
+
+      @GHA @WalletType_Askar_AnonCreds
+      Examples:
+         | issuer | Acme_capabilities                          | Bob_capabilities | Schema_name       | Credential_data   | Proof_request     |
          | Faber  | --revocation --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
 
 
@@ -98,17 +118,22 @@ Feature: RFC 0454 Aries agent present proof
       When "Faber" sends a request for proof presentation <Proof_request> to "Bob"
       Then "Faber" has the proof verification fail
 
+      @WalletType_Askar
       Examples:
          | issuer | Acme_capabilities                          | Bob_capabilities | Schema_name       | Credential_data   | Proof_request     |
          | Acme   | --revocation --public-did                  |                  | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Faber  | --revocation --public-did                  |                  | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Acme   | --revocation --public-did --mediation      |                  | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Acme   | --revocation --public-did --multitenant    | --multitenant    | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
+
+      @WalletType_Askar_AnonCreds
+      Examples:
+         | issuer | Acme_capabilities                          | Bob_capabilities | Schema_name       | Credential_data   | Proof_request     |
          | Faber  | --revocation --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Acme   | --revocation --public-did --mediation --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Acme   | --revocation --public-did --multitenant --wallet-type askar-anoncreds | --multitenant --wallet-type askar-anoncreds | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
 
-   @T003-RFC0454.1 @GHA
+   @T003-RFC0454.1
    Scenario Outline: Present Proof for multiple credentials where the one is revocable and one isn't, neither credential is revoked
       Given we have "4" agents
          | name  | role     | capabilities         |
@@ -124,9 +149,14 @@ Feature: RFC 0454 Aries agent present proof
       When "Faber" sends a request for proof presentation <Proof_request> to "Bob"
       Then "Faber" has the proof verified
 
+      @GHA @WalletType_Askar
       Examples:
          | issuer1 | Acme1_capabilities        | issuer2 | Acme2_capabilities | Bob_cap | Schema_name_1     | Credential_data_1 | Schema_name_2 | Credential_data_2 | Proof_request                    |
          | Acme1   | --revocation --public-did | Acme2   | --public-did       |         | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id |
+
+      @WalletType_Askar_AnonCreds
+      Examples:
+         | issuer1 | Acme1_capabilities        | issuer2 | Acme2_capabilities | Bob_cap | Schema_name_1     | Credential_data_1 | Schema_name_2 | Credential_data_2 | Proof_request                    |
          | Acme1   | --revocation --public-did --wallet-type askar-anoncreds | Acme2   | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id |
 
    @T003-RFC0454.1f
@@ -145,12 +175,17 @@ Feature: RFC 0454 Aries agent present proof
       When "Faber" sends a request for proof presentation <Proof_request> to "Bob"
       Then "Faber" has the proof verification fail
 
+      @WalletType_Askar
       Examples:
          | issuer1 | Acme1_capabilities        | issuer2 | Acme2_capabilities | Bob_cap | Schema_name_1     | Credential_data_1 | Schema_name_2 | Credential_data_2 | Proof_request                    |
          | Acme1   | --revocation --public-did | Acme2   | --public-did       |         | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id_r2 |
+
+      @WalletType_Askar_AnonCreds
+      Examples:
+         | issuer1 | Acme1_capabilities        | issuer2 | Acme2_capabilities | Bob_cap | Schema_name_1     | Credential_data_1 | Schema_name_2 | Credential_data_2 | Proof_request                    |
          | Acme1   | --revocation --public-did --wallet-type askar-anoncreds | Acme2   | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id_r2 |
 
-   @T003-RFC0454.2 @GHA
+   @T003-RFC0454.2
    Scenario Outline: Present Proof for multiple credentials where the one is revocable and one isn't, and the revocable credential is revoked, and the proof checks for revocation and fails
       Given we have "4" agents
          | name  | role     | capabilities         |
@@ -167,13 +202,18 @@ Feature: RFC 0454 Aries agent present proof
       When "Faber" sends a request for proof presentation <Proof_request> to "Bob"
       Then "Faber" has the proof verification fail
 
+      @GHA @WalletType_Askar
       Examples:
          | issuer1 | Acme1_capabilities        | issuer2 | Acme2_capabilities | Bob_cap | Schema_name_1     | Credential_data_1 | Schema_name_2 | Credential_data_2 | Proof_request                    |
          | Acme1   | --revocation --public-did | Acme2   | --public-did       |         | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id |
          | Acme1   | --revocation --public-did | Acme2   | --public-did       |         | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id_r2 |
+
+      @WalletType_Askar_AnonCreds
+      Examples:
+         | issuer1 | Acme1_capabilities        | issuer2 | Acme2_capabilities | Bob_cap | Schema_name_1     | Credential_data_1 | Schema_name_2 | Credential_data_2 | Proof_request                    |
          | Acme1   | --revocation --public-did --wallet-type askar-anoncreds | Acme2   | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id |
 
-   @T003-RFC0454.3 @GHA
+   @T003-RFC0454.3
    Scenario Outline: Present Proof for multiple credentials where the one is revocable and one isn't, and the revocable credential is revoked, and the proof doesn't check for revocation and passes
       Given we have "4" agents
          | name  | role     | capabilities         |
@@ -190,7 +230,12 @@ Feature: RFC 0454 Aries agent present proof
       When "Faber" sends a request with explicit revocation status for proof presentation <Proof_request> to "Bob"
       Then "Faber" has the proof verified
 
+      @GHA @WalletType_Askar
       Examples:
          | issuer1 | Acme1_capabilities        | issuer2 | Acme2_capabilities | Bob_cap | Schema_name_1     | Credential_data_1 | Schema_name_2 | Credential_data_2 | Proof_request                             |
          | Acme1   | --revocation --public-did | Acme2   | --public-did       |         | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id_no_revoc |
+
+      @WalletType_Askar_AnonCreds
+      Examples:
+         | issuer1 | Acme1_capabilities        | issuer2 | Acme2_capabilities | Bob_cap | Schema_name_1     | Credential_data_1 | Schema_name_2 | Credential_data_2 | Proof_request                             |
          | Acme1   | --revocation --public-did --wallet-type askar-anoncreds | Acme2   | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense_v2 | Data_DL_MaxValues | health_id     | Data_DL_MaxValues | DL_age_over_19_v2_with_health_id_no_revoc |


### PR DESCRIPTION
Move the @GHA tag to the scenarios of each test to allow for some fine tuning of what is included in the github actions.  Exclude most of the AnonCreds tests (but keep a representative sample included).  Add tags for Askar vs Askar-anoncreds wallet types.


