### PR TITLE
Anoncreds - Cred Def and Revocation Endorsement

### DIFF
--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -25,6 +25,7 @@ cat > .pytest.ini <<EOF
 testpaths = "aries_cloudagent"
 addopts = --quiet
 markers = [
+    "anoncreds: Tests specifically relating to AnonCreds support",
     "askar: Tests specifically relating to Aries-Askar support",
     "indy: Tests specifically relating to Hyperledger Indy SDK support",
     "indy_credx: Tests specifically relating to Indy-Credx support",

--- a/aries_cloudagent/anoncreds/base.py
+++ b/aries_cloudagent/anoncreds/base.py
@@ -144,7 +144,7 @@ class BaseAnonCredsRegistrar(BaseAnonCredsHandler):
         self,
         profile: Profile,
         schema: AnonCredsSchema,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> SchemaResult:
         """Register a schema on the registry."""
 
@@ -154,7 +154,7 @@ class BaseAnonCredsRegistrar(BaseAnonCredsHandler):
         profile: Profile,
         schema: GetSchemaResult,
         credential_definition: CredDef,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> CredDefResult:
         """Register a credential definition on the registry."""
 
@@ -163,7 +163,7 @@ class BaseAnonCredsRegistrar(BaseAnonCredsHandler):
         self,
         profile: Profile,
         revocation_registry_definition: RevRegDef,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevRegDefResult:
         """Register a revocation registry definition on the registry."""
 
@@ -173,7 +173,7 @@ class BaseAnonCredsRegistrar(BaseAnonCredsHandler):
         profile: Profile,
         rev_reg_def: RevRegDef,
         rev_list: RevList,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevListResult:
         """Register a revocation list on the registry."""
 
@@ -185,6 +185,6 @@ class BaseAnonCredsRegistrar(BaseAnonCredsHandler):
         prev_list: RevList,
         curr_list: RevList,
         revoked: Sequence[int],
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevListResult:
         """Update a revocation list on the registry."""

--- a/aries_cloudagent/anoncreds/default/did_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/did_indy/registry.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from typing import Optional, Pattern, Sequence
+from typing import Pattern, Sequence
 
 from ....config.injection_context import InjectionContext
 from ....core.profile import Profile
@@ -55,7 +55,7 @@ class DIDIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         self,
         profile: Profile,
         schema: AnonCredsSchema,
-        options: Optional[dict],
+        options: dict = {},
     ) -> SchemaResult:
         """Register a schema on the registry."""
         raise NotImplementedError()
@@ -71,7 +71,7 @@ class DIDIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         profile: Profile,
         schema: GetSchemaResult,
         credential_definition: CredDef,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> CredDefResult:
         """Register a credential definition on the registry."""
         raise NotImplementedError()
@@ -86,7 +86,7 @@ class DIDIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         self,
         profile: Profile,
         revocation_registry_definition: RevRegDef,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevRegDefResult:
         """Register a revocation registry definition on the registry."""
         raise NotImplementedError()
@@ -102,7 +102,7 @@ class DIDIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         profile: Profile,
         rev_reg_def: RevRegDef,
         rev_list: RevList,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevListResult:
         """Register a revocation list on the registry."""
         raise NotImplementedError()
@@ -114,7 +114,7 @@ class DIDIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         prev_list: RevList,
         curr_list: RevList,
         revoked: Sequence[int],
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevListResult:
         """Update a revocation list on the registry."""
         raise NotImplementedError()

--- a/aries_cloudagent/anoncreds/default/did_web/registry.py
+++ b/aries_cloudagent/anoncreds/default/did_web/registry.py
@@ -1,7 +1,7 @@
 """DID Web Registry."""
 
 import re
-from typing import Optional, Pattern, Sequence
+from typing import Pattern, Sequence
 
 from ....config.injection_context import InjectionContext
 from ....core.profile import Profile
@@ -50,7 +50,7 @@ class DIDWebRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         self,
         profile: Profile,
         schema: AnonCredsSchema,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> SchemaResult:
         """Register a schema on the registry."""
         raise NotImplementedError()
@@ -66,7 +66,7 @@ class DIDWebRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         profile: Profile,
         schema: GetSchemaResult,
         credential_definition: CredDef,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> CredDefResult:
         """Register a credential definition on the registry."""
         raise NotImplementedError()
@@ -81,7 +81,7 @@ class DIDWebRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         self,
         profile: Profile,
         revocation_registry_definition: RevRegDef,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevRegDefResult:
         """Register a revocation registry definition on the registry."""
         raise NotImplementedError()
@@ -97,7 +97,7 @@ class DIDWebRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         profile: Profile,
         rev_reg_def: RevRegDef,
         rev_list: RevList,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevListResult:
         """Register a revocation list on the registry."""
         raise NotImplementedError()
@@ -109,7 +109,7 @@ class DIDWebRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         prev_list: RevList,
         curr_list: RevList,
         revoked: Sequence[int],
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevListResult:
         """Update a revocation list on the registry."""
         raise NotImplementedError()

--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -5,7 +5,7 @@ import logging
 import re
 import uuid
 from asyncio import shield
-from typing import List, Optional, Pattern, Sequence, Tuple
+from typing import List, Pattern, Sequence, Tuple
 
 from base58 import alphabet
 
@@ -198,7 +198,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         self,
         profile: Profile,
         schema: AnonCredsSchema,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> SchemaResult:
         """Register a schema on the registry."""
 
@@ -359,7 +359,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         profile: Profile,
         schema: GetSchemaResult,
         credential_definition: CredDef,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> CredDefResult:
         """Register a credential definition on the registry."""
 
@@ -367,10 +367,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
 
         ledger = profile.inject_or(BaseLedger)
         if not ledger:
-            reason = "No ledger available"
-            if not profile.settings.get_value("wallet.type"):
-                reason += ": missing wallet-type?"
-            raise AnonCredsRegistrationError(reason)
+            raise AnonCredsRegistrationError("No ledger available")
 
         # Check if in wallet but not on ledger
         issuer = AnonCredsIssuer(profile)
@@ -395,44 +392,107 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         }
         LOGGER.debug("Cred def value: %s", indy_cred_def)
 
