### PR TITLE
Fix - missing revocation notification

### DIFF
--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -47,6 +47,7 @@ from ...base import (
     BaseAnonCredsRegistrar,
     BaseAnonCredsResolver,
 )
+from ...events import RevListFinishedEvent
 from ...issuer import AnonCredsIssuer, AnonCredsIssuerError
 from ...models.anoncreds_cred_def import (
     CredDef,
@@ -966,6 +967,11 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         )
 
         if write_ledger:
+            await self.notify(
+                RevListFinishedEvent.with_payload(
+                    curr_list.rev_reg_def_id, newly_revoked_indices
+                )
+            )
             return RevListResult(
                 job_id=None,
                 revocation_list_state=RevListState(
@@ -983,6 +989,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
             "context": {
                 "job_id": job_id,
                 "rev_reg_def_id": rev_reg_def_id,
+                "rev_list": curr_list.serialize(),
                 "options": {
                     "endorser_connection_id": endorser_connection_id,
                     "create_transaction_for_endorser": create_transaction,

--- a/aries_cloudagent/anoncreds/events.py
+++ b/aries_cloudagent/anoncreds/events.py
@@ -109,7 +109,8 @@ class RevRegDefFinishedEvent(Event):
 class RevListFinishedPayload(NamedTuple):
     """Payload of rev list finished event."""
 
-    rev_reg_def_id: str
+    rev_reg_id: str
+    revoked: list
     options: dict
 
 
@@ -131,11 +132,12 @@ class RevListFinishedEvent(Event):
     @classmethod
     def with_payload(
         cls,
-        rev_reg_def_id: str,
+        rev_reg_id: str,
+        revoked: list,
         options: Optional[dict] = None,
     ):
         """With payload."""
-        payload = RevListFinishedPayload(rev_reg_def_id, options)
+        payload = RevListFinishedPayload(rev_reg_id, revoked, options)
         return cls(payload)
 
     @property

--- a/aries_cloudagent/anoncreds/revocation_setup.py
+++ b/aries_cloudagent/anoncreds/revocation_setup.py
@@ -8,6 +8,7 @@ from aries_cloudagent.protocols.endorse_transaction.v1_0.util import is_author_r
 from ..anoncreds.revocation import AnonCredsRevocation
 from ..core.event_bus import EventBus
 from ..core.profile import Profile
+from ..revocation.util import notify_revocation_published_event
 from .events import (
     CRED_DEF_FINISHED_PATTERN,
     REV_LIST_FINISHED_PATTERN,
@@ -105,4 +106,6 @@ class DefaultRevocationSetup(AnonCredsRevocationSetupManager):
 
     async def on_rev_list(self, profile: Profile, event: RevListFinishedEvent):
         """Handle rev list finished."""
-        LOGGER.debug("Revocation list finished: %s", event.payload.rev_reg_def_id)
+        await notify_revocation_published_event(
+            profile, event.payload.rev_reg_id, event.payload.revoked
+        )

--- a/aries_cloudagent/anoncreds/tests/test_revocation.py
+++ b/aries_cloudagent/anoncreds/tests/test_revocation.py
@@ -596,9 +596,7 @@ class TestAnonCredsRevocation(IsolatedAsyncioTestCase):
 
         # Fetch doesn't find list then it should be created
         await self.revocation.finish_revocation_list(
-            job_id="test-job-id",
-            rev_reg_def_id="test-rev-reg-def-id",
-            revoked=[]
+            job_id="test-job-id", rev_reg_def_id="test-rev-reg-def-id", revoked=[]
         )
         assert mock_finish.called
 

--- a/aries_cloudagent/anoncreds/tests/test_revocation.py
+++ b/aries_cloudagent/anoncreds/tests/test_revocation.py
@@ -598,13 +598,13 @@ class TestAnonCredsRevocation(IsolatedAsyncioTestCase):
         await self.revocation.finish_revocation_list(
             job_id="test-job-id",
             rev_reg_def_id="test-rev-reg-def-id",
+            revoked=[]
         )
         assert mock_finish.called
 
         # Fetch finds list then there's nothing to do, it's already finished and updated
         await self.revocation.finish_revocation_list(
-            job_id="test-job-id",
-            rev_reg_def_id="test-rev-reg-def-id",
+            job_id="test-job-id", rev_reg_def_id="test-rev-reg-def-id", revoked=[]
         )
         assert mock_finish.call_count == 1
 

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/manager.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/manager.py
@@ -863,14 +863,17 @@ class TransactionManager:
         elif ledger_response["result"]["txn"]["type"] == "114":
             # revocation entry transaction
             rev_reg_id = ledger_response["result"]["txn"]["data"]["revocRegDefId"]
+            revoked = ledger_response["result"]["txn"]["data"]["value"].get(
+                "revoked", []
+            )
             meta_data["context"]["rev_reg_id"] = rev_reg_id
             if is_anoncreds:
                 await AnonCredsRevocation(self._profile).finish_revocation_list(
-                    meta_data["context"]["job_id"], rev_reg_id
+                    meta_data["context"]["job_id"], rev_reg_id, revoked
                 )
             else:
                 await notify_revocation_entry_endorsed_event(
-                    self._profile, rev_reg_id, meta_data
+                    self._profile, rev_reg_id, meta_data, revoked
                 )
 
         elif ledger_response["result"]["txn"]["type"] == "1":

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/tests/test_manager.py
@@ -940,7 +940,7 @@ class TestTransactionManager(IsolatedAsyncioTestCase):
                 "txn": {
                     "type": "114",
                     "metadata": {"from": TEST_DID},
-                    "data": {"revocRegDefId": REV_REG_ID},
+                    "data": {"revocRegDefId": REV_REG_ID, "value": {"revoked": [1]}},
                 },
                 "txnMetadata": {"txnId": REV_REG_ID},
             },

--- a/aries_cloudagent/revocation/manager.py
+++ b/aries_cloudagent/revocation/manager.py
@@ -180,9 +180,6 @@ class RevocationManager:
                         write_ledger=write_ledger,
                         endorser_did=endorser_did,
                     )
-                    await notify_revocation_published_event(
-                        self._profile, rev_reg_id, [cred_rev_id]
-                    )
                     return rev_entry_resp
         else:
             async with self._profile.transaction() as txn:
@@ -299,9 +296,6 @@ class RevocationManager:
                         rev_entry_resp = await issuer_rr_upd.send_entry(self._profile)
                 published = sorted(crid for crid in crids if crid not in failed_crids)
                 result[issuer_rr_rec.revoc_reg_id] = published
-                await notify_revocation_published_event(
-                    self._profile, issuer_rr_rec.revoc_reg_id, published
-                )
 
         return rev_entry_resp, result
 

--- a/aries_cloudagent/revocation/manager.py
+++ b/aries_cloudagent/revocation/manager.py
@@ -4,24 +4,24 @@ import json
 import logging
 from typing import Mapping, Optional, Sequence, Text, Tuple
 
-from ..protocols.revocation_notification.v1_0.models.rev_notification_record import (
-    RevNotificationRecord,
-)
 from ..connections.models.conn_record import ConnRecord
 from ..core.error import BaseError
 from ..core.profile import Profile
 from ..indy.issuer import IndyIssuer
-from ..storage.error import StorageNotFoundError
-from .indy import IndyRevocation
-from .models.issuer_cred_rev_record import IssuerCredRevRecord
-from .models.issuer_rev_reg_record import IssuerRevRegRecord
-from .util import notify_pending_cleared_event, notify_revocation_published_event
 from ..protocols.issue_credential.v1_0.models.credential_exchange import (
     V10CredentialExchange,
 )
 from ..protocols.issue_credential.v2_0.models.cred_ex_record import (
     V20CredExRecord,
 )
+from ..protocols.revocation_notification.v1_0.models.rev_notification_record import (
+    RevNotificationRecord,
+)
+from ..storage.error import StorageNotFoundError
+from .indy import IndyRevocation
+from .models.issuer_cred_rev_record import IssuerCredRevRecord
+from .models.issuer_rev_reg_record import IssuerRevRegRecord
+from .util import notify_pending_cleared_event, notify_revocation_published_event
 
 
 class RevocationManagerError(BaseError):
@@ -180,6 +180,9 @@ class RevocationManager:
                         write_ledger=write_ledger,
                         endorser_did=endorser_did,
                     )
+                    await notify_revocation_published_event(
+                        self._profile, rev_reg_id, [cred_rev_id]
+                    )
                     return rev_entry_resp
         else:
             async with self._profile.transaction() as txn:
@@ -296,10 +299,9 @@ class RevocationManager:
                         rev_entry_resp = await issuer_rr_upd.send_entry(self._profile)
                 published = sorted(crid for crid in crids if crid not in failed_crids)
                 result[issuer_rr_rec.revoc_reg_id] = published
-                if not connection_id:
-                    await notify_revocation_published_event(
-                        self._profile, issuer_rr_rec.revoc_reg_id, crids
-                    )
+                await notify_revocation_published_event(
+                    self._profile, issuer_rr_rec.revoc_reg_id, published
+                )
 
         return rev_entry_resp, result
 

--- a/aries_cloudagent/revocation/tests/test_manager.py
+++ b/aries_cloudagent/revocation/tests/test_manager.py
@@ -83,7 +83,6 @@ class TestRevocationManager(IsolatedAsyncioTestCase):
             revoc.return_value.get_ledger_registry = mock.CoroutineMock(
                 return_value=mock_rev_reg
             )
-            test_module.notify_revocation_published_event = mock.CoroutineMock()
 
             await self.manager.revoke_credential_by_cred_ex_id(CRED_EX_ID, publish=True)
 
@@ -93,7 +92,6 @@ class TestRevocationManager(IsolatedAsyncioTestCase):
             mock_issuer_rev_reg_record.tails_local_path,
             ["2", "1"],
         )
-        assert test_module.notify_revocation_published_event.called
 
     async def test_revoke_credential_publish_endorser(self):
         conn_record = ConnRecord(
@@ -168,7 +166,6 @@ class TestRevocationManager(IsolatedAsyncioTestCase):
             revoc.return_value.get_ledger_registry = mock.CoroutineMock(
                 return_value=mock_rev_reg
             )
-            test_module.notify_revocation_published_event = mock.CoroutineMock()
 
             await self.manager.revoke_credential_by_cred_ex_id(
                 cred_ex_id=CRED_EX_ID,
@@ -176,8 +173,6 @@ class TestRevocationManager(IsolatedAsyncioTestCase):
                 connection_id=conn_id,
                 write_ledger=False,
             )
-
-            assert test_module.notify_revocation_published_event.called
 
         issuer.revoke_credentials.assert_awaited_once_with(
             mock_issuer_rev_reg_record.cred_def_id,
@@ -385,7 +380,6 @@ class TestRevocationManager(IsolatedAsyncioTestCase):
                 side_effect=[(json.dumps(delta), []) for delta in deltas]
             )
             self.profile.context.injector.bind_instance(IndyIssuer, issuer)
-            test_module.notify_revocation_published_event = mock.CoroutineMock()
             manager = RevocationManager(self.profile)
             _, result = await manager.publish_pending_revocations(
                 rrid2crid={REV_REG_ID: "2"}, connection_id=conn_id
@@ -393,7 +387,6 @@ class TestRevocationManager(IsolatedAsyncioTestCase):
             assert result == {REV_REG_ID: ["2"]}
             mock_issuer_rev_reg_records[0].clear_pending.assert_called_once()
             mock_issuer_rev_reg_records[1].clear_pending.assert_not_called()
-            assert test_module.notify_revocation_published_event.called
 
     async def test_publish_pending_revocations_endorser_x(self):
         deltas = [

--- a/aries_cloudagent/revocation/util.py
+++ b/aries_cloudagent/revocation/util.py
@@ -5,7 +5,6 @@ from typing import Sequence
 
 from ..core.profile import Profile
 
-
 REVOCATION_EVENT_PREFIX = "acapy::REVOCATION::"
 EVENT_LISTENER_PATTERN = re.compile(f"^{REVOCATION_EVENT_PREFIX}(.*)?$")
 REVOCATION_REG_INIT_EVENT = "REGISTRY_INIT"
@@ -52,11 +51,12 @@ async def notify_revocation_reg_endorsed_event(
 
 
 async def notify_revocation_entry_endorsed_event(
-    profile: Profile, rev_reg_id: str, meta_data: dict
+    profile: Profile, rev_reg_id: str, meta_data: dict, revoked: list
 ):
     """Send notification for a revocation registry entry endorsement event."""
     topic = f"{REVOCATION_EVENT_PREFIX}{REVOCATION_ENTRY_ENDORSED_EVENT}::{rev_reg_id}"
     await profile.notify(topic, meta_data)
+    await notify_revocation_published_event(profile, rev_reg_id, revoked)
 
 
 async def notify_revocation_published_event(

--- a/aries_cloudagent/revocation_anoncreds/manager.py
+++ b/aries_cloudagent/revocation_anoncreds/manager.py
@@ -16,7 +16,6 @@ from ..protocols.revocation_notification.v1_0.models.rev_notification_record imp
 )
 from ..revocation.util import (
     notify_pending_cleared_event,
-    notify_revocation_published_event,
 )
 from ..storage.error import StorageNotFoundError
 from .models.issuer_cred_rev_record import IssuerCredRevRecord
@@ -129,9 +128,6 @@ class RevocationManager:
                     result.revoked,
                     options=options,
                 )
-            await notify_revocation_published_event(
-                self._profile, rev_reg_id, [cred_rev_id]
-            )
 
         else:
             await revoc.mark_pending_revocations(rev_reg_id, int(cred_rev_id))
@@ -237,9 +233,6 @@ class RevocationManager:
                     rrid, result.prev, result.curr, result.revoked, options
                 )
                 published_crids[rrid] = sorted(result.revoked)
-                await notify_revocation_published_event(
-                    self._profile, rrid, [str(crid) for crid in result.revoked]
-                )
 
         return published_crids
 


### PR DESCRIPTION
This fixes the issue with the revocation notification not happening.

There was a couple things that didn't make sense. 

- For the `/revoke` endpoint if was never calling notify. It was only creating the notification record. This may have been deliberate (see comment), but needs to notify at some point, which it isn't doing.
- For the `/publish-revocations` endpoint it was not calling notify when there was a connection_id, but this is only used for explicitly using a specific endorser connection. When in author and preconfigured mode, this parameter isn't even used. I think it was trying to prevent the notify from happening for endorsement scenarios. (see next comment)

***comment***: right now the revocation notification is happening after requesting endorsement but before the new list entry has been written to the ledger. This is the same for anoncreds. I'm not sure if this is what we actually want. It kinda makes sense to have it immediately when the issuer revokes, but it also makes sense not to notify until after the endorsement has happened and the entry has been written.

Tested with traction and bc wallet. 

Still testing some scenarios.