### PR TITLE
fix: partial revert of ConnRecord schema change

### DIFF
--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -232,9 +232,7 @@ class ConnRecord(BaseRecord):
         self.their_role = (
             ConnRecord.Role.get(their_role).rfc160
             if isinstance(their_role, str)
-            else None
-            if their_role is None
-            else their_role.rfc160
+            else None if their_role is None else their_role.rfc160
         )
         self.invitation_key = invitation_key
         self.invitation_msg_id = invitation_msg_id

--- a/aries_cloudagent/connections/models/conn_record.py
+++ b/aries_cloudagent/connections/models/conn_record.py
@@ -41,7 +41,7 @@ class ConnRecord(BaseRecord):
     class Meta:
         """ConnRecord metadata."""
 
-        schema_class = "ConnRecordSchema"
+        schema_class = "MaybeStoredConnRecordSchema"
 
     class Protocol(Enum):
         """Supported Protocols for Connection."""
@@ -232,7 +232,9 @@ class ConnRecord(BaseRecord):
         self.their_role = (
             ConnRecord.Role.get(their_role).rfc160
             if isinstance(their_role, str)
-            else None if their_role is None else their_role.rfc160
+            else None
+            if their_role is None
+            else their_role.rfc160
         )
         self.invitation_key = invitation_key
         self.invitation_msg_id = invitation_msg_id
@@ -637,11 +639,11 @@ class ConnRecord(BaseRecord):
         return super().__eq__(other)
 
 
-class ConnRecordSchema(BaseRecordSchema):
+class MaybeStoredConnRecordSchema(BaseRecordSchema):
     """Schema to allow serialization/deserialization of connection records."""
 
     class Meta:
-        """ConnRecordSchema metadata."""
+        """MaybeStoredConnRecordSchema metadata."""
 
         model_class = ConnRecord
 
@@ -763,7 +765,7 @@ class ConnRecordSchema(BaseRecordSchema):
     )
 
 
-class StoredConnRecordSchema(ConnRecordSchema):
+class ConnRecordSchema(MaybeStoredConnRecordSchema):
     """Schema representing stored ConnRecords."""
 
     class Meta:

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -16,7 +16,7 @@ from marshmallow import fields, validate, validates_schema
 
 from ....admin.request_context import AdminRequestContext
 from ....cache.base import BaseCache
-from ....connections.models.conn_record import ConnRecord, StoredConnRecordSchema
+from ....connections.models.conn_record import ConnRecord, ConnRecordSchema
 from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
 from ....messaging.valid import (
@@ -48,7 +48,7 @@ class ConnectionListSchema(OpenAPISchema):
     """Result schema for connection list."""
 
     results = fields.List(
-        fields.Nested(StoredConnRecordSchema()),
+        fields.Nested(ConnRecordSchema()),
         required=True,
         metadata={"description": "List of connection records"},
     )
@@ -233,7 +233,7 @@ class ConnectionStaticResultSchema(OpenAPISchema):
             "example": INDY_RAW_PUBLIC_KEY_EXAMPLE,
         },
     )
-    record = fields.Nested(StoredConnRecordSchema(), required=True)
+    record = fields.Nested(ConnRecordSchema(), required=True)
 
 
 class ConnectionsListQueryStringSchema(OpenAPISchema):
@@ -485,7 +485,7 @@ async def connections_list(request: web.BaseRequest):
 
 @docs(tags=["connection"], summary="Fetch a single connection record")
 @match_info_schema(ConnectionsConnIdMatchInfoSchema())
-@response_schema(StoredConnRecordSchema(), 200, description="")
+@response_schema(ConnRecordSchema(), 200, description="")
 async def connections_retrieve(request: web.BaseRequest):
     """Request handler for fetching a single connection record.
 
@@ -670,7 +670,7 @@ async def connections_create_invitation(request: web.BaseRequest):
 )
 @querystring_schema(ReceiveInvitationQueryStringSchema())
 @request_schema(ReceiveInvitationRequestSchema())
-@response_schema(StoredConnRecordSchema(), 200, description="")
+@response_schema(ConnRecordSchema(), 200, description="")
 async def connections_receive_invitation(request: web.BaseRequest):
     """Request handler for receiving a new connection invitation.
 
@@ -711,7 +711,7 @@ async def connections_receive_invitation(request: web.BaseRequest):
 )
 @match_info_schema(ConnectionsConnIdMatchInfoSchema())
 @querystring_schema(AcceptInvitationQueryStringSchema())
-@response_schema(StoredConnRecordSchema(), 200, description="")
+@response_schema(ConnRecordSchema(), 200, description="")
 async def connections_accept_invitation(request: web.BaseRequest):
     """Request handler for accepting a stored connection invitation.
 
@@ -761,7 +761,7 @@ async def connections_accept_invitation(request: web.BaseRequest):
 )
 @match_info_schema(ConnectionsConnIdMatchInfoSchema())
 @querystring_schema(AcceptRequestQueryStringSchema())
-@response_schema(StoredConnRecordSchema(), 200, description="")
+@response_schema(ConnRecordSchema(), 200, description="")
 async def connections_accept_request(request: web.BaseRequest):
     """Request handler for accepting a stored connection request.
 

--- a/aries_cloudagent/protocols/didexchange/v1_0/routes.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/routes.py
@@ -14,7 +14,7 @@ from aiohttp_apispec import (
 from marshmallow import fields
 
 from ....admin.request_context import AdminRequestContext
-from ....connections.models.conn_record import ConnRecord, StoredConnRecordSchema
+from ....connections.models.conn_record import ConnRecord, ConnRecordSchema
 from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
 from ....messaging.valid import (
@@ -197,7 +197,7 @@ class DIDXRejectRequestSchema(OpenAPISchema):
 )
 @match_info_schema(DIDXConnIdMatchInfoSchema())
 @querystring_schema(DIDXAcceptInvitationQueryStringSchema())
-@response_schema(StoredConnRecordSchema(), 200, description="")
+@response_schema(ConnRecordSchema(), 200, description="")
 async def didx_accept_invitation(request: web.BaseRequest):
     """Request handler for accepting a stored connection invitation.
 
@@ -243,7 +243,7 @@ async def didx_accept_invitation(request: web.BaseRequest):
     summary="Create and send a request against public DID's implicit invitation",
 )
 @querystring_schema(DIDXCreateRequestImplicitQueryStringSchema())
-@response_schema(StoredConnRecordSchema(), 200, description="")
+@response_schema(ConnRecordSchema(), 200, description="")
 async def didx_create_request_implicit(request: web.BaseRequest):
     """Request handler for creating and sending a request to an implicit invitation.
 
@@ -294,7 +294,7 @@ async def didx_create_request_implicit(request: web.BaseRequest):
 )
 @querystring_schema(DIDXReceiveRequestImplicitQueryStringSchema())
 @request_schema(DIDXRequestSchema())
-@response_schema(StoredConnRecordSchema(), 200, description="")
+@response_schema(ConnRecordSchema(), 200, description="")
 async def didx_receive_request_implicit(request: web.BaseRequest):
     """Request handler for receiving a request against public DID's implicit invitation.
 
@@ -340,7 +340,7 @@ async def didx_receive_request_implicit(request: web.BaseRequest):
 )
 @match_info_schema(DIDXConnIdMatchInfoSchema())
 @querystring_schema(DIDXAcceptRequestQueryStringSchema())
-@response_schema(StoredConnRecordSchema(), 200, description="")
+@response_schema(ConnRecordSchema(), 200, description="")
 async def didx_accept_request(request: web.BaseRequest):
     """Request handler for accepting a stored connection request.
 
@@ -385,7 +385,7 @@ async def didx_accept_request(request: web.BaseRequest):
 )
 @match_info_schema(DIDXConnIdMatchInfoSchema())
 @request_schema(DIDXRejectRequestSchema())