-        try:
-            async with ledger:
-                seq_no = await shield(
+        endorser_did = None
+        create_transaction = options.get("create_transaction_for_endorser", False)
+
+        if is_author_role(profile) or create_transaction:
+            endorser_did, endorser_connection_id = await get_endorser_info(
+                profile, options
+            )
+
+        write_ledger = (
+            True if endorser_did is None and not create_transaction else False
+        )
+
+        async with ledger:
+            try:
+                result = await shield(
                     ledger.send_credential_definition_anoncreds(
                         credential_definition.schema_id,
                         cred_def_id,
                         indy_cred_def,
-                        write_ledger=True,
-                        endorser_did=credential_definition.issuer_id,
+                        write_ledger=write_ledger,
+                        endorser_did=endorser_did,
                     )
                 )
-        except LedgerObjectAlreadyExistsError as err:
-            if await issuer.credential_definition_in_wallet(cred_def_id):
-                raise AnonCredsObjectAlreadyExists(
-                    f"Credential definition with id {cred_def_id} "
-                    "already exists in wallet and on ledger.",
-                    cred_def_id,
+            except LedgerObjectAlreadyExistsError as err:
+                if await issuer.credential_definition_in_wallet(cred_def_id):
+                    raise AnonCredsObjectAlreadyExists(
+                        f"Credential definition with id {cred_def_id} "
+                        "already exists in wallet and on ledger.",
+                        cred_def_id,
+                    ) from err
+                else:
+                    raise AnonCredsObjectAlreadyExists(
+                        f"Credential definition {cred_def_id} is on "
+                        f"ledger but not in wallet {profile.name}",
+                        cred_def_id,
+                    ) from err
+
+        # Didn't need endorsement
+        if write_ledger:
+            return CredDefResult(
+                job_id=None,
+                credential_definition_state=CredDefState(
+                    state=CredDefState.STATE_FINISHED,
+                    credential_definition_id=cred_def_id,
+                    credential_definition=credential_definition,
+                ),
+                registration_metadata={},
+                credential_definition_metadata={"seqNo": result},
+            )
+
+        # Need endorsement, so execute transaction flow
+        job_id = uuid.uuid4().hex
+
+        meta_data = {
+            "context": {
+                "job_id": job_id,
+                "cred_def_id": cred_def_id,
+                "options": options,
+            },
+        }
+
+        (cred_def_id, cred_def) = result
+        transaction_manager = TransactionManager(profile)
+
+        try:
+            transaction = await transaction_manager.create_record(
+                messages_attach=cred_def["signed_txn"],
+                connection_id=endorser_connection_id,
+                meta_data=meta_data,
+            )
+        except StorageError:
+            raise AnonCredsRegistrationError("Failed to store transaction record")
+
+        if profile.settings.get("endorser.auto_request"):
+            try:
+                (
+                    transaction,
+                    transaction_request,
+                ) = await transaction_manager.create_request(transaction=transaction)
+            except (StorageError, TransactionManagerError) as err:
+                raise AnonCredsRegistrationError(
+                    "Transaction manager failed to create request: " + err.roll_up
                 ) from err
-            else:
-                raise AnonCredsObjectAlreadyExists(
-                    f"Credential definition {cred_def_id} is on "
-                    f"ledger but not in wallet {profile.name}",
-                    cred_def_id,
-                ) from err
-        except (AnonCredsIssuerError, LedgerError) as err:
-            raise AnonCredsRegistrationError(
-                "Failed to register credential definition"
-            ) from err
+
+            responder = profile.inject(BaseResponder)
+            await responder.send(
+                message=transaction_request,
+                connection_id=endorser_connection_id,
+            )
 
         return CredDefResult(
-            job_id=None,
+            job_id=job_id,
             credential_definition_state=CredDefState(
-                state=CredDefState.STATE_FINISHED,
+                state=CredDefState.STATE_WAIT,
                 credential_definition_id=cred_def_id,
                 credential_definition=credential_definition,
             ),
-            registration_metadata={},
-            credential_definition_metadata={"seqNo": seq_no, **(options or {})},
+            registration_metadata={
+                "txn": transaction.serialize(),
+            },
+            credential_definition_metadata={},
         )
 
     async def get_revocation_registry_definition(
@@ -487,48 +547,119 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         self,
         profile: Profile,
         revocation_registry_definition: RevRegDef,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevRegDefResult:
         """Register a revocation registry definition on the registry."""
-
         rev_reg_def_id = self.make_rev_reg_def_id(revocation_registry_definition)
 
-        try:
-            # Translate anoncreds object to indy object
-            indy_rev_reg_def = {
-                "ver": "1.0",
-                "id": rev_reg_def_id,
-                "revocDefType": revocation_registry_definition.type,
-                "credDefId": revocation_registry_definition.cred_def_id,
-                "tag": revocation_registry_definition.tag,
-                "value": {
-                    "issuanceType": "ISSUANCE_BY_DEFAULT",
-                    "maxCredNum": revocation_registry_definition.value.max_cred_num,
-                    "publicKeys": revocation_registry_definition.value.public_keys,
-                    "tailsHash": revocation_registry_definition.value.tails_hash,
-                    "tailsLocation": revocation_registry_definition.value.tails_location,
-                },
-            }
+        ledger = profile.inject(BaseLedger)
+        if not ledger:
+            raise AnonCredsRegistrationError("No ledger available")
 
-            ledger = profile.inject(BaseLedger)
+        # Translate anoncreds object to indy object
+        indy_rev_reg_def = {
+            "ver": "1.0",
+            "id": rev_reg_def_id,
+            "revocDefType": revocation_registry_definition.type,
+            "credDefId": revocation_registry_definition.cred_def_id,
+            "tag": revocation_registry_definition.tag,
+            "value": {
+                "issuanceType": "ISSUANCE_BY_DEFAULT",
+                "maxCredNum": revocation_registry_definition.value.max_cred_num,
+                "publicKeys": revocation_registry_definition.value.public_keys,
+                "tailsHash": revocation_registry_definition.value.tails_hash,
+                "tailsLocation": revocation_registry_definition.value.tails_location,
+            },
+        }
+
+        endorser_did = None
+        create_transaction = options.get(
+            "create_transaction_for_endorser", False
+        ) or profile.settings.get("endorser.auto_create_rev_reg", False)
+
+        if is_author_role(profile) or create_transaction:
+            endorser_did, endorser_connection_id = await get_endorser_info(
+                profile, options
+            )
+
+        write_ledger = (
+            True if endorser_did is None and not create_transaction else False
+        )
+
+        try:
             async with ledger:
-                resp = await ledger.send_revoc_reg_def(
+                result = await ledger.send_revoc_reg_def(
                     indy_rev_reg_def,
                     revocation_registry_definition.issuer_id,
+                    write_ledger=write_ledger,
+                    endorser_did=endorser_did,
                 )
-            seq_no = resp["result"]["txnMetadata"]["seqNo"]
         except LedgerError as err:
-            raise AnonCredsRegistrationError() from err
+            raise AnonCredsRegistrationError(err.roll_up) from err
+
+        # Didn't need endorsement
+        if write_ledger:
+            return RevRegDefResult(
+                job_id=None,
+                revocation_registry_definition_state=RevRegDefState(
+                    state=RevRegDefState.STATE_FINISHED,
+                    revocation_registry_definition_id=rev_reg_def_id,
+                    revocation_registry_definition=revocation_registry_definition,
+                ),
+                registration_metadata={},
+                revocation_registry_definition_metadata={"seqNo": result},
+            )
+
+        # Need endorsement, so execute transaction flow
+        (rev_reg_def_id, reg_rev_def) = result
+
+        job_id = uuid.uuid4().hex
+        meta_data = {
+            "context": {
+                "job_id": job_id,
+                "rev_reg_def_id": rev_reg_def_id,
+                "options": options,
+            }
+        }
+
+        transaction_manager = TransactionManager(profile)
+        try:
+            transaction = await transaction_manager.create_record(
+                messages_attach=reg_rev_def["signed_txn"],
+                connection_id=endorser_connection_id,
+                meta_data=meta_data,
+            )
+        except StorageError:
+            raise AnonCredsRegistrationError("Failed to store transaction record")
+
+        if profile.settings.get("endorser.auto_request"):
+            try:
+                (
+                    transaction,
+                    transaction_request,
+                ) = await transaction_manager.create_request(transaction=transaction)
+            except (StorageError, TransactionManagerError) as err:
+                raise AnonCredsRegistrationError(
+                    "Transaction manager failed to create request: " + err.roll_up
+                ) from err
+
+            responder = profile.inject(BaseResponder)
+            await responder.send(
+                message=transaction_request,
+                connection_id=endorser_connection_id,
+            )
 
         return RevRegDefResult(
-            job_id=None,
+            job_id=job_id,
             revocation_registry_definition_state=RevRegDefState(
-                state=RevRegDefState.STATE_FINISHED,
+                state=RevRegDefState.STATE_WAIT,
                 revocation_registry_definition_id=rev_reg_def_id,
                 revocation_registry_definition=revocation_registry_definition,
             ),
-            registration_metadata={},
-            revocation_registry_definition_metadata={"seqNo": seq_no},
+            registration_metadata={
+                "txn": transaction.serialize(),
+            },
+            revocation_registry_definition_metadata={},
         )
 
     async def _get_or_fetch_rev_reg_def_max_cred_num(
@@ -640,6 +771,8 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         rev_list: RevList,
         rev_reg_def_type: str,
         entry: dict,
+        write_ledger: bool,
+        endorser_did: str = None,
     ) -> dict:
         """Send a revocation registry entry to the ledger with fixes if needed."""
         # TODO Handle multitenancy and multi-ledger (like in get cred def)
@@ -652,8 +785,8 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
                     rev_reg_def_type,
                     entry,
                     rev_list.issuer_id,
-                    write_ledger=True,
-                    endorser_did=None,
+                    write_ledger=write_ledger,
+                    endorser_did=endorser_did,
                 )
         except LedgerTransactionError as err:
             if "InvalidClientRequest" in err.roll_up:
@@ -664,13 +797,14 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
                 # In this scenario we try to post a correction
                 LOGGER.warn("Retry ledger update/fix due to error")
                 LOGGER.warn(err)
-                (_, _, res) = await self.fix_ledger_entry(
+                (_, _, rev_entry_res) = await self.fix_ledger_entry(
                     profile,
                     rev_list,
                     True,
                     ledger.pool.genesis_txns,
+                    write_ledger,
+                    endorser_did,
                 )
-                rev_entry_res = {"result": res}
                 LOGGER.warn("Ledger update/fix applied")
             elif "InvalidClientTaaAcceptanceError" in err.roll_up:
                 # if no write access (with "InvalidClientTaaAcceptanceError")
@@ -695,35 +829,97 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         profile: Profile,
         rev_reg_def: RevRegDef,
         rev_list: RevList,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevListResult:
         """Register a revocation list on the registry."""
+
         rev_reg_entry = {"ver": "1.0", "value": {"accum": rev_list.current_accumulator}}
 
-        rev_entry_res = await self._revoc_reg_entry_with_fix(
-            profile, rev_list, rev_reg_def.type, rev_reg_entry
+        endorser_did = None
+        create_transaction = options.get(
+            "create_transaction_for_endorser", False
+        ) or profile.settings.get("endorser.auto_create_rev_reg", False)
+
+        if is_author_role(profile) or create_transaction:
+            endorser_did, endorser_connection_id = await get_endorser_info(
+                profile, options
+            )
+
+        write_ledger = (
+            True if endorser_did is None and not create_transaction else False
         )
 
-        seq_no = None
+        result = await self._revoc_reg_entry_with_fix(
+            profile,
+            rev_list,
+            rev_reg_def.type,
+            rev_reg_entry,
+            write_ledger,
+            endorser_did,
+        )
+
+        if write_ledger:
+            return RevListResult(
+                job_id=None,
+                revocation_list_state=RevListState(
+                    state=RevListState.STATE_FINISHED,
+                    revocation_list=rev_list,
+                ),
+                registration_metadata={},
+                revocation_list_metadata={"seqNo": result},
+            )
+
+        (rev_reg_def_id, requested_txn) = result
+
+        job_id = uuid.uuid4().hex
+        meta_data = {
+            "context": {
+                "job_id": job_id,
+                "rev_reg_def_id": rev_reg_def_id,
+                "options": {
+                    "endorser_connection_id": endorser_connection_id,
+                    "create_transaction_for_endorser": create_transaction,
+                },
+            }
+        }
+
+        transaction_manager = TransactionManager(profile)
         try:
-            seq_no = rev_entry_res["result"]["txnMetadata"]["seqNo"]
-        except KeyError:
-            LOGGER.warning("Failed to parse sequence number from ledger response")
+            transaction = await transaction_manager.create_record(
+                messages_attach=requested_txn["signed_txn"],
+                connection_id=endorser_connection_id,
+                meta_data=meta_data,
+            )
+        except StorageError:
+            raise AnonCredsRegistrationError("Failed to store transaction record")
+
+        if profile.settings.get("endorser.auto_request"):
+            try:
+                (
+                    transaction,
+                    transaction_request,
+                ) = await transaction_manager.create_request(transaction=transaction)
+            except (StorageError, TransactionManagerError) as err:
+                raise AnonCredsRegistrationError(
+                    "Transaction manager failed to create request: " + err.roll_up
+                ) from err
+
+            responder = profile.inject(BaseResponder)
+            await responder.send(
+                message=transaction_request,
+                connection_id=endorser_connection_id,
+            )
 
         return RevListResult(
-            job_id=None,
+            job_id=job_id,
             revocation_list_state=RevListState(
-                state=RevListState.STATE_FINISHED,
+                state=RevListState.STATE_WAIT,
                 revocation_list=rev_list,
             ),
-            registration_metadata={},
-            revocation_list_metadata=(
-                {}
-                if seq_no is None
-                else {
-                    "seqNo": seq_no,
-                }
-            ),
+            registration_metadata={
+                "txn": transaction.serialize(),
+            },
+            revocation_list_metadata={},
         )
 
     async def update_revocation_list(
@@ -733,7 +929,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         prev_list: RevList,
         curr_list: RevList,
         revoked: Sequence[int],
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevListResult:
         """Update a revocation list."""
         newly_revoked_indices = list(revoked)
@@ -746,20 +942,89 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
             },
         }
 
-        rev_entry_res = await self._revoc_reg_entry_with_fix(
-            profile, curr_list, rev_reg_def.type, rev_reg_entry
+        endorser_did = None
+        create_transaction = options.get("create_transaction_for_endorser", False)
+
+        if is_author_role(profile) or create_transaction:
+            endorser_did, endorser_connection_id = await get_endorser_info(
+                profile, options
+            )
+
+        write_ledger = (
+            True if endorser_did is None and not create_transaction else False
         )
 
+        result = await self._revoc_reg_entry_with_fix(
+            profile,
+            curr_list,
+            rev_reg_def.type,
+            rev_reg_entry,
+            write_ledger,
+            endorser_did,
+        )
+
+        if write_ledger:
+            return RevListResult(
+                job_id=None,
+                revocation_list_state=RevListState(
+                    state=RevListState.STATE_FINISHED,
+                    revocation_list=curr_list,
+                ),
+                registration_metadata={},
+                revocation_list_metadata={"seqNo": result},
+            )
+
+        (rev_reg_def_id, requested_txn) = result
+
+        job_id = uuid.uuid4().hex
+        meta_data = {
+            "context": {
+                "job_id": job_id,
+                "rev_reg_def_id": rev_reg_def_id,
+                "options": {
+                    "endorser_connection_id": endorser_connection_id,
+                    "create_transaction_for_endorser": create_transaction,
+                },
+            }
+        }
+
+        transaction_manager = TransactionManager(profile)
+        try:
+            transaction = await transaction_manager.create_record(
+                messages_attach=requested_txn["signed_txn"],
+                connection_id=endorser_connection_id,
+                meta_data=meta_data,
+            )
+        except StorageError:
+            raise AnonCredsRegistrationError("Failed to store transaction record")
+
+        if profile.settings.get("endorser.auto_request"):
+            try:
+                (
+                    transaction,
+                    transaction_request,
+                ) = await transaction_manager.create_request(transaction=transaction)
+            except (StorageError, TransactionManagerError) as err:
+                raise AnonCredsRegistrationError(
+                    "Transaction manager failed to create request: " + err.roll_up
+                ) from err
+
+            responder = profile.inject(BaseResponder)
+            await responder.send(
+                message=transaction_request,
+                connection_id=endorser_connection_id,
+            )
+
         return RevListResult(
-            job_id=None,
+            job_id=job_id,
             revocation_list_state=RevListState(
-                state=RevListState.STATE_FINISHED,
+                state=RevListState.STATE_WAIT,
                 revocation_list=curr_list,
             ),
-            registration_metadata={},
-            revocation_list_metadata={
-                "seqNo": rev_entry_res["result"]["txnMetadata"]["seqNo"],
+            registration_metadata={
+                "txn": transaction.serialize(),
             },
+            revocation_list_metadata={},
         )
 
     async def fix_ledger_entry(
@@ -768,6 +1033,8 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         rev_list: RevList,
         apply_ledger_update: bool,
         genesis_transactions: str,
+        write_ledger: bool = True,
+        endorser_did: str = None,
     ) -> Tuple[dict, dict, dict]:
         """Fix the ledger entry to match wallet-recorded credentials."""
         # get rev reg delta (revocations published to ledger)
@@ -831,11 +1098,14 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
                         raise LedgerError(reason=reason)
 
                     async with ledger:
-                        ledger_response = await ledger.send_revoc_reg_entry(
-                            rev_list.rev_reg_def_id, "CL_ACCUM", recovery_txn
+                        applied_txn = await ledger.send_revoc_reg_entry(
+                            rev_list.rev_reg_def_id,
+                            "CL_ACCUM",
+                            recovery_txn,
+                            rev_list.issuer_id,
+                            write_ledger,
+                            endorser_did,
                         )
-
-                    applied_txn = ledger_response["result"]
 
         return (rev_reg_delta, recovery_txn, applied_txn)
 
@@ -855,14 +1125,15 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
             raise LedgerError("No ledger available")
 
         try:
-            return await shield(
-                ledger.txn_submit(
-                    ledger_transaction,
-                    sign=sign,
-                    taa_accept=taa_accept,
-                    sign_did=sign_did,
-                    write_ledger=write_ledger,
+            async with ledger:
+                return await shield(
+                    ledger.txn_submit(
+                        ledger_transaction,
+                        sign=sign,
+                        taa_accept=taa_accept,
+                        sign_did=sign_did,
+                        write_ledger=write_ledger,
+                    )
                 )
-            )
         except LedgerError as err:
             raise AnonCredsRegistrationError(err.roll_up) from err

--- a/aries_cloudagent/anoncreds/default/legacy_indy/tests/test_registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/tests/test_registry.py
@@ -5,26 +5,45 @@ import re
 from unittest import IsolatedAsyncioTestCase
 
 import pytest
+from anoncreds import Schema
 from base58 import alphabet
 
-from aries_cloudagent.anoncreds.base import (
+from .....anoncreds.base import (
     AnonCredsRegistrationError,
     AnonCredsSchemaAlreadyExists,
 )
-from aries_cloudagent.anoncreds.models.anoncreds_schema import (
+from .....anoncreds.models.anoncreds_schema import (
     AnonCredsSchema,
+    GetSchemaResult,
     SchemaResult,
 )
-from aries_cloudagent.askar.profile_anon import AskarAnoncredsProfile
-from aries_cloudagent.connections.models.conn_record import ConnRecord
-from aries_cloudagent.core.in_memory.profile import InMemoryProfile
-from aries_cloudagent.ledger.error import LedgerError, LedgerObjectAlreadyExistsError
-from aries_cloudagent.messaging.responder import BaseResponder
-from aries_cloudagent.protocols.endorse_transaction.v1_0.manager import (
+from .....askar.profile_anon import AskarAnoncredsProfile
+from .....connections.models.conn_record import ConnRecord
+from .....core.in_memory.profile import InMemoryProfile
+from .....ledger.base import BaseLedger
+from .....ledger.error import LedgerError, LedgerObjectAlreadyExistsError
+from .....messaging.responder import BaseResponder
+from .....protocols.endorse_transaction.v1_0.manager import (
     TransactionManager,
 )
-from aries_cloudagent.tests import mock
-
+from .....protocols.endorse_transaction.v1_0.models.transaction_record import (
+    TransactionRecord,
+)
+from .....tests import mock
+from ....issuer import AnonCredsIssuer
+from ....models.anoncreds_cred_def import (
+    CredDef,
+    CredDefResult,
+    CredDefValue,
+    CredDefValuePrimary,
+)
+from ....models.anoncreds_revocation import (
+    RevList,
+    RevListResult,
+    RevRegDef,
+    RevRegDefResult,
+    RevRegDefValue,
+)
 from .. import registry as test_module
 
 B58 = alphabet if isinstance(alphabet, str) else alphabet.decode("ascii")
@@ -241,6 +260,473 @@ class TestLegacyIndyRegistry(IsolatedAsyncioTestCase):
             BaseResponder
         )._instance.send.called
 
+    @mock.patch.object(
+        AnonCredsIssuer, "credential_definition_in_wallet", return_value=False
+    )
+    async def test_register_credential_definition_no_endorsement(self, mock_in_wallet):
+        schema = Schema.create(
+            name="MYCO Biomarker",
+            version="1.0",
+            issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+            attr_names=["attr1", "attr2"],
+        )
+
+        schema_result = GetSchemaResult(
+            schema_id="schema-id",
+            schema=schema,
+            schema_metadata={
+                "seqNo": 1,
+            },
+            resolution_metadata={},
+        )
+
+        cred_def = CredDef(
+            issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+            schema_id="CsQY9MGeD3CQP4EyuVFo5m:2:MYCO Biomarker:0.0.3",
+            tag="default",
+            type="CL",
+            value=CredDefValue(primary=CredDefValuePrimary("n", "s", {}, "rctxt", "z")),
+        )
+
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            mock.MagicMock(
+                send_credential_definition_anoncreds=mock.CoroutineMock(return_value=2)
+            ),
+        )
+
+        result = await self.registry.register_credential_definition(
+            self.profile, schema_result, cred_def, {}
+        )
+
+        assert isinstance(result, CredDefResult)
+        assert mock_in_wallet.called
+
+    @mock.patch.object(
+        AnonCredsIssuer, "credential_definition_in_wallet", return_value=False
+    )
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_id",
+        return_value=mock.CoroutineMock(
+            metadata_get=mock.CoroutineMock(return_value={"endorser_did": "test_did"})
+        ),
+    )
+    @mock.patch.object(
+        TransactionManager,
+        "create_record",
+        return_value=TransactionRecord(),
+    )
+    async def test_register_credential_definition_with_author_role(
+        self, mock_create_record, mock_get_endorser_info, mock_in_wallet
+    ):
+        schema = Schema.create(
+            name="MYCO Biomarker",
+            version="1.0",
+            issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+            attr_names=["attr1", "attr2"],
+        )
+
+        schema_result = GetSchemaResult(
+            schema_id="schema-id",
+            schema=schema,
+            schema_metadata={
+                "seqNo": 1,
+            },
+            resolution_metadata={},
+        )
+
+        cred_def = CredDef(
+            issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+            schema_id="CsQY9MGeD3CQP4EyuVFo5m:2:MYCO Biomarker:0.0.3",
+            tag="default",
+            type="CL",
+            value=CredDefValue(primary=CredDefValuePrimary("n", "s", {}, "rctxt", "z")),
+        )
+
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            mock.MagicMock(
+                send_credential_definition_anoncreds=mock.CoroutineMock(
+                    return_value=("id", {"signed_txn": "txn"})
+                )
+            ),
+        )
+        self.profile.settings.set_value("endorser.author", True)
+
+        result = await self.registry.register_credential_definition(
+            self.profile,
+            schema_result,
+            cred_def,
+            {"endorser_connection_id": "test_connection_id"},
+        )
+
+        assert isinstance(result, CredDefResult)
+        assert result.job_id is not None
+        assert mock_in_wallet.called
+        assert mock_get_endorser_info.called
+        assert mock_create_record.called
+
+    @mock.patch.object(
+        AnonCredsIssuer, "credential_definition_in_wallet", return_value=False
+    )
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_id",
+        return_value=mock.CoroutineMock(
+            metadata_get=mock.CoroutineMock(return_value={"endorser_did": "test_did"})
+        ),
+    )
+    @mock.patch.object(
+        TransactionManager,
+        "create_record",
+        return_value=TransactionRecord(),
+    )
+    async def test_register_credential_definition_with_create_transaction_option(
+        self, mock_create_record, mock_get_endorser_info, mock_in_wallet
+    ):
+        schema = Schema.create(
+            name="MYCO Biomarker",
+            version="1.0",
+            issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+            attr_names=["attr1", "attr2"],
+        )
+
+        schema_result = GetSchemaResult(
+            schema_id="schema-id",
+            schema=schema,
+            schema_metadata={
+                "seqNo": 1,
+            },
+            resolution_metadata={},
+        )
+
+        cred_def = CredDef(
+            issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+            schema_id="CsQY9MGeD3CQP4EyuVFo5m:2:MYCO Biomarker:0.0.3",
+            tag="default",
+            type="CL",
+            value=CredDefValue(primary=CredDefValuePrimary("n", "s", {}, "rctxt", "z")),
+        )
+
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            mock.MagicMock(
+                send_credential_definition_anoncreds=mock.CoroutineMock(
+                    return_value=("id", {"signed_txn": "txn"})
+                )
+            ),
+        )
+
+        result = await self.registry.register_credential_definition(
+            self.profile,
+            schema_result,
+            cred_def,
+            {
+                "endorser_connection_id": "test_connection_id",
+                "create_transaction_for_endorser": True,
+            },
+        )
+
+        assert isinstance(result, CredDefResult)
+        assert result.job_id is not None
+        assert mock_in_wallet.called
+        assert mock_get_endorser_info.called
+        assert mock_create_record.called
+
+    @mock.patch.object(
+        AnonCredsIssuer, "credential_definition_in_wallet", return_value=False
+    )
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_id",
+        return_value=mock.CoroutineMock(
+            metadata_get=mock.CoroutineMock(return_value={"endorser_did": "test_did"})
+        ),
+    )
+    @mock.patch.object(
+        TransactionManager,
+        "create_record",
+        return_value=TransactionRecord(),
+    )
+    @mock.patch.object(
+        TransactionManager,
+        "create_request",
+        return_value=(TransactionRecord(), "transaction_request"),
+    )
+    async def test_register_credential_definition_with_transaction_and_auto_request(
+        self,
+        mock_create_request,
+        mock_create_record,
+        mock_get_endorser_info,
+        mock_in_wallet,
+    ):
+        schema = Schema.create(
+            name="MYCO Biomarker",
+            version="1.0",
+            issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+            attr_names=["attr1", "attr2"],
+        )
+
+        schema_result = GetSchemaResult(
+            schema_id="schema-id",
+            schema=schema,
+            schema_metadata={
+                "seqNo": 1,
+            },
+            resolution_metadata={},
+        )
+
+        cred_def = CredDef(
+            issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+            schema_id="CsQY9MGeD3CQP4EyuVFo5m:2:MYCO Biomarker:0.0.3",
+            tag="default",
+            type="CL",
+            value=CredDefValue(primary=CredDefValuePrimary("n", "s", {}, "rctxt", "z")),
+        )
+
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            mock.MagicMock(
+                send_credential_definition_anoncreds=mock.CoroutineMock(
+                    return_value=("id", {"signed_txn": "txn"})
+                )
+            ),
+        )
+        self.profile.context.injector.bind_instance(
+            BaseResponder,
+            mock.MagicMock(send=mock.CoroutineMock(return_value=None)),
+        )
+        self.profile.settings.set_value("endorser.auto_request", True)
+
+        result = await self.registry.register_credential_definition(
+            self.profile,
+            schema_result,
+            cred_def,
+            {
+                "endorser_connection_id": "test_connection_id",
+                "create_transaction_for_endorser": True,
+            },
+        )
+
+        assert isinstance(result, CredDefResult)
+        assert result.job_id is not None
+        assert mock_in_wallet.called
+        assert mock_get_endorser_info.called
+        assert mock_create_record.called
+        assert mock_create_request.called
+        assert self.profile.context.injector.get_provider(
+            BaseResponder
+        )._instance.send.called
+
+    async def test_register_revocation_registry_definition_no_endorsement(self):
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            mock.MagicMock(send_revoc_reg_def=mock.CoroutineMock(return_value=1)),
+        )
+        result = await self.registry.register_revocation_registry_definition(
+            self.profile,
+            RevRegDef(
+                tag="tag",
+                cred_def_id="CsQY9MGeD3CQP4EyuVFo5m:3:CL:14951:MYCO_Biomarker",
+                value=RevRegDefValue(
+                    max_cred_num=100,
+                    public_keys={
+                        "accum_key": {"z": "1 0BB...386"},
+                    },
+                    tails_hash="not-correct-hash",
+                    tails_location="http://tails-server.com",
+                ),
+                issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                type="CL_ACCUM",
+            ),
+            {},
+        )
+
+        assert isinstance(result, RevRegDefResult)
+        assert self.profile.context.injector.get_provider(
+            BaseLedger
+        )._instance.send_revoc_reg_def.called
+
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_id",
+        return_value=mock.CoroutineMock(
+            metadata_get=mock.CoroutineMock(return_value={"endorser_did": "test_did"})
+        ),
+    )
+    @mock.patch.object(
+        TransactionManager,
+        "create_record",
+        return_value=TransactionRecord(),
+    )
+    @mock.patch.object(
+        TransactionManager,
+        "create_request",
+        return_value=(TransactionRecord(), "transaction_request"),
+    )
+    async def test_register_revocation_registry_definition_with_author_role(
+        self, mock_create_request, mock_create_record, mock_endorser_connection
+    ):
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            mock.MagicMock(send_revoc_reg_def=mock.CoroutineMock(return_value=1)),
+        )
+        self.profile.settings.set_value("endorser.author", True)
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            mock.MagicMock(
+                send_revoc_reg_def=mock.CoroutineMock(
+                    return_value=("id", {"signed_txn": "txn"})
+                )
+            ),
+        )
+        self.profile.context.injector.bind_instance(
+            BaseResponder,
+            mock.MagicMock(send=mock.CoroutineMock(return_value=None)),
+        )
+
+        self.profile.settings.set_value("endorser.auto_request", True)
+
+        result = await self.registry.register_revocation_registry_definition(
+            self.profile,
+            RevRegDef(
+                tag="tag",
+                cred_def_id="CsQY9MGeD3CQP4EyuVFo5m:3:CL:14951:MYCO_Biomarker",
+                value=RevRegDefValue(
+                    max_cred_num=100,
+                    public_keys={
+                        "accum_key": {"z": "1 0BB...386"},
+                    },
+                    tails_hash="not-correct-hash",
+                    tails_location="http://tails-server.com",
+                ),
+                issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                type="CL_ACCUM",
+            ),
+            {
+                "endorser_connection_id": "test_connection_id",
+            },
+        )
+
+        assert isinstance(result, RevRegDefResult)
+        assert self.profile.context.injector.get_provider(
+            BaseLedger
+        )._instance.send_revoc_reg_def.called
+        assert mock_create_record.called
+        assert mock_create_request.called
+        assert self.profile.context.injector.get_provider(
+            BaseResponder
+        )._instance.send.called
+
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_id",
+        return_value=mock.CoroutineMock(
+            metadata_get=mock.CoroutineMock(return_value={"endorser_did": "test_did"})
+        ),
+    )
+    @mock.patch.object(
+        TransactionManager,
+        "create_record",
+        return_value=TransactionRecord(),
+    )
+    async def test_register_revocation_registry_definition_with_create_transaction_option(
+        self, mock_create_record, mock_endorser_connection
+    ):
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            mock.MagicMock(send_revoc_reg_def=mock.CoroutineMock(return_value=1)),
+        )
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            mock.MagicMock(
+                send_revoc_reg_def=mock.CoroutineMock(
+                    return_value=("id", {"signed_txn": "txn"})
+                )
+            ),
+        )
+
+        result = await self.registry.register_revocation_registry_definition(
+            self.profile,
+            RevRegDef(
+                tag="tag",
+                cred_def_id="CsQY9MGeD3CQP4EyuVFo5m:3:CL:14951:MYCO_Biomarker",
+                value=RevRegDefValue(
+                    max_cred_num=100,
+                    public_keys={
+                        "accum_key": {"z": "1 0BB...386"},
+                    },
+                    tails_hash="not-correct-hash",
+                    tails_location="http://tails-server.com",
+                ),
+                issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                type="CL_ACCUM",
+            ),
+            {
+                "endorser_connection_id": "test_connection_id",
+                "create_transaction_for_endorser": True,
+            },
+        )
+
+        assert isinstance(result, RevRegDefResult)
+        assert self.profile.context.injector.get_provider(
+            BaseLedger
+        )._instance.send_revoc_reg_def.called
+        assert mock_create_record.called
+
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_id",
+        return_value=mock.CoroutineMock(
+            metadata_get=mock.CoroutineMock(return_value={"endorser_did": "test_did"})
+        ),
+    )
+    @mock.patch.object(
+        TransactionManager,
+        "create_record",
+        return_value=TransactionRecord(),
+    )
+    async def test_register_revocation_registry_definition_with_create_transaction_and_auto_request(
+        self, mock_create_record, mock_endorser_connection
+    ):
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            mock.MagicMock(
+                send_revoc_reg_def=mock.CoroutineMock(
+                    return_value=("id", {"signed_txn": "txn"})
+                )
+            ),
+        )
+
+        result = await self.registry.register_revocation_registry_definition(
+            self.profile,
+            RevRegDef(
+                tag="tag",
+                cred_def_id="CsQY9MGeD3CQP4EyuVFo5m:3:CL:14951:MYCO_Biomarker",
+                value=RevRegDefValue(
+                    max_cred_num=100,
+                    public_keys={
+                        "accum_key": {"z": "1 0BB...386"},
+                    },
+                    tails_hash="not-correct-hash",
+                    tails_location="http://tails-server.com",
+                ),
+                issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                type="CL_ACCUM",
+            ),
+            {
+                "endorser_connection_id": "test_connection_id",
+                "create_transaction_for_endorser": True,
+            },
+        )
+
+        assert isinstance(result, RevRegDefResult)
+        assert self.profile.context.injector.get_provider(
+            BaseLedger
+        )._instance.send_revoc_reg_def.called
+        assert mock_create_record.called
+
     async def test_txn_submit(self):
         self.profile.inject = mock.MagicMock(
             side_effect=[
@@ -263,3 +749,230 @@ class TestLegacyIndyRegistry(IsolatedAsyncioTestCase):
 
         result = await self.registry.txn_submit(self.profile, "test_txn")
         assert result == "transaction response"
+
+    async def test_register_revocation_list_no_endorsement(self):
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            mock.MagicMock(send_revoc_reg_entry=mock.CoroutineMock(return_value=1)),
+        )
+        result = await self.registry.register_revocation_list(
+            self.profile,
+            RevRegDef(
+                tag="tag",
+                cred_def_id="CsQY9MGeD3CQP4EyuVFo5m:3:CL:14951:MYCO_Biomarker",
+                value=RevRegDefValue(
+                    max_cred_num=100,
+                    public_keys={
+                        "accum_key": {"z": "1 0BB...386"},
+                    },
+                    tails_hash="not-correct-hash",
+                    tails_location="http://tails-server.com",
+                ),
+                issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                type="CL_ACCUM",
+            ),
+            RevList(
+                issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                current_accumulator="21 124C594B6B20E41B681E92B2C43FD165EA9E68BC3C9D63A82C8893124983CAE94 21 124C5341937827427B0A3A32113BD5E64FB7AB39BD3E5ABDD7970874501CA4897 6 5438CB6F442E2F807812FD9DC0C39AFF4A86B1E6766DBB5359E86A4D70401B0F 4 39D1CA5C4716FFC4FE0853C4FF7F081DFD8DF8D2C2CA79705211680AC77BF3A1 6 70504A5493F89C97C225B68310811A41AD9CD889301F238E93C95AD085E84191 4 39582252194D756D5D86D0EED02BF1B95CE12AED2FA5CD3C53260747D891993C",
+                revocation_list=[0, 1, 1, 0],
+                timestamp=1669640864487,
+                rev_reg_def_id="4xE68b6S5VRFrKMMG1U95M:4:4xE68b6S5VRFrKMMG1U95M:3:CL:59232:default:CL_ACCUM:4ae1cc6c-f6bd-486c-8057-88f2ce74e960",
+            ),
+            {},
+        )
+
+        assert isinstance(result, RevListResult)
+        assert self.profile.context.injector.get_provider(
+            BaseLedger
+        )._instance.send_revoc_reg_entry.called
+
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_id",
+        return_value=mock.CoroutineMock(
+            metadata_get=mock.CoroutineMock(return_value={"endorser_did": "test_did"})
+        ),
+    )
+    @mock.patch.object(
+        TransactionManager,
+        "create_record",
+        return_value=TransactionRecord(),
+    )
+    async def test_register_revocation_list_with_author_role(
+        self, mock_create_record, mock_endorsement_conn
+    ):
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            mock.MagicMock(
+                send_revoc_reg_entry=mock.CoroutineMock(
+                    return_value=("id", {"signed_txn": "txn"})
+                )
+            ),
+        )
+        self.profile.settings.set_value("endorser.author", True)
+
+        result = await self.registry.register_revocation_list(
+            self.profile,
+            RevRegDef(
+                tag="tag",
+                cred_def_id="CsQY9MGeD3CQP4EyuVFo5m:3:CL:14951:MYCO_Biomarker",
+                value=RevRegDefValue(
+                    max_cred_num=100,
+                    public_keys={
+                        "accum_key": {"z": "1 0BB...386"},
+                    },
+                    tails_hash="not-correct-hash",
+                    tails_location="http://tails-server.com",
+                ),
+                issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                type="CL_ACCUM",
+            ),
+            RevList(
+                issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                current_accumulator="21 124C594B6B20E41B681E92B2C43FD165EA9E68BC3C9D63A82C8893124983CAE94 21 124C5341937827427B0A3A32113BD5E64FB7AB39BD3E5ABDD7970874501CA4897 6 5438CB6F442E2F807812FD9DC0C39AFF4A86B1E6766DBB5359E86A4D70401B0F 4 39D1CA5C4716FFC4FE0853C4FF7F081DFD8DF8D2C2CA79705211680AC77BF3A1 6 70504A5493F89C97C225B68310811A41AD9CD889301F238E93C95AD085E84191 4 39582252194D756D5D86D0EED02BF1B95CE12AED2FA5CD3C53260747D891993C",
+                revocation_list=[0, 1, 1, 0],
+                timestamp=1669640864487,
+                rev_reg_def_id="4xE68b6S5VRFrKMMG1U95M:4:4xE68b6S5VRFrKMMG1U95M:3:CL:59232:default:CL_ACCUM:4ae1cc6c-f6bd-486c-8057-88f2ce74e960",
+            ),
+            {
+                "endorser_connection_id": "test_connection_id",
+            },
+        )
+
+        assert isinstance(result, RevListResult)
+        assert self.profile.context.injector.get_provider(
+            BaseLedger
+        )._instance.send_revoc_reg_entry.called
+        assert mock_create_record.called
+
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_id",
+        return_value=mock.CoroutineMock(
+            metadata_get=mock.CoroutineMock(return_value={"endorser_did": "test_did"})
+        ),
+    )
+    @mock.patch.object(
+        TransactionManager,
+        "create_record",
+        return_value=TransactionRecord(),
+    )
+    async def test_register_revocation_list_with_create_transaction_option(
+        self, mock_create_record, mock_endorsement_conn
+    ):
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            mock.MagicMock(
+                send_revoc_reg_entry=mock.CoroutineMock(
+                    return_value=("id", {"signed_txn": "txn"})
+                )
+            ),
+        )
+
+        result = await self.registry.register_revocation_list(
+            self.profile,
+            RevRegDef(
+                tag="tag",
+                cred_def_id="CsQY9MGeD3CQP4EyuVFo5m:3:CL:14951:MYCO_Biomarker",
+                value=RevRegDefValue(
+                    max_cred_num=100,
+                    public_keys={
+                        "accum_key": {"z": "1 0BB...386"},
+                    },
+                    tails_hash="not-correct-hash",
+                    tails_location="http://tails-server.com",
+                ),
+                issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                type="CL_ACCUM",
+            ),
+            RevList(
+                issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                current_accumulator="21 124C594B6B20E41B681E92B2C43FD165EA9E68BC3C9D63A82C8893124983CAE94 21 124C5341937827427B0A3A32113BD5E64FB7AB39BD3E5ABDD7970874501CA4897 6 5438CB6F442E2F807812FD9DC0C39AFF4A86B1E6766DBB5359E86A4D70401B0F 4 39D1CA5C4716FFC4FE0853C4FF7F081DFD8DF8D2C2CA79705211680AC77BF3A1 6 70504A5493F89C97C225B68310811A41AD9CD889301F238E93C95AD085E84191 4 39582252194D756D5D86D0EED02BF1B95CE12AED2FA5CD3C53260747D891993C",
+                revocation_list=[0, 1, 1, 0],
+                timestamp=1669640864487,
+                rev_reg_def_id="4xE68b6S5VRFrKMMG1U95M:4:4xE68b6S5VRFrKMMG1U95M:3:CL:59232:default:CL_ACCUM:4ae1cc6c-f6bd-486c-8057-88f2ce74e960",
+            ),
+            {
+                "endorser_connection_id": "test_connection_id",
+                "create_transaction_for_endorser": True,
+            },
+        )
+
+        assert isinstance(result, RevListResult)
+        assert self.profile.context.injector.get_provider(
+            BaseLedger
+        )._instance.send_revoc_reg_entry.called
+        assert mock_create_record.called
+
+    @mock.patch.object(
+        ConnRecord,
+        "retrieve_by_id",
+        return_value=mock.CoroutineMock(
+            metadata_get=mock.CoroutineMock(return_value={"endorser_did": "test_did"})
+        ),
+    )
+    @mock.patch.object(
+        TransactionManager,
+        "create_record",
+        return_value=TransactionRecord(),
+    )
+    @mock.patch.object(
+        TransactionManager,
+        "create_request",
+        return_value=(TransactionRecord(), "transaction_request"),
+    )
+    async def test_register_revocation_list_with_create_transaction_option_and_auto_request(
+        self, mock_create_request, mock_create_record, mock_endorsement_conn
+    ):
+        self.profile.context.injector.bind_instance(
+            BaseLedger,
+            mock.MagicMock(
+                send_revoc_reg_entry=mock.CoroutineMock(
+                    return_value=("id", {"signed_txn": "txn"})
+                )
+            ),
+        )
+        self.profile.context.injector.bind_instance(
+            BaseResponder,
+            mock.MagicMock(send=mock.CoroutineMock(return_value=None)),
+        )
+        self.profile.settings.set_value("endorser.auto_request", True)
+
+        result = await self.registry.register_revocation_list(
+            self.profile,
+            RevRegDef(
+                tag="tag",
+                cred_def_id="CsQY9MGeD3CQP4EyuVFo5m:3:CL:14951:MYCO_Biomarker",
+                value=RevRegDefValue(
+                    max_cred_num=100,
+                    public_keys={
+                        "accum_key": {"z": "1 0BB...386"},
+                    },
+                    tails_hash="not-correct-hash",
+                    tails_location="http://tails-server.com",
+                ),
+                issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                type="CL_ACCUM",
+            ),
+            RevList(
+                issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                current_accumulator="21 124C594B6B20E41B681E92B2C43FD165EA9E68BC3C9D63A82C8893124983CAE94 21 124C5341937827427B0A3A32113BD5E64FB7AB39BD3E5ABDD7970874501CA4897 6 5438CB6F442E2F807812FD9DC0C39AFF4A86B1E6766DBB5359E86A4D70401B0F 4 39D1CA5C4716FFC4FE0853C4FF7F081DFD8DF8D2C2CA79705211680AC77BF3A1 6 70504A5493F89C97C225B68310811A41AD9CD889301F238E93C95AD085E84191 4 39582252194D756D5D86D0EED02BF1B95CE12AED2FA5CD3C53260747D891993C",
+                revocation_list=[0, 1, 1, 0],
+                timestamp=1669640864487,
+                rev_reg_def_id="4xE68b6S5VRFrKMMG1U95M:4:4xE68b6S5VRFrKMMG1U95M:3:CL:59232:default:CL_ACCUM:4ae1cc6c-f6bd-486c-8057-88f2ce74e960",
+            ),
+            {
+                "endorser_connection_id": "test_connection_id",
+                "create_transaction_for_endorser": True,
+            },
+        )
+
+        assert isinstance(result, RevListResult)
+        assert self.profile.context.injector.get_provider(
+            BaseLedger
+        )._instance.send_revoc_reg_entry.called
+        assert mock_create_record.called
+        assert mock_create_request.called
+        assert self.profile.context.injector.get_provider(
+            BaseResponder
+        )._instance.send.called

