### PR TITLE
Get and create anoncreds profile when using anoncreds subwallet

### DIFF
--- a/aries_cloudagent/multitenant/askar_profile_manager.py
+++ b/aries_cloudagent/multitenant/askar_profile_manager.py
@@ -2,6 +2,7 @@
 
 from typing import Iterable, Optional, cast
 
+from ..askar.profile_anon import AskarAnoncredsProfile
 from ..askar.profile import AskarProfile
 from ..config.injection_context import InjectionContext
 from ..config.wallet import wallet_config
@@ -103,6 +104,14 @@ class AskarProfileMultitenantManager(BaseMultitenantManager):
         ).extend(extra_settings)
 
         assert self._multitenant_profile.opened
+
+        # return anoncreds profile if explicitly set as wallet type
+        if profile_context.settings.get("wallet.type") == "askar-anoncreds":
+            return AskarAnoncredsProfile(
+                self._multitenant_profile.opened,
+                profile_context,
+                profile_id=wallet_record.wallet_id,
+            )
 
         return AskarProfile(
             self._multitenant_profile.opened,


### PR DESCRIPTION
This should fix https://github.com/hyperledger/aries-cloudagent-python/issues/2792, unless there's something I'm not aware of. 

Start the multitenant admin with
``` yml
wallet-type: askar-anoncreds
multitenancy-config: wallet_type=askar-profile
wallet-storage-type: default
```
and create tenant with 

``` json
{
  "extra_settings": {},
  "key_management_mode": "managed",
  "label": "Tenant 0",
  "wallet_dispatch_type": "default",
  "wallet_key": "tenant_key_0",
  "wallet_name": "tenant_0",
  "wallet_type": "askar-anoncreds"
}
```

Can create the ledger objects through the api. Before the change was get wrong profile error.