-@response_schema(StoredConnRecordSchema(), 200, description="")
+@response_schema(ConnRecordSchema(), 200, description="")
 async def didx_reject(request: web.BaseRequest):
     """Abandon or reject a DID Exchange."""
     context: AdminRequestContext = request["context"]

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -90,20 +90,6 @@
     },
     "name" : "jsonld"
   }, {
-    "description" : "Issue and verify LDP VCs and VPs",
-    "externalDocs" : {
-      "description" : "Specification",
-      "url" : "https://www.w3.org/TR/vc-data-model/"
-    },
-    "name" : "ldp-vc"
-  }, {
-    "description" : "Manage credentials and presentations",
-    "externalDocs" : {
-      "description" : "Specification",
-      "url" : "https://w3c-ccg.github.io/vc-api"
-    },
-    "name" : "vc-api"
-  }, {
     "description" : "Interaction with ledger",
     "externalDocs" : {
       "description" : "Overview",
@@ -172,6 +158,13 @@
       "url" : "https://github.com/hyperledger/aries-rfcs/tree/527849ec3aa2a8fd47a7bb6c57f918ff8bcb5e8c/features/0048-trust-ping"
     },
     "name" : "trustping"
+  }, {
+    "description" : "Endpoints for managing w3c credentials and presentations",
+    "externalDocs" : {
+      "description" : "Specification",
+      "url" : "https://w3c-ccg.github.io/vc-api/"
+    },
+    "name" : "vc-api"
   }, {
     "description" : "DID and tag policy management",
     "externalDocs" : {
@@ -383,7 +376,7 @@
           "in" : "query",
           "name" : "state",
           "schema" : {
-            "enum" : [ "request", "abandoned", "active", "init", "error", "invitation", "start", "response", "completed" ],
+            "enum" : [ "active", "error", "invitation", "start", "init", "completed", "request", "response", "abandoned" ],
             "type" : "string"
           }
         }, {
@@ -554,7 +547,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/StoredConnRecord"
+                  "$ref" : "#/components/schemas/ConnRecord"
                 }
               }
             },
@@ -607,7 +600,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/StoredConnRecord"
+                  "$ref" : "#/components/schemas/ConnRecord"
                 }
               }
             },
@@ -657,7 +650,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/StoredConnRecord"
+                  "$ref" : "#/components/schemas/ConnRecord"
                 }
               }
             },
@@ -692,7 +685,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/StoredConnRecord"
+                  "$ref" : "#/components/schemas/ConnRecord"
                 }
               }
             },
@@ -1430,7 +1423,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/StoredConnRecord"
+                  "$ref" : "#/components/schemas/ConnRecord"
                 }
               }
             },
@@ -1489,7 +1482,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/StoredConnRecord"
+                  "$ref" : "#/components/schemas/ConnRecord"
                 }
               }
             },
@@ -1532,7 +1525,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/StoredConnRecord"
+                  "$ref" : "#/components/schemas/ConnRecord"
                 }
               }
             },
@@ -1582,7 +1575,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/StoredConnRecord"
+                  "$ref" : "#/components/schemas/ConnRecord"
                 }
               }
             },
@@ -1619,7 +1612,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/StoredConnRecord"
+                  "$ref" : "#/components/schemas/ConnRecord"
                 }
               }
             },
@@ -5910,13 +5903,31 @@
         "tags" : [ "endorse-transaction" ]
       }
     },
-    "/vc/ldp/issue" : {
+    "/vc/credentials" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ListCredentialsResponse"
+                }
+              }
+            },
+            "description" : ""
+          }
+        },
+        "summary" : "List credentials",
+        "tags" : [ "vc-api" ]
+      }
+    },
+    "/vc/credentials/issue" : {
       "post" : {
         "requestBody" : {
           "content" : {
             "*/*" : {
               "schema" : {
-                "$ref" : "#/components/schemas/LdpIssueRequest"
+                "$ref" : "#/components/schemas/IssueCredentialRequest"
               }
             }
           },
@@ -5927,25 +5938,31 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/LdpIssueResponse"
+                  "$ref" : "#/components/schemas/IssueCredentialResponse"
                 }
               }
             },
             "description" : ""
           }
         },
-        "summary" : "Sign an LDP VC.",
-        "tags" : [ "ldp_vc" ],
+        "summary" : "Issue a credential",
+        "tags" : [ "vc-api" ],
         "x-codegen-request-body-name" : "body"
       }
     },
-    "/vc/ldp/verify" : {
+    "/vc/credentials/store" : {
+      "post" : {
+        "summary" : "Store a credential",
+        "tags" : [ "vc-api" ]
+      }
+    },
+    "/vc/credentials/verify" : {
       "post" : {
         "requestBody" : {
           "content" : {
             "*/*" : {
               "schema" : {
-                "$ref" : "#/components/schemas/LdpVerifyRequest"
+                "$ref" : "#/components/schemas/VerifyCredentialRequest"
               }
             }
           },
@@ -5956,15 +5973,99 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/LdpVerifyResponse"
+                  "$ref" : "#/components/schemas/VerifyCredentialResponse"
                 }
               }
             },
             "description" : ""
           }
         },
-        "summary" : "Verify an LDP VC or VP.",
-        "tags" : [ "ldp_vc" ],
+        "summary" : "Verify a credential",
+        "tags" : [ "vc-api" ],
+        "x-codegen-request-body-name" : "body"
+      }
+    },
+    "/vc/credentials/{credential_id}" : {
+      "get" : {
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "credential_id",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/FetchCredentialResponse"
+                }
+              }
+            },
+            "description" : ""
+          }
+        },
+        "summary" : "Fetch credential by ID",
+        "tags" : [ "vc-api" ]
+      }
+    },
+    "/vc/presentations/prove" : {
+      "post" : {
+        "requestBody" : {
+          "content" : {
+            "*/*" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ProvePresentationRequest"
+              }
+            }
+          },
+          "required" : false
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProvePresentationResponse"
+                }
+              }
+            },
+            "description" : ""
+          }
+        },
+        "summary" : "Prove a presentation",
+        "tags" : [ "vc-api" ],
+        "x-codegen-request-body-name" : "body"
+      }
+    },
+    "/vc/presentations/verify" : {
+      "post" : {
+        "requestBody" : {
+          "content" : {
+            "*/*" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/VerifyPresentationRequest"
+              }
+            }
+          },
+          "required" : false
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VerifyPresentationResponse"
+                }
+              }
+            },
+            "description" : ""
+          }
+        },
+        "summary" : "Verify a Presentation",
+        "tags" : [ "vc-api" ],
         "x-codegen-request-body-name" : "body"
       }
     },
@@ -6671,6 +6772,117 @@
         },
         "type" : "object"
       },
