### PR TITLE
Anoncreds schema endorsement

### DIFF
--- a/aries_cloudagent/anoncreds/default/did_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/did_indy/registry.py
@@ -6,6 +6,7 @@ from typing import Optional, Pattern, Sequence
 
 from ....config.injection_context import InjectionContext
 from ....core.profile import Profile
+from ...base import BaseAnonCredsRegistrar, BaseAnonCredsResolver
 from ...models.anoncreds_cred_def import (
     CredDef,
     CredDefResult,
@@ -14,13 +15,12 @@ from ...models.anoncreds_cred_def import (
 from ...models.anoncreds_revocation import (
     GetRevListResult,
     GetRevRegDefResult,
-    RevRegDef,
-    RevRegDefResult,
     RevList,
     RevListResult,
+    RevRegDef,
+    RevRegDefResult,
 )
 from ...models.anoncreds_schema import AnonCredsSchema, GetSchemaResult, SchemaResult
-from ...base import BaseAnonCredsRegistrar, BaseAnonCredsResolver
 
 LOGGER = logging.getLogger(__name__)
 

--- a/aries_cloudagent/anoncreds/default/legacy_indy/author.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/author.py
@@ -1,0 +1,54 @@
+"""Author specific for indy legacy."""
+
+from typing import Optional
+
+from aiohttp import web
+
+from aries_cloudagent.connections.models.conn_record import ConnRecord
+from aries_cloudagent.messaging.models.base import BaseModelError
+from aries_cloudagent.protocols.endorse_transaction.v1_0.util import (
+    get_endorser_connection_id,
+)
+from aries_cloudagent.storage.error import StorageNotFoundError
+
+
+async def get_endorser_info(profile, options: Optional[dict] = {}):
+    """Gets the endorser did for the current transaction."""
+    endorser_connection_id = options.get("endorser_connection_id", None)
+    if not endorser_connection_id:
+        endorser_connection_id = await get_endorser_connection_id(profile)
+
+    if not endorser_connection_id:
+        raise web.HTTPForbidden(reason="No endorser connection found")
+
+    try:
+        async with profile.session() as session:
+            connection_record = await ConnRecord.retrieve_by_id(
+                session, endorser_connection_id
+            )
+            endorser_info = await connection_record.metadata_get(
+                session, "endorser_info"
+            )
+    except StorageNotFoundError as err:
+        raise web.HTTPNotFound(
+            reason=f"Connection for endorser with id {endorser_connection_id} not found"
+        ) from err
+    except BaseModelError as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
+
+    if not endorser_info:
+        raise web.HTTPForbidden(
+            reason=(
+                "Endorser Info is not set up in "
+                "connection metadata for this connection record"
+            )
+        )
+    if "endorser_did" not in endorser_info.keys():
+        raise web.HTTPForbidden(
+            reason=(
+                ' "endorser_did" is not set in "endorser_info"'
+                " in connection metadata for this connection record"
+            )
+        )
+
+    return endorser_info["endorser_did"], endorser_connection_id

--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -298,7 +298,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         return SchemaResult(
             job_id=job_id,
             schema_state=SchemaState(
-                state=SchemaState.STATE_TRANSACTION_REQUESTED,
+                state=SchemaState.STATE_WAIT,
                 schema_id=schema_id,
                 schema=schema,
             ),

--- a/aries_cloudagent/anoncreds/default/legacy_indy/tests/test_registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/tests/test_registry.py
@@ -1,9 +1,31 @@
 """Test LegacyIndyRegistry."""
 
-import pytest
+import json
 import re
-from ..registry import LegacyIndyRegistry
+
+import pytest
+from asynctest import TestCase
 from base58 import alphabet
+
+from aries_cloudagent.anoncreds.base import (
+    AnonCredsRegistrationError,
+    AnonCredsSchemaAlreadyExists,
+)
+from aries_cloudagent.anoncreds.models.anoncreds_schema import (
+    AnonCredsSchema,
+    SchemaResult,
+)
+from aries_cloudagent.askar.profile_anon import AskarAnoncredsProfile
+from aries_cloudagent.connections.models.conn_record import ConnRecord
+from aries_cloudagent.core.in_memory.profile import InMemoryProfile
+from aries_cloudagent.ledger.error import LedgerError, LedgerObjectAlreadyExistsError
+from aries_cloudagent.messaging.responder import BaseResponder
+from aries_cloudagent.protocols.endorse_transaction.v1_0.manager import (
+    TransactionManager,
+)
+from aries_cloudagent.tests import mock
+
+from .. import registry as test_module
 
 B58 = alphabet if isinstance(alphabet, str) else alphabet.decode("ascii")
 INDY_DID = rf"^(did:sov:)?[{B58}]{{21,22}}$"
@@ -33,23 +55,211 @@ TEST_INDY_REV_REG_DEF_ID = (
     "WgWxqztrNooG92RXvxSTWv:4:WgWxqztrNooG92RXvxSTWv:3:CL:20:tag:CL_ACCUM:0"
 )
 
+mock_schema = AnonCredsSchema(
+    issuer_id="did:indy:sovrin:SGrjRL82Y9ZZbzhUDXokvQ",
+    attr_names=["name", "age", "vmax"],
+    name="test_schema",
+    version="1.0",
+)
 
-@pytest.fixture
-def registry():
-    """Registry fixture"""
-    yield LegacyIndyRegistry()
 
+@pytest.mark.anoncreds
+class TestLegacyIndyRegistry(TestCase):
+    def setUp(self):
+        self.profile = InMemoryProfile.test_profile(
+            settings={"wallet-type": "askar-anoncreds"},
+            profile_class=AskarAnoncredsProfile,
+        )
+        self.registry = test_module.LegacyIndyRegistry()
 
-@pytest.mark.indy
-class TestLegacyIndyRegistry:
-    @pytest.mark.asyncio
-    async def test_supported_did_regex(self, registry: LegacyIndyRegistry):
+    async def test_supported_did_regex(self):
         """Test the supported_did_regex."""
 
-        assert registry.supported_identifiers_regex == SUPPORTED_ID_REGEX
-        assert bool(registry.supported_identifiers_regex.match(TEST_INDY_DID))
-        assert bool(registry.supported_identifiers_regex.match(TEST_INDY_DID_1))
-        assert bool(registry.supported_identifiers_regex.match(TEST_INDY_SCHEMA_ID))
+        assert self.registry.supported_identifiers_regex == SUPPORTED_ID_REGEX
+        assert bool(self.registry.supported_identifiers_regex.match(TEST_INDY_DID))
+        assert bool(self.registry.supported_identifiers_regex.match(TEST_INDY_DID_1))
         assert bool(
-            registry.supported_identifiers_regex.match(TEST_INDY_REV_REG_DEF_ID)
+            self.registry.supported_identifiers_regex.match(TEST_INDY_SCHEMA_ID)
         )
+        assert bool(
+            self.registry.supported_identifiers_regex.match(TEST_INDY_REV_REG_DEF_ID)
+        )
+
+    async def test_register_schema_no_endorsement(self):
+        self.profile.inject_or = mock.MagicMock(
+            return_value=mock.CoroutineMock(
+                send_schema_anoncreds=mock.CoroutineMock(return_value=1)
+            )
+        )
+
+        result = await self.registry.register_schema(self.profile, mock_schema, {})
+
+        assert isinstance(result, SchemaResult)
+
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_id",
+        return_value=mock.CoroutineMock(
+            metadata_get=mock.CoroutineMock(return_value={"endorser_did": "test_did"})
+        ),
+    )
+    async def test_register_schema_with_author_role(self, mock_endorser_conn_record):
+        self.profile.inject_or = mock.MagicMock(
+            return_value=mock.CoroutineMock(
+                send_schema_anoncreds=mock.CoroutineMock(
+                    return_value=(
+                        "test_schema_id",
+                        {
+                            "signed_txn": "test_signed_txn",
+                        },
+                    )
+                )
+            )
+        )
+        self.profile.settings.set_value("endorser.author", True)
+
+        result = await self.registry.register_schema(
+            self.profile, mock_schema, {"endorser_connection_id": "test_connection_id"}
+        )
+
+        assert result.registration_metadata["txn"] is not None
+        assert mock_endorser_conn_record.called
+
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_id",
+        return_value=mock.CoroutineMock(
+            metadata_get=mock.CoroutineMock(return_value={"endorser_did": "test_did"})
+        ),
+    )
+    async def test_register_schema_already_exists(self, mock_endorser_conn_record):
+        self.profile.inject_or = mock.MagicMock(
+            return_value=mock.CoroutineMock(
+                send_schema_anoncreds=mock.CoroutineMock(
+                    side_effect=LedgerObjectAlreadyExistsError(
+                        "test", "test", mock_schema
+                    )
+                )
+            )
+        )
+        self.profile.settings.set_value("endorser.author", True)
+
+        with self.assertRaises(AnonCredsSchemaAlreadyExists):
+            await self.registry.register_schema(
+                self.profile,
+                mock_schema,
+                {"endorser_connection_id": "test_connection_id"},
+            )
+
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_id",
+        return_value=mock.CoroutineMock(
+            metadata_get=mock.CoroutineMock(return_value={"endorser_did": "test_did"})
+        ),
+    )
+    async def test_register_schema_with_create_trasaction_param(
+        self, mock_endorser_conn_record
+    ):
+        self.profile.inject_or = mock.MagicMock(
+            return_value=mock.CoroutineMock(
+                send_schema_anoncreds=mock.CoroutineMock(
+                    return_value=(
+                        "test_schema_id",
+                        {
+                            "signed_txn": "test_signed_txn",
+                        },
+                    )
+                )
+            )
+        )
+
+        result = await self.registry.register_schema(
+            self.profile,
+            mock_schema,
+            {
+                "endorser_connection_id": "test_connection_id",
+                "create_transaction_for_endorser": True,
+            },
+        )
+
+        assert result.registration_metadata["txn"] is not None
+        assert mock_endorser_conn_record.called
+
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_id",
+        return_value=mock.CoroutineMock(
+            metadata_get=mock.CoroutineMock(return_value={"endorser_did": "test_did"})
+        ),
+    )
+    @mock.patch.object(
+        TransactionManager,
+        "create_request",
+    )
+    async def test_register_schema_with_author_role_and_create_request(
+        self, mock_create_request, mock_endorser_conn_record
+    ):
+        class MockTransaction:
+            def __init__(self, txn):
+                self.txn = txn
+
+            def serialize(self):
+                return json.dumps(self.txn)
+
+        self.profile.inject_or = mock.MagicMock(
+            return_value=mock.CoroutineMock(
+                send_schema_anoncreds=mock.CoroutineMock(
+                    return_value=(
+                        "test_schema_id",
+                        {
+                            "signed_txn": "test_signed_txn",
+                        },
+                    )
+                )
+            )
+        )
+
+        mock_create_request.return_value = (
+            MockTransaction({"test": "test"}),
+            "transaction_request",
+        )
+
+        self.profile.settings.set_value("endorser.author", True)
+        self.profile.settings.set_value("endorser.auto_request", True)
+        self.profile.context.injector.bind_instance(
+            BaseResponder, mock.MagicMock(send=mock.CoroutineMock(return_value=None))
+        )
+
+        result = await self.registry.register_schema(
+            self.profile, mock_schema, {"endorser_connection_id": "test_connection_id"}
+        )
+
+        assert result.registration_metadata["txn"] is not None
+        assert mock_create_request.called
+        assert self.profile.context.injector.get_provider(
+            BaseResponder
+        )._instance.send.called
+
+    async def test_txn_submit(self):
+        self.profile.inject = mock.MagicMock(
+            side_effect=[
+                None,
+                mock.CoroutineMock(
+                    txn_submit=mock.CoroutineMock(side_effect=LedgerError("test error"))
+                ),
+                mock.CoroutineMock(
+                    txn_submit=mock.CoroutineMock(return_value="transaction response")
+                ),
+            ]
+        )
+
+        # No ledger
+        with self.assertRaises(LedgerError):
+            await self.registry.txn_submit(self.profile, "test_txn")
+        # Write error
+        with self.assertRaises(AnonCredsRegistrationError):
+            await self.registry.txn_submit(self.profile, "test_txn")
+
+        result = await self.registry.txn_submit(self.profile, "test_txn")
+        assert result == "transaction response"

