### PR TITLE
Remove exception on connectionless presentation problem report handler

### DIFF
--- a/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_problem_report_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_problem_report_handler.py
@@ -30,16 +30,14 @@ class PresentationProblemReportHandler(BaseHandler):
             raise HandlerException(
                 "Connection used for presentation problem report not ready"
             )
-        elif not context.connection_record:
-            raise HandlerException(
-                "Connectionless not supported for presentation problem report"
-            )
 
         presentation_manager = PresentationManager(context.profile)
         try:
             await presentation_manager.receive_problem_report(
                 context.message,
-                context.connection_record.connection_id,
+                context.connection_record.connection_id
+                if context.connection_record is not None
+                else None,
             )
         except (StorageError, StorageNotFoundError):
             self._logger.exception(


### PR DESCRIPTION
This is to support being able to get callbacks to [vc-authn-oidc](https://github.com/bcgov/vc-authn-oidc) when a user declines the presentation request sent to their agent.

Presently ACA-PY is throwing an exception if the problem report does not contain a connection record.
Remove that exception and allow the recieve_problem_report to continue (and supply None for the connection ID in that case).