+      "ConnRecord" : {
+        "properties" : {
+          "accept" : {
+            "description" : "Connection acceptance: manual or auto",
+            "enum" : [ "manual", "auto" ],
+            "example" : "auto",
+            "type" : "string"
+          },
+          "alias" : {
+            "description" : "Optional alias to apply to connection for later use",
+            "example" : "Bob, providing quotes",
+            "type" : "string"
+          },
+          "connection_id" : {
+            "description" : "Connection identifier",
+            "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "type" : "string"
+          },
+          "connection_protocol" : {
+            "description" : "Connection protocol used",
+            "enum" : [ "connections/1.0", "didexchange/1.0" ],
+            "example" : "connections/1.0",
+            "type" : "string"
+          },
+          "created_at" : {
+            "description" : "Time of record creation",
+            "example" : "2021-12-31T23:59:59Z",
+            "pattern" : "^\\d{4}-\\d\\d-\\d\\d[T ]\\d\\d:\\d\\d(?:\\:(?:\\d\\d(?:\\.\\d{1,6})?))?(?:[+-]\\d\\d:?\\d\\d|Z|)$",
+            "type" : "string"
+          },
+          "error_msg" : {
+            "description" : "Error message",
+            "example" : "No DIDDoc provided; cannot connect to public DID",
+            "type" : "string"
+          },
+          "inbound_connection_id" : {
+            "description" : "Inbound routing connection id to use",
+            "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "type" : "string"
+          },
+          "invitation_key" : {
+            "description" : "Public key for connection",
+            "example" : "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV",
+            "pattern" : "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{43,44}$",
+            "type" : "string"
+          },
+          "invitation_mode" : {
+            "description" : "Invitation mode",
+            "enum" : [ "once", "multi", "static" ],
+            "example" : "once",
+            "type" : "string"
+          },
+          "invitation_msg_id" : {
+            "description" : "ID of out-of-band invitation message",
+            "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "type" : "string"
+          },
+          "my_did" : {
+            "description" : "Our DID for connection",
+            "example" : "did:peer:WgWxqztrNooG92RXvxSTWv",
+            "pattern" : "^(did:sov:)?[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}$|^did:([a-zA-Z0-9_]+):([a-zA-Z0-9_.%-]+(:[a-zA-Z0-9_.%-]+)*)((;[a-zA-Z0-9_.:%-]+=[a-zA-Z0-9_.:%-]*)*)(\\/[^#?]*)?([?][^#]*)?(\\#.*)?$$",
+            "type" : "string"
+          },
+          "request_id" : {
+            "description" : "Connection request identifier",
+            "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "type" : "string"
+          },
+          "rfc23_state" : {
+            "description" : "State per RFC 23",
+            "example" : "invitation-sent",
+            "readOnly" : true,
+            "type" : "string"
+          },
+          "state" : {
+            "description" : "Current record state",
+            "example" : "active",
+            "type" : "string"
+          },
+          "their_did" : {
+            "description" : "Their DID for connection",
+            "example" : "did:peer:WgWxqztrNooG92RXvxSTWv",
+            "pattern" : "^(did:sov:)?[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}$|^did:([a-zA-Z0-9_]+):([a-zA-Z0-9_.%-]+(:[a-zA-Z0-9_.%-]+)*)((;[a-zA-Z0-9_.:%-]+=[a-zA-Z0-9_.:%-]*)*)(\\/[^#?]*)?([?][^#]*)?(\\#.*)?$$",
+            "type" : "string"
+          },
+          "their_label" : {
+            "description" : "Their label for connection",
+            "example" : "Bob",
+            "type" : "string"
+          },
+          "their_public_did" : {
+            "description" : "Other agent's public DID for connection",
+            "example" : "2cpBmR3FqGKWi5EyUbpRY8",
+            "type" : "string"
+          },
+          "their_role" : {
+            "description" : "Their role in the connection protocol",
+            "enum" : [ "invitee", "requester", "inviter", "responder" ],
+            "example" : "requester",
+            "type" : "string"
+          },
+          "updated_at" : {
+            "description" : "Time of last record update",
+            "example" : "2021-12-31T23:59:59Z",
+            "pattern" : "^\\d{4}-\\d\\d-\\d\\d[T ]\\d\\d:\\d\\d(?:\\:(?:\\d\\d(?:\\.\\d{1,6})?))?(?:[+-]\\d\\d:?\\d\\d|Z|)$",
+            "type" : "string"
+          }
+        },
+        "required" : [ "connection_id" ],
+        "type" : "object"
+      },
       "ConnectionInvitation" : {
         "properties" : {
           "@id" : {
@@ -6735,7 +6947,7 @@
           "results" : {
             "description" : "List of connection records",
             "items" : {
-              "$ref" : "#/components/schemas/StoredConnRecord"
+              "$ref" : "#/components/schemas/ConnRecord"
             },
             "type" : "array"
           }
@@ -6831,7 +7043,7 @@
             "type" : "string"
           },
           "record" : {
-            "$ref" : "#/components/schemas/StoredConnRecord"
+            "$ref" : "#/components/schemas/ConnRecord"
           },
           "their_did" : {
             "description" : "Remote DID",
@@ -7227,6 +7439,10 @@
               "type" : "object"
             },
             "type" : "array"
+          },
+          "credentialStatus" : {
+            "example" : "",
+            "type" : "object"
           },
           "credentialSubject" : {
             "example" : "",
@@ -7919,6 +8135,14 @@
             "example" : "https://myhost:8021",
             "pattern" : "^[A-Za-z0-9\\.\\-\\+]+://([A-Za-z0-9][.A-Za-z0-9-_]+[A-Za-z0-9])+(:[1-9][0-9]*)?(/[^?&#]+)?$",
             "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "FetchCredentialResponse" : {
+        "properties" : {
+          "results" : {
+            "$ref" : "#/components/schemas/VerifiableCredential"
           }
         },
         "type" : "object"
@@ -9282,7 +9506,47 @@
         "required" : [ "connection_id", "invitation", "invitation_url" ],
         "type" : "object"
       },
+      "IssuanceOptions" : {
+        "properties" : {
+          "challenge" : {
+            "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "type" : "string"
+          },
+          "created" : {
+            "example" : "2010-01-01T19:23:24Z",
+            "type" : "string"
+          },
+          "domain" : {
+            "example" : "website.example",
+            "type" : "string"
+          },
+          "type" : {
+            "example" : "Ed25519Signature2020",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
       "IssueCredentialModuleResponse" : {
+        "type" : "object"
+      },
+      "IssueCredentialRequest" : {
+        "properties" : {
+          "credential" : {
+            "$ref" : "#/components/schemas/Credential"
+          },
+          "options" : {
+            "$ref" : "#/components/schemas/IssuanceOptions"
+          }
+        },
+        "type" : "object"
+      },
+      "IssueCredentialResponse" : {
+        "properties" : {
+          "verifiableCredential" : {
+            "$ref" : "#/components/schemas/VerifiableCredential"
+          }
+        },
         "type" : "object"
       },
       "IssuerCredRevRecord" : {
@@ -9665,63 +9929,6 @@
         },
         "type" : "object"
       },
-      "LdpIssueRequest" : {
-        "properties" : {
-          "credential" : {
-            "$ref" : "#/components/schemas/Credential"
-          },
-          "options" : {
-            "$ref" : "#/components/schemas/LDProofVCOptions"
-          }
-        },
-        "type" : "object"
-      },
-      "LdpIssueResponse" : {
-        "properties" : {
-          "vc" : {
-            "$ref" : "#/components/schemas/VerifiableCredential"
-          }
-        },
-        "type" : "object"
-      },
-      "LdpVerifyRequest" : {
-        "properties" : {
-          "options" : {
-            "$ref" : "#/components/schemas/LDProofVCOptions"
-          },
-          "vc" : {
-            "$ref" : "#/components/schemas/VerifiableCredential"
-          },
-          "vp" : {
-            "$ref" : "#/components/schemas/VerifiableCredential"
-          }
-        },
-        "type" : "object"
-      },
-      "LdpVerifyResponse" : {
-        "properties" : {
-          "credential_results" : {
-            "items" : {
-              "$ref" : "#/components/schemas/DocumentVerificationResult"
-            },
-            "type" : "array"
-          },
-          "errors" : {
-            "items" : {
-              "type" : "string"
-            },
-            "type" : "array"
-          },
-          "presentation_result" : {
-            "$ref" : "#/components/schemas/DocumentVerificationResult"
-          },
-          "verified" : {
-            "type" : "boolean"
-          }
-        },
-        "required" : [ "verified" ],
-        "type" : "object"
-      },
       "LedgerConfigInstance" : {
         "properties" : {
           "genesis_file" : {
@@ -9777,7 +9984,7 @@
           },
           "domain" : {
             "description" : "A string value specifying the restricted domain of the signature.",
-            "example" : "example.com",
+            "example" : "https://example.com",
             "pattern" : "\\w+:(\\/?\\/?)[^\\s]+",
             "type" : "string"
           },
@@ -9814,6 +10021,9 @@
           }
         },
         "required" : [ "created", "proofPurpose", "type", "verificationMethod" ],
+        "type" : "object"
+      },
+      "ListCredentialsResponse" : {
         "type" : "object"
       },
       "MediationCreateRequest" : {
@@ -10130,6 +10340,11 @@
           "invitation" : {
             "$ref" : "#/components/schemas/InvitationRecord_invitation"
           },
+          "multi_use" : {
+            "description" : "Allow for multiple uses of the oobinvitation",
+            "example" : true,
+            "type" : "boolean"
+          },
           "oob_id" : {
             "description" : "Oob record identifier",
             "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
@@ -10204,6 +10419,48 @@
             "type" : "string"
           }
         },
+        "type" : "object"
+      },
+      "Presentation" : {
+        "properties" : {
+          "@context" : {
+            "description" : "The JSON-LD context of the presentation",
+            "example" : [ "https://www.w3.org/2018/credentials/v1" ],
+            "items" : {
+              "type" : "object"
+            },
+            "type" : "array"
+          },
+          "holder" : {
+            "description" : "The JSON-LD Verifiable Credential Holder. Either string of object with id field.",
+            "example" : "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+            "type" : "object"
+          },
+          "id" : {
+            "example" : "http://example.edu/presentations/1872",
+            "pattern" : "\\w+:(\\/?\\/?)[^\\s]+",
+            "type" : "string"
+          },
+          "proof" : {
+            "$ref" : "#/components/schemas/Presentation_proof"
+          },
+          "type" : {
+            "description" : "The JSON-LD type of the presentation",
+            "example" : [ "VerifiablePresentation" ],
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "verifiableCredential" : {
+            "items" : {
+              "properties" : { },
+              "type" : "object"
+            },
+            "type" : "array"
+          }
+        },
+        "required" : [ "@context", "type" ],
         "type" : "object"
       },
       "PresentationDefinition" : {
@@ -10293,6 +10550,30 @@
         "required" : [ "request_presentations~attach" ],
         "type" : "object"
       },
+      "PresentationVerificationResult" : {
+        "properties" : {
+          "credential_results" : {
+            "items" : {
+              "$ref" : "#/components/schemas/DocumentVerificationResult"
+            },
+            "type" : "array"
+          },
+          "errors" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "presentation_result" : {
+            "$ref" : "#/components/schemas/DocumentVerificationResult"
+          },
+          "verified" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "verified" ],
+        "type" : "object"
+      },
       "ProfileSettings" : {
         "properties" : {
           "settings" : {
@@ -10343,6 +10624,25 @@
           }
         },
         "required" : [ "pid" ],
+        "type" : "object"
+      },
+      "ProvePresentationRequest" : {
+        "properties" : {
+          "options" : {
+            "$ref" : "#/components/schemas/IssuanceOptions"
+          },
+          "presentation" : {
+            "$ref" : "#/components/schemas/Presentation"
+          }
+        },
+        "type" : "object"
+      },
+      "ProvePresentationResponse" : {
+        "properties" : {
+          "verifiablePresentation" : {
+            "$ref" : "#/components/schemas/VerifiablePresentation"
+          }
+        },
         "type" : "object"
       },
       "PublishRevocations" : {
@@ -11044,117 +11344,6 @@
         "required" : [ "proof" ],
         "type" : "object"
       },
-      "StoredConnRecord" : {
-        "properties" : {
-          "accept" : {
-            "description" : "Connection acceptance: manual or auto",
-            "enum" : [ "manual", "auto" ],
-            "example" : "auto",
-            "type" : "string"
-          },
-          "alias" : {
-            "description" : "Optional alias to apply to connection for later use",
-            "example" : "Bob, providing quotes",
-            "type" : "string"
-          },
-          "connection_id" : {
-            "description" : "Connection identifier",
-            "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-            "type" : "string"
-          },
-          "connection_protocol" : {
-            "description" : "Connection protocol used",
-            "enum" : [ "connections/1.0", "didexchange/1.0" ],
-            "example" : "connections/1.0",
-            "type" : "string"
-          },
-          "created_at" : {
-            "description" : "Time of record creation",
-            "example" : "2021-12-31T23:59:59Z",
-            "pattern" : "^\\d{4}-\\d\\d-\\d\\d[T ]\\d\\d:\\d\\d(?:\\:(?:\\d\\d(?:\\.\\d{1,6})?))?(?:[+-]\\d\\d:?\\d\\d|Z|)$",
-            "type" : "string"
-          },
-          "error_msg" : {
-            "description" : "Error message",
-            "example" : "No DIDDoc provided; cannot connect to public DID",
-            "type" : "string"
-          },
-          "inbound_connection_id" : {
-            "description" : "Inbound routing connection id to use",
-            "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-            "type" : "string"
-          },
-          "invitation_key" : {
-            "description" : "Public key for connection",
-            "example" : "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV",
-            "pattern" : "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{43,44}$",
-            "type" : "string"
-          },
-          "invitation_mode" : {
-            "description" : "Invitation mode",
-            "enum" : [ "once", "multi", "static" ],
-            "example" : "once",
-            "type" : "string"
-          },
-          "invitation_msg_id" : {
-            "description" : "ID of out-of-band invitation message",
-            "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-            "type" : "string"
-          },
-          "my_did" : {
-            "description" : "Our DID for connection",
-            "example" : "did:peer:WgWxqztrNooG92RXvxSTWv",
-            "pattern" : "^(did:sov:)?[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}$|^did:([a-zA-Z0-9_]+):([a-zA-Z0-9_.%-]+(:[a-zA-Z0-9_.%-]+)*)((;[a-zA-Z0-9_.:%-]+=[a-zA-Z0-9_.:%-]*)*)(\\/[^#?]*)?([?][^#]*)?(\\#.*)?$$",
-            "type" : "string"
-          },
-          "request_id" : {
-            "description" : "Connection request identifier",
-            "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-            "type" : "string"
-          },
-          "rfc23_state" : {
-            "description" : "State per RFC 23",
-            "example" : "invitation-sent",
-            "readOnly" : true,
-            "type" : "string"
-          },
-          "state" : {
-            "description" : "Current record state",
-            "example" : "active",
-            "type" : "string"
-          },
-          "their_did" : {
-            "description" : "Their DID for connection",
-            "example" : "did:peer:WgWxqztrNooG92RXvxSTWv",
-            "pattern" : "^(did:sov:)?[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}$|^did:([a-zA-Z0-9_]+):([a-zA-Z0-9_.%-]+(:[a-zA-Z0-9_.%-]+)*)((;[a-zA-Z0-9_.:%-]+=[a-zA-Z0-9_.:%-]*)*)(\\/[^#?]*)?([?][^#]*)?(\\#.*)?$$",
-            "type" : "string"
-          },
-          "their_label" : {
-            "description" : "Their label for connection",
-            "example" : "Bob",
-            "type" : "string"
-          },
-          "their_public_did" : {
-            "description" : "Other agent's public DID for connection",
-            "example" : "2cpBmR3FqGKWi5EyUbpRY8",
-            "type" : "string"
-          },
-          "their_role" : {
-            "description" : "Their role in the connection protocol",
-            "enum" : [ "invitee", "requester", "inviter", "responder" ],
-            "example" : "requester",
-            "type" : "string"
-          },
-          "updated_at" : {
-            "description" : "Time of last record update",
-            "example" : "2021-12-31T23:59:59Z",
-            "pattern" : "^\\d{4}-\\d\\d-\\d\\d[T ]\\d\\d:\\d\\d(?:\\:(?:\\d\\d(?:\\.\\d{1,6})?))?(?:[+-]\\d\\d:?\\d\\d|Z|)$",
-            "type" : "string"
-          }
-        },
-        "required" : [ "connection_id" ],
-        "type" : "object"
-      },
       "SubmissionRequirements" : {
         "properties" : {
           "count" : {
@@ -11374,7 +11563,7 @@
                 "author_goal_code" : "aries.transaction.ledger.write",
                 "context" : "did:sov",
                 "method" : "add-signature",
-                "signature_type" : "<requested signature type>",
+                "signature_type" : "default",
                 "signer_goal_code" : "aries.transaction.endorse"
               },
               "properties" : { },
@@ -13615,6 +13804,10 @@
             },
             "type" : "array"
           },
+          "credentialStatus" : {
+            "example" : "",
+            "type" : "object"
+          },
           "credentialSubject" : {
             "example" : "",
             "type" : "object"
@@ -13654,6 +13847,86 @@
           }
         },
         "required" : [ "@context", "credentialSubject", "issuanceDate", "issuer", "proof", "type" ],
+        "type" : "object"
+      },
+      "VerifiablePresentation" : {
+        "properties" : {
+          "@context" : {
+            "description" : "The JSON-LD context of the presentation",
+            "example" : [ "https://www.w3.org/2018/credentials/v1" ],
+            "items" : {
+              "type" : "object"
+            },
+            "type" : "array"
+          },
+          "holder" : {
+            "description" : "The JSON-LD Verifiable Credential Holder. Either string of object with id field.",
+            "example" : "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+            "type" : "object"
+          },
+          "id" : {
+            "example" : "http://example.edu/presentations/1872",
+            "pattern" : "\\w+:(\\/?\\/?)[^\\s]+",
+            "type" : "string"
+          },
+          "proof" : {
+            "$ref" : "#/components/schemas/Presentation_proof"
+          },
+          "type" : {
+            "description" : "The JSON-LD type of the presentation",
+            "example" : [ "VerifiablePresentation" ],
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "verifiableCredential" : {
+            "items" : {
+              "properties" : { },
+              "type" : "object"
+            },
+            "type" : "array"
+          }
+        },
+        "required" : [ "@context", "proof", "type" ],
+        "type" : "object"
+      },
+      "VerifyCredentialRequest" : {
+        "properties" : {
+          "options" : {
+            "$ref" : "#/components/schemas/LDProofVCOptions"
+          },
+          "verifiableCredential" : {
+            "$ref" : "#/components/schemas/VerifiableCredential"
+          }
+        },
+        "type" : "object"
+      },
+      "VerifyCredentialResponse" : {
+        "properties" : {
+          "results" : {
+            "$ref" : "#/components/schemas/PresentationVerificationResult"
+          }
+        },
+        "type" : "object"
+      },
+      "VerifyPresentationRequest" : {
+        "properties" : {
+          "options" : {
+            "$ref" : "#/components/schemas/LDProofVCOptions"
+          },
+          "verifiablePresentation" : {
+            "$ref" : "#/components/schemas/VerifiablePresentation"
+          }
+        },
+        "type" : "object"
+      },
+      "VerifyPresentationResponse" : {
+        "properties" : {
+          "results" : {
+            "$ref" : "#/components/schemas/PresentationVerificationResult"
+          }
+        },
         "type" : "object"
       },
       "VerifyRequest" : {
@@ -14075,6 +14348,20 @@
           "$ref" : "#/components/schemas/CredentialStatusOptions"
         } ],
         "description" : "The credential status mechanism to use for the credential. Omitting the property indicates the issued credential will not include a credential status",