--- a/aries_cloudagent/anoncreds/events.py
+++ b/aries_cloudagent/anoncreds/events.py
@@ -23,6 +23,7 @@ class CredDefFinishedPayload(NamedTuple):
     issuer_id: str
     support_revocation: bool
     max_cred_num: int
+    options: dict
 
 
 class CredDefFinishedEvent(Event):
@@ -51,10 +52,11 @@ class CredDefFinishedEvent(Event):
         issuer_id: str,
         support_revocation: bool,
         max_cred_num: int,
+        options: dict = {},
     ):
         """With payload."""
         payload = CredDefFinishedPayload(
-            schema_id, cred_def_id, issuer_id, support_revocation, max_cred_num
+            schema_id, cred_def_id, issuer_id, support_revocation, max_cred_num, options
         )
         return cls(payload)
 
@@ -69,6 +71,7 @@ class RevRegDefFinishedPayload(NamedTuple):
 
     rev_reg_def_id: str
     rev_reg_def: RevRegDef
+    options: dict
 
 
 class RevRegDefFinishedEvent(Event):
@@ -91,9 +94,10 @@ class RevRegDefFinishedEvent(Event):
         cls,
         rev_reg_def_id: str,
         rev_reg_def: RevRegDef,
+        options: dict = {},
     ):
         """With payload."""
