### PR TITLE
Emit did:peer:2 for didexchange

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -1170,6 +1170,12 @@ class ProtocolGroup(ArgumentGroup):
                 "using unencrypted rather than encrypted tags"
             ),
         )
+        parser.add_argument(
+            "--emit-did-peer-2",
+            action="store_true",
+            env_var="ACAPY_EMIT_DID_PEER_2",
+            help=("Emit did:peer:2 DIDs in DID Exchange Protocol"),
+        )
 
     def get_settings(self, args: Namespace) -> dict:
         """Get protocol settings."""
@@ -1236,6 +1242,10 @@ class ProtocolGroup(ArgumentGroup):
         if args.exch_use_unencrypted_tags:
             settings["exch_use_unencrypted_tags"] = True
             environ["EXCH_UNENCRYPTED_TAGS"] = "True"
+
+        if args.emit_did_peer_2:
+            settings["emit_did_peer_2"] = True
+
         return settings
 
 

--- a/aries_cloudagent/config/default_per_tenant_logging_config.ini
+++ b/aries_cloudagent/config/default_per_tenant_logging_config.ini
@@ -1,27 +1,28 @@
 [loggers]
-keys=root
+keys = root
 
 [handlers]
-keys=stream_handler, timed_file_handler
+keys = stream_handler, timed_file_handler
 
 [formatters]
-keys=formatter
+keys = formatter
 
 [logger_root]
-level=ERROR
-handlers=stream_handler, timed_file_handler
+level = ERROR
+handlers = stream_handler, timed_file_handler
 
 [handler_stream_handler]
-class=StreamHandler
-level=DEBUG
-formatter=formatter
-args=(sys.stderr,)
+class = StreamHandler
+level = DEBUG
+formatter = formatter
+args = (sys.stderr,)
 
 [handler_timed_file_handler]
-class=logging.handlers.TimedRotatingFileMultiProcessHandler
-level=DEBUG
-formatter=formatter
-args=('/home/aries/log/acapy-agent.log', 'd', 7, 1,)
+class = logging.handlers.TimedRotatingFileMultiProcessHandler
+level = DEBUG
+formatter = formatter
+args = ('test.log', 'd', 7, 1)
 
 [formatter_formatter]
-format=%(asctime)s %(wallet_id)s %(levelname)s %(pathname)s:%(lineno)d %(message)s
+format = %(asctime)s %(wallet_id)s %(levelname)s %(pathname)s:%(lineno)d %(message)s
+

--- a/aries_cloudagent/config/default_per_tenant_logging_config.yml
+++ b/aries_cloudagent/config/default_per_tenant_logging_config.yml
@@ -1,23 +1,23 @@
-version: 1
 formatters:
   default:
     format: '%(asctime)s %(wallet_id)s %(levelname)s %(pathname)s:%(lineno)d %(message)s'
 handlers:
   console:
     class: logging.StreamHandler
-    level: DEBUG
     formatter: default
+    level: DEBUG
     stream: ext://sys.stderr
   rotating_file:
-    class: logging.handlers.TimedRotatingFileMultiProcessHandler
-    level: DEBUG
-    filename: '/home/aries/log/acapy-agent.log'
-    when: 'd'
-    interval: 7
     backupCount: 1
+    class: logging.handlers.TimedRotatingFileMultiProcessHandler
+    filename: test.log
     formatter: default
+    interval: 7
+    level: DEBUG
+    when: d
 root:
-  level: INFO
   handlers:
-    - console
-    - rotating_file
+  - console
+  - rotating_file
+  level: INFO
+version: 1

--- a/aries_cloudagent/connections/base_manager.py
+++ b/aries_cloudagent/connections/base_manager.py
@@ -19,6 +19,7 @@ from pydid.verification_method import (
     Ed25519VerificationKey2018,
     Ed25519VerificationKey2020,
     JsonWebKey2020,
+    Multikey,
 )
 
 from ..cache.base import BaseCache
@@ -440,6 +441,13 @@ class BaseConnectionManager:
                     f"Key type {type(method).__name__} "
                     f"with kty {method.public_key_jwk.get('kty')} is not supported"
                 )
+        elif isinstance(method, Multikey):
+            codec, key = multicodec.unwrap(multibase.decode(method.material))
+            if codec != multicodec.multicodec("ed25519-pub"):
+                raise BaseConnectionManagerError(
+                    "Expected ed25519 multicodec, got: %s", codec
+                )
+            return bytes_to_b58(key)
         else:
             raise BaseConnectionManagerError(
                 f"Key type {type(method).__name__} is not supported"

--- a/aries_cloudagent/connections/base_manager.py
+++ b/aries_cloudagent/connections/base_manager.py
@@ -118,7 +118,7 @@ class BaseConnectionManager:
                     "id": f"#didcomm-{index}",
                     "type": "did-communication",
                     "priority": index,
-                    "recipientKeys": ["#keys-1"],
+                    "recipientKeys": ["#key-1"],
                     "routingKeys": routing_keys,
                     "serviceEndpoint": endpoint,
                 }

--- a/aries_cloudagent/messaging/decorators/attach_decorator.py
+++ b/aries_cloudagent/messaging/decorators/attach_decorator.py
@@ -598,6 +598,40 @@ class AttachDecorator(BaseModel):
             return None
 
     @classmethod