+        "type" : "object"
+      },
+      "Presentation_proof" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/LinkedDataProof"
+        } ],
+        "description" : "The proof of the presentation",
+        "example" : {
+          "created" : "2019-12-11T03:50:55",
+          "jws" : "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0JiNjQiXX0..lKJU0Df_keblRKhZAS9Qq6zybm-HqUXNVZ8vgEPNTAjQKBhQDxvXNo7nvtUBb_Eq1Ch6YBKY5qBQ",
+          "proofPurpose" : "assertionMethod",
+          "type" : "Ed25519Signature2018",
+          "verificationMethod" : "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL#z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL"
+        },
         "type" : "object"
       },
       "SchemaSendResult_schema" : {

--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -84,20 +84,6 @@
       "url" : "https://tools.ietf.org/html/rfc7515"
     }
   }, {
-    "name" : "ldp-vc",
-    "description" : "Issue and verify LDP VCs and VPs",
-    "externalDocs" : {
-      "description" : "Specification",
-      "url" : "https://www.w3.org/TR/vc-data-model/"
-    }
-  }, {
-    "description" : "Manage credentials and presentations",
-    "externalDocs" : {
-      "description" : "Specification",
-      "url" : "https://w3c-ccg.github.io/vc-api"
-    },
-    "name" : "vc-api"
-  }, {
     "name" : "ledger",
     "description" : "Interaction with ledger",
     "externalDocs" : {
@@ -165,6 +151,13 @@
     "externalDocs" : {
       "description" : "Specification",
       "url" : "https://github.com/hyperledger/aries-rfcs/tree/527849ec3aa2a8fd47a7bb6c57f918ff8bcb5e8c/features/0048-trust-ping"
+    }
+  }, {
+    "name" : "vc-api",
+    "description" : "Endpoints for managing w3c credentials and presentations",
+    "externalDocs" : {
+      "description" : "Specification",
+      "url" : "https://w3c-ccg.github.io/vc-api/"
     }
   }, {
     "name" : "wallet",
@@ -346,7 +339,7 @@
           "description" : "Connection state",
           "required" : false,
           "type" : "string",
-          "enum" : [ "request", "abandoned", "active", "init", "error", "invitation", "start", "response", "completed" ]
+          "enum" : [ "active", "error", "invitation", "start", "init", "completed", "request", "response", "abandoned" ]
         }, {
           "name" : "their_did",
           "in" : "query",
@@ -485,7 +478,7 @@
           "200" : {
             "description" : "",
             "schema" : {
-              "$ref" : "#/definitions/StoredConnRecord"
+              "$ref" : "#/definitions/ConnRecord"
             }
           }
         }
@@ -507,7 +500,7 @@
           "200" : {
             "description" : "",
             "schema" : {
-              "$ref" : "#/definitions/StoredConnRecord"
+              "$ref" : "#/definitions/ConnRecord"
             }
           }
         }
