### PR TITLE
Update the SupportedRFCs Document to be up to date

### DIFF
--- a/SupportedRFCs.md
+++ b/SupportedRFCs.md
@@ -8,7 +8,7 @@ ACA-Py or the repository `main` branch. Reminders (and PRs!) to update this page
 welcome! If you have any questions, please contact us on the #aries channel on
 [Hyperledger Discord](https://discord.gg/hyperledger) or through an issue in this repo.
 
-**Last Update**: 2021-12-22, Release 0.7.3
+**Last Update**: 2024-01-17, Release 0.11.0
 
 > The checklist version of this document was created as a joint effort
 > between [Northern Block](https://northernblock.io/), [Animo Solutions](https://animo.id/) and the Ontario government, on behalf of the Ontario government.
@@ -49,47 +49,63 @@ A summary of the Aries Interop Profiles and Aries RFCs supported in ACA-Py can b
 | Mediator Client | :white_check_mark: |
 | Indy Transaction Author | :white_check_mark:        |    |
 | Indy Transaction Endorser | :white_check_mark:  | |
-| Indy Endorser Service | :construction:        | Help Wanted! See the [aries-endorser-service](https://github.com/bcgov/aries-endorser-service), an under-construction, pre-configured, production ready Aries Endorser Service based on a released version of ACA-Py. On completion, we expect this repository to be moved into the Hyperledger GitHub organization. |
+| Indy Endorser Service | :white_check_mark:        | See the [aries-endorser-service](https://github.com/hyperledger/aries-endorser-service), a pre-configured, production ready Aries Endorser Service based on a released version of ACA-Py. |
 
 ## Credential Types
 
 | Credential Type | Supported | Notes |
 | --- | :--: | -- |
-| [Indy AnonCreds](https://hyperledger-indy.readthedocs.io/projects/sdk/en/latest/docs/design/002-anoncreds/README.html) | :white_check_mark: | Includes full issue VC, present proof, and revoke VC support. |
-| [W3C Standard Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) | :white_check_mark: | Supports only JSON-LD Credentials using the `Ed25519Signature2018`, `BbsBlsSignature2020` and `BbsBlsSignatureProof2020` signature suites.<br><br>Supports the [DIF Presentation Exchange](https://identity.foundation/presentation-exchange/) data format for presentation requests and presentation submissions. |
+| [Hyperledger AnonCreds] | :white_check_mark: | Includes full issue VC, present proof, and revoke VC support. |
+| [W3C Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model/) | :white_check_mark: | Supports JSON-LD Data Integrity Proof Credentials using the `Ed25519Signature2018`, `BbsBlsSignature2020` and `BbsBlsSignatureProof2020` signature suites.<br><br>Supports the [DIF Presentation Exchange](https://identity.foundation/presentation-exchange/) data format for presentation requests and presentation submissions.<br><br>Work currently underway to add support for [Hyperledger AnonCreds] in W3C VC JSON-LD Format |
+
+[Hyperledger AnonCreds]: https://www.hyperledger.org/projects/anoncreds
 
 ## DID Methods
 
 | Method | Supported | Notes |
 | --- | :--: | -- |
+| "unqualified" | :white_check_mark: | Pre-DID standard identifiers. Used either in a peer-to-peer context, or as an alternate form of a `did:sov` DID published on an Indy network. |
 | `did:sov` | :white_check_mark: |  |
 | `did:web` | :white_check_mark: | Resolution only |
 | `did:key` | :white_check_mark: | |
-| `did:peer` | :warning:| AIP 1.0-based `did:peer` DIDs are used, meaning the DIDs are not prefixed with `did:peer` and are not following the conventions of AIP 2.0's [RFC 0627: Static Peer DIDs](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0627-static-peer-dids) |
-| Universal Resolver | :construction: | A [plug in](https://github.com/sicpa-dlab/acapy-resolver-universal) from [SICPA](https://www.sicpa.com/) is available that can be added to an ACA-Py installation to support a [universal resolver](https://dev.uniresolver.io/) capability, providing support for most DID methods in the [W3C DID Method Registry](https://w3c.github.io/did-spec-registries/#did-methods). |
+| `did:peer` | :white_check_mark:| Algorithms `2`/`3` and `4` |
+| Universal Resolver | :white_check_mark: | A [plug in](https://github.com/sicpa-dlab/acapy-resolver-universal) from [SICPA](https://www.sicpa.com/) is available that can be added to an ACA-Py installation to support a [universal resolver](https://dev.uniresolver.io/) capability, providing support for most DID methods in the [W3C DID Method Registry](https://w3c.github.io/did-spec-registries/#did-methods). |
 
 ## Secure Storage Types
 
 | Secure Storage Types | Supported | Notes |
  --- | :--: | -- |
-| [Aries Askar](https://github.com/hyperledger/aries-askar) | :white_check_mark: | Recommended - Aries Askar provides equivalent/evolved secure storage and cryptography support to the "indy-wallet" part of the Indy SDK. When using Askar (via the `--wallet-type askar` startup parameter), other Indy SDK functionality is handled by [Indy Shared RS](https://github.com/hyperledger/indy-shared-rs) (AnonCreds) and [Indy VDR](https://github.com/hyperledger/indy-vdr) (Indy ledger interactions). |
-| [Indy SDK "indy-wallet"](https://github.com/hyperledger/indy-sdk/tree/master/docs/design/003-wallet-storage) | :white_check_mark: | Full support for the features of the "indy-wallet" secure storage capabilities found in the Indy SDK. |
+| [Aries Askar] | :white_check_mark: | Recommended - Aries Askar provides equivalent/evolved secure storage and cryptography support to the "indy-wallet" part of the Indy SDK. When using Askar (via the `--wallet-type askar` startup parameter), other functionality is handled by [CredX](https://github.com/hyperledger/indy-shared-rs) (AnonCreds) and [Indy VDR](https://github.com/hyperledger/indy-vdr) (Indy ledger interactions). |
+| [Aries Askar]-AnonCreds | :white_check_mark: | Recommended - When using Askar/AnonCreds (via the `--wallet-type askar-anoncreds` startup parameter), other functionality is handled by [AnonCreds RS](https://github.com/hyperledger/anoncreds-rs) (AnonCreds) and [Indy VDR](https://github.com/hyperledger/indy-vdr) (Indy ledger interactions).<br><br>This `wallet-type` will eventually be the same as `askar` when we have fully integrated the AnonCreds RS library into ACA-Py. |
+| [Indy SDK](https://github.com/hyperledger/indy-sdk/tree/master/docs/design/003-wallet-storage) | :warning: Deprecated | Full support for the features of the "indy-wallet" secure storage capabilities found in the Indy SDK. |
+
+> New installations of ACA-Py should **NOT** use the [Indy SDK]. Existing deployments using the [Indy SDK] should transition to [Aries Askar] and related components as soon as possible.
+
+[Aries Askar]: https://github.com/hyperledger/aries-askar
+[Indy SDK]: https://github.com/hyperledger/indy-sdk/tree/master/docs/design/003-wallet-storage
 
 ## Miscellaneous Features
 
 | Feature | Supported | Notes |
  --- | :--: | -- |
+| ACA-Py Plugins | :white_check_mark:  | The [ACA-Py Plugins] repository contains a growing set of plugins that are maintained and (mostly) tested against new releases of ACA-Py. |
 | Multi use invitations            | :white_check_mark:  |         |
 | Invitations using public did     | :white_check_mark:        |         |
 | Implicit pickup of messages in role of mediator | :white_check_mark:        |         |
-| [Revocable Indy Credentials](https://github.com/hyperledger/indy-hipe/tree/main/text/0011-cred-revocation) | :white_check_mark:        |         |
+| [Revocable AnonCreds Credentials](https://github.com/hyperledger/indy-hipe/tree/main/text/0011-cred-revocation) | :white_check_mark:        |         |
 | Multi-Tenancy      | :white_check_mark:        | [Documentation](https://github.com/hyperledger/aries-cloudagent-python/blob/main/Multitenancy.md) |
+| Multi-Tenant Management | :white_check_mark: | The [Traction] open source project from BC Gov is a layer on top of ACA-Py that enables the easy management of ACA-Py tenants, with an Administrative UI ("The Innkeeper") and a Tenant UI for using ACA-Py in a web UI (setting up, issuing, holding and verifying credentials) |
 | Connection-less (non OOB protocol / AIP 1.0)               | :white_check_mark:        | Only for issue credential and present proof          |
 | Connection-less (OOB protocol / AIP 2.0)               | :white_check_mark:        | Only for present proof          |
 | Signed Attachments               | :white_check_mark:        | Used for OOB         |
 | Multi Indy ledger support (with automatic detection) | :white_check_mark: | Support added in the 0.7.3 Release.   |
-| Persistence of mediated messages | :construction:        | Work is mostly complete to add external, persistent queue handling, including support for multiple external queue implementations (notably, plugins for [Redis](https://github.com/bcgov/aries-acapy-plugin-redis-events) and [Kafka](https://github.com/sicpa-dlab/aries-acapy-plugin-kafka-events)). Documentation for that is being worked on. Without persistent queue support, messages are stored in an in-memory queue and so are subject to loss in the case of a sudden termination of an ACA-Py process. The in-memory queue is properly handled in the case of a graceful shutdown of an ACA-Py process (e.g. processing of the queue completes and no new messages are accepted).  |
-| Storage Import & Export           | :warning:        | Supported by directly interacting with the indy-sdk or Aries Askar (e.g., no Admin API endpoint available for wallet import & export). Aries Askar support includes the ability to import storage exported from the Indy SDK's "indy-wallet" component. However, a full migration approach from a production ACA-Py using the Indy-SDK storage to use Aries Askar storage has not been implemeted and documented. |
+| Persistence of mediated messages | :white_check_mark:        | Plugins in the [ACA-Py Plugins] repository are available for persistent queue support using Redis and Kafka. Without persistent queue support, messages are stored in an in-memory queue and so are subject to loss in the case of a sudden termination of an ACA-Py process. The in-memory queue is properly handled in the case of a graceful shutdown of an ACA-Py process (e.g. processing of the queue completes and no new messages are accepted).  |
+| Storage Import & Export           | :warning:        | Supported by directly interacting with the Aries Askar (e.g., no Admin API endpoint available for wallet import & export). Aries Askar support includes the ability to import storage exported from the Indy SDK's "indy-wallet" component. Documentation for migrating from Indy SDK storage to Askar can be found in the [Indy SDK to Askar Migration Guide].|
+| SD-JWTs | :white_check_mark: | Signing and verifying SD-JWTs is supported |
+
+[ACA-Py Plugins]: https://github.com/hyperledger/aries-acapy-plugins
+[Indy SDK to Askar Migration Guide]: ./IndySDKtoAskarMigration.md
+[Traction]: https://github.com/bcgov/traction
 
 ## Supported RFCs
 
@@ -110,12 +126,12 @@ are fully supported in ACA-Py **EXCEPT** as noted in the table below.
 
 | RFC | Supported | Notes |
  --- | :--: | -- |
-| [0023-did-exchange](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0023-did-exchange)   | :warning:   |   Not using DIDDoc conventions yet, still using DID format of 0160-connections (which is incorrect and outdated). Also using incorrect format for `did:peer`  (or not using a `did:` prefix at all) |
+| [0023-did-exchange](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0023-did-exchange)   | :white_check_mark:   |   Still supports unqualified DIDs, but did:peer DIDs are supported as well. |
 | [0211-route-coordination](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0211-route-coordination)   | :warning:  | Only pre-AIP 2.0 version. Must be updated to use `did:key` for full AIP 2.0 support  |
-| [0317-please-ack](https://github.com/hyperledger/aries-rfcs/tree/main/features/0317-please-ack) |  :x: | |
+| [0317-please-ack](https://github.com/hyperledger/aries-rfcs/tree/main/features/0317-please-ack) |  :x: | An investigation was done into supporting `please-ack` and a number of complications were found. As a result, we expect that `please-ack` will be dropped from AIP 2.0. It has not been implemented by any Aries frameworks or deployments. |
 | [0360-use-did-key](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0360-use-did-key)     | :warning:  |  Creating and resolving `did:key` DIDs is supported, but not all protocols are updated yet to use `did:key`. This is a breaking change for AIP 1.0 -> AIP 2.0.                |
 | [0587-encryption-envelope-v2](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0587-encryption-envelope-v2) | :construction: | Support for the DIDComm V2 envelope format is a work in progress, including the PRs ([AIP-2 base64url consistency](https://github.com/hyperledger/aries-cloudagent-python/pull/1188) and [Small AIP-2 updates](https://github.com/hyperledger/aries-cloudagent-python/pull/1056)) |
-| [0627-static-peer-dids](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0627-static-peer-dids)          | :x:  |  |
+| [0627-static-peer-dids](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0627-static-peer-dids)          | :white_check_mark:  | Peer DIDs `2/3` and `4` are supported in ACA-Py. |
 
 ### Other Supported RFCs
 

--- a/SupportedRFCs.md
+++ b/SupportedRFCs.md
@@ -22,7 +22,7 @@ ACA-Py and other Aries Frameworks and Agents.
 | AIP Version | Supported | Notes |
 |  - | :-------: | -------- |
 | AIP 1.0     | :white_check_mark:  | Fully supported. |
-| AIP 2.0     | :warning:        |  Largely supported with exceptions highlighted [below](#aip-20). |
+| AIP 2.0     | :white_check_mark:  | Fully supported, with a couple of very minor exceptions noted [below](#aip-20). |
 
 A summary of the Aries Interop Profiles and Aries RFCs supported in ACA-Py can be found [later in this document](#supported-rfcs).
 
@@ -126,12 +126,8 @@ are fully supported in ACA-Py **EXCEPT** as noted in the table below.
 
 | RFC | Supported | Notes |
  --- | :--: | -- |
-| [0023-did-exchange](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0023-did-exchange)   | :white_check_mark:   |   Still supports unqualified DIDs, but did:peer DIDs are supported as well. |
-| [0211-route-coordination](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0211-route-coordination)   | :warning:  | Only pre-AIP 2.0 version. Must be updated to use `did:key` for full AIP 2.0 support  |
+| [0587-encryption-envelope-v2](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0587-encryption-envelope-v2) | :construction: | Support for the DIDComm V2 envelope format is a work in progress |
 | [0317-please-ack](https://github.com/hyperledger/aries-rfcs/tree/main/features/0317-please-ack) |  :x: | An investigation was done into supporting `please-ack` and a number of complications were found. As a result, we expect that `please-ack` will be dropped from AIP 2.0. It has not been implemented by any Aries frameworks or deployments. |
-| [0360-use-did-key](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0360-use-did-key)     | :warning:  |  Creating and resolving `did:key` DIDs is supported, but not all protocols are updated yet to use `did:key`. This is a breaking change for AIP 1.0 -> AIP 2.0.                |
-| [0587-encryption-envelope-v2](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0587-encryption-envelope-v2) | :construction: | Support for the DIDComm V2 envelope format is a work in progress, including the PRs ([AIP-2 base64url consistency](https://github.com/hyperledger/aries-cloudagent-python/pull/1188) and [Small AIP-2 updates](https://github.com/hyperledger/aries-cloudagent-python/pull/1056)) |
-| [0627-static-peer-dids](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0627-static-peer-dids)          | :white_check_mark:  | Peer DIDs `2/3` and `4` are supported in ACA-Py. |
 
 ### Other Supported RFCs
 


### PR DESCRIPTION
I'd welcome feedback on this on other things we want to highlight in this document.

@dbluhm @andrewwhitehead @ianco, do you think these AIP 2.0 comments are still accurate:

| RFC | Supported | Notes |
 --- | :--: | -- |
| [0211-route-coordination](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0211-route-coordination)   | :warning:  | Only pre-AIP 2.0 version. Must be updated to use `did:key` for full AIP 2.0 support  |
| [0360-use-did-key](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0360-use-did-key)     | :warning:  |  Creating and resolving `did:key` DIDs is supported, but not all protocols are updated yet to use `did:key`. This is a breaking change for AIP 1.0 -> AIP 2.0.                |
| [0587-encryption-envelope-v2](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0587-encryption-envelope-v2) | :construction: | Support for the DIDComm V2 envelope format is a work in progress, including the PRs ([AIP-2 base64url consistency](https://github.com/hyperledger/aries-cloudagent-python/pull/1188) and [Small AIP-2 updates](https://github.com/hyperledger/aries-cloudagent-python/pull/1056)) |