+    def data_base65_string(
+        cls,
+        content: str,
+        *,
+        ident: str = None,
+        description: str = None,
+        filename: str = None,
+        lastmod_time: str = None,
+        byte_count: int = None,
+    ):
+        """Create `AttachDecorator` instance on base64-encoded string data.
+
+        Given string content, base64-encode, and embed it as data; mark
+        `text/string` MIME type.
+
+        Args:
+            content: string content
+            ident: optional attachment identifier (default random UUID4)
+            description: optional attachment description
+            filename: optional attachment filename
+            lastmod_time: optional attachment last modification time
+            byte_count: optional attachment byte count
+        """
+        return AttachDecorator(
+            ident=ident or str(uuid.uuid4()),
+            description=description,
+            filename=filename,
+            mime_type="text/string",
+            lastmod_time=lastmod_time,
+            byte_count=byte_count,
+            data=AttachDecoratorData(base64_=bytes_to_b64(content.encode())),
+        )
+
+    @classmethod
     def data_base64(
         cls,
         mapping: Mapping,

--- a/aries_cloudagent/messaging/decorators/attach_decorator.py
+++ b/aries_cloudagent/messaging/decorators/attach_decorator.py
@@ -598,7 +598,7 @@ class AttachDecorator(BaseModel):
             return None
 
     @classmethod
-    def data_base65_string(
+    def data_base64_string(
         cls,
         content: str,
         *,

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -655,13 +655,14 @@ class DIDXManager(BaseConnectionManager):
 
         if use_public_did or emit_did_peer_2:
             # Omit DID Doc attachment if we're using a public DID
-            attach = None
-            if conn_rec.invitation_msg_id is None:
-                # Rotation needed
-                attach = AttachDecorator.data_base64_string(did)
-                async with self.profile.session() as session:
-                    wallet = session.inject(BaseWallet)
+            attach = AttachDecorator.data_base64_string(did)
+            async with self.profile.session() as session:
+                wallet = session.inject(BaseWallet)
+                if conn_rec.invitation_key is not None:
                     await attach.data.sign(conn_rec.invitation_key, wallet)
+                else:
+                    self._logger.warning("Invitation key was not set for connection")
+                    attach = None
             response = DIDXResponse(did=did, did_rotate_attach=attach)
         else:
             did_doc = await self.create_did_document(

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -294,20 +294,6 @@ class DIDXManager(BaseConnectionManager):
 
         my_info = None
 
-        if conn_rec.my_did:
-            async with self.profile.session() as session:
-                wallet = session.inject(BaseWallet)
-                my_info = await wallet.get_local_did(conn_rec.my_did)
-        else:
-            # Create new DID for connection
-            async with self.profile.session() as session:
-                wallet = session.inject(BaseWallet)
-                my_info = await wallet.create_local_did(
-                    method=SOV,
-                    key_type=ED25519,
-                )
-                conn_rec.my_did = my_info.did
-
         # Create connection request message
         if my_endpoint:
             my_endpoints = [my_endpoint]
@@ -318,7 +304,25 @@ class DIDXManager(BaseConnectionManager):
                 my_endpoints.append(default_endpoint)
             my_endpoints.extend(self.profile.settings.get("additional_endpoints", []))
 
-        if use_public_did:
+        emit_did_peer_2 = self.profile.settings.get("emit_did_peer_2")
+        if conn_rec.my_did:
+            async with self.profile.session() as session:
+                wallet = session.inject(BaseWallet)
+                my_info = await wallet.get_local_did(conn_rec.my_did)
+        elif emit_did_peer_2:
+            my_info = await self.create_did_peer_2(my_endpoints, mediation_records)
+            conn_rec.my_did = my_info.did
+        else:
+            # Create new DID for connection
+            async with self.profile.session() as session:
+                wallet = session.inject(BaseWallet)
+                my_info = await wallet.create_local_did(
+                    method=SOV,
+                    key_type=ED25519,
+                )
+                conn_rec.my_did = my_info.did
+
+        if use_public_did or emit_did_peer_2:
             # Omit DID Doc attachment if we're using a public DID
             did_doc = None
             attach = None
@@ -605,6 +609,16 @@ class DIDXManager(BaseConnectionManager):
         async with self.profile.session() as session:
             request = await conn_rec.retrieve_request(session)
 
+        if my_endpoint:
+            my_endpoints = [my_endpoint]
+        else:
+            my_endpoints = []
+            default_endpoint = self.profile.settings.get("default_endpoint")
+            if default_endpoint:
+                my_endpoints.append(default_endpoint)
+            my_endpoints.extend(self.profile.settings.get("additional_endpoints", []))
+
+        emit_did_peer_2 = self.profile.settings.get("emit_did_peer_2")
         if conn_rec.my_did:
             async with self.profile.session() as session:
                 wallet = session.inject(BaseWallet)
@@ -620,6 +634,10 @@ class DIDXManager(BaseConnectionManager):
             did = my_info.did
             if not did.startswith("did:"):
                 did = f"did:sov:{did}"
+        elif emit_did_peer_2:
+            my_info = await self.create_did_peer_2(my_endpoints, mediation_records)
+            conn_rec.my_did = my_info.did
+            did = my_info.did
         else:
             async with self.profile.session() as session:
                 wallet = session.inject(BaseWallet)
@@ -635,20 +653,16 @@ class DIDXManager(BaseConnectionManager):
             self.profile, conn_rec, mediation_records
         )
 
-        # Create connection response message
-        if my_endpoint:
-            my_endpoints = [my_endpoint]
-        else:
-            my_endpoints = []
-            default_endpoint = self.profile.settings.get("default_endpoint")
-            if default_endpoint:
-                my_endpoints.append(default_endpoint)
-            my_endpoints.extend(self.profile.settings.get("additional_endpoints", []))
-
-        if use_public_did:
+        if use_public_did or emit_did_peer_2:
             # Omit DID Doc attachment if we're using a public DID
-            did_doc = None
             attach = None
+            if conn_rec.invitation_msg_id is None:
+                # Rotation needed
+                attach = AttachDecorator.data_base65_string(did)
+                async with self.profile.session() as session:
+                    wallet = session.inject(BaseWallet)
+                    await attach.data.sign(conn_rec.invitation_key, wallet)
+            response = DIDXResponse(did=did, did_rotate_attach=attach)
         else:
             did_doc = await self.create_did_document(
                 my_info,
@@ -659,8 +673,8 @@ class DIDXManager(BaseConnectionManager):
             async with self.profile.session() as session:
                 wallet = session.inject(BaseWallet)
                 await attach.data.sign(conn_rec.invitation_key, wallet)
+            response = DIDXResponse(did=did, did_doc_attach=attach)
 
-        response = DIDXResponse(did=did, did_doc_attach=attach)
         # Assign thread information
         response.assign_thread_from(request)
         response.assign_trace_from(request)
@@ -782,6 +796,23 @@ class DIDXManager(BaseConnectionManager):
         else:
             if response.did is None:
                 raise DIDXManagerError("No DID in response")
+
+            if response.did_rotate_attach is None:
+                raise DIDXManagerError(
+                    "did_rotate~attach required if no signed doc attachment"
+                )
+
+            self._logger.debug("did_rotate~attach found; verifying signature")
+            async with self.profile.session() as session:
+                wallet = session.inject(BaseWallet)
+                signed_did = await self.verify_rotate(
+                    wallet, response.did_rotate_attach, conn_rec.invitation_key
+                )
+                if their_did != response.did:
+                    raise DIDXManagerError(
+                        f"Connection DID {their_did} "
+                        f"does not match singed DID rotate {signed_did}"
+                    )
 
             self._logger.debug(
                 "No DID Doc attachment in response; doc will be resolved from DID"
@@ -954,6 +985,23 @@ class DIDXManager(BaseConnectionManager):
             raise DIDXManagerError("DID doc attachment signature failed verification")
 
         return json.loads(signed_diddoc_bytes.decode())
+
+    async def verify_rotate(
+        self,
+        wallet: BaseWallet,
+        attached: AttachDecorator,
+        invi_key: str = None,
+    ) -> str:
+        """Verify a signed DID rotate attachment and return did."""
+        signed_diddoc_bytes = attached.data.signed
+        if not signed_diddoc_bytes:
+            raise DIDXManagerError("DID rotate attachment is not signed.")
+        if not await attached.data.verify(wallet, invi_key):
+            raise DIDXManagerError(
+                "DID rotate attachment signature failed verification"
+            )
+
+        return signed_diddoc_bytes.decode()
 
     async def manager_error_to_problem_report(
         self,

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -658,7 +658,7 @@ class DIDXManager(BaseConnectionManager):
             attach = None
             if conn_rec.invitation_msg_id is None:
                 # Rotation needed
-                attach = AttachDecorator.data_base65_string(did)
+                attach = AttachDecorator.data_base64_string(did)
                 async with self.profile.session() as session:
                     wallet = session.inject(BaseWallet)
                     await attach.data.sign(conn_rec.invitation_key, wallet)

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -634,7 +634,7 @@ class DIDXManager(BaseConnectionManager):
             did = my_info.did
             if not did.startswith("did:"):
                 did = f"did:sov:{did}"
-        elif emit_did_peer_2:
+        elif emit_did_peer_2 or (conn_rec.their_did and conn_rec.their_did.startswith("did:peer:2")):
             my_info = await self.create_did_peer_2(my_endpoints, mediation_records)
             conn_rec.my_did = my_info.did
             did = my_info.did

--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -634,7 +634,9 @@ class DIDXManager(BaseConnectionManager):
             did = my_info.did
             if not did.startswith("did:"):
                 did = f"did:sov:{did}"
-        elif emit_did_peer_2 or (conn_rec.their_did and conn_rec.their_did.startswith("did:peer:2")):
+        elif emit_did_peer_2 or (
+            conn_rec.their_did and conn_rec.their_did.startswith("did:peer:2")
+        ):
             my_info = await self.create_did_peer_2(my_endpoints, mediation_records)
             conn_rec.my_did = my_info.did
             did = my_info.did

--- a/aries_cloudagent/protocols/didexchange/v1_0/messages/response.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/messages/response.py
@@ -29,6 +29,7 @@ class DIDXResponse(AgentMessage):
         *,
         did: str = None,
         did_doc_attach: Optional[AttachDecorator] = None,
+        did_rotate_attach: Optional[AttachDecorator] = None,
         **kwargs,
     ):
         """Initialize DID exchange response object under RFC 23.
@@ -40,6 +41,7 @@ class DIDXResponse(AgentMessage):
         super().__init__(**kwargs)
         self.did = did
         self.did_doc_attach = did_doc_attach
+        self.did_rotate_attach = did_rotate_attach
 
 
 class DIDXResponseSchema(AgentMessageSchema):
@@ -60,4 +62,10 @@ class DIDXResponseSchema(AgentMessageSchema):
         required=False,
         data_key="did_doc~attach",
         metadata={"description": "As signed attachment, DID Doc associated with DID"},
+    )
+    did_rotate_attach = fields.Nested(
+        AttachDecoratorSchema,
+        required=False,
+        data_key="did_rotate~attach",
+        metadata={"description": "As signed attachment, DID signed by invitation key"},
     )

--- a/aries_cloudagent/protocols/didexchange/v1_0/messages/tests/test_response.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/messages/tests/test_response.py
@@ -59,10 +59,13 @@ class TestDIDXResponse(IsolatedAsyncioTestCase, TestConfig):
 
         did_doc_attach = AttachDecorator.data_base64(self.make_did_doc().serialize())
         await did_doc_attach.data.sign(self.did_info.verkey, self.wallet)
+        did_rotate_attach = AttachDecorator.data_base64_string(self.test_verkey)
+        await did_rotate_attach.data.sign(self.did_info.verkey, self.wallet)
 
         self.response = DIDXResponse(
             did=TestConfig.test_did,
             did_doc_attach=did_doc_attach,
+            did_rotate_attach=did_rotate_attach,
         )
 
     def test_init(self):
@@ -116,13 +119,17 @@ class TestDIDXResponseSchema(IsolatedAsyncioTestCase, TestConfig):
 
         did_doc_attach = AttachDecorator.data_base64(self.make_did_doc().serialize())
         await did_doc_attach.data.sign(self.did_info.verkey, self.wallet)
+        did_rotate_attach = AttachDecorator.data_base64_string(self.test_verkey)
+        await did_rotate_attach.data.sign(self.did_info.verkey, self.wallet)
 
         self.response = DIDXResponse(
             did=TestConfig.test_did,
             did_doc_attach=did_doc_attach,
+            did_rotate_attach=did_rotate_attach,
         )
 
     async def test_make_model(self):
         data = self.response.serialize()
         model_instance = DIDXResponse.deserialize(data)
         assert isinstance(model_instance, DIDXResponse)
+        assert model_instance.did_rotate_attach

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -565,7 +565,6 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
             assert request.did_doc_attach is None
             mock_create_did_peer_2.assert_called_once()
 
-
     async def test_receive_request_explicit_public_did(self):
         async with self.profile.session() as session:
             mock_request = mock.MagicMock(
@@ -1645,7 +1644,7 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
         ) as mock_retrieve_req, mock.patch.object(
         conn_rec, "save", mock.CoroutineMock()
         ) as mock_save:
-            mock_create_did_peer_2.return_value = DIDInfo(
+             mock_create_did_peer_2.return_value = DIDInfo(
                 TestConfig.test_did_peer_2,
                 TestConfig.test_verkey,
                 None,

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -1903,6 +1903,7 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
 
             with self.assertRaises(DIDXManagerError):
                 await self.manager.accept_response(mock_response, receipt)
+                
     async def test_accept_response_find_by_thread_id_no_did_doc_attached(self):
         mock_response = mock.AsyncMock()
         mock_response._thread = mock.AsyncMock()

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -1903,7 +1903,7 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
 
             with self.assertRaises(DIDXManagerError):
                 await self.manager.accept_response(mock_response, receipt)
-                
+
     async def test_accept_response_find_by_thread_id_no_did_doc_attached(self):
         mock_response = mock.AsyncMock()
         mock_response._thread = mock.AsyncMock()

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -1643,7 +1643,7 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
         ) as mock_retrieve_req, mock.patch.object(
             conn_rec, "save", mock.CoroutineMock()
         ) as mock_save:
-             mock_create_did_peer_2.return_value = DIDInfo(
+            mock_create_did_peer_2.return_value = DIDInfo(
                 TestConfig.test_did_peer_2,
                 TestConfig.test_verkey,
                 None,

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -1626,7 +1626,6 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
             )
             await self.manager.create_response(conn_rec, "http://10.20.30.40:5060/")
 
-
     async def test_create_response_inkind_peer_did(self):
         # created did:peer:2 when receiving a did:peer:2, even if setting is False
         conn_rec = ConnRecord(
@@ -1640,9 +1639,9 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
         with mock.patch.object(
             self.manager, "create_did_peer_2", mock.CoroutineMock()
         ) as mock_create_did_peer_2, mock.patch.object(
-        test_module.ConnRecord, "retrieve_request", mock.CoroutineMock()
+            test_module.ConnRecord, "retrieve_request", mock.CoroutineMock()
         ) as mock_retrieve_req, mock.patch.object(
-        conn_rec, "save", mock.CoroutineMock()
+            conn_rec, "save", mock.CoroutineMock()
         ) as mock_save:
              mock_create_did_peer_2.return_value = DIDInfo(
                 TestConfig.test_did_peer_2,

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -1,10 +1,10 @@
 import json
-
 from unittest import IsolatedAsyncioTestCase
-from aries_cloudagent.tests import mock
+
 from pydid import DIDDocument
 
-from .. import manager as test_module
+from aries_cloudagent.tests import mock
+
 from .....cache.base import BaseCache
 from .....cache.in_memory import InMemoryCache
 from .....connections.models.conn_record import ConnRecord
@@ -22,7 +22,7 @@ from .....resolver.tests import DOC
 from .....storage.error import StorageNotFoundError
 from .....transport.inbound.receipt import MessageReceipt
 from .....wallet.did_info import DIDInfo
-from .....wallet.did_method import DIDMethods, SOV
+from .....wallet.did_method import SOV, DIDMethods
 from .....wallet.error import WalletError
 from .....wallet.in_memory import InMemoryWallet
 from .....wallet.key_type import ED25519
@@ -34,6 +34,7 @@ from ....discovery.v2_0.manager import V20DiscoveryMgr
 from ....out_of_band.v1_0.manager import OutOfBandManager
 from ....out_of_band.v1_0.messages.invitation import HSProto, InvitationMessage
 from ....out_of_band.v1_0.messages.service import Service as OOBService
+from .. import manager as test_module
 from ..manager import DIDXManager, DIDXManagerError
 from ..messages.problem_report import DIDXProblemReport, ProblemReportReason
 
@@ -1902,10 +1903,9 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
 
             with self.assertRaises(DIDXManagerError):
                 await self.manager.accept_response(mock_response, receipt)
-
     async def test_accept_response_find_by_thread_id_no_did_doc_attached(self):
-        mock_response = mock.MagicMock()
-        mock_response._thread = mock.MagicMock()
+        mock_response = mock.AsyncMock()
+        mock_response._thread = mock.AsyncMock()
         mock_response.did = TestConfig.test_target_did
         mock_response.did_doc_attach = None
 

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -22,7 +22,7 @@ from .....resolver.tests import DOC
 from .....storage.error import StorageNotFoundError
 from .....transport.inbound.receipt import MessageReceipt
 from .....wallet.did_info import DIDInfo
-from .....wallet.did_method import SOV, DIDMethods
+from .....wallet.did_method import PEER2, SOV, DIDMethods
 from .....wallet.error import WalletError
 from .....wallet.in_memory import InMemoryWallet
 from .....wallet.key_type import ED25519
@@ -47,6 +47,8 @@ class TestConfig:
 
     test_target_did = "GbuDUYXaUZRfHD2jeDuQuP"
     test_target_verkey = "9WCgWKUaAJj3VWxxtzvvMQN3AoFxoBtBDo9ntwJnVVCC"
+
+    test_did_peer_2 = "did:peer:2.Vz6MkeobNdKHDnMXhob5GPWmpEyNx3r9j6gqiKYJQ9J2wEPvx.SeyJpZCI6IiNkaWRjb21tLTAiLCJ0IjoiZGlkLWNvbW11bmljYXRpb24iLCJwcmlvcml0eSI6MCwicmVjaXBpZW50S2V5cyI6WyIja2V5LTEiXSwiciI6W10sInMiOiJodHRwOi8vaG9zdC5kb2NrZXIuaW50ZXJuYWw6OTA3MCJ9"
 
     def make_did_doc(self, did, verkey):
         doc = DIDDoc(did=did)
@@ -527,7 +529,7 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
             connection_id="dummy",
             my_did=self.did_info.did,
             their_did=TestConfig.test_target_did,
-            their_role=ConnRecord.Role.REQUEST.rfc23,
+            their_role=ConnRecord.Role.REQUESTER.rfc23,
             state=ConnRecord.State.REQUEST.rfc23,
             retrieve_invitation=mock.CoroutineMock(
                 return_value=mock.MagicMock(
@@ -540,7 +542,7 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
         request = await self.manager.create_request(mock_conn_rec, use_public_did=True)
         assert request.did_doc_attach is None
 
-    async def test_emit_did_peer_2(self):
+    async def test_create_request_emit_did_peer_2(self):
         mock_conn_rec = mock.MagicMock(
             connection_id="dummy",
             retrieve_invitation=mock.CoroutineMock(
@@ -1623,6 +1625,37 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
             )
 
             await self.manager.create_response(conn_rec, "http://10.20.30.40:5060/")
+
+
+    async def test_create_response_inkind_peer_did(self):
+        # created did:peer:2 when receiving a did:peer:2, even if setting is False
+        conn_rec = ConnRecord(
+            connection_id="dummy",
+            their_did=TestConfig.test_did_peer_2,
+            state=ConnRecord.State.REQUEST.rfc23,
+        )
+
+        
+
+        self.profile.context.update_settings({"emit_did_peer_2": False})
+
+        with mock.patch.object(
+                self.manager, "create_did_peer_2", mock.CoroutineMock()
+            ) as mock_create_did_peer_2, mock.patch.object(
+            test_module.ConnRecord, "retrieve_request", mock.CoroutineMock()
+            ) as mock_retrieve_req, mock.patch.object(
+            conn_rec, "save", mock.CoroutineMock()
+            ) as mock_save:
+            
+            mock_create_did_peer_2.return_value = DIDInfo(
+                TestConfig.test_did_peer_2,
+                TestConfig.test_verkey,
+                None,
+                method=PEER2,
+                key_type=ED25519,
+            )
+            response = await self.manager.create_response(conn_rec, "http://10.20.30.40:5060/")
+            mock_create_did_peer_2.assert_called_once()
 
     async def test_create_response_bad_state(self):
         with self.assertRaises(DIDXManagerError):

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -557,9 +557,11 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
         self.profile.context.update_settings({"emit_did_peer_2": True})
 
         with mock.patch.object(
-                self.manager, "create_did_peer_2", mock.AsyncMock()
-            ) as mock_create_did_peer_2:
-            request = await self.manager.create_request(mock_conn_rec, use_public_did=True)
+            self.manager, "create_did_peer_2", mock.AsyncMock()
+        ) as mock_create_did_peer_2:
+            request = await self.manager.create_request(
+                mock_conn_rec, use_public_did=True
+            )
             assert request.did_doc_attach is None
             mock_create_did_peer_2.assert_called_once()
 
@@ -1623,7 +1625,6 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
                     data=mock.MagicMock(sign=mock.CoroutineMock())
                 )
             )
-
             await self.manager.create_response(conn_rec, "http://10.20.30.40:5060/")
 
 
@@ -1635,18 +1636,15 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
             state=ConnRecord.State.REQUEST.rfc23,
         )
 
-        
-
         self.profile.context.update_settings({"emit_did_peer_2": False})
 
         with mock.patch.object(
-                self.manager, "create_did_peer_2", mock.CoroutineMock()
-            ) as mock_create_did_peer_2, mock.patch.object(
-            test_module.ConnRecord, "retrieve_request", mock.CoroutineMock()
-            ) as mock_retrieve_req, mock.patch.object(
-            conn_rec, "save", mock.CoroutineMock()
-            ) as mock_save:
-            
+            self.manager, "create_did_peer_2", mock.CoroutineMock()
+        ) as mock_create_did_peer_2, mock.patch.object(
+        test_module.ConnRecord, "retrieve_request", mock.CoroutineMock()
+        ) as mock_retrieve_req, mock.patch.object(
+        conn_rec, "save", mock.CoroutineMock()
+        ) as mock_save:
             mock_create_did_peer_2.return_value = DIDInfo(
                 TestConfig.test_did_peer_2,
                 TestConfig.test_verkey,
@@ -1654,8 +1652,11 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
                 method=PEER2,
                 key_type=ED25519,
             )
-            response = await self.manager.create_response(conn_rec, "http://10.20.30.40:5060/")
+            response = await self.manager.create_response(
+                conn_rec, "http://10.20.30.40:5060/"
+            )
             mock_create_did_peer_2.assert_called_once()
+            assert response.did.startswith("did:peer:2")
 
     async def test_create_response_bad_state(self):
         with self.assertRaises(DIDXManagerError):

--- a/aries_cloudagent/wallet/base.py
+++ b/aries_cloudagent/wallet/base.py
@@ -1,7 +1,7 @@
 """Wallet base class."""
 
 from abc import ABC, abstractmethod
-from typing import List, Sequence, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 from ..ledger.base import BaseLedger
 from ..ledger.endpoint_type import EndpointType
@@ -17,7 +17,10 @@ class BaseWallet(ABC):
 
     @abstractmethod
     async def create_signing_key(
-        self, key_type: KeyType, seed: str = None, metadata: dict = None
+        self,
+        key_type: KeyType,
+        seed: Optional[str] = None,
+        metadata: Optional[dict] = None,
     ) -> KeyInfo:
         """Create a new public/private signing keypair.
 
@@ -29,6 +32,28 @@ class BaseWallet(ABC):
         Returns:
             A `KeyInfo` representing the new record
 
+        """
+
+    @abstractmethod
+    async def create_key(
+        self,
+        key_type: KeyType,
+        seed: Optional[str] = None,
+        metadata: Optional[dict] = None,
+    ) -> KeyInfo:
+        """Create a new public/private keypair.
+
+        Args:
+            key_type: Key type to create
+            seed: Seed for key
+            metadata: Optional metadata to store with the keypair
+
+        Returns:
+            A `KeyInfo` representing the new record
+
+        Raises:
+            WalletDuplicateError: If the resulting verkey already exists in the wallet
+            WalletError: If there is another backend error
         """
 
     @abstractmethod
@@ -87,9 +112,9 @@ class BaseWallet(ABC):
         self,
         method: DIDMethod,
         key_type: KeyType,
-        seed: str = None,
-        did: str = None,
-        metadata: dict = None,
+        seed: Optional[str] = None,
+        did: Optional[str] = None,
+        metadata: Optional[dict] = None,
     ) -> DIDInfo:
         """Create and store a new local DID.
 
@@ -103,6 +128,20 @@ class BaseWallet(ABC):
         Returns:
             The created `DIDInfo`
 
+        """
+
+    @abstractmethod
+    async def store_did(self, did_info: DIDInfo) -> DIDInfo:
+        """Store a DID in the wallet.
+
+        This enables components external to the wallet to define how a DID
+        is created and then store it in the wallet for later use.
+
+        Args:
+            did_info: The DID to store
+
+        Returns:
+            The stored `DIDInfo`
         """
 
     async def create_public_did(

--- a/aries_cloudagent/wallet/crypto.py
+++ b/aries_cloudagent/wallet/crypto.py
@@ -102,7 +102,7 @@ def sign_pk_from_sk(secret: bytes) -> bytes:
     return secret[seed_len:]
 
 
-def validate_seed(seed: Union[str, bytes]) -> bytes:
+def validate_seed(seed: Union[str, bytes, None]) -> bytes:
     """Convert a seed parameter to standard format and check length.
 
     Args:

--- a/aries_cloudagent/wallet/did_method.py
+++ b/aries_cloudagent/wallet/did_method.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Dict, List, Mapping, Optional
 
 from .error import BaseError
-from .key_type import BLS12381G2, ED25519, KeyType
+from .key_type import BLS12381G2, ED25519, X25519, KeyType
 
 
 class HolderDefinedDid(Enum):
@@ -70,6 +70,12 @@ KEY = DIDMethod(
     key_types=[ED25519, BLS12381G2],
     rotation=False,
 )
+PEER2 = DIDMethod(
+    name="did:peer:2",
+    key_types=[ED25519, X25519],
+    rotation=False,
+    holder_defined_did=HolderDefinedDid.NO,
+)
 
 
 class DIDMethods:
@@ -80,6 +86,7 @@ class DIDMethods:
         self._registry: Dict[str, DIDMethod] = {
             SOV.method_name: SOV,
             KEY.method_name: KEY,
+            PEER2.method_name: PEER2,
         }
 
     def registered(self, method: str) -> bool:

--- a/aries_cloudagent/wallet/indy.py
+++ b/aries_cloudagent/wallet/indy.py
@@ -3,7 +3,7 @@
 import json
 import logging
 
-from typing import List, Sequence, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 import indy.anoncreds
 import indy.did
@@ -136,7 +136,10 @@ class IndySdkWallet(BaseWallet):
         return verkey
 
     async def create_signing_key(
-        self, key_type: KeyType, seed: str = None, metadata: dict = None
+        self,
+        key_type: KeyType,
+        seed: Optional[str] = None,
+        metadata: Optional[dict] = None,
     ) -> KeyInfo:
         """Create a new public/private signing keypair.
 
@@ -151,6 +154,28 @@ class IndySdkWallet(BaseWallet):
             WalletDuplicateError: If the resulting verkey already exists in the wallet
             WalletError: If there is a libindy error
 
+        """
+        return await self.create_key(key_type, seed, metadata)
+
+    async def create_key(
+        self,
+        key_type: KeyType,
+        seed: Optional[str] = None,
+        metadata: Optional[dict] = None,
+    ) -> KeyInfo:
+        """Create a new public/private keypair.
+
+        Args:
+            key_type: Key type to create
+            seed: Seed for key
+            metadata: Optional metadata to store with the keypair
+
+        Returns:
+            A `KeyInfo` representing the new record
+
+        Raises:
+            WalletDuplicateError: If the resulting verkey already exists in the wallet
+            WalletError: If there is another backend error
         """
 
         # must save metadata to allow identity check
@@ -415,9 +440,9 @@ class IndySdkWallet(BaseWallet):
         self,
         method: DIDMethod,
         key_type: KeyType,
-        seed: str = None,
-        did: str = None,
-        metadata: dict = None,
+        seed: Optional[str] = None,
+        did: Optional[str] = None,
+        metadata: Optional[dict] = None,
     ) -> DIDInfo:
         """Create and store a new local DID.
 
@@ -457,6 +482,20 @@ class IndySdkWallet(BaseWallet):
             return await self.__create_keypair_local_did(
                 method, key_type, metadata, seed
             )
+
+    async def store_did(self, did_info: DIDInfo) -> DIDInfo:
+        """Store a DID in the wallet.
+
+        This enables components external to the wallet to define how a DID
+        is created and then store it in the wallet for later use.
+
+        Args:
+            did_info: The DID to store
+
+        Returns:
+            The stored `DIDInfo`
+        """
+        raise WalletError("This operation is not supported by Indy-SDK wallets")
 
     async def get_local_dids(self) -> Sequence[DIDInfo]:
         """Get list of defined local DIDs.

--- a/demo/bdd_support/agent_backchannel_client.py
+++ b/demo/bdd_support/agent_backchannel_client.py
@@ -29,8 +29,8 @@ def async_sleep(delay):
 ######################################################################
 # high level aries agent interface
 ######################################################################
-def create_agent_container_with_args(in_args: list):
-    return run_coroutine(create_agent_with_args_list, in_args)
+def create_agent_container_with_args(in_args: list, extra_args: list = None):
+    return run_coroutine(create_agent_with_args_list, in_args, extra_args)
 
 
 def aries_container_initialize(

--- a/demo/features/0160-connection.feature
+++ b/demo/features/0160-connection.feature
@@ -18,19 +18,19 @@ Feature: RFC 0160 Aries agent connection functions
 
       @GHA @WalletType_Askar
       Examples:
-         | Acme_capabilities                                 | Bob_capabilities                     |
-         | --public-did                                      |                                      |
-         | --public-did --did-exchange                       | --did-exchange                       |
-         | --public-did --mediation                          | --mediation                          |
-         | --public-did --multitenant                        | --multitenant                        |
-         | --public-did --mediation --multitenant --log-file | --mediation --multitenant --log-file |
+         | Acme_capabilities                                 | Acme_extra | Bob_capabilities                     | Bob_extra |
+         | --public-did                                      |            |                                      |           |
+         | --public-did --did-exchange                       |            | --did-exchange                       |           |
+         | --public-did --mediation                          |            | --mediation                          |           |
+         | --public-did --multitenant                        |            | --multitenant                        |           |
+         | --public-did --mediation --multitenant --log-file |            |--mediation --multitenant --log-file  |           |
 
       @GHA @WalletType_Askar_AnonCreds
       Examples:
-         | Acme_capabilities                      | Bob_capabilities          |
-         | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds |
-         | --public-did --wallet-type askar-anoncreds |                               |
-         | --public-did                           | --wallet-type askar-anoncreds |
-         | --public-did --did-exchange --wallet-type askar-anoncreds | --did-exchange --wallet-type askar-anoncreds |
-         | --public-did --mediation --wallet-type askar-anoncreds | --mediation --wallet-type askar-anoncreds |
-         | --public-did --multitenant --wallet-type askar-anoncreds | --multitenant --wallet-type askar-anoncreds |
+         | Acme_capabilities                                         | Acme_extra | Bob_capabilities                              | Bob_extra | 
+         | --public-did --wallet-type askar-anoncreds                |            | --wallet-type askar-anoncreds                 |           |
+         | --public-did --wallet-type askar-anoncreds                |            |                                               |           |
+         | --public-did                                              |            | --wallet-type askar-anoncreds                 |           |
+         | --public-did --did-exchange --wallet-type askar-anoncreds |            | --did-exchange --wallet-type askar-anoncreds  |           |
+         | --public-did --mediation --wallet-type askar-anoncreds    |            | --mediation --wallet-type askar-anoncreds     |           |
+         | --public-did --multitenant --wallet-type askar-anoncreds  |            | --multitenant --wallet-type askar-anoncreds   |           |

--- a/demo/features/0160-connection.feature
+++ b/demo/features/0160-connection.feature
@@ -3,13 +3,18 @@ Feature: RFC 0160 Aries agent connection functions
    @T001-RFC0160
    Scenario Outline: establish a connection between two agents
       Given we have "2" agents
-         | name  | role    | capabilities        |
-         | Acme  | inviter | <Acme_capabilities> |
-         | Bob   | invitee | <Bob_capabilities>  |
+         | name  | role    | capabilities        | extra        |
+         | Acme  | inviter | <Acme_capabilities> | <Acme_extra> |
+         | Bob   | invitee | <Bob_capabilities>  | <Bob_extra>  |
       When "Acme" generates a connection invitation
       And "Bob" receives the connection invitation
       Then "Acme" has an active connection
       And "Bob" has an active connection
+
+      @GHA @UnqualifiedDids
+      Examples:
+         | Acme_capabilities           | Acme_extra        | Bob_capabilities | Bob_extra        |
+         | --public-did --did-exchange | --emit-did-peer-2 | --did-exchange   |--emit-did-peer-2 |
 
       @GHA @WalletType_Askar
       Examples:
@@ -29,4 +34,3 @@ Feature: RFC 0160 Aries agent connection functions
          | --public-did --did-exchange --wallet-type askar-anoncreds | --did-exchange --wallet-type askar-anoncreds |
          | --public-did --mediation --wallet-type askar-anoncreds | --mediation --wallet-type askar-anoncreds |
          | --public-did --multitenant --wallet-type askar-anoncreds | --multitenant --wallet-type askar-anoncreds |
-         | --public-did --did-exchange --emit-did-peer-2 | --did-exchange --emit-did-peer-2 |

--- a/demo/features/0160-connection.feature
+++ b/demo/features/0160-connection.feature
@@ -15,6 +15,7 @@ Feature: RFC 0160 Aries agent connection functions
       Examples:
          | Acme_capabilities           | Acme_extra        | Bob_capabilities | Bob_extra        |
          | --public-did --did-exchange | --emit-did-peer-2 | --did-exchange   |--emit-did-peer-2 |
+         | --public-did --did-exchange | --emit-did-peer-2 | --did-exchange   |                  |
 
       @GHA @WalletType_Askar
       Examples:
@@ -23,7 +24,7 @@ Feature: RFC 0160 Aries agent connection functions
          | --public-did --did-exchange                       |            | --did-exchange                       |           |
          | --public-did --mediation                          |            | --mediation                          |           |
          | --public-did --multitenant                        |            | --multitenant                        |           |
-         | --public-did --mediation --multitenant --log-file |            |--mediation --multitenant --log-file  |           |
+         | --public-did --mediation --multitenant --log-file |            | --mediation --multitenant --log-file |           |
 
       @GHA @WalletType_Askar_AnonCreds
       Examples:

--- a/demo/features/0160-connection.feature
+++ b/demo/features/0160-connection.feature
@@ -29,3 +29,4 @@ Feature: RFC 0160 Aries agent connection functions
          | --public-did --did-exchange --wallet-type askar-anoncreds | --did-exchange --wallet-type askar-anoncreds |
          | --public-did --mediation --wallet-type askar-anoncreds | --mediation --wallet-type askar-anoncreds |
          | --public-did --multitenant --wallet-type askar-anoncreds | --multitenant --wallet-type askar-anoncreds |
+         | --public-did --did-exchange --emit-did-peer-2 | --did-exchange --emit-did-peer-2 |

--- a/demo/features/steps/0160-connection.py
+++ b/demo/features/steps/0160-connection.py
@@ -41,7 +41,7 @@ def step_impl(context, n):
         agent_name = row["name"]
         agent_role = row["role"]
         agent_params = row["capabilities"]
-        agent_extra_args = row.get("extra", "").split(" ")
+        agent_extra_args = row.get("extra")
         in_args = [
             "--ident",
             agent_name,
@@ -57,6 +57,8 @@ def step_impl(context, n):
                     extra_args.get("wallet-type"),
                 ]
             )
+        if agent_extra_args:
+            agent_extra_args = agent_extra_args.split(" ")
 
         context.active_agents[agent_name] = {
             "name": agent_name,

--- a/demo/features/steps/0160-connection.py
+++ b/demo/features/steps/0160-connection.py
@@ -52,13 +52,16 @@ def step_impl(context, n):
         ]
         if agent_params and 0 < len(agent_params):
             in_args.extend(agent_params.split(" "))
-        if extra_args and extra_args.get("wallet-type"):
-            in_args.extend(
-                [
-                    "--wallet-type",
-                    extra_args.get("wallet-type"),
-                ]
-            )
+        if extra_args:
+            if extra_args.get("wallet-type"):
+                in_args.extend(
+                    [
+                        "--wallet-type",
+                        extra_args.get("wallet-type"),
+                    ]
+                )
+            if extra_args.get("emit-did-peer-2"):
+                in_args.append("--emit-did-peer-2")
 
         context.active_agents[agent_name] = {
             "name": agent_name,

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -6,6 +6,7 @@ import os
 import random
 import sys
 import time
+from typing import List
 import yaml
 
 from qrcode import QRCode
@@ -60,9 +61,10 @@ class AriesAgent(DemoAgent):
         log_file: str = None,
         log_config: str = None,
         log_level: str = None,
+        extra_args: List[str] = None,
         **kwargs,
     ):
-        extra_args = []
+        extra_args = extra_args or []
         if not no_auto:
             extra_args.extend(
                 (
@@ -711,6 +713,7 @@ class AgentContainer:
         log_file: str = None,
         log_config: str = None,
         log_level: str = None,
+        extra_args: List[str] = None,
     ):
         # configuration parameters
         self.genesis_txns = genesis_txns
@@ -750,6 +753,7 @@ class AgentContainer:
         self.agent = None
         self.mediator_agent = None
         self.taa_accept = taa_accept
+        self.extra_args = extra_args
 
     async def initialize(
         self,
@@ -786,6 +790,7 @@ class AgentContainer:
                 log_file=self.log_file,
                 log_config=self.log_config,
                 log_level=self.log_level,
+                extra_args=self.extra_args,
             )
         else:
             self.agent = the_agent
@@ -1159,8 +1164,7 @@ class AgentContainer:
         )
 
     async def admin_GET(self, path, text=False, params=None) -> dict:
-        """
-        Execute an admin GET request in the context of the current wallet.
+        """Execute an admin GET request in the context of the current wallet.
 
         path = /path/of/request
         text = True if the expected response is text, False if json data
@@ -1169,8 +1173,7 @@ class AgentContainer:
         return await self.agent.admin_GET(path, text=text, params=params)
 
     async def admin_POST(self, path, data=None, text=False, params=None) -> dict:
-        """
-        Execute an admin POST request in the context of the current wallet.
+        """Execute an admin POST request in the context of the current wallet.
 
         path = /path/of/request
         data = payload to post with the request
@@ -1180,8 +1183,7 @@ class AgentContainer:
         return await self.agent.admin_POST(path, data=data, text=text, params=params)
 
     async def admin_PATCH(self, path, data=None, text=False, params=None) -> dict:
-        """
-        Execute an admin PATCH request in the context of the current wallet.
+        """Execute an admin PATCH request in the context of the current wallet.
 
         path = /path/of/request
         data = payload to post with the request
@@ -1191,8 +1193,7 @@ class AgentContainer:
         return await self.agent.admin_PATCH(path, data=data, text=text, params=params)
 
     async def admin_PUT(self, path, data=None, text=False, params=None) -> dict:
-        """
-        Execute an admin PUT request in the context of the current wallet.
+        """Execute an admin PUT request in the context of the current wallet.
 
         path = /path/of/request
         data = payload to post with the request
@@ -1202,18 +1203,16 @@ class AgentContainer:
         return await self.agent.admin_PUT(path, data=data, text=text, params=params)
 
     async def admin_DELETE(self, path, data=None, text=False, params=None) -> dict:
-        """
-        Execute an admin DELETE request in the context of the current wallet.
+        """Execute an admin DELETE request in the context of the current wallet.
         path = /path/of/request
         data = payload to post with the request
         text = True if the expected response is text, False if json data
-        params = any additional parameters to pass with the request
+        params = any additional parameters to pass with the request.
         """
         return await self.agent.admin_DELETE(path, data=data, text=text, params=params)
 
     async def agency_admin_GET(self, path, text=False, params=None) -> dict:
-        """
-        Execute an agency GET request in the context of the base wallet (multitenant only).
+        """Execute an agency GET request in the context of the base wallet (multitenant only).
 
         path = /path/of/request
         text = True if the expected response is text, False if json data
@@ -1222,8 +1221,7 @@ class AgentContainer:
         return await self.agent.agency_admin_GET(path, text=text, params=params)
 
     async def agency_admin_POST(self, path, data=None, text=False, params=None) -> dict:
-        """
-        Execute an agency POST request in the context of the base wallet (multitenant only).
+        """Execute an agency POST request in the context of the base wallet (multitenant only).
 
         path = /path/of/request
         data = payload to post with the request
@@ -1236,8 +1234,7 @@ class AgentContainer:
 
 
 def arg_parser(ident: str = None, port: int = 8020):
-    """
-    Standard command-line arguments.
+    """Standard command-line arguments.
 
     "ident", if specified, refers to one of the standard demo personas - alice, faber, acme or performance.
     """
@@ -1390,14 +1387,14 @@ def arg_parser(ident: str = None, port: int = 8020):
     return parser
 
 
-async def create_agent_with_args_list(in_args: list):
+async def create_agent_with_args_list(in_args: list, extra_args: list = None):
     parser = arg_parser()
     args = parser.parse_args(in_args)
 
-    return await create_agent_with_args(args)
+    return await create_agent_with_args(args, extra_args=extra_args)
 
 
-async def create_agent_with_args(args, ident: str = None):
+async def create_agent_with_args(args, ident: str = None, extra_args: list = None):
     if ("did_exchange" in args and args.did_exchange) and args.mediation:
         raise Exception(
             "DID-Exchange connection protocol is not (yet) compatible with mediation"
@@ -1507,6 +1504,7 @@ async def create_agent_with_args(args, ident: str = None):
         log_file=log_file,
         log_config=log_config,
         log_level=log_level,
+        extra_args=extra_args,
     )
 
     return agent
@@ -1581,7 +1579,7 @@ async def test_main(
 
         # alice accept invitation
         invite_details = invite["invitation"]
-        connection = await alice_container.input_invitation(invite_details)
+        await alice_container.input_invitation(invite_details)
 
         # wait for faber connection to activate
         await faber_container.detect_connection()


### PR DESCRIPTION
Rather than manage repo permissions. I'm reopening @dbluhm 's [PR](https://github.com/hyperledger/aries-cloudagent-python/pull/2578) here so I can verify and add/restore tests. 

- [x] Restore Unittests
- [x] Restore integration tests
- [x] Add new unit tests (check initiation with flag, check responding in kind without flag)
- [x] Add new integration tests (check connection with both flags set and one flag set)
