### PR TITLE
feat: inject profile

### DIFF
--- a/aries_cloudagent/config/base.py
+++ b/aries_cloudagent/config/base.py
@@ -158,5 +158,5 @@ class BaseInjector(ABC):
 class BaseProvider(ABC):
     """Base provider class."""
 
-    def provide(self, settings: BaseSettings, injector: BaseInjector):
+    def provide(self, settings: BaseSettings, injector: BaseInjector) -> Any:
         """Provide the object instance given a config and injector."""

--- a/aries_cloudagent/config/provider.py
+++ b/aries_cloudagent/config/provider.py
@@ -2,7 +2,7 @@
 
 import hashlib
 
-from typing import Sequence, Union
+from typing import Optional, Sequence, Union
 from weakref import ReferenceType
 
 from ..utils.classloader import DeferLoad
@@ -44,7 +44,7 @@ class ClassProvider(BaseProvider):
         self,
         instance_cls: Union[str, type],
         *ctor_args,
-        init_method: str = None,
+        init_method: Optional[str] = None,
         **ctor_kwargs
     ):
         """Initialize the class provider."""
@@ -52,8 +52,10 @@ class ClassProvider(BaseProvider):
         self._ctor_kwargs = ctor_kwargs
         self._init_method = init_method
         if isinstance(instance_cls, str):
-            instance_cls = DeferLoad(instance_cls)
-        self._instance_cls = instance_cls
+            cls = DeferLoad(instance_cls)
+        else:
+            cls = instance_cls
+        self._instance_cls: Union[type, DeferLoad] = cls
 
     def provide(self, config: BaseSettings, injector: BaseInjector):
         """Provide the object instance given a config and injector."""

--- a/aries_cloudagent/core/profile.py
+++ b/aries_cloudagent/core/profile.py
@@ -4,6 +4,7 @@ import logging
 
 from abc import ABC, abstractmethod
 from typing import Any, Mapping, Optional, Type
+from weakref import ref
 
 from .event_bus import EventBus, Event
 from ..config.base import InjectionError
@@ -27,14 +28,19 @@ class Profile(ABC):
     def __init__(
         self,
         *,
-        context: InjectionContext = None,
-        name: str = None,
+        context: Optional[InjectionContext] = None,
+        name: Optional[str] = None,
         created: bool = False,
     ):
         """Initialize a base profile."""
-        self._context = context or InjectionContext()
+        context = context or InjectionContext()
+        scope = "profile"
+        if name:
+            scope += ":" + name
+        self._context = context.start_scope(scope)
         self._created = created
         self._name = name or Profile.DEFAULT_NAME
+        self._context.injector.bind_instance(Profile, ref(self))
 
     @property
     def backend(self) -> str:


### PR DESCRIPTION
This PR adds the Profile to the injection context. This enables creating a `ClassProvider` for a class that takes a profile in its init method:

```python
class ExamplePluggable:
    def __init__(self, profile: Profile):
        self.profile = profile
    def do_something(self):
        self.profile.notify("some:event", {"with": "data"})

async def setup(context: InjectionContext):
    context.injector.bind_provider(
        ExamplePluggable,
        ClassProvider(ExamplePluggable, ClassProvider.Inject(Profile))
    )

# ... Somewhere else ...
plugged_in = profile.inject(ExamplePluggable)
plugged_in.do_something()
```

It's a common pattern to create a class with a profile instance. This will make it easier to turn some of these components into pluggable components. For example, the `VcLdpManager`. At the moment, it's created directly where it's needed:

```python
manager = VcLdpManager(self.profile)
# do something with manager
```

With this change, I can create an (override-able) class provider for VcLdpManager, which changes the above into:

```python
manager = self.profile.inject(VcLdpManager)
# do something with manager
```

The only way this could be done previously was by binding providers in the Profile init method itself. This made it more difficult to make more components pluggable.

Side note: it's critical that the profile instance be injected as a weak reference or it will never be "finalized" (garbage collected) in multitenant contexts.