@@ -569,7 +562,7 @@
           "200" : {
             "description" : "",
             "schema" : {
-              "$ref" : "#/definitions/StoredConnRecord"
+              "$ref" : "#/definitions/ConnRecord"
             }
           }
         }
@@ -598,7 +591,7 @@
           "200" : {
             "description" : "",
             "schema" : {
-              "$ref" : "#/definitions/StoredConnRecord"
+              "$ref" : "#/definitions/ConnRecord"
             }
           }
         }
@@ -1201,7 +1194,7 @@
           "200" : {
             "description" : "",
             "schema" : {
-              "$ref" : "#/definitions/StoredConnRecord"
+              "$ref" : "#/definitions/ConnRecord"
             }
           }
         }
@@ -1250,7 +1243,7 @@
           "200" : {
             "description" : "",
             "schema" : {
-              "$ref" : "#/definitions/StoredConnRecord"
+              "$ref" : "#/definitions/ConnRecord"
             }
           }
         }
@@ -1285,7 +1278,7 @@
           "200" : {
             "description" : "",
             "schema" : {
-              "$ref" : "#/definitions/StoredConnRecord"
+              "$ref" : "#/definitions/ConnRecord"
             }
           }
         }
@@ -1327,7 +1320,7 @@
           "200" : {
             "description" : "",
             "schema" : {
-              "$ref" : "#/definitions/StoredConnRecord"
+              "$ref" : "#/definitions/ConnRecord"
             }
           }
         }
@@ -1356,7 +1349,7 @@
           "200" : {
             "description" : "",
             "schema" : {
-              "$ref" : "#/definitions/StoredConnRecord"
+              "$ref" : "#/definitions/ConnRecord"
             }
           }
         }
