### PR TITLE
Anoncreds revoke and publish-revocations endorsement

### DIFF
--- a/aries_cloudagent/anoncreds/revocation_setup.py
+++ b/aries_cloudagent/anoncreds/revocation_setup.py
@@ -1,5 +1,6 @@
 """Automated setup process for AnonCreds credential definitions with revocation."""
 
+import logging
 from abc import ABC, abstractmethod
 
 from aries_cloudagent.protocols.endorse_transaction.v1_0.util import is_author_role
@@ -15,6 +16,8 @@ from .events import (
     RevListFinishedEvent,
     RevRegDefFinishedEvent,
 )
+
+LOGGER = logging.getLogger(__name__)
 
 
 class AnonCredsRevocationSetupManager(ABC):
@@ -102,3 +105,4 @@ class DefaultRevocationSetup(AnonCredsRevocationSetupManager):
 
     async def on_rev_list(self, profile: Profile, event: RevListFinishedEvent):
         """Handle rev list finished."""
+        LOGGER.debug("Revocation list finished: %s", event.payload.rev_reg_def_id)

--- a/aries_cloudagent/anoncreds/tests/test_revocation.py
+++ b/aries_cloudagent/anoncreds/tests/test_revocation.py
@@ -591,11 +591,22 @@ class TestAnonCredsRevocation(IsolatedAsyncioTestCase):
     @mock.patch.object(test_module.AnonCredsRevocation, "_finish_registration")
     async def test_finish_revocation_list(self, mock_finish, mock_handle):
         self.profile.context.injector.bind_instance(EventBus, MockEventBus())
+
+        mock_handle.fetch = mock.CoroutineMock(side_effect=[None, MockEntry()])
+
+        # Fetch doesn't find list then it should be created
         await self.revocation.finish_revocation_list(
             job_id="test-job-id",
             rev_reg_def_id="test-rev-reg-def-id",
         )
         assert mock_finish.called
+
+        # Fetch finds list then there's nothing to do, it's already finished and updated
+        await self.revocation.finish_revocation_list(
+            job_id="test-job-id",
+            rev_reg_def_id="test-rev-reg-def-id",
+        )
+        assert mock_finish.call_count == 1
 
     @mock.patch.object(InMemoryProfileSession, "handle")
     async def test_update_revocation_list_get_rev_reg_errors(self, mock_handle):

--- a/aries_cloudagent/revocation_anoncreds/tests/test_routes.py
+++ b/aries_cloudagent/revocation_anoncreds/tests/test_routes.py
@@ -1,20 +1,18 @@
 import os
-import pytest
 import shutil
-
-from aiohttp.web import HTTPNotFound
 from unittest import IsolatedAsyncioTestCase
-from aries_cloudagent.tests import mock
 
+import pytest
+from aiohttp.web import HTTPNotFound
+
+from aries_cloudagent.tests import mock
 
 from ...anoncreds.models.anoncreds_revocation import (
     RevRegDef,
     RevRegDefValue,
 )
 from ...askar.profile import AskarProfile
-
 from ...core.in_memory import InMemoryProfile
-
 from .. import routes as test_module
 
 

--- a/demo/features/0586-sign-transaction.feature
+++ b/demo/features/0586-sign-transaction.feature
@@ -102,6 +102,7 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
       And "Bob" authors a revocation registry entry publishing transaction
       Then "Acme" can verify the credential from "Bob" was revoked
 
+      @GHA
       Examples:
          | Acme_capabilities                                   | Bob_capabilities                          | Schema_name    | Credential_data          |
          | --revocation --public-did --did-exchange            | --revocation --did-exchange               | driverslicense | Data_DL_NormalizedValues |
@@ -114,7 +115,7 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | Acme_capabilities                                   | Bob_capabilties                           | Schema_name    | Credential_data          |
          | --multitenant --multi-ledger --revocation --public-did | --multitenant --multi-ledger --revocation | driverslicense | Data_DL_NormalizedValues |
 
-      @WalletType_Askar_AnonCreds
+      @WalletType_Askar_AnonCreds @GHA
       Examples:
          | Acme_capabilities                                   | Bob_capabilities                                            | Schema_name    | Credential_data          |
          | --revocation --public-did --did-exchange            | --revocation --did-exchange --wallet-type askar-anoncreds   | anoncreds-testing | Data_AC_NormalizedValues | 
