### PR TITLE
Fix incorrect Sphinx search library version reference

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 # Defining the exact versions for ReadTheDocs that will make sure things don't break
 sphinx==4.2.0
 sphinx_rtd_theme==1.0.0
-readthedocs-sphinx-search==1.3.2
+readthedocs-sphinx-search==0.3.2


### PR DESCRIPTION
I did test it locally, but I think my process is not picking things like this up.