--- a/aries_cloudagent/anoncreds/events.py
+++ b/aries_cloudagent/anoncreds/events.py
@@ -6,16 +6,15 @@ from typing import NamedTuple
 from ..core.event_bus import Event
 from .models.anoncreds_revocation import RevRegDef
 
-
 CRED_DEF_FINISHED_EVENT = "anoncreds::credential-definition::finished"
 REV_REG_DEF_FINISHED_EVENT = "anoncreds::revocation-registry-definition::finished"
 REV_LIST_FINISHED_EVENT = "anoncreds::revocation-list::finished"
+SCHEMA_REGISTRATION_FINISHED_EVENT = "anoncreds::schema::registration::finished"
 
-CRED_DEF_FINISHED_PATTERN = re.compile("anoncreds::credential-definition::finished")
-REV_REG_DEF_FINISHED_PATTERN = re.compile(
-    "anoncreds::revocation-registry-definition::finished"
-)
-REV_LIST_FINISHED_PATTERN = re.compile("anoncreds::revocation-list::finished")
+CRED_DEF_FINISHED_PATTERN = re.compile(CRED_DEF_FINISHED_EVENT)
+REV_REG_DEF_FINISHED_PATTERN = re.compile(REV_REG_DEF_FINISHED_EVENT)
+REV_LIST_FINISHED_PATTERN = re.compile(REV_LIST_FINISHED_EVENT)
+SCHEMA_REGISTRATION_FINISHED_PATTERN = re.compile(SCHEMA_REGISTRATION_FINISHED_EVENT)
 
 
 class CredDefFinishedPayload(NamedTuple):