-        payload = RevRegDefFinishedPayload(rev_reg_def_id, rev_reg_def)
+        payload = RevRegDefFinishedPayload(rev_reg_def_id, rev_reg_def, options)
         return cls(payload)
 
     @property
@@ -104,6 +108,9 @@ class RevRegDefFinishedEvent(Event):
 
 class RevListFinishedPayload(NamedTuple):
     """Payload of rev list finished event."""
+
+    rev_reg_def_id: str
+    options: dict
 
 
 class RevListFinishedEvent(Event):
@@ -120,6 +127,16 @@ class RevListFinishedEvent(Event):
         """
         self._topic = REV_LIST_FINISHED_EVENT
         self._payload = payload
+
+    @classmethod
+    def with_payload(
+        cls,
+        rev_reg_def_id: str,
+        options: dict = {},
+    ):
+        """With payload."""
+        payload = RevListFinishedPayload(rev_reg_def_id, options)
+        return cls(payload)
 
     @property
     def payload(self) -> RevListFinishedPayload:

--- a/aries_cloudagent/anoncreds/registry.py
+++ b/aries_cloudagent/anoncreds/registry.py
@@ -91,7 +91,7 @@ class AnonCredsRegistry:
         self,
         profile: Profile,
         schema: AnonCredsSchema,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> SchemaResult:
         """Register a schema on the registry."""
         registrar = await self._registrar_for_identifier(schema.issuer_id)
@@ -112,7 +112,7 @@ class AnonCredsRegistry:
         profile: Profile,
         schema: GetSchemaResult,
         credential_definition: CredDef,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> CredDefResult:
         """Register a credential definition on the registry."""
         registrar = await self._registrar_for_identifier(
@@ -138,7 +138,7 @@ class AnonCredsRegistry:
         self,
         profile: Profile,
         revocation_registry_definition: RevRegDef,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevRegDefResult:
         """Register a revocation registry definition on the registry."""
         registrar = await self._registrar_for_identifier(
@@ -160,7 +160,7 @@ class AnonCredsRegistry:
         profile: Profile,
         rev_reg_def: RevRegDef,
         rev_list: RevList,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevListResult:
         """Register a revocation list on the registry."""
         registrar = await self._registrar_for_identifier(rev_list.issuer_id)
@@ -175,7 +175,7 @@ class AnonCredsRegistry:
         prev_list: RevList,
         curr_list: RevList,
         revoked: Sequence[int],
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevListResult:
         """Update a revocation list on the registry."""
         registrar = await self._registrar_for_identifier(prev_list.issuer_id)

--- a/aries_cloudagent/anoncreds/revocation.py
+++ b/aries_cloudagent/anoncreds/revocation.py
@@ -498,9 +498,7 @@ class AnonCredsRevocation:
                 "Error saving new revocation registry"
             ) from err
 
-    async def finish_revocation_list(
-        self, job_id: str, rev_reg_def_id: str
-    ):
+    async def finish_revocation_list(self, job_id: str, rev_reg_def_id: str):
         """Mark a revocation list as finished."""
         async with self.profile.transaction() as txn:
             await self._finish_registration(

--- a/aries_cloudagent/anoncreds/revocation.py
+++ b/aries_cloudagent/anoncreds/revocation.py
@@ -34,7 +34,7 @@ from ..core.error import BaseError
 from ..core.event_bus import Event, EventBus
 from ..core.profile import Profile, ProfileSession
 from ..tails.base import BaseTailsServer
-from .events import RevRegDefFinishedEvent
+from .events import RevListFinishedEvent, RevRegDefFinishedEvent
 from .issuer import (
     CATEGORY_CRED_DEF,
     CATEGORY_CRED_DEF_PRIVATE,
@@ -43,6 +43,7 @@ from .issuer import (
 )
 from .models.anoncreds_revocation import (
     RevList,
+    RevListResult,
     RevRegDef,
     RevRegDefResult,
     RevRegDefState,
@@ -144,7 +145,7 @@ class AnonCredsRevocation:
         registry_type: str,
         tag: str,
         max_cred_num: int,
-        options: Optional[dict] = None,
+        options: dict = {},
     ) -> RevRegDefResult:
         """Create a new revocation registry and register on network.
 