@@ -4838,47 +4831,139 @@
         }
       }
     },
-    "/vc/ldp/issue" : {
-      "post" : {
-        "tags" : [ "ldp_vc" ],
-        "summary" : "Sign an LDP VC.",
+    "/vc/credentials" : {
+      "get" : {
+        "tags" : [ "vc-api" ],
+        "summary" : "List credentials",
         "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "in" : "body",
-          "name" : "body",
-          "required" : false,
-          "schema" : {
-            "$ref" : "#/definitions/LdpIssueRequest"
-          }
-        } ],
+        "parameters" : [ ],
         "responses" : {
           "200" : {
             "description" : "",
             "schema" : {
-              "$ref" : "#/definitions/LdpIssueResponse"
+              "$ref" : "#/definitions/ListCredentialsResponse"
             }
           }
         }
       }
     },
-    "/vc/ldp/verify" : {
+    "/vc/credentials/issue" : {
       "post" : {
-        "tags" : [ "ldp_vc" ],
-        "summary" : "Verify an LDP VC or VP.",
+        "tags" : [ "vc-api" ],
+        "summary" : "Issue a credential",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
           "required" : false,
           "schema" : {
-            "$ref" : "#/definitions/LdpVerifyRequest"
+            "$ref" : "#/definitions/IssueCredentialRequest"
           }
         } ],
         "responses" : {
           "200" : {
             "description" : "",
             "schema" : {
-              "$ref" : "#/definitions/LdpVerifyResponse"
+              "$ref" : "#/definitions/IssueCredentialResponse"
+            }
+          }
+        }
+      }
+    },
+    "/vc/credentials/store" : {
+      "post" : {
+        "tags" : [ "vc-api" ],
+        "summary" : "Store a credential",
+        "produces" : [ "application/json" ],
+        "parameters" : [ ],
+        "responses" : { }
+      }
+    },
+    "/vc/credentials/verify" : {
+      "post" : {
+        "tags" : [ "vc-api" ],
+        "summary" : "Verify a credential",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/VerifyCredentialRequest"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "schema" : {
+              "$ref" : "#/definitions/VerifyCredentialResponse"
+            }
+          }
+        }
+      }
+    },
+    "/vc/credentials/{credential_id}" : {
+      "get" : {
+        "tags" : [ "vc-api" ],
+        "summary" : "Fetch credential by ID",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "credential_id",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "schema" : {
+              "$ref" : "#/definitions/FetchCredentialResponse"
+            }
+          }
+        }
+      }
+    },
+    "/vc/presentations/prove" : {
+      "post" : {
+        "tags" : [ "vc-api" ],
+        "summary" : "Prove a presentation",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/ProvePresentationRequest"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "schema" : {
+              "$ref" : "#/definitions/ProvePresentationResponse"
+            }
+          }
+        }
+      }
+    },
+    "/vc/presentations/verify" : {
+      "post" : {
+        "tags" : [ "vc-api" ],
+        "summary" : "Verify a Presentation",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/VerifyPresentationRequest"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "schema" : {
+              "$ref" : "#/definitions/VerifyPresentationResponse"
             }
           }
         }
@@ -5526,6 +5611,117 @@
         }
       }
     },
+    "ConnRecord" : {
+      "type" : "object",
+      "required" : [ "connection_id" ],
+      "properties" : {
+        "accept" : {
+          "type" : "string",
+          "example" : "auto",
+          "description" : "Connection acceptance: manual or auto",
+          "enum" : [ "manual", "auto" ]
+        },
+        "alias" : {
+          "type" : "string",
+          "example" : "Bob, providing quotes",
+          "description" : "Optional alias to apply to connection for later use"
+        },
+        "connection_id" : {
+          "type" : "string",
+          "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          "description" : "Connection identifier"
+        },
+        "connection_protocol" : {
+          "type" : "string",
+          "example" : "connections/1.0",
+          "description" : "Connection protocol used",
+          "enum" : [ "connections/1.0", "didexchange/1.0" ]
+        },
+        "created_at" : {
+          "type" : "string",
+          "example" : "2021-12-31T23:59:59Z",
+          "description" : "Time of record creation",
+          "pattern" : "^\\d{4}-\\d\\d-\\d\\d[T ]\\d\\d:\\d\\d(?:\\:(?:\\d\\d(?:\\.\\d{1,6})?))?(?:[+-]\\d\\d:?\\d\\d|Z|)$"
+        },
+        "error_msg" : {
+          "type" : "string",
+          "example" : "No DIDDoc provided; cannot connect to public DID",
+          "description" : "Error message"
+        },
+        "inbound_connection_id" : {
+          "type" : "string",
+          "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          "description" : "Inbound routing connection id to use"
+        },
+        "invitation_key" : {
+          "type" : "string",
+          "example" : "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV",
+          "description" : "Public key for connection",
+          "pattern" : "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{43,44}$"
+        },
+        "invitation_mode" : {
+          "type" : "string",
+          "example" : "once",
+          "description" : "Invitation mode",
+          "enum" : [ "once", "multi", "static" ]
+        },
+        "invitation_msg_id" : {
+          "type" : "string",
+          "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          "description" : "ID of out-of-band invitation message"
+        },
+        "my_did" : {
+          "type" : "string",
+          "example" : "did:peer:WgWxqztrNooG92RXvxSTWv",
+          "description" : "Our DID for connection",
+          "pattern" : "^(did:sov:)?[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}$|^did:([a-zA-Z0-9_]+):([a-zA-Z0-9_.%-]+(:[a-zA-Z0-9_.%-]+)*)((;[a-zA-Z0-9_.:%-]+=[a-zA-Z0-9_.:%-]*)*)(\\/[^#?]*)?([?][^#]*)?(\\#.*)?$$"
+        },
+        "request_id" : {
+          "type" : "string",
+          "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          "description" : "Connection request identifier"
+        },
+        "rfc23_state" : {
+          "type" : "string",
+          "example" : "invitation-sent",
+          "description" : "State per RFC 23",
+          "readOnly" : true
+        },
+        "state" : {
+          "type" : "string",
+          "example" : "active",
+          "description" : "Current record state"
+        },
+        "their_did" : {
+          "type" : "string",
+          "example" : "did:peer:WgWxqztrNooG92RXvxSTWv",
+          "description" : "Their DID for connection",
+          "pattern" : "^(did:sov:)?[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}$|^did:([a-zA-Z0-9_]+):([a-zA-Z0-9_.%-]+(:[a-zA-Z0-9_.%-]+)*)((;[a-zA-Z0-9_.:%-]+=[a-zA-Z0-9_.:%-]*)*)(\\/[^#?]*)?([?][^#]*)?(\\#.*)?$$"
+        },
+        "their_label" : {
+          "type" : "string",
+          "example" : "Bob",
+          "description" : "Their label for connection"
+        },
+        "their_public_did" : {
+          "type" : "string",
+          "example" : "2cpBmR3FqGKWi5EyUbpRY8",
+          "description" : "Other agent's public DID for connection"
+        },
+        "their_role" : {
+          "type" : "string",
+          "example" : "requester",
+          "description" : "Their role in the connection protocol",
+          "enum" : [ "invitee", "requester", "inviter", "responder" ]
+        },
+        "updated_at" : {
+          "type" : "string",
+          "example" : "2021-12-31T23:59:59Z",
+          "description" : "Time of last record update",
+          "pattern" : "^\\d{4}-\\d\\d-\\d\\d[T ]\\d\\d:\\d\\d(?:\\:(?:\\d\\d(?:\\.\\d{1,6})?))?(?:[+-]\\d\\d:?\\d\\d|Z|)$"
+        }
+      }
+    },
     "ConnectionInvitation" : {
       "type" : "object",
       "properties" : {
@@ -5593,7 +5789,7 @@
           "type" : "array",
           "description" : "List of connection records",
           "items" : {
-            "$ref" : "#/definitions/StoredConnRecord"
+            "$ref" : "#/definitions/ConnRecord"
           }
         }
       }