@@ -126,5 +125,36 @@ class RevListFinishedEvent(Event):
 
     @property
     def payload(self) -> RevListFinishedPayload:
+        """Return payload."""
+        return self._payload
+
+
+class SchemaRegistrationFinishedPayload(NamedTuple):
+    """Payload of schema transaction event."""
+
+    meta_data: dict
+
+
+class SchemaRegistrationFinishedEvent(Event):
+    """Event for schema post-process."""
+
+    def __init__(self, payload: SchemaRegistrationFinishedPayload):
+        """Initialize an instance.
+
+        Args:
+            schema_id: schema id
+            meta_data: meta data
+        """
+        self._topic = SCHEMA_REGISTRATION_FINISHED_EVENT
+        self._payload = payload
+
+    @classmethod
+    def with_payload(cls, meta_data: dict):
+        """With payload."""
+        payload = SchemaRegistrationFinishedPayload(meta_data)
+        return cls(payload)
+
+    @property
+    def payload(self) -> SchemaRegistrationFinishedPayload:
         """Return payload."""
         return self._payload

--- a/aries_cloudagent/anoncreds/events.py
+++ b/aries_cloudagent/anoncreds/events.py
@@ -9,12 +9,10 @@ from .models.anoncreds_revocation import RevRegDef
 CRED_DEF_FINISHED_EVENT = "anoncreds::credential-definition::finished"
 REV_REG_DEF_FINISHED_EVENT = "anoncreds::revocation-registry-definition::finished"
 REV_LIST_FINISHED_EVENT = "anoncreds::revocation-list::finished"
