### PR TITLE
Return 404 when schema not found

### DIFF
--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -1,9 +1,11 @@
 """Legacy Indy Registry."""
-from asyncio import shield
 import json
 import logging
 import re
+from asyncio import shield
 from typing import List, Optional, Pattern, Sequence, Tuple
+
+from base58 import alphabet
 
 from ....cache.base import BaseCache
 from ....config.injection_context import InjectionContext
@@ -40,14 +42,14 @@ from ...models.anoncreds_cred_def import (
     GetCredDefResult,
 )
 from ...models.anoncreds_revocation import (
-    GetRevRegDefResult,
     GetRevListResult,
-    RevRegDef,
-    RevRegDefResult,
-    RevRegDefState,
+    GetRevRegDefResult,
     RevList,
     RevListResult,
     RevListState,
+    RevRegDef,
+    RevRegDefResult,
+    RevRegDefState,
     RevRegDefValue,
 )
 from ...models.anoncreds_schema import (
@@ -56,7 +58,6 @@ from ...models.anoncreds_schema import (
     SchemaResult,
     SchemaState,
 )
-from base58 import alphabet
 
 LOGGER = logging.getLogger(__name__)
 
@@ -158,7 +159,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
                 schema = await ledger.get_schema(schema_id)
                 if schema is None:
                     raise AnonCredsObjectNotFound(
-                        f"Credential definition not found: {schema_id}",
+                        f"Schema not found: {schema_id}",
                         {"ledger_id": ledger_id},
                     )
 

--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -12,7 +12,6 @@ from aiohttp_apispec import (
     request_schema,
     response_schema,
 )
-
 from marshmallow import fields
 from marshmallow.validate import Regexp
 
@@ -397,6 +396,8 @@ async def schemas_get_schema(request: web.BaseRequest):
     async with ledger:
         try:
             schema = await ledger.get_schema(schema_id)
+            if not schema:
+                raise web.HTTPNotFound(reason=f"Schema not found: {schema_id}")
         except LedgerError as err:
             raise web.HTTPBadRequest(reason=err.roll_up) from err
 


### PR DESCRIPTION
Return a 404 from schema get by id endpoints when the schema is not found.

This could probably be applied to other endpoints as well but I'll be going over the anoncreds endpoints in more detail and can look at them when i'm doing that.