@@ -5688,7 +5884,7 @@
           "pattern" : "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{43,44}$"
         },
         "record" : {
-          "$ref" : "#/definitions/StoredConnRecord"
+          "$ref" : "#/definitions/ConnRecord"
         },
         "their_did" : {
           "type" : "string",
@@ -6082,6 +6278,9 @@
           "example" : [ "https://www.w3.org/2018/credentials/v1", "https://www.w3.org/2018/credentials/examples/v1" ],
           "description" : "The JSON-LD context of the credential",
           "items" : { }
+        },
+        "credentialStatus" : {
+          "example" : ""
         },
         "credentialSubject" : {
           "example" : ""
@@ -6768,6 +6967,14 @@
           "example" : "https://myhost:8021",
           "description" : "Their endpoint",
           "pattern" : "^[A-Za-z0-9\\.\\-\\+]+://([A-Za-z0-9][.A-Za-z0-9-_]+[A-Za-z0-9])+(:[1-9][0-9]*)?(/[^?&#]+)?$"
+        }
+      }
+    },
+    "FetchCredentialResponse" : {
+      "type" : "object",
+      "properties" : {
+        "results" : {
+          "$ref" : "#/definitions/VerifiableCredential"
         }
       }
     },
@@ -8123,8 +8330,48 @@
         }
       }
     },
+    "IssuanceOptions" : {
+      "type" : "object",
+      "properties" : {
+        "challenge" : {
+          "type" : "string",
+          "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+        },
+        "created" : {
+          "type" : "string",
+          "example" : "2010-01-01T19:23:24Z"
+        },
+        "domain" : {
+          "type" : "string",
+          "example" : "website.example"
+        },
+        "type" : {
+          "type" : "string",
+          "example" : "Ed25519Signature2020"
+        }
+      }
+    },
     "IssueCredentialModuleResponse" : {
       "type" : "object"
+    },
+    "IssueCredentialRequest" : {
+      "type" : "object",
+      "properties" : {
+        "credential" : {
+          "$ref" : "#/definitions/Credential"
+        },
+        "options" : {
+          "$ref" : "#/definitions/IssuanceOptions"
+        }
+      }
+    },
+    "IssueCredentialResponse" : {
+      "type" : "object",
+      "properties" : {
+        "verifiableCredential" : {
+          "$ref" : "#/definitions/VerifiableCredential"
+        }
+      }
     },
     "IssuerCredRevRecord" : {
       "type" : "object",
@@ -8506,63 +8753,6 @@
         }
       }
     },
-    "LdpIssueRequest" : {
-      "type" : "object",
-      "properties" : {
-        "credential" : {
-          "$ref" : "#/definitions/Credential"
-        },
-        "options" : {
-          "$ref" : "#/definitions/LDProofVCOptions"
-        }
-      }
-    },
-    "LdpIssueResponse" : {
-      "type" : "object",
-      "properties" : {
-        "vc" : {
-          "$ref" : "#/definitions/VerifiableCredential"
-        }
-      }
-    },
-    "LdpVerifyRequest" : {
-      "type" : "object",
-      "properties" : {
-        "options" : {
-          "$ref" : "#/definitions/LDProofVCOptions"
-        },
-        "vc" : {
-          "$ref" : "#/definitions/VerifiableCredential"
-        },
-        "vp" : {
-          "$ref" : "#/definitions/VerifiableCredential"
-        }
-      }
-    },
-    "LdpVerifyResponse" : {
-      "type" : "object",
-      "required" : [ "verified" ],
-      "properties" : {
-        "credential_results" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/DocumentVerificationResult"
-          }
-        },
-        "errors" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
-        },
-        "presentation_result" : {
-          "$ref" : "#/definitions/DocumentVerificationResult"
-        },
-        "verified" : {
-          "type" : "boolean"
-        }
-      }
-    },
     "LedgerConfigInstance" : {
       "type" : "object",
       "properties" : {
@@ -8620,7 +8810,7 @@
         },
         "domain" : {
           "type" : "string",
-          "example" : "example.com",
+          "example" : "https://example.com",
           "description" : "A string value specifying the restricted domain of the signature.",
           "pattern" : "\\w+:(\\/?\\/?)[^\\s]+"
         },
@@ -8656,6 +8846,9 @@
           "pattern" : "\\w+:(\\/?\\/?)[^\\s]+"
         }
       }
+    },
+    "ListCredentialsResponse" : {
+      "type" : "object"
     },
     "MediationCreateRequest" : {
       "type" : "object"
@@ -8973,6 +9166,11 @@
         "invitation" : {
           "$ref" : "#/definitions/InvitationRecord_invitation"
         },
+        "multi_use" : {
+          "type" : "boolean",
+          "example" : true,
+          "description" : "Allow for multiple uses of the oobinvitation"
+        },
         "oob_id" : {
           "type" : "string",
           "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
@@ -9044,6 +9242,45 @@
         "thread_id" : {
           "type" : "string",
           "description" : "Thread ID of the ping message"
+        }
+      }
+    },
+    "Presentation" : {
+      "type" : "object",
+      "required" : [ "@context", "type" ],
+      "properties" : {
+        "@context" : {
+          "type" : "array",
+          "example" : [ "https://www.w3.org/2018/credentials/v1" ],
+          "description" : "The JSON-LD context of the presentation",
+          "items" : { }
+        },
+        "holder" : {
+          "example" : "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+          "description" : "The JSON-LD Verifiable Credential Holder. Either string of object with id field."
+        },
+        "id" : {
+          "type" : "string",
+          "example" : "http://example.edu/presentations/1872",
+          "pattern" : "\\w+:(\\/?\\/?)[^\\s]+"
+        },
+        "proof" : {
+          "$ref" : "#/definitions/Presentation_proof"
+        },
+        "type" : {
+          "type" : "array",
+          "example" : [ "VerifiablePresentation" ],
+          "description" : "The JSON-LD type of the presentation",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "verifiableCredential" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : { }
+          }
         }
       }
     },
@@ -9134,6 +9371,30 @@
         }
       }
     },
+    "PresentationVerificationResult" : {
+      "type" : "object",
+      "required" : [ "verified" ],
+      "properties" : {
+        "credential_results" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/DocumentVerificationResult"
+          }
+        },
+        "errors" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "presentation_result" : {
+          "$ref" : "#/definitions/DocumentVerificationResult"
+        },
+        "verified" : {
+          "type" : "boolean"
+        }
+      }
+    },
     "ProfileSettings" : {
       "type" : "object",
       "properties" : {
@@ -9183,6 +9444,25 @@
             "description" : "Role: requester or responder"
           },
           "x-nullable" : true
+        }
+      }
+    },
+    "ProvePresentationRequest" : {
+      "type" : "object",
+      "properties" : {
+        "options" : {
+          "$ref" : "#/definitions/IssuanceOptions"
+        },
+        "presentation" : {
+          "$ref" : "#/definitions/Presentation"
+        }
+      }
+    },
+    "ProvePresentationResponse" : {
+      "type" : "object",
+      "properties" : {
+        "verifiablePresentation" : {
+          "$ref" : "#/definitions/VerifiablePresentation"
         }
       }
     },
@@ -9883,117 +10163,6 @@
         }
       }
     },
