### PR TITLE
Revert profile inject

### DIFF
--- a/aries_cloudagent/config/provider.py
+++ b/aries_cloudagent/config/provider.py
@@ -1,14 +1,12 @@
 """Service provider implementations."""
 
 import hashlib
-
 from typing import Optional, Sequence, Union
 from weakref import ReferenceType
 
 from ..utils.classloader import DeferLoad
 from ..utils.stats import Collector
-
-from .base import BaseProvider, BaseSettings, BaseInjector, InjectionError
+from .base import BaseInjector, BaseProvider, BaseSettings, InjectionError
 
 
 class InstanceProvider(BaseProvider):
@@ -52,10 +50,8 @@ class ClassProvider(BaseProvider):
         self._ctor_kwargs = ctor_kwargs
         self._init_method = init_method
         if isinstance(instance_cls, str):
-            cls = DeferLoad(instance_cls)
-        else:
-            cls = instance_cls
-        self._instance_cls: Union[type, DeferLoad] = cls
+            instance_cls = DeferLoad(instance_cls)
+        self._instance_cls = instance_cls
 
     def provide(self, config: BaseSettings, injector: BaseInjector):
         """Provide the object instance given a config and injector."""

--- a/aries_cloudagent/core/profile.py
+++ b/aries_cloudagent/core/profile.py
@@ -1,20 +1,17 @@
 """Classes for managing profile information within a request context."""
 
 import logging
-
 from abc import ABC, abstractmethod
 from typing import Any, Mapping, Optional, Type
-from weakref import ref
 
-from .event_bus import EventBus, Event
 from ..config.base import InjectionError
-from ..config.injector import BaseInjector, InjectType
 from ..config.injection_context import InjectionContext
+from ..config.injector import BaseInjector, InjectType
 from ..config.provider import BaseProvider
 from ..config.settings import BaseSettings
 from ..utils.classloader import ClassLoader, ClassNotFoundError
-
 from .error import ProfileSessionInactiveError
+from .event_bus import Event, EventBus
 
 LOGGER = logging.getLogger(__name__)
 
@@ -33,14 +30,9 @@ class Profile(ABC):
         created: bool = False,
     ):
         """Initialize a base profile."""
-        context = context or InjectionContext()
-        scope = "profile"
-        if name:
-            scope += ":" + name
-        self._context = context.start_scope(scope)
+        self._context = context or InjectionContext()
         self._created = created
         self._name = name or Profile.DEFAULT_NAME
-        self._context.injector.bind_instance(Profile, ref(self))
 
     @property
     def backend(self) -> str:

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/handler.py
@@ -132,7 +132,7 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
         self, cred_ex_record: V20CredExRecord, proposal_data: Mapping
     ) -> CredFormatAttachment:
         """Create linked data proof credential proposal."""
-        manager = self.profile.inject(VcLdpManager)
+        manager = VcLdpManager(self.profile)
         detail = LDProofVCDetail.deserialize(proposal_data)
         assert detail.options and isinstance(detail.options, LDProofVCOptions)
         assert detail.credential and isinstance(detail.credential, VerifiableCredential)
@@ -164,7 +164,7 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
         # but also when we create an offer (manager does some weird stuff)
         offer_data = cred_proposal_message.attachment(LDProofCredFormatHandler.format)
         detail = LDProofVCDetail.deserialize(offer_data)
-        manager = self.profile.inject(VcLdpManager)
+        manager = VcLdpManager(self.profile)
         assert detail.options and isinstance(detail.options, LDProofVCOptions)
         assert detail.credential and isinstance(detail.credential, VerifiableCredential)
         try:
@@ -224,7 +224,7 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
             )
 
         detail = LDProofVCDetail.deserialize(request_data)
-        manager = self.profile.inject(VcLdpManager)
+        manager = VcLdpManager(self.profile)
         assert detail.options and isinstance(detail.options, LDProofVCOptions)
         assert detail.credential and isinstance(detail.credential, VerifiableCredential)
         try:
@@ -290,7 +290,7 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
             LDProofCredFormatHandler.format
         )
         detail = LDProofVCDetail.deserialize(detail_dict)
-        manager = self.profile.inject(VcLdpManager)
+        manager = VcLdpManager(self.profile)
         assert detail.options and isinstance(detail.options, LDProofVCOptions)
         assert detail.credential and isinstance(detail.credential, VerifiableCredential)
         try:
@@ -381,7 +381,7 @@ class LDProofCredFormatHandler(V20CredFormatHandler):
         credential = VerifiableCredential.deserialize(cred_dict, unknown=INCLUDE)
 
         # Get signature suite, proof purpose and document loader