@@ -200,51 +201,68 @@ class AnonCredsRevocation:
 
         public_tails_uri = self.generate_public_tails_uri(rev_reg_def)
         rev_reg_def.value.tails_location = public_tails_uri
+
         anoncreds_registry = self.profile.inject(AnonCredsRegistry)
         result = await anoncreds_registry.register_revocation_registry_definition(
             self.profile, rev_reg_def, options
         )
 
-        ident = result.rev_reg_def_id or result.job_id
-        if not ident:
+        await self.store_revocation_registry_definition(
+            result, rev_reg_def_private, options
+        )
+        return result
+
+    async def store_revocation_registry_definition(
+        self,
+        result: RevRegDefResult,
+        rev_reg_def_private: RevocationRegistryDefinitionPrivate,
+        options: dict = {},
+    ):
+        """Store a revocation registry definition."""
+        identifier = result.job_id or result.rev_reg_def_id
+        if not identifier:
             raise AnonCredsRevocationError(
                 "Revocation registry definition id or job id not found"
             )
 
         # TODO Handle `failed` state
 
+        rev_reg_def = (
+            result.revocation_registry_definition_state.revocation_registry_definition
+        )
+
         try:
             async with self.profile.transaction() as txn:
                 await txn.handle.insert(
                     CATEGORY_REV_REG_DEF,
-                    ident,
+                    identifier,
                     rev_reg_def.to_json(),
                     tags={
-                        "cred_def_id": cred_def_id,
+                        "cred_def_id": rev_reg_def.cred_def_id,
                         "state": result.revocation_registry_definition_state.state,
                         "active": json.dumps(False),
                     },
                 )
                 await txn.handle.insert(
                     CATEGORY_REV_REG_DEF_PRIVATE,
-                    ident,
+                    identifier,
                     rev_reg_def_private.to_json_buffer(),
                 )
                 await txn.commit()
 
             if result.revocation_registry_definition_state.state == STATE_FINISHED:
                 await self.notify(
-                    RevRegDefFinishedEvent.with_payload(ident, rev_reg_def)
+                    RevRegDefFinishedEvent.with_payload(
+                        identifier, rev_reg_def, options
+                    )
                 )
         except AskarError as err:
             raise AnonCredsRevocationError(
                 "Error saving new revocation registry"
             ) from err
 
-        return result
-
     async def finish_revocation_registry_definition(
-        self, job_id: str, rev_reg_def_id: str
+        self, job_id: str, rev_reg_def_id: str, options: dict = {}
     ):
         """Mark a rev reg def as finished."""
         async with self.profile.transaction() as txn:
@@ -261,7 +279,7 @@ class AnonCredsRevocation:
             await txn.commit()
 
         await self.notify(
-            RevRegDefFinishedEvent.with_payload(rev_reg_def_id, rev_reg_def)
+            RevRegDefFinishedEvent.with_payload(rev_reg_def_id, rev_reg_def, options)
         )
 
     async def get_created_revocation_registry_definitions(
@@ -376,7 +394,7 @@ class AnonCredsRevocation:
             await txn.commit()
 
     async def create_and_register_revocation_list(
-        self, rev_reg_def_id: str, options: Optional[dict] = None
+        self, rev_reg_def_id: str, options: dict = {}
     ):
         """Create and register a revocation list."""
         try:
@@ -439,13 +457,25 @@ class AnonCredsRevocation:
         )
 
         # TODO Handle `failed` state
+        await self.store_revocation_registry_list(result)
+
+        return result
+
+    async def store_revocation_registry_list(self, result: RevListResult):
+        """Store a revocation registry list."""
+
+        identifier = result.job_id or result.rev_reg_def_id
+        if not identifier:
+            raise AnonCredsRevocationError(
+                "Revocation registry definition id or job id not found"
+            )
 
         rev_list = result.revocation_list_state.revocation_list
         try:
             async with self.profile.session() as session:
                 await session.handle.insert(
                     CATEGORY_REV_LIST,
-                    rev_reg_def_id,
+                    identifier,
                     value_json={
                         "rev_list": rev_list.serialize(),
                         "pending": None,
@@ -457,35 +487,32 @@ class AnonCredsRevocation:
                         "pending": json.dumps(False),
                     },
                 )
+
+            if result.revocation_list_state.state == STATE_FINISHED:
+                await self.notify(
+                    RevListFinishedEvent.with_payload(rev_list.rev_reg_def_id)
+                )
+
         except AskarError as err:
             raise AnonCredsRevocationError(
                 "Error saving new revocation registry"
             ) from err
 
-        return result
-
-    async def finish_revocation_list(self, rev_reg_def_id: str):
+    async def finish_revocation_list(
+        self, job_id: str, rev_reg_def_id: str, options: dict = {}
+    ):
         """Mark a revocation list as finished."""
         async with self.profile.transaction() as txn:
