### PR TITLE
Move emit events to profile and delay sending until after commit

### DIFF
--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -430,7 +430,7 @@ class BaseRecord(BaseModel):
         if not payload:
             payload = self.serialize()
 
-        await session.profile.notify(topic, payload)
+        await session.emit_event(topic, payload)
 
     @classmethod
     def log_state(

--- a/demo/features/0453-issue-credential.feature
+++ b/demo/features/0453-issue-credential.feature
@@ -12,18 +12,26 @@ Feature: RFC 0453 Aries agent issue credential
     When "Acme" offers a credential with data <Credential_data>
     Then "Bob" has the credential issued
 
-    @GHA @WalletType_Askar
+    @GHA @WalletType_Askar @BasicTest
+    Examples:
+       | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
+       | --public-did --did-exchange            | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
+
+    @GHA @WalletType_Askar @AltTests
     Examples:
        | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
        | --public-did                           |                           | driverslicense | Data_DL_NormalizedValues |
-       | --public-did --did-exchange            | --did-exchange            | driverslicense | Data_DL_NormalizedValues |
        | --public-did --mediation               | --mediation               | driverslicense | Data_DL_NormalizedValues |
        | --public-did --multitenant             | --multitenant --log-file  | driverslicense | Data_DL_NormalizedValues |
 
-    @GHA @WalletType_Askar_AnonCreds
+    @GHA @WalletType_Askar_AnonCreds @BasicTest
     Examples:
        | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
        | --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
+
+    @GHA @WalletType_Askar_AnonCreds @AltTests
+    Examples:
+       | Acme_capabilities                      | Bob_capabilities          | Schema_name    | Credential_data          |
        | --public-did --wallet-type askar-anoncreds |                               | driverslicense | Data_DL_NormalizedValues |
        | --public-did                           | --wallet-type askar-anoncreds | driverslicense | Data_DL_NormalizedValues |
 


### PR DESCRIPTION
See issue #2000 

This update doesn't break anything ...  I haven't been able to duplicate the issue (by strategically inserting `sleep()` statements) so I can't 100% confirm that this fixes the issue, but I think it "should" ...