-SCHEMA_REGISTRATION_FINISHED_EVENT = "anoncreds::schema::registration::finished"
 
 CRED_DEF_FINISHED_PATTERN = re.compile(CRED_DEF_FINISHED_EVENT)
 REV_REG_DEF_FINISHED_PATTERN = re.compile(REV_REG_DEF_FINISHED_EVENT)
 REV_LIST_FINISHED_PATTERN = re.compile(REV_LIST_FINISHED_EVENT)
-SCHEMA_REGISTRATION_FINISHED_PATTERN = re.compile(SCHEMA_REGISTRATION_FINISHED_EVENT)
 
 
 class CredDefFinishedPayload(NamedTuple):
@@ -125,36 +123,5 @@ class RevListFinishedEvent(Event):
 
     @property
     def payload(self) -> RevListFinishedPayload:
-        """Return payload."""
-        return self._payload
-
-
-class SchemaRegistrationFinishedPayload(NamedTuple):
-    """Payload of schema transaction event."""
-
-    meta_data: dict
-
-
-class SchemaRegistrationFinishedEvent(Event):
-    """Event for schema post-process."""
-
-    def __init__(self, payload: SchemaRegistrationFinishedPayload):
-        """Initialize an instance.
-
-        Args:
-            schema_id: schema id
-            meta_data: meta data
-        """
-        self._topic = SCHEMA_REGISTRATION_FINISHED_EVENT
-        self._payload = payload
-
-    @classmethod
-    def with_payload(cls, meta_data: dict):
-        """With payload."""
-        payload = SchemaRegistrationFinishedPayload(meta_data)
-        return cls(payload)
-
-    @property
-    def payload(self) -> SchemaRegistrationFinishedPayload:
         """Return payload."""
         return self._payload