-            entry = await txn.handle.fetch(
+            await self._finish_registration(
+                txn,
                 CATEGORY_REV_LIST,
+                job_id,
                 rev_reg_def_id,
-                for_update=True,
-            )
-            if not entry:
-                raise AnonCredsRevocationError(
-                    f"revocation list with id {rev_reg_def_id} could not be found"
-                )
-
-            tags = entry.tags
-            tags["state"] = STATE_FINISHED
-            await txn.handle.replace(
-                CATEGORY_REV_LIST,
-                rev_reg_def_id,
-                value=entry.value,
-                tags=tags,
+                state=STATE_FINISHED,
             )
             await txn.commit()
+
+        await self.notify(RevListFinishedEvent.with_payload(rev_reg_def_id, options))
 
     async def update_revocation_list(
         self,
@@ -493,7 +520,7 @@ class AnonCredsRevocation:
         prev: RevList,
         curr: RevList,
         revoked: Sequence[int],
-        options: Optional[dict] = None,
+        options: dict = {},
     ):
         """Publish and update to a revocation list."""
         try:

--- a/aries_cloudagent/anoncreds/revocation.py
+++ b/aries_cloudagent/anoncreds/revocation.py
@@ -499,7 +499,7 @@ class AnonCredsRevocation:
             ) from err
 
     async def finish_revocation_list(
-        self, job_id: str, rev_reg_def_id: str, options: dict = {}
+        self, job_id: str, rev_reg_def_id: str
     ):
         """Mark a revocation list as finished."""
         async with self.profile.transaction() as txn:
@@ -512,7 +512,7 @@ class AnonCredsRevocation:
             )
             await txn.commit()
 