-    "StoredConnRecord" : {
-      "type" : "object",
-      "required" : [ "connection_id" ],
-      "properties" : {
-        "accept" : {
-          "type" : "string",
-          "example" : "auto",
-          "description" : "Connection acceptance: manual or auto",
-          "enum" : [ "manual", "auto" ]
-        },
-        "alias" : {
-          "type" : "string",
-          "example" : "Bob, providing quotes",
-          "description" : "Optional alias to apply to connection for later use"
-        },
-        "connection_id" : {
-          "type" : "string",
-          "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-          "description" : "Connection identifier"
-        },
-        "connection_protocol" : {
-          "type" : "string",
-          "example" : "connections/1.0",
-          "description" : "Connection protocol used",
-          "enum" : [ "connections/1.0", "didexchange/1.0" ]
-        },
-        "created_at" : {
-          "type" : "string",
-          "example" : "2021-12-31T23:59:59Z",
-          "description" : "Time of record creation",
-          "pattern" : "^\\d{4}-\\d\\d-\\d\\d[T ]\\d\\d:\\d\\d(?:\\:(?:\\d\\d(?:\\.\\d{1,6})?))?(?:[+-]\\d\\d:?\\d\\d|Z|)$"
-        },
-        "error_msg" : {
-          "type" : "string",
-          "example" : "No DIDDoc provided; cannot connect to public DID",
-          "description" : "Error message"
-        },
-        "inbound_connection_id" : {
-          "type" : "string",
-          "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-          "description" : "Inbound routing connection id to use"
-        },
-        "invitation_key" : {
-          "type" : "string",
-          "example" : "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV",
-          "description" : "Public key for connection",
-          "pattern" : "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{43,44}$"
-        },
-        "invitation_mode" : {
-          "type" : "string",
-          "example" : "once",
-          "description" : "Invitation mode",
-          "enum" : [ "once", "multi", "static" ]
-        },
-        "invitation_msg_id" : {
-          "type" : "string",
-          "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-          "description" : "ID of out-of-band invitation message"
-        },
-        "my_did" : {
-          "type" : "string",
-          "example" : "did:peer:WgWxqztrNooG92RXvxSTWv",
-          "description" : "Our DID for connection",
-          "pattern" : "^(did:sov:)?[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}$|^did:([a-zA-Z0-9_]+):([a-zA-Z0-9_.%-]+(:[a-zA-Z0-9_.%-]+)*)((;[a-zA-Z0-9_.:%-]+=[a-zA-Z0-9_.:%-]*)*)(\\/[^#?]*)?([?][^#]*)?(\\#.*)?$$"
-        },
-        "request_id" : {
-          "type" : "string",
-          "example" : "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-          "description" : "Connection request identifier"
-        },
-        "rfc23_state" : {
-          "type" : "string",
-          "example" : "invitation-sent",
-          "description" : "State per RFC 23",
-          "readOnly" : true
-        },
-        "state" : {
-          "type" : "string",
-          "example" : "active",
-          "description" : "Current record state"
-        },
-        "their_did" : {
-          "type" : "string",
-          "example" : "did:peer:WgWxqztrNooG92RXvxSTWv",
-          "description" : "Their DID for connection",
-          "pattern" : "^(did:sov:)?[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}$|^did:([a-zA-Z0-9_]+):([a-zA-Z0-9_.%-]+(:[a-zA-Z0-9_.%-]+)*)((;[a-zA-Z0-9_.:%-]+=[a-zA-Z0-9_.:%-]*)*)(\\/[^#?]*)?([?][^#]*)?(\\#.*)?$$"
-        },
-        "their_label" : {
-          "type" : "string",
-          "example" : "Bob",
-          "description" : "Their label for connection"
-        },
-        "their_public_did" : {
-          "type" : "string",
-          "example" : "2cpBmR3FqGKWi5EyUbpRY8",
-          "description" : "Other agent's public DID for connection"
-        },
-        "their_role" : {
-          "type" : "string",
-          "example" : "requester",
-          "description" : "Their role in the connection protocol",
-          "enum" : [ "invitee", "requester", "inviter", "responder" ]
-        },
-        "updated_at" : {
-          "type" : "string",
-          "example" : "2021-12-31T23:59:59Z",
-          "description" : "Time of last record update",
-          "pattern" : "^\\d{4}-\\d\\d-\\d\\d[T ]\\d\\d:\\d\\d(?:\\:(?:\\d\\d(?:\\.\\d{1,6})?))?(?:[+-]\\d\\d:?\\d\\d|Z|)$"
-        }
-      }
-    },
     "SubmissionRequirements" : {
       "type" : "object",
       "properties" : {
@@ -10216,7 +10385,7 @@
               "author_goal_code" : "aries.transaction.ledger.write",
               "context" : "did:sov",
               "method" : "add-signature",
-              "signature_type" : "<requested signature type>",
+              "signature_type" : "default",
               "signer_goal_code" : "aries.transaction.endorse"
             },
             "properties" : { }
@@ -12462,6 +12631,9 @@
           "description" : "The JSON-LD context of the credential",
           "items" : { }
         },
+        "credentialStatus" : {
+          "example" : ""
+        },
         "credentialSubject" : {
           "example" : ""
         },
@@ -12496,6 +12668,83 @@
           "items" : {
             "type" : "string"
           }
+        }
+      }
+    },
+    "VerifiablePresentation" : {
+      "type" : "object",
+      "required" : [ "@context", "proof", "type" ],
+      "properties" : {
+        "@context" : {
+          "type" : "array",
+          "example" : [ "https://www.w3.org/2018/credentials/v1" ],
+          "description" : "The JSON-LD context of the presentation",
+          "items" : { }
+        },
+        "holder" : {
+          "example" : "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+          "description" : "The JSON-LD Verifiable Credential Holder. Either string of object with id field."
+        },
+        "id" : {
+          "type" : "string",
+          "example" : "http://example.edu/presentations/1872",
+          "pattern" : "\\w+:(\\/?\\/?)[^\\s]+"
+        },
+        "proof" : {
+          "$ref" : "#/definitions/Presentation_proof"
+        },
+        "type" : {
+          "type" : "array",
+          "example" : [ "VerifiablePresentation" ],
+          "description" : "The JSON-LD type of the presentation",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "verifiableCredential" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : { }
+          }
+        }
+      }
+    },
+    "VerifyCredentialRequest" : {
+      "type" : "object",
+      "properties" : {
+        "options" : {
+          "$ref" : "#/definitions/LDProofVCOptions"
+        },
+        "verifiableCredential" : {
+          "$ref" : "#/definitions/VerifiableCredential"
+        }
+      }
+    },
+    "VerifyCredentialResponse" : {
+      "type" : "object",
+      "properties" : {
+        "results" : {
+          "$ref" : "#/definitions/PresentationVerificationResult"
+        }
+      }
+    },
+    "VerifyPresentationRequest" : {
+      "type" : "object",
+      "properties" : {
+        "options" : {
+          "$ref" : "#/definitions/LDProofVCOptions"
+        },
+        "verifiablePresentation" : {
+          "$ref" : "#/definitions/VerifiablePresentation"
+        }
+      }
+    },
+    "VerifyPresentationResponse" : {
+      "type" : "object",
+      "properties" : {
+        "results" : {
+          "$ref" : "#/definitions/PresentationVerificationResult"
         }
       }
     },
@@ -12781,6 +13030,11 @@
     "LDProofVCOptions_credentialStatus" : {
       "type" : "object",
       "description" : "The credential status mechanism to use for the credential. Omitting the property indicates the issued credential will not include a credential status"
+    },
+    "Presentation_proof" : {
+      "type" : "object",
+      "description" : "The proof of the presentation",
+      "example" : "{\"created\":\"2019-12-11T03:50:55\",\"jws\":\"eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0JiNjQiXX0..lKJU0Df_keblRKhZAS9Qq6zybm-HqUXNVZ8vgEPNTAjQKBhQDxvXNo7nvtUBb_Eq1Ch6YBKY5qBQ\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL#z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL\"}"
     },
     "SchemaSendResult_schema" : {
       "type" : "object",


### PR DESCRIPTION
This PR partially reverts some of the changes made in #2661 relating to the `ConnRecordSchema`. The changes in that PR caused the generated openapi to rename the definition to `StoredConnRecord`. We can get the same fix while not causing a change to the name in the openapi; this is preferable because otherwise it impacts downstream consumers of the openapi definition.