--- a/aries_cloudagent/anoncreds/models/anoncreds_schema.py
+++ b/aries_cloudagent/anoncreds/models/anoncreds_schema.py
@@ -143,7 +143,6 @@ class SchemaState(BaseModel):
     STATE_FAILED = "failed"
     STATE_ACTION = "action"
     STATE_WAIT = "wait"
-    STATE_TRANSACTION_REQUESTED = "transaction_requested"
 
     class Meta:
         """SchemaState metadata."""

--- a/aries_cloudagent/anoncreds/models/anoncreds_schema.py
+++ b/aries_cloudagent/anoncreds/models/anoncreds_schema.py
@@ -6,12 +6,11 @@ from anoncreds import Schema
 from marshmallow import EXCLUDE, fields
 from marshmallow.validate import OneOf
 
-from aries_cloudagent.messaging.valid import (
+from ...messaging.models.base import BaseModel, BaseModelSchema
+from ...messaging.valid import (
     INDY_OR_KEY_DID_EXAMPLE,
     INDY_SCHEMA_ID_EXAMPLE,
 )
-
-from ...messaging.models.base import BaseModel, BaseModelSchema
 
 
 class AnonCredsSchema(BaseModel):
@@ -144,6 +143,7 @@ class SchemaState(BaseModel):
     STATE_FAILED = "failed"
     STATE_ACTION = "action"
     STATE_WAIT = "wait"
+    STATE_TRANSACTION_REQUESTED = "transaction_requested"
 
     class Meta:
         """SchemaState metadata."""

--- a/aries_cloudagent/anoncreds/registry.py
+++ b/aries_cloudagent/anoncreds/registry.py
@@ -3,8 +3,14 @@
 import logging
 from typing import List, Optional, Sequence
 
-
 from ..core.profile import Profile
+from .base import (
+    AnonCredsRegistrationError,
+    AnonCredsResolutionError,
+    BaseAnonCredsHandler,
+    BaseAnonCredsRegistrar,
+    BaseAnonCredsResolver,
+)
 from .models.anoncreds_cred_def import (
     CredDef,
     CredDefResult,
@@ -13,19 +19,12 @@ from .models.anoncreds_cred_def import (
 from .models.anoncreds_revocation import (
     GetRevListResult,
     GetRevRegDefResult,
-    RevRegDef,
-    RevRegDefResult,
     RevList,
     RevListResult,
+    RevRegDef,
+    RevRegDefResult,
 )
 from .models.anoncreds_schema import AnonCredsSchema, GetSchemaResult, SchemaResult
-from .base import (
-    AnonCredsRegistrationError,
-    AnonCredsResolutionError,
-    BaseAnonCredsHandler,
-    BaseAnonCredsRegistrar,
-    BaseAnonCredsResolver,
-)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/aries_cloudagent/anoncreds/routes.py
+++ b/aries_cloudagent/anoncreds/routes.py
@@ -15,8 +15,7 @@ from marshmallow import fields
 
 from ..admin.request_context import AdminRequestContext
 from ..askar.profile import AskarProfile
-from ..core.event_bus import Event, EventBus
-from ..core.profile import Profile
+from ..core.event_bus import EventBus
 from ..ledger.error import LedgerError
 from ..messaging.models.openapi import OpenAPISchema
 from ..messaging.valid import (
@@ -41,7 +40,6 @@ from .base import (
     AnonCredsRegistrationError,
     AnonCredsResolutionError,
 )
-from .events import SCHEMA_REGISTRATION_FINISHED_PATTERN
 from .issuer import AnonCredsIssuer, AnonCredsIssuerError
 from .models.anoncreds_cred_def import CredDefResultSchema, GetCredDefResultSchema
 from .models.anoncreds_revocation import RevListResultSchema, RevRegDefResultSchema
@@ -667,15 +665,6 @@ def register_events(event_bus: EventBus):
     # TODO Make this pluggable?
     setup_manager = DefaultRevocationSetup()
     setup_manager.register_events(event_bus)
-    event_bus.subscribe(SCHEMA_REGISTRATION_FINISHED_PATTERN, on_schema_event)
-
-
-async def on_schema_event(profile: Profile, event: Event):
-    """Schema post processing."""
-    await AnonCredsIssuer(profile).finish_schema(
-        event.payload.meta_data["context"]["job_id"],
-        event.payload.meta_data["context"]["schema_id"],
-    )
 
 
 async def register(app: web.Application):

--- a/aries_cloudagent/anoncreds/tests/test_routes.py
+++ b/aries_cloudagent/anoncreds/tests/test_routes.py
@@ -6,7 +6,6 @@ from asynctest import TestCase as AsyncTestCase
 
 from aries_cloudagent.admin.request_context import AdminRequestContext
 from aries_cloudagent.anoncreds.base import AnonCredsObjectNotFound
-from aries_cloudagent.anoncreds.events import SchemaRegistrationFinishedEvent
 from aries_cloudagent.anoncreds.issuer import AnonCredsIssuer
 from aries_cloudagent.anoncreds.models.anoncreds_schema import (
     AnonCredsSchema,
@@ -19,7 +18,6 @@ from aries_cloudagent.askar.profile_anon import AskarAnoncredsProfile
 from aries_cloudagent.core.event_bus import MockEventBus
 from aries_cloudagent.core.in_memory.profile import (
     InMemoryProfile,
-    InMemoryProfileSession,
 )
 from aries_cloudagent.revocation_anoncreds.manager import RevocationManager
 from aries_cloudagent.tests import mock
@@ -385,7 +383,6 @@ class TestAnoncredsRoutes(AsyncTestCase):
         mock_event_bus.subscribe = mock.MagicMock()
         test_module.register_events(mock_event_bus)
         assert mock_revocation_setup_listeners.call_count == 1
-        assert mock_event_bus.subscribe.call_count == 1
 
     async def test_register(self):
         mock_app = mock.MagicMock()
@@ -398,22 +395,3 @@ class TestAnoncredsRoutes(AsyncTestCase):
         mock_app = mock.MagicMock(_state={"swagger_dict": {}})
         test_module.post_process_routes(mock_app)
         assert "tags" in mock_app._state["swagger_dict"]
-
-    @mock.patch.object(
-        InMemoryProfileSession,
-        "handle",
-    )
-    @mock.patch.object(AnonCredsIssuer, "finish_schema")
-    async def test_on_schema_event_valid_payload(self, mock_finish, mock_handle):
-        mock_handle.insert = mock.CoroutineMock(return_value=None)
-        test_event = SchemaRegistrationFinishedEvent.with_payload(
-            {
-                "context": {
-                    "job_id": "test_job_id",
-                    "schema_id": "test_schema_id",
-                }
-            }
-        )
-
-        await test_module.on_schema_event(self.profile, test_event)
-        assert mock_finish.call_count == 1

--- a/aries_cloudagent/anoncreds/tests/test_routes.py
+++ b/aries_cloudagent/anoncreds/tests/test_routes.py
@@ -6,11 +6,21 @@ from asynctest import TestCase as AsyncTestCase
 
 from aries_cloudagent.admin.request_context import AdminRequestContext
 from aries_cloudagent.anoncreds.base import AnonCredsObjectNotFound
+from aries_cloudagent.anoncreds.events import SchemaRegistrationFinishedEvent
 from aries_cloudagent.anoncreds.issuer import AnonCredsIssuer
+from aries_cloudagent.anoncreds.models.anoncreds_schema import (
+    AnonCredsSchema,
+    SchemaResult,
+    SchemaState,
+)
 from aries_cloudagent.anoncreds.revocation import AnonCredsRevocation
 from aries_cloudagent.anoncreds.revocation_setup import DefaultRevocationSetup
 from aries_cloudagent.askar.profile_anon import AskarAnoncredsProfile
-from aries_cloudagent.core.in_memory.profile import InMemoryProfile
+from aries_cloudagent.core.event_bus import MockEventBus
+from aries_cloudagent.core.in_memory.profile import (
+    InMemoryProfile,
+    InMemoryProfileSession,
+)
 from aries_cloudagent.revocation_anoncreds.manager import RevocationManager
 from aries_cloudagent.tests import mock
 
@@ -64,7 +74,19 @@ class TestAnoncredsRoutes(AsyncTestCase):
     @mock.patch.object(
         AnonCredsIssuer,
         "create_and_register_schema",
-        return_value=MockSchema("schemaId"),
+        return_value=SchemaResult(
+            job_id=None,
+            schema_state=SchemaState(
+                state="finished",
+                schema_id=None,
+                schema=AnonCredsSchema(
+                    issuer_id="issuer-id",
+                    name="name",
+                    version="1.0",
+                    attr_names=["attr1", "attr2"],
+                ),
+            ),
+        ),
     )
     async def test_schemas_post(self, mock_create_and_register_schema):
         self.request.json = mock.CoroutineMock(
@@ -82,7 +104,7 @@ class TestAnoncredsRoutes(AsyncTestCase):
             ]
         )
         result = await test_module.schemas_post(self.request)
-        assert json.loads(result.body)["schema_id"] == "schemaId"
+        assert result is not None
 
         assert mock_create_and_register_schema.call_count == 1
 
@@ -358,9 +380,12 @@ class TestAnoncredsRoutes(AsyncTestCase):
         assert mock_publish.call_count == 1
 
     @mock.patch.object(DefaultRevocationSetup, "register_events")
-    async def test_register_events(self, mock_manager):
-        test_module.register_events("event_bus")
-        mock_manager.assert_called_once_with("event_bus")
+    async def test_register_events(self, mock_revocation_setup_listeners):
+        mock_event_bus = MockEventBus()
+        mock_event_bus.subscribe = mock.MagicMock()
+        test_module.register_events(mock_event_bus)
+        assert mock_revocation_setup_listeners.call_count == 1
+        assert mock_event_bus.subscribe.call_count == 1
 
     async def test_register(self):
         mock_app = mock.MagicMock()
@@ -373,3 +398,22 @@ class TestAnoncredsRoutes(AsyncTestCase):
         mock_app = mock.MagicMock(_state={"swagger_dict": {}})
         test_module.post_process_routes(mock_app)
         assert "tags" in mock_app._state["swagger_dict"]
+
+    @mock.patch.object(
+        InMemoryProfileSession,
+        "handle",
+    )
+    @mock.patch.object(AnonCredsIssuer, "finish_schema")
+    async def test_on_schema_event_valid_payload(self, mock_finish, mock_handle):
+        mock_handle.insert = mock.CoroutineMock(return_value=None)
+        test_event = SchemaRegistrationFinishedEvent.with_payload(
+            {
+                "context": {
+                    "job_id": "test_job_id",
+                    "schema_id": "test_schema_id",
+                }
+            }
+        )
+
+        await test_module.on_schema_event(self.profile, test_event)
+        assert mock_finish.call_count == 1

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/tests/test_manager.py
@@ -1,16 +1,17 @@
 import asyncio
 import json
 import uuid
-
 from unittest import IsolatedAsyncioTestCase
-from aries_cloudagent.tests import mock
 
 from .....admin.request_context import AdminRequestContext
+from .....anoncreds.default.legacy_indy.registry import LegacyIndyRegistry
 from .....cache.base import BaseCache
 from .....cache.in_memory import InMemoryCache
 from .....connections.models.conn_record import ConnRecord
+from .....core.event_bus import EventBus
 from .....ledger.base import BaseLedger
 from .....storage.error import StorageNotFoundError
+from .....tests import mock
 from .....wallet.base import BaseWallet
 from .....wallet.did_method import SOV, DIDMethods
 from .....wallet.key_type import ED25519
@@ -496,6 +497,62 @@ class TestTransactionManager(IsolatedAsyncioTestCase):
             save_record.assert_called_once()
 
         assert transaction_record.state == TransactionRecord.STATE_TRANSACTION_ACKED
+
+    @mock.patch.object(
+        LegacyIndyRegistry,
+        "txn_submit",
+        return_value=json.dumps(
+            {
+                "result": {
+                    "txn": {"type": "101", "metadata": {"from": TEST_DID}},
+                    "txnMetadata": {"txnId": SCHEMA_ID},
+                }
+            }
+        ),
+    )
+    async def test_complete_transaction_anoncreds(self, mock_txn_submit):
+        self.profile.settings.set_value("wallet.type", "askar-anoncreds")
+
+        transaction_record = await self.manager.create_record(
+            messages_attach=self.test_messages_attach,
+            connection_id=self.test_connection_id,
+        )
+        future = asyncio.Future()
+        future.set_result(
+            mock.MagicMock(return_value=mock.MagicMock(add_record=mock.CoroutineMock()))
+        )
+        self.ledger.get_indy_storage = future
+        self.profile.context.injector.bind_instance(
+            EventBus, mock.MagicMock(notify=mock.CoroutineMock())
+        )
+
+        with mock.patch.object(
+            TransactionRecord, "save", autospec=True
+        ) as save_record, mock.patch.object(
+            ConnRecord, "retrieve_by_id"
+        ) as mock_conn_rec_retrieve:
+            mock_conn_rec_retrieve.return_value = mock.MagicMock(
+                metadata_get=mock.CoroutineMock(
+                    return_value={
+                        "transaction_their_job": (
+                            TransactionJob.TRANSACTION_ENDORSER.name
+                        ),
+                        "transaction_my_job": (TransactionJob.TRANSACTION_AUTHOR.name),
+                    }
+                )
+            )
+
+            (
+                transaction_record,
+                transaction_acknowledgement_message,
+            ) = await self.manager.complete_transaction(transaction_record, False)
+            save_record.assert_called_once()
+
+        assert transaction_record.state == TransactionRecord.STATE_TRANSACTION_ACKED
+        assert mock_txn_submit.called
+        assert self.profile.context.injector.get_provider(
+            EventBus
+        )._instance.notify.called
 
     async def test_create_refuse_response_bad_state(self):
         transaction_record = await self.manager.create_record(

--- a/demo/features/0586-sign-transaction.feature
+++ b/demo/features/0586-sign-transaction.feature
@@ -28,6 +28,13 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | --multitenant --multi-ledger | --multitenant --multi-ledger | driverslicense |
          | --multitenant --multi-ledger --revocation | --multitenant --multi-ledger --revocation | driverslicense |
 
+      @WalletType_Askar_AnonCreds
+      Examples:
+         | Acme_capabilities         | Bob_capabilities          | Schema_name    |
+         | --wallet-type askar-anoncreds | --wallet-type askar-anoncreds   | anoncreds-testing |
+         | --wallet-type askar-anoncreds |                                 | driverslicense    |
+         |                               | --wallet-type askar-anoncreds   | anoncreds-testing |
+
 
    @T001.1-RFC0586 @GHA
    Scenario Outline: endorse a transaction and write to the ledger


### PR DESCRIPTION
Adds the flow for schema endorsement.

The endorsement flow is triggered by the agent having an author role or by manually setting the `create_transaction_for_endorser` option request param.

The anoncreds registry submits the transaction based on wallet type, and the post processing (storing the schema in the wallet) is triggered by the transaction manager using a new anoncreds schema event.

The endorsement integration tests are run with anoncreds wallets on the endorser and author roles. Added unit tests mostly on the registry register schema flow. 