-        await self.notify(RevListFinishedEvent.with_payload(rev_reg_def_id, options))
+        await self.notify(RevListFinishedEvent.with_payload(rev_reg_def_id))
 
     async def update_revocation_list(
         self,

--- a/aries_cloudagent/anoncreds/revocation_setup.py
+++ b/aries_cloudagent/anoncreds/revocation_setup.py
@@ -82,11 +82,14 @@ class DefaultRevocationSetup(AnonCredsRevocationSetupManager):
     async def on_rev_reg_def(self, profile: Profile, event: RevRegDefFinishedEvent):
         """Handle rev reg def finished."""
         payload = event.payload
-        auto_create_revocation = is_author_role(profile) and profile.settings.get(
-            "endorser.auto_create_rev_reg", False
-        )
 
-        if payload.options.get("support_revocation", False) or auto_create_revocation:
+        auto_create_revocation = True
+        if is_author_role(profile):
+            auto_create_revocation = profile.settings.get(
+                "endorser.auto_create_rev_reg", False
+            )
+
+        if auto_create_revocation:
             revoc = AnonCredsRevocation(profile)
             await revoc.upload_tails_file(payload.rev_reg_def)
             await revoc.create_and_register_revocation_list(

--- a/aries_cloudagent/anoncreds/tests/test_issuer.py
+++ b/aries_cloudagent/anoncreds/tests/test_issuer.py
@@ -545,7 +545,7 @@ class TestAnonCredsIssuer(IsolatedAsyncioTestCase):
                     return_value=GetSchemaResult(
                         schema_id="schema-id",
                         schema=AnonCredsSchema(
-                            issuer_id="issuer-id",
+                            issuer_id="did:sov:3avoBCqDMFHFaKUHug9s8W",
                             name="schema-name",
                             version="1.0",
                             attr_names=["attr1", "attr2"],
@@ -587,8 +587,8 @@ class TestAnonCredsIssuer(IsolatedAsyncioTestCase):
                 commit=mock.CoroutineMock(return_value=None),
             )
         )
-        # Creating fails
-        with self.assertRaises(test_module.AnonCredsIssuerError):
+        # Creating fails with bad issuer_id
+        with self.assertRaises(test_module.AnoncredsError):
             await self.issuer.create_and_register_credential_definition(
                 issuer_id="issuer-id",
                 schema_id="CsQY9MGeD3CQP4EyuVFo5m:2:MYCO Biomarker:0.0.3",

--- a/aries_cloudagent/anoncreds/tests/test_revocation.py
+++ b/aries_cloudagent/anoncreds/tests/test_revocation.py
@@ -30,6 +30,7 @@ from aries_cloudagent.anoncreds.models.anoncreds_schema import (
     AnonCredsSchema,
     GetSchemaResult,
 )
+from aries_cloudagent.anoncreds.registry import AnonCredsRegistry
 from aries_cloudagent.anoncreds.tests.mock_objects import (
     MOCK_REV_REG_DEF,
 )
@@ -37,7 +38,7 @@ from aries_cloudagent.anoncreds.tests.test_issuer import MockCredDefEntry
 from aries_cloudagent.askar.profile_anon import (
     AskarAnoncredsProfile,
 )
-from aries_cloudagent.core.event_bus import Event, MockEventBus
+from aries_cloudagent.core.event_bus import Event, EventBus, MockEventBus
 from aries_cloudagent.core.in_memory.profile import (
     InMemoryProfile,
     InMemoryProfileSession,
@@ -555,8 +556,9 @@ class TestAnonCredsRevocation(IsolatedAsyncioTestCase):
         )
         mock_handle.insert = mock.CoroutineMock(return_value=None)
 
-        self.profile.inject = mock.Mock(
-            return_value=mock.MagicMock(
+        self.profile.context.injector.bind_instance(
+            AnonCredsRegistry,
+            mock.MagicMock(
                 register_revocation_list=mock.CoroutineMock(
                     return_value=RevListResult(
                         job_id="test-job-id",
@@ -568,8 +570,9 @@ class TestAnonCredsRevocation(IsolatedAsyncioTestCase):
                         revocation_list_metadata={},
                     )
                 )
-            )
+            ),
         )
+        self.profile.context.injector.bind_instance(EventBus, MockEventBus())
         await self.revocation.create_and_register_revocation_list(
             rev_reg_def_id="test-rev-reg-def-id",
         )
@@ -580,39 +583,19 @@ class TestAnonCredsRevocation(IsolatedAsyncioTestCase):
         assert mock_deserialize_cred_def.called
         assert mock_deserialize_rev_reg.called
         assert mock_load_rev_list.called
+        assert self.profile.context.injector.get_provider(
+            AnonCredsRegistry
+        )._instance.register_revocation_list.called
 
     @mock.patch.object(InMemoryProfileSession, "handle")
-    async def test_finish_revocation_list(self, mock_handle):
-        mock_handle.fetch = mock.CoroutineMock(
-            side_effect=[
-                None,
-                MockEntry(
-                    tags={
-                        "state": RevListState.STATE_FINISHED,
-                    }
-                ),
-            ]
-        )
-        mock_handle.replace = mock.CoroutineMock(return_value=None)
-
-        # fetch returns None
-        with self.assertRaises(test_module.AnonCredsRevocationError):
-            await self.revocation.finish_revocation_list(
-                rev_reg_def_id="test-rev-reg-def-id",
-            )
-        assert mock_handle.fetch.call_count == 1
-        assert mock_handle.replace.call_count == 0
-
-        # valid
+    @mock.patch.object(test_module.AnonCredsRevocation, "_finish_registration")
+    async def test_finish_revocation_list(self, mock_finish, mock_handle):
+        self.profile.context.injector.bind_instance(EventBus, MockEventBus())
         await self.revocation.finish_revocation_list(
+            job_id="test-job-id",
             rev_reg_def_id="test-rev-reg-def-id",
         )
-        assert mock_handle.fetch.call_count == 2
-        assert mock_handle.replace.call_count == 1
-        assert (
-            mock_handle.replace.call_args.kwargs["tags"]["state"]
-            == RevListState.STATE_FINISHED
-        )
+        assert mock_finish.called
 
     @mock.patch.object(InMemoryProfileSession, "handle")
     async def test_update_revocation_list_get_rev_reg_errors(self, mock_handle):

--- a/aries_cloudagent/anoncreds/tests/test_revocation_setup.py
+++ b/aries_cloudagent/anoncreds/tests/test_revocation_setup.py
@@ -1,0 +1,250 @@
+from unittest import IsolatedAsyncioTestCase
+
+import pytest
+
+from aries_cloudagent.tests import mock
+
+from ...askar.profile_anon import AskarAnoncredsProfile
+from ...core.in_memory.profile import InMemoryProfile
+from .. import revocation_setup as test_module
+from ..events import (
+    CredDefFinishedEvent,
+    CredDefFinishedPayload,
+    RevRegDefFinishedEvent,
+    RevRegDefFinishedPayload,
+)
+from ..models.anoncreds_revocation import RevRegDef, RevRegDefValue
+from ..revocation import AnonCredsRevocation
+
+
+@pytest.mark.anoncreds
+class TestAnonCredsRevocationSetup(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.profile = InMemoryProfile.test_profile(
+            settings={
+                "wallet-type": "askar-anoncreds",
+                "tails_server_base_url": "http://tails-server.com",
+            },
+            profile_class=AskarAnoncredsProfile,
+        )
+        self.revocation_setup = test_module.DefaultRevocationSetup()
+
+    @mock.patch.object(
+        AnonCredsRevocation,
+        "create_and_register_revocation_registry_definition",
+        return_value=None,
+    )
+    async def test_on_cred_def_support_revocation_registers_revocation_def(
+        self, mock_register_revocation_registry_definition
+    ):
+
+        event = CredDefFinishedEvent(
+            CredDefFinishedPayload(
+                schema_id="schema_id",
+                cred_def_id="cred_def_id",
+                issuer_id="issuer_id",
+                support_revocation=True,
+                max_cred_num=100,
+                options={},
+            )
+        )
+        await self.revocation_setup.on_cred_def(self.profile, event)
+
+        assert mock_register_revocation_registry_definition.called
+
+    @mock.patch.object(
+        AnonCredsRevocation,
+        "create_and_register_revocation_registry_definition",
+        return_value=None,
+    )
+    async def test_on_cred_def_author_with_auto_create_rev_reg_config_registers_reg_def(
+        self, mock_register_revocation_registry_definition
+    ):
+
+        self.profile.settings["endorser.author"] = True
+        self.profile.settings["endorser.auto_create_rev_reg"] = True
+        event = CredDefFinishedEvent(
+            CredDefFinishedPayload(
+                schema_id="schema_id",
+                cred_def_id="cred_def_id",
+                issuer_id="issuer_id",
+                support_revocation=False,
+                max_cred_num=100,
+                options={},
+            )
+        )
+        await self.revocation_setup.on_cred_def(self.profile, event)
+
+        assert mock_register_revocation_registry_definition.called
+
+    @mock.patch.object(
+        AnonCredsRevocation,
+        "create_and_register_revocation_registry_definition",
+        return_value=None,
+    )
+    async def test_on_cred_def_author_with_auto_create_rev_reg_config_and_support_revoc_option_registers_reg_def(
+        self, mock_register_revocation_registry_definition
+    ):
+
+        self.profile.settings["endorser.author"] = True
+        self.profile.settings["endorser.auto_create_rev_reg"] = True
+        event = CredDefFinishedEvent(
+            CredDefFinishedPayload(
+                schema_id="schema_id",
+                cred_def_id="cred_def_id",
+                issuer_id="issuer_id",
+                support_revocation=True,
+                max_cred_num=100,
+                options={},
+            )
+        )
+        await self.revocation_setup.on_cred_def(self.profile, event)
+
+        assert mock_register_revocation_registry_definition.called
+
+    @mock.patch.object(
+        AnonCredsRevocation,
+        "create_and_register_revocation_registry_definition",
+        return_value=None,
+    )
+    async def test_on_cred_def_not_author_or_support_rev_option(
+        self, mock_register_revocation_registry_definition
+    ):
+
+        event = CredDefFinishedEvent(
+            CredDefFinishedPayload(
+                schema_id="schema_id",
+                cred_def_id="cred_def_id",
+                issuer_id="issuer_id",
+                support_revocation=False,
+                max_cred_num=100,
+                options={},
+            )
+        )
+        await self.revocation_setup.on_cred_def(self.profile, event)
+
+        assert not mock_register_revocation_registry_definition.called
+
+    @mock.patch.object(
+        AnonCredsRevocation,
+        "upload_tails_file",
+        return_value=None,
+    )
+    @mock.patch.object(
+        AnonCredsRevocation,
+        "create_and_register_revocation_list",
+        return_value=None,
+    )
+    @mock.patch.object(
+        AnonCredsRevocation,
+        "set_active_registry",
+        return_value=None,
+    )
+    async def test_on_rev_reg_def_with_support_revoc_option_registers_list(
+        self, mock_set_active_reg, mock_register, mock_upload
+    ):
+        event = RevRegDefFinishedEvent(
+            RevRegDefFinishedPayload(
+                rev_reg_def_id="rev_reg_def_id",
+                rev_reg_def=RevRegDef(
+                    tag="0",
+                    cred_def_id="CsQY9MGeD3CQP4EyuVFo5m:3:CL:14951:MYCO_Biomarker",
+                    value=RevRegDefValue(
+                        max_cred_num=100,
+                        public_keys={
+                            "accum_key": {"z": "1 0BB...386"},
+                        },
+                        tails_hash="58NNWYnVxVFzAfUztwGSNBL4551XNq6nXk56pCiKJxxt",
+                        tails_location="http://tails-server.com",
+                    ),
+                    issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                    type="CL_ACCUM",
+                ),
+                options={
+                    "support_revocation": True,
+                },
+            )
+        )
+
+        await self.revocation_setup.on_rev_reg_def(self.profile, event)
+        assert mock_upload.called
+        assert mock_register.called
+        assert mock_set_active_reg.called
+
+    @mock.patch.object(
+        AnonCredsRevocation,
+        "upload_tails_file",
+        return_value=None,
+    )
+    @mock.patch.object(
+        AnonCredsRevocation,
+        "create_and_register_revocation_list",
+        return_value=None,
+    )
+    async def test_on_rev_reg_def_author_and_auto_create_rev_reg(
+        self, mock_register, mock_upload
+    ):
+        self.profile.settings["endorser.author"] = True
+        self.profile.settings["endorser.auto_create_rev_reg"] = True
+        event = RevRegDefFinishedEvent(
+            RevRegDefFinishedPayload(
+                rev_reg_def_id="rev_reg_def_id",
+                rev_reg_def=RevRegDef(
+                    tag="tag",
+                    cred_def_id="CsQY9MGeD3CQP4EyuVFo5m:3:CL:14951:MYCO_Biomarker",
+                    value=RevRegDefValue(
+                        max_cred_num=100,
+                        public_keys={
+                            "accum_key": {"z": "1 0BB...386"},
+                        },
+                        tails_hash="58NNWYnVxVFzAfUztwGSNBL4551XNq6nXk56pCiKJxxt",
+                        tails_location="http://tails-server.com",
+                    ),
+                    issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                    type="CL_ACCUM",
+                ),
+                options={},
+            )
+        )
+
+        await self.revocation_setup.on_rev_reg_def(self.profile, event)
+        assert mock_upload.called
+        assert mock_register.called
+
+    @mock.patch.object(
+        AnonCredsRevocation,
+        "upload_tails_file",
+        return_value=None,
+    )
+    @mock.patch.object(
+        AnonCredsRevocation,
+        "create_and_register_revocation_list",
+        return_value=None,
+    )
+    async def test_on_rev_reg_def_no_support_revoc_or_author_and_auto_create(
+        self, mock_register, mock_upload
+    ):
+        event = RevRegDefFinishedEvent(
+            RevRegDefFinishedPayload(
+                rev_reg_def_id="rev_reg_def_id",
+                rev_reg_def=RevRegDef(
+                    tag="tag",
+                    cred_def_id="CsQY9MGeD3CQP4EyuVFo5m:3:CL:14951:MYCO_Biomarker",
+                    value=RevRegDefValue(
+                        max_cred_num=100,
+                        public_keys={
+                            "accum_key": {"z": "1 0BB...386"},
+                        },
+                        tails_hash="58NNWYnVxVFzAfUztwGSNBL4551XNq6nXk56pCiKJxxt",
+                        tails_location="http://tails-server.com",
+                    ),
+                    issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
+                    type="CL_ACCUM",
+                ),
+                options={},
+            )
+        )
+
+        await self.revocation_setup.on_rev_reg_def(self.profile, event)
+        assert not mock_upload.called
+        assert not mock_register.called

--- a/aries_cloudagent/anoncreds/tests/test_revocation_setup.py
+++ b/aries_cloudagent/anoncreds/tests/test_revocation_setup.py
@@ -160,9 +160,7 @@ class TestAnonCredsRevocationSetup(IsolatedAsyncioTestCase):
                     issuer_id="CsQY9MGeD3CQP4EyuVFo5m",
                     type="CL_ACCUM",
                 ),
-                options={
-                    "support_revocation": True,
-                },
+                options={},
             )
         )
 
@@ -221,9 +219,11 @@ class TestAnonCredsRevocationSetup(IsolatedAsyncioTestCase):
         "create_and_register_revocation_list",
         return_value=None,
     )
-    async def test_on_rev_reg_def_no_support_revoc_or_author_and_auto_create(
+    async def test_on_rev_reg_def_author_and_do_not_auto_create_rev_reg(
         self, mock_register, mock_upload
     ):
+        self.profile.settings["endorser.author"] = True
+        self.profile.settings["endorser.auto_create_rev_reg"] = False
         event = RevRegDefFinishedEvent(
             RevRegDefFinishedPayload(
                 rev_reg_def_id="rev_reg_def_id",

--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -380,6 +380,16 @@ class BaseLedger(ABC, metaclass=ABCMeta):
         """Create the ledger request for publishing a schema."""
 
     @abstractmethod
+    async def _create_revoc_reg_def_request(
+        self,
+        public_info: DIDInfo,
+        revoc_reg_def: dict,
+        write_ledger: bool = True,
+        endorser_did: str = None,
+    ):
+        """Create the ledger request for publishing a revocation registry definition."""
+
+    @abstractmethod
     async def get_revoc_reg_def(self, revoc_reg_id: str) -> dict:
         """Look up a revocation registry definition by ID."""
 
@@ -734,9 +744,8 @@ class BaseLedger(ABC, metaclass=ABCMeta):
             cred_def_req, True, sign_did=public_info, write_ledger=write_ledger
         )
 
-        # TODO Clean up
-        # if not write_ledger:
-        #     return (credential_definition_id, {"signed_txn": resp}, novel)
+        if not write_ledger:
+            return (cred_def_id, {"signed_txn": resp})
 
         seq_no = json.loads(resp)["result"]["txnMetadata"]["seqNo"]
         return seq_no

--- a/aries_cloudagent/revocation_anoncreds/manager.py
+++ b/aries_cloudagent/revocation_anoncreds/manager.py
@@ -14,12 +14,12 @@ from ..protocols.issue_credential.v2_0.models.cred_ex_record import V20CredExRec
 from ..protocols.revocation_notification.v1_0.models.rev_notification_record import (
     RevNotificationRecord,
 )
-from ..storage.error import StorageNotFoundError
-from .models.issuer_cred_rev_record import IssuerCredRevRecord
 from ..revocation.util import (
     notify_pending_cleared_event,
     notify_revocation_published_event,
 )
+from ..storage.error import StorageNotFoundError
+from .models.issuer_cred_rev_record import IssuerCredRevRecord
 
 
 class RevocationManagerError(BaseError):

--- a/demo/features/0586-sign-transaction.feature
+++ b/demo/features/0586-sign-transaction.feature
@@ -19,20 +19,25 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
       Then "Bob" can write the transaction to the ledger
       And "Bob" has written the schema <Schema_name> to the ledger
 
+      @GHA
       Examples:
          | Acme_capabilities         | Bob_capabilities          | Schema_name    |
          | --did-exchange            | --did-exchange            | driverslicense |
          | --mediation               | --mediation               | driverslicense |
          | --multitenant             | --multitenant             | driverslicense |
          | --mediation --multitenant | --mediation --multitenant | driverslicense |
+
+      @Mulitledger
+      Examples:
+         | Acme_capabilities         | Bob_capabilities          | Schema_name    |
          | --multitenant --multi-ledger | --multitenant --multi-ledger | driverslicense |
          | --multitenant --multi-ledger --revocation | --multitenant --multi-ledger --revocation | driverslicense |
 
-      @WalletType_Askar_AnonCreds
+      @WalletType_Askar_AnonCreds @GHA
       Examples:
          | Acme_capabilities         | Bob_capabilities          | Schema_name    |
          | --wallet-type askar-anoncreds | --wallet-type askar-anoncreds   | anoncreds-testing |
-         | --wallet-type askar-anoncreds |                                 | driverslicense    |
+         | --wallet-type askar-anoncreds |                                 | driverslicense |
          |                               | --wallet-type askar-anoncreds   | anoncreds-testing |
 
 
@@ -55,8 +60,9 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
       And "Bob" has written the schema <Schema_name> to the ledger
 
       Examples:
-         | Acme_capabilities         | Bob_capabilities          | Schema_name    |
-         |                           |                           | driverslicense |
+         | Acme_capabilities         | Bob_capabilities              | Schema_name        |
+         |                           |                               | driverslicense     |
+         |                           | --wallet-type askar-anoncreds | anoncreds-testing  |
 
 
    @T002-RFC0586
@@ -102,7 +108,16 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | --revocation --public-did --mediation               | --revocation --mediation                  | driverslicense | Data_DL_NormalizedValues |
          | --revocation --public-did --multitenant             | --revocation --multitenant                | driverslicense | Data_DL_NormalizedValues |
          | --revocation --public-did --mediation --multitenant | --revocation --mediation --multitenant    | driverslicense | Data_DL_NormalizedValues |
+
+      @Mulitledger
+      Examples:
+         | Acme_capabilities                                   | Bob_capabilties                           | Schema_name    | Credential_data          |
          | --multitenant --multi-ledger --revocation --public-did | --multitenant --multi-ledger --revocation | driverslicense | Data_DL_NormalizedValues |
+
+      @WalletType_Askar_AnonCreds
+      Examples:
+         | Acme_capabilities                                   | Bob_capabilities                                            | Schema_name    | Credential_data          |
+         | --revocation --public-did --did-exchange            | --revocation --did-exchange --wallet-type askar-anoncreds   | anoncreds-testing | Data_AC_NormalizedValues | 
 
    @T002.1-RFC0586 @GHA
    Scenario Outline: endorse a schema and cred def transaction, write to the ledger, issue and revoke a credential, manually invoking each endorsement endpoint
@@ -145,6 +160,12 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | Acme_capabilities                                   | Bob_capabilities                          | Schema_name    | Credential_data          |
          | --revocation --public-did                           | --revocation                              | driverslicense | Data_DL_NormalizedValues |
 
+      @WalletType_Askar_AnonCreds
+      Examples:
+         | Acme_capabilities                                   | Bob_capabilities                             | Schema_name       | Credential_data          |
+         | --revocation --public-did                           | --revocation --wallet-type askar-anoncreds   | anoncreds-testing | Data_AC_NormalizedValues | 
+
+
    @T003-RFC0586
    Scenario Outline: endorse a schema and cred def transaction, write to the ledger, issue and revoke a credential, with auto endorsing workflow
       Given we have "2" agents
@@ -175,7 +196,7 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | --endorser-role endorser --revocation --public-did --multitenant             | --endorser-role author --revocation --multitenant             | driverslicense | Data_DL_NormalizedValues |
          | --endorser-role endorser --revocation --public-did --mediation --multitenant | --endorser-role author --revocation --mediation --multitenant | driverslicense | Data_DL_NormalizedValues |
 
-   @T003.1-RFC0586 @GHA
+   @T003.1-RFC0586 @GHA 
    Scenario Outline: endorse a schema and cred def transaction, write to the ledger, issue and revoke a credential, with auto endorsing workflow
       Given we have "2" agents
          | name  | role     | capabilities        |
@@ -202,3 +223,27 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | Acme_capabilities                                   | Bob_capabilities                          | Schema_name    | Credential_data          |
          | --endorser-role endorser --revocation --public-did  | --endorser-role author --revocation       | driverslicense | Data_DL_NormalizedValues |
          | --endorser-role endorser --revocation --public-did  | --endorser-role author --revocation --multitenant | driverslicense | Data_DL_NormalizedValues |
+
+   @T003.2-RFC0586 @GHA
+   Scenario Outline: endorse a schema and cred def transaction, write to the ledger, and issue a credential, with auto endorsing workflow
+      Given we have "2" agents
+         | name  | role     | capabilities        |
+         | Acme  | endorser | <Acme_capabilities> |
+         | Bob   | author   | <Bob_capabilities>  |
+      And "Acme" and "Bob" have an existing connection
+      When "Acme" has a DID with role "ENDORSER"
+      And "Acme" connection has job role "TRANSACTION_ENDORSER"
+      And "Bob" connection has job role "TRANSACTION_AUTHOR"
+      And "Bob" connection sets endorser info
+      And "Bob" has a DID with role "AUTHOR"
+      And "Bob" authors a schema transaction with <Schema_name>
+      And "Bob" has written the schema <Schema_name> to the ledger
+      And "Bob" authors a credential definition transaction with <Schema_name>
+      And "Bob" has written the credential definition for <Schema_name> to the ledger
+      And "Bob" has written the revocation registry definition to the ledger
+      And "Bob" has written the revocation registry entry transaction to the ledger
+      And "Acme" has an issued <Schema_name> credential <Credential_data> from "Bob"
+
+      Examples:
+         | Acme_capabilities                                   | Bob_capabilities                          | Schema_name    | Credential_data          |
+         | --endorser-role endorser --revocation --public-did  | --endorser-role author --revocation --wallet-type askar-anoncreds | anoncreds-testing | Data_AC_NormalizedValues | 

--- a/demo/features/steps/0586-sign-transaction.py
+++ b/demo/features/steps/0586-sign-transaction.py
@@ -15,6 +15,11 @@ from bdd_support.agent_backchannel_client import (
 )
 from behave import given, then, when
 
+
+def is_anoncreds(agent):
+    return agent["agent"].wallet_type == "askar-anoncreds"
+
+
 # This step is defined in another feature file
 # Given "Acme" and "Bob" have an existing connection
 
@@ -98,8 +103,10 @@ def step_impl(context, agent_name, schema_name):
 
     schema_info = read_schema_data(schema_name)
     connection_id = agent["agent"].agent.connection_id
+    if "txn_ids" not in context:
+        context.txn_ids = {}
 
-    if agent["agent"].wallet_type != "askar-anoncreds":
+    if not is_anoncreds(agent):
         created_txn = agent_container_POST(
             agent["agent"],
             "/schemas",
@@ -109,6 +116,13 @@ def step_impl(context, agent_name, schema_name):
                 "create_transaction_for_endorser": "true",
             },
         )
+        # assert goodness
+        if agent["agent"].endorser_role and agent["agent"].endorser_role == "author":
+            assert created_txn["txn"]["state"] == "request_sent"
+        else:
+            assert created_txn["txn"]["state"] == "transaction_created"
+
+        context.txn_ids["AUTHOR"] = created_txn["txn"]["transaction_id"]
     else:
         schema_info["schema"]["issuerId"] = context.public_dids["AUTHOR"]
         schema_info["options"]["create_transaction_for_endorser"] = True
@@ -119,15 +133,16 @@ def step_impl(context, agent_name, schema_name):
             data=schema_info,
         )
 
-    # assert goodness
-    if agent["agent"].endorser_role and agent["agent"].endorser_role == "author":
-        assert created_txn["txn"]["state"] == "request_sent"
-    else:
-        assert created_txn["txn"]["state"] == "transaction_created"
+        if agent["agent"].endorser_role and agent["agent"].endorser_role == "author":
+            assert (
+                created_txn["registration_metadata"]["txn"]["state"] == "request_sent"
+            )
+            assert created_txn["schema_state"]["state"] == "wait"
+            assert created_txn["job_id"] is not None
 
-    if "txn_ids" not in context:
-        context.txn_ids = {}
-    context.txn_ids["AUTHOR"] = created_txn["txn"]["transaction_id"]
+        context.txn_ids["AUTHOR"] = created_txn["registration_metadata"]["txn"][
+            "transaction_id"
+        ]
 
 
 @when('"{agent_name}" requests endorsement for the transaction')
@@ -208,7 +223,7 @@ def step_impl(context, agent_name, schema_name):
     assert len(schemas["schema_ids"]) == 1
 
     schema_id = schemas["schema_ids"][0]
-    if agent["agent"].wallet_type != "askar-anoncreds":
+    if not is_anoncreds(agent):
         agent_container_GET(agent["agent"], "/schemas/" + schema_id)
     else:
         agent_container_GET(agent["agent"], "/anoncreds/schema/" + schema_id)
@@ -230,17 +245,41 @@ def step_impl(context, agent_name, schema_name):
     assert len(schemas["schema_ids"]) == 1
 
     schema_id = schemas["schema_ids"][0]
-    created_txn = agent_container_POST(
-        agent["agent"],
-        "/credential-definitions",
-        data={
-            "schema_id": schema_id,
-            "tag": "test_cred_def_with_endorsement",
-            "support_revocation": True,
-            "revocation_registry_size": 1000,
-        },
-        params={"conn_id": connection_id, "create_transaction_for_endorser": "true"},
-    )
+
+    if not is_anoncreds(agent):
+        created_txn = agent_container_POST(
+            agent["agent"],
+            "/credential-definitions",
+            data={
+                "schema_id": schema_id,
+                "tag": "test_cred_def_with_endorsement",
+                "support_revocation": True,
+                "revocation_registry_size": 1000,
+            },
+            params={
+                "conn_id": connection_id,
+                "create_transaction_for_endorser": "true",
+            },
+        )
+    else:
+        anoncreds_cred_def_result = agent_container_POST(
+            agent["agent"],
+            "/anoncreds/credential-definition",
+            data={
+                "credential_definition": {
+                    "issuerId": schema_id.split(":")[0],
+                    "schemaId": schema_id,
+                    "tag": "test_cred_def_with_endorsement",
+                },
+                "options": {
+                    "endorser_connection_id": connection_id,
+                    "create_transaction_for_endorser": True,
+                    "support_revocation": True,
+                    "revocation_registry_size": 1000,
+                },
+            },
+        )
+        created_txn = anoncreds_cred_def_result["registration_metadata"]
 
     # assert goodness
     if agent["agent"].endorser_role and agent["agent"].endorser_role == "author":
@@ -293,36 +332,61 @@ def step_impl(context, agent_name, schema_name):
 
     connection_id = agent["agent"].agent.connection_id
 
-    # generate revocation registry transaction
-    rev_reg = agent_container_POST(
-        agent["agent"],
-        "/revocation/create-registry",
-        data={"credential_definition_id": context.cred_def_id, "max_cred_num": 1000},
-        params={},
-    )
-    rev_reg_id = rev_reg["result"]["revoc_reg_id"]
-    assert rev_reg_id is not None
+    if not is_anoncreds(agent):
+        # generate revocation registry transaction
+        rev_reg = agent_container_POST(
+            agent["agent"],
+            "/revocation/create-registry",
+            data={
+                "credential_definition_id": context.cred_def_id,
+                "max_cred_num": 1000,
+            },
+            params={},
+        )
+        rev_reg_id = rev_reg["result"]["revoc_reg_id"]
+        assert rev_reg_id is not None
 
-    # update revocation registry
-    agent_container_PATCH(
-        agent["agent"],
-        f"/revocation/registry/{rev_reg_id}",
-        data={
-            "tails_public_uri": f"http://host.docker.internal:6543/revocation/registry/{rev_reg_id}/tails-file"
-        },
-        params={},
-    )
+        # update revocation registry
+        agent_container_PATCH(
+            agent["agent"],
+            f"/revocation/registry/{rev_reg_id}",
+            data={
+                "tails_public_uri": f"http://host.docker.internal:6543/revocation/registry/{rev_reg_id}/tails-file"
+            },
+            params={},
+        )
 
-    # create rev_reg transaction
-    created_txn = agent_container_POST(
-        agent["agent"],
-        f"/revocation/registry/{rev_reg_id}/definition",
-        data={},
-        params={
-            "conn_id": connection_id,
-            "create_transaction_for_endorser": "true",
-        },
-    )
+        # create rev_reg transaction
+        created_txn = agent_container_POST(
+            agent["agent"],
+            f"/revocation/registry/{rev_reg_id}/definition",
+            data={},
+            params={
+                "conn_id": connection_id,
+                "create_transaction_for_endorser": "true",
+            },
+        )
+    else:
+        # generate revocation registry transaction
+        anoncreds_rev_reg_result = agent_container_POST(
+            agent["agent"],
+            "/anoncreds/revocation-registry-definition",
+            data={
+                "revocation_registry_definition": {
+                    "credDefId": context.cred_def_id,
+                    "issuerId": context.cred_def_id.split(":")[0],
+                    "maxCredNum": 666,
+                    "tag": "default",
+                },
+                "options": {
+                    "endorser_connection_id": connection_id,
+                    "create_transaction_for_endorser": True,
+                },
+            },
+            params={},
+        )
+        created_txn = anoncreds_rev_reg_result["registration_metadata"]
+
     assert created_txn["txn"]["state"] == "transaction_created"
     if "txn_ids" not in context:
         context.txn_ids = {}
@@ -346,10 +410,14 @@ def step_impl(context, agent_name):
                 "cred_def_id": context.cred_def_id,
             },
         )
