### PR TITLE
Add anoncreds multitenant endorsement integration tests

### DIFF
--- a/demo/features/0586-sign-transaction.feature
+++ b/demo/features/0586-sign-transaction.feature
@@ -36,13 +36,11 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
       @WalletType_Askar_AnonCreds @GHA
       Examples:
          | Acme_capabilities         | Bob_capabilities          | Schema_name    |
-         | --wallet-type askar-anoncreds | --wallet-type askar-anoncreds   | anoncreds-testing |
          | --wallet-type askar-anoncreds |                                 | driverslicense |
          |                               | --wallet-type askar-anoncreds   | anoncreds-testing |
-         |                               | --wallet-type askar-anoncreds --multitenant  | anoncreds-testing |
 
 
-   @T001.1-RFC0586 @GHA
+   @T001.1-RFC0586
    Scenario Outline: endorse a transaction and write to the ledger
       Given we have "2" agents
          | name  | role     | capabilities        |
@@ -121,7 +119,7 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | Acme_capabilities                                   | Bob_capabilities                                            | Schema_name    | Credential_data          |
          | --revocation --public-did --did-exchange            | --revocation --did-exchange --wallet-type askar-anoncreds   | anoncreds-testing | Data_AC_NormalizedValues | 
 
-   @T002.1-RFC0586 @GHA
+   @T002.1-RFC0586
    Scenario Outline: endorse a schema and cred def transaction, write to the ledger, issue and revoke a credential, manually invoking each endorsement endpoint
       Given we have "2" agents
          | name  | role     | capabilities        |
@@ -235,4 +233,4 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
       Examples:
          | Acme_capabilities                                   | Bob_capabilities                             | Schema_name       | Credential_data          |
          | --endorser-role endorser --revocation --public-did  | --endorser-role author --revocation --wallet-type askar-anoncreds   | anoncreds-testing | Data_AC_NormalizedValues |
-         | --endorser-role endorser --revocation --public-did  | --endorser-role author --revocation --multitanant --wallet-type askar-anoncreds   | anoncreds-testing | Data_AC_NormalizedValues |
+         | --endorser-role endorser --revocation --public-did  | --endorser-role author --revocation --multitenant --wallet-type askar-anoncreds   | anoncreds-testing | Data_AC_NormalizedValues |

--- a/demo/features/0586-sign-transaction.feature
+++ b/demo/features/0586-sign-transaction.feature
@@ -39,6 +39,7 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
          | --wallet-type askar-anoncreds | --wallet-type askar-anoncreds   | anoncreds-testing |
          | --wallet-type askar-anoncreds |                                 | driverslicense |
          |                               | --wallet-type askar-anoncreds   | anoncreds-testing |
+         |                               | --wallet-type askar-anoncreds --multitenant  | anoncreds-testing |
 
 
    @T001.1-RFC0586 @GHA
@@ -234,3 +235,4 @@ Feature: RFC 0586 Aries sign (endorse) transactions functions
       Examples:
          | Acme_capabilities                                   | Bob_capabilities                             | Schema_name       | Credential_data          |
          | --endorser-role endorser --revocation --public-did  | --endorser-role author --revocation --wallet-type askar-anoncreds   | anoncreds-testing | Data_AC_NormalizedValues |
+         | --endorser-role endorser --revocation --public-did  | --endorser-role author --revocation --multitanant --wallet-type askar-anoncreds   | anoncreds-testing | Data_AC_NormalizedValues |


### PR DESCRIPTION
So, I had a misunderstanding. Endorsement for anoncreds in multitenancy is currently working when the admin agent is askar-anoncreds wallet type and the tenants are created with askar-anoncreds wallet type.

This PR will just add integration tests for this scenario.

I think it's important to have the feature https://github.com/hyperledger/aries-cloudagent-python/issues/2786 available for multitenancy going forward as this is where some of my confusion came from. When I first thought this didn't work, the author tenant wasn't setup completely. (It's pretty much finished other than some unit testing problems)

The other issue somewhat related to this issue is https://github.com/hyperledger/aries-cloudagent-python/issues/2792 but work can be done off of this issue as it is more relevant.

I'm thinking about how this is going to work with the admin agent on `askar` and a tenant is on `askar-anoncreds` and vice versa, and how this is going to work with the upgrade script etc. Currently this doesn't work because the wallet type of the admin agent is what decides what endpoints are available.

I don't think these questions are related to this ticket though so the tests should be enough to close this issue.