-        manager = self.profile.inject(VcLdpManager)
+        manager = VcLdpManager(self.profile)
         try:
             result = await manager.verify_credential(credential)
         except VcLdpManagerError as err:

--- a/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/formats/ld_proof/tests/test_handler.py
@@ -1,11 +1,11 @@
 from copy import deepcopy
-from .......vc.ld_proofs.error import LinkedDataProofException
 from unittest import IsolatedAsyncioTestCase
-from aries_cloudagent.tests import mock
 from unittest.mock import patch
+
 from marshmallow import ValidationError
 
-from .. import handler as test_module
+from aries_cloudagent.tests import mock
+
 from .......core.in_memory import InMemoryProfile
 from .......messaging.decorators.attach_decorator import AttachDecorator
 from .......storage.vc_holder.base import VCHolder
@@ -15,6 +15,7 @@ from .......vc.ld_proofs.constants import (
     SECURITY_CONTEXT_BBS_URL,
     SECURITY_CONTEXT_ED25519_2020_URL,
 )
+from .......vc.ld_proofs.error import LinkedDataProofException
 from .......vc.tests.document_loader import custom_document_loader
 from .......vc.vc_ld.manager import VcLdpManager
 from .......vc.vc_ld.models.credential import VerifiableCredential
@@ -39,8 +40,9 @@ from ....messages.cred_request import V20CredRequest
 from ....models.cred_ex_record import V20CredExRecord
 from ....models.detail.ld_proof import V20CredExRecordLDProof
 from ...handler import V20CredFormatError
-from ..handler import LDProofCredFormatHandler
+from .. import handler as test_module
 from ..handler import LOGGER as LD_PROOF_LOGGER
+from ..handler import LDProofCredFormatHandler
 from ..models.cred_detail import LDProofVCDetail
 
 TEST_DID_SOV = "did:sov:LjgpST2rjsoxYegQDRm7EL"
@@ -249,7 +251,7 @@ class TestV20LDProofCredFormatHandler(IsolatedAsyncioTestCase):
 
     async def test_create_offer(self):
         with mock.patch.object(
-            self.manager,
+            VcLdpManager,
             "assert_can_issue_with_id_and_proof_type",
             mock.CoroutineMock(),
         ) as mock_can_issue, patch.object(
@@ -289,7 +291,7 @@ class TestV20LDProofCredFormatHandler(IsolatedAsyncioTestCase):
         )
 
         with mock.patch.object(
-            self.manager,
+            VcLdpManager,
             "assert_can_issue_with_id_and_proof_type",
             mock.CoroutineMock(),
         ), patch.object(test_module, "get_properties_without_context", return_value=[]):
@@ -314,7 +316,7 @@ class TestV20LDProofCredFormatHandler(IsolatedAsyncioTestCase):
         )
 
         with mock.patch.object(
-            self.manager,
+            VcLdpManager,
             "assert_can_issue_with_id_and_proof_type",
             mock.CoroutineMock(),
         ), patch.object(test_module, "get_properties_without_context", return_value=[]):
@@ -585,7 +587,7 @@ class TestV20LDProofCredFormatHandler(IsolatedAsyncioTestCase):
         )
 
         with mock.patch.object(
-            self.manager,
+            VcLdpManager,
             "issue",
             mock.CoroutineMock(
                 return_value=VerifiableCredential.deserialize(LD_PROOF_VC)
@@ -843,7 +845,7 @@ class TestV20LDProofCredFormatHandler(IsolatedAsyncioTestCase):
         self.holder.store_credential = mock.CoroutineMock()
 
         with mock.patch.object(
-            self.manager,
+            VcLdpManager,
             "verify_credential",
             mock.CoroutineMock(return_value=DocumentVerificationResult(verified=True)),
         ) as mock_verify_credential:

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
@@ -446,7 +446,7 @@ class DIFPresFormatHandler(V20PresFormatHandler):
         pres_request = pres_ex_record.pres_request.attachment(
             DIFPresFormatHandler.format
         )
-        manager = self.profile.inject(VcLdpManager)
+        manager = VcLdpManager(self.profile)
 
         options = LDProofVCOptions.deserialize(pres_request["options"])
         if not options.challenge:


### PR DESCRIPTION
Reverts the changes made in https://github.com/hyperledger/aries-cloudagent-python/pull/2705 which caused problems with certain multitenant environments (still unknown). If this is something we want we can look at doing it again in a future release.

Tested the problem described in issue https://github.com/hyperledger/aries-cloudagent-python/issues/2777 by running the multitenant provider plugin integration tests. Could see the problem in 0.12.0dev0, but all the tests pass when pointing to my forked branch with the revert.

I believe this was only used for the `VcLdpManager` to prevent creating a new instance for every handler method call. I reverted these occurrences back to creating a new manager instance. 