+        # anoncreds returns a job_id here immediately
+        # check id is a rev_reg_def_id or reset list
+        if [x for x in rev_regs["rev_reg_ids"] if str(x).count(":") > 0].__len__() == 0:
+            rev_regs = {"rev_reg_ids": []}
         i = i - 1
     assert len(rev_regs["rev_reg_ids"]) >= 1
 
-    rev_reg_id = rev_regs["rev_reg_ids"][0]
+    rev_reg_id = [x for x in rev_regs["rev_reg_ids"] if str(x).count(":") > 0][0]
 
     context.rev_reg_id = rev_reg_id
 
@@ -363,21 +431,38 @@ def step_impl(context, agent_name):
 def step_impl(context, agent_name):
     agent = context.active_agents[agent_name]
 
-    # activate rev_reg
-    agent_container_PATCH(
-        agent["agent"],
-        f"/revocation/registry/{context.rev_reg_id}/set-state",
-        data={},
-        params={"state": "active"},
-    )
+    if not is_anoncreds(agent):
+        # activate rev_reg
+        agent_container_PATCH(
+            agent["agent"],
+            f"/revocation/registry/{context.rev_reg_id}/set-state",
+            data={},
+            params={"state": "active"},
+        )
 
-    # upload rev_reg
-    agent_container_PUT(
-        agent["agent"],
-        f"/revocation/registry/{context.rev_reg_id}/tails-file",
-        data={},
-        params={},
-    )
+        # upload rev_reg
+        agent_container_PUT(
+            agent["agent"],
+            f"/revocation/registry/{context.rev_reg_id}/tails-file",
+            data={},
+            params={},
+        )
+    else:
+        # activate rev_reg
+        agent_container_PUT(
+            agent["agent"],
+            f"/anoncreds/registry/{context.rev_reg_id}/active",
+            data={},
+            params={},
+        )
+
+        # upload rev_reg
+        agent_container_PUT(
+            agent["agent"],
+            f"/anoncreds/registry/{context.rev_reg_id}/tails-file",
+            data={},
+            params={},
+        )
 
 
 @given(
@@ -394,16 +479,20 @@ def step_impl(context, agent_name):
 
     # a registry is promoted to active when its initial entry is sent
     i = 5
+
+    async_sleep(2.0)
+
     while i > 0:
         async_sleep(1.0)
-        reg_info = agent_container_GET(
-            agent["agent"],
-            f"/revocation/registry/{context.rev_reg_id}",
-        )
-        state = reg_info["result"]["state"]
-        if state in ["active", "finished"]:
-            return
-        i = i - 1
+        if context.rev_reg_id is not None:
+            reg_info = agent_container_GET(
+                agent["agent"],
+                f"/revocation/registry/{context.rev_reg_id}",
+            )
+            state = reg_info["result"]["state"]
+            if state in ["active", "finished"]:
+                return
+            i = i - 1
 
     assert False
 
@@ -421,15 +510,31 @@ def step_impl(context, agent_name, schema_name):
 
     # generate revocation registry entry transaction
     # create rev_reg transaction
-    created_txn = agent_container_POST(
-        agent["agent"],
-        f"/revocation/registry/{context.rev_reg_id}/entry",
-        data={},
-        params={
-            "conn_id": connection_id,
-            "create_transaction_for_endorser": "true",
-        },
-    )
+    if not is_anoncreds(agent):
+        created_txn = agent_container_POST(
+            agent["agent"],
+            f"/revocation/registry/{context.rev_reg_id}/entry",
+            data={},
+            params={
+                "conn_id": connection_id,
+                "create_transaction_for_endorser": "true",
+            },
+        )
+    else:
+        anoncreds_result = agent_container_POST(
+            agent["agent"],
+            "/anoncreds/revocation-list",
+            data={
+                "rev_reg_def_id": context.rev_reg_id,
+                "options": {
+                    "create_transaction_for_endorser": "true",
+                    "endorser_connection_id": connection_id,
+                },
+            },
+            params={},
+        )
+        created_txn = anoncreds_result["registration_metadata"]
+
     assert created_txn["txn"]["state"] == "transaction_created"
     if "txn_ids" not in context:
         context.txn_ids = {}


### PR DESCRIPTION
- Implements anoncreds endorsement of cred def's and revocation objects
- enables the integration tests both manual and auto endorsement transactions

For the anoncreds transaction objects the previous implementation changed the structure of the objects. I really didn't like this so I changed it in the indy ledger module with if statements.

I changed the optional[dict] params in anoncreds to be an empty dict by default to avoid null checking in a lot of places.

Note: The only thing not completed for single tenant is publishing revocations. I want to do this in another task/PR. I created an integration test for anoncreds that stops just prior to publishing revocations.

