### PR TITLE
Fix subwallet record removal

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -1700,13 +1700,13 @@ class WalletGroup(ArgumentGroup):
             settings["wallet.replace_public_did"] = True
         if args.recreate_wallet:
             settings["wallet.recreate"] = True
-        # check required settings for 'indy' wallets
+        # check required settings for persistent wallets
         if settings["wallet.type"] in ["indy", "askar", "askar-anoncreds"]:
             # requires name, key
             if not args.wallet_name or not args.wallet_key:
                 raise ArgsParseError(
                     "Parameters --wallet-name and --wallet-key must be provided "
-                    "for indy wallets"
+                    "for persistent wallets"
                 )
             # postgres storage requires additional configuration
             if (

--- a/aries_cloudagent/multitenant/base.py
+++ b/aries_cloudagent/multitenant/base.py
@@ -181,6 +181,7 @@ class BaseMultitenantManager(ABC):
             )
 
             await wallet_record.save(session)
+
         try:
             # provision wallet
             profile = await self.get_wallet_profile(
@@ -202,7 +203,8 @@ class BaseMultitenantManager(ABC):
                     profile, public_did_info.verkey
                 )
         except Exception:
-            await wallet_record.delete_record(session)
+            async with self._profile.session() as session:
+                await wallet_record.delete_record(session)
             raise
 
         return wallet_record

--- a/aries_cloudagent/wallet/models/wallet_record.py
+++ b/aries_cloudagent/wallet/models/wallet_record.py
@@ -80,7 +80,7 @@ class WalletRecord(BaseRecord):
         return self.settings.get("wallet.key")
 
     @property
-    def wallet_key_derivation_method(self):
+    def wallet_key_derivation_method(self) -> Optional[str]:
         """Accessor for the key derivation method of the wallet."""
         return self.settings.get("wallet.key_derivation_method")
 


### PR DESCRIPTION
If subwallet initialization fails (for example due to an invalid wallet key: #2682) then the wallet record is meant to be removed. This could fail because a session was not being opened first.