@@ -196,6 +197,11 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | --endorser-role endorser --revocation --public-did --multitenant             | --endorser-role author --revocation --multitenant             | driverslicense | Data_DL_NormalizedValues |
          | --endorser-role endorser --revocation --public-did --mediation --multitenant | --endorser-role author --revocation --mediation --multitenant | driverslicense | Data_DL_NormalizedValues |
 
+      @WalletType_Askar_AnonCreds
+      Examples:
+         | Acme_capabilities                                   | Bob_capabilities                             | Schema_name       | Credential_data          |
+         | --endorser-role endorser --revocation --public-did  | --endorser-role author --revocation --wallet-type askar-anoncreds   | anoncreds-testing | Data_AC_NormalizedValues |
+
    @T003.1-RFC0586 @GHA 
    Scenario Outline: endorse a schema and cred def transaction, write to the ledger, issue and revoke a credential, with auto endorsing workflow
       Given we have "2" agents
@@ -224,26 +230,7 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | --endorser-role endorser --revocation --public-did  | --endorser-role author --revocation       | driverslicense | Data_DL_NormalizedValues |
          | --endorser-role endorser --revocation --public-did  | --endorser-role author --revocation --multitenant | driverslicense | Data_DL_NormalizedValues |
 
-   @T003.2-RFC0586 @GHA
-   Scenario Outline: endorse a schema and cred def transaction, write to the ledger, and issue a credential, with auto endorsing workflow
-      Given we have "2" agents
-         | name  | role     | capabilities        |
-         | Acme  | endorser | <Acme_capabilities> |
-         | Bob   | author   | <Bob_capabilities>  |
-      And "Acme" and "Bob" have an existing connection
-      When "Acme" has a DID with role "ENDORSER"
-      And "Acme" connection has job role "TRANSACTION_ENDORSER"
-      And "Bob" connection has job role "TRANSACTION_AUTHOR"
-      And "Bob" connection sets endorser info
-      And "Bob" has a DID with role "AUTHOR"
-      And "Bob" authors a schema transaction with <Schema_name>
-      And "Bob" has written the schema <Schema_name> to the ledger
-      And "Bob" authors a credential definition transaction with <Schema_name>
-      And "Bob" has written the credential definition for <Schema_name> to the ledger
-      And "Bob" has written the revocation registry definition to the ledger
-      And "Bob" has written the revocation registry entry transaction to the ledger
-      And "Acme" has an issued <Schema_name> credential <Credential_data> from "Bob"
-
+      @WalletType_Askar_AnonCreds
       Examples:
-         | Acme_capabilities                                   | Bob_capabilities                          | Schema_name    | Credential_data          |
-         | --endorser-role endorser --revocation --public-did  | --endorser-role author --revocation --wallet-type askar-anoncreds | anoncreds-testing | Data_AC_NormalizedValues | 
+         | Acme_capabilities                                   | Bob_capabilities                             | Schema_name       | Credential_data          |
+         | --endorser-role endorser --revocation --public-did  | --endorser-role author --revocation --wallet-type askar-anoncreds   | anoncreds-testing | Data_AC_NormalizedValues |


### PR DESCRIPTION
Opening for visibility. I'm still going to manually test more but the Integration tests are passing for endorsement and publishing revocations.

One area of confusion for me is what happens with the local wallet verse the ledger. Write now an endorsement transaction is created when the `update_revocation_list` is called with changes. Then the local wallet is updated. At the same time the endorsement manager receives the `114` event and notifies the anoncreds `RevocationListFinished` event handler. It checks if the wallet contains a record for the list via `rev_reg_def_id` and if it doesn't it creates the record. If it does then it assumes the record has been updated already and does nothing. 

I was trying some other stuff like deleting the record and creating a new one with a `wait` state but couldn't decide if this was necessary, or something we wanted to do.

I deleted the `/anoncreds/revoke` and `/anoncreds/publish-revocation` endpoints and instead just have the `/revocation/revoke` and `/revocation/publish-revocation`. I thought this was appropriate because the revocation endpoint are all loaded for anoncreds specifically and the rest of the anoncreds endpoints are to do with creating objects. I changed the params for requesting a transaction manually to use the body options and updated the integration tests.