### PR TITLE
fix: save multi_use to the DB for OOB invitations

### DIFF
--- a/aries_cloudagent/protocols/out_of_band/v1_0/models/oob_record.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/models/oob_record.py
@@ -303,6 +303,6 @@ class OobRecordSchema(BaseExchangeSchema):
         required=False,
         metadata={
             "description": "Allow for multiple uses of the oobinvitation",
-            "example": True
+            "example": True,
         },
     )

--- a/aries_cloudagent/protocols/out_of_band/v1_0/models/oob_record.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/models/oob_record.py
@@ -111,6 +111,7 @@ class OobRecord(BaseExchangeRecord):
                     "role",
                     "our_service",
                     "invi_msg_id",
+                    "multi_use",
                 )
             },
             **{
@@ -296,4 +297,12 @@ class OobRecordSchema(BaseExchangeSchema):
             OobRecord.get_attributes_by_prefix("ROLE_", walk_mro=False)
         ),
         metadata={"description": "OOB Role", "example": OobRecord.ROLE_RECEIVER},
+    )
+
+    multi_use = fields.Boolean(
+        required=False,
+        metadata={
+            "description": "Allow for multiple uses of the oobinvitation",
+            "example": True
+        },
     )

--- a/aries_cloudagent/protocols/out_of_band/v1_0/models/tests/test_out_of_band.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/models/tests/test_out_of_band.py
@@ -1,0 +1,33 @@
+import pytest
+
+from ..oob_record import OobRecord
+from ...messages.invitation import InvitationMessage
+from ......core.in_memory import InMemoryProfile
+from ......core.profile import ProfileSession
+
+
+@pytest.fixture()
+async def session():
+    profile = InMemoryProfile.test_profile()
+    async with profile.session() as session:
+        yield session
+
+
+@pytest.mark.asyncio
+async def test_oob_record_multi_use(session: ProfileSession):
+    """Test oob record multi_use."""
+    invi_msg = InvitationMessage(handshake_protocols=["connections/1.0"])
+    oob_rec = OobRecord(
+        state=OobRecord.STATE_INITIAL,
+        invi_msg_id="67890",
+        role=OobRecord.ROLE_SENDER,
+        invitation=invi_msg,
+        multi_use=True,
+    )
+
+    await oob_rec.save(session)
+    saved_record = await OobRecord.retrieve_by_id(session, record_id=oob_rec.oob_id)
+    assert saved_record
+    assert isinstance(saved_record, OobRecord)
+    assert oob_rec.multi_use
+    assert saved_record.multi_use


### PR DESCRIPTION
It was reported by a collegue that when using Out-of-band invitations with the connections handshake protocol, along with a public DID and connection re-use enabled, ACA-Py was only able to handle a single invitations. As if Connection Re-use wasn't working or the multi_use flag was ignored.

Turns out, we flat out weren't saving the multi_use flag to the database which is a big problem if you want to re-use the invitation. When DID-Exchanged is used, since DID-Exchange allows for a connection-less exchange of information. We only say the behaviour of the OOB Invitation getting deleted if we ran through the receive_reuse_message() method in the manager, which deletes the record if it's not set for multi_use.