### PR TITLE
Remove tiny-vim from being added to the container image to reduce reported vulnerabilities from scanning

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,6 @@ RUN apt-get update -y && \
     net-tools \
     openssl \
     sqlite3 \
-    vim-tiny \
     zlib1g && \
     rm -rf /var/lib/apt/lists/* /usr/share/doc/*
 

--- a/docker/Dockerfile.indy
+++ b/docker/Dockerfile.indy
@@ -130,7 +130,6 @@ RUN apt-get update -y && \
     net-tools \
     openssl \
     sqlite3 \
-    vim-tiny \
     zlib1g && \
     rm -rf /var/lib/apt/lists/* /usr/share/doc/*
 


### PR DESCRIPTION
Signed-off-by: Stephen Curran <swcurran@gmail.com>
