### PR TITLE
Fix connection reuse handling in demo

### DIFF
--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -61,6 +61,8 @@ class AriesAgent(DemoAgent):
         log_file: str = None,
         log_config: str = None,
         log_level: str = None,
+        reuse_connections: bool = False,
+        public_did_connections: bool = False,
         extra_args: List[str] = [],
         **kwargs,
     ):
@@ -90,6 +92,8 @@ class AriesAgent(DemoAgent):
             log_file=log_file,
             log_config=log_config,
             log_level=log_level,
+            reuse_connections=reuse_connections,
+            public_did_connections=public_did_connections,
             **kwargs,
         )
         self.connection_id = None
@@ -117,10 +121,13 @@ class AriesAgent(DemoAgent):
 
     async def handle_connection_reuse(self, message):
         # we are reusing an existing connection, set our status to the existing connection
-        if not self._connection_ready.done():
-            self.connection_id = message["connection_id"]
-            self.log("Connected")
-            self._connection_ready.set_result(True)
+        if self._connection_ready is not None:
+            if not self._connection_ready.done():
+                self.connection_id = message["connection_id"]
+                self.log("Connected")
+                self._connection_ready.set_result(True)
+        else:
+            self.log("Connected on existing connection")
 
     async def handle_connection_reuse_accepted(self, message):
         # we are reusing an existing connection, set our status to the existing connection
@@ -144,7 +151,8 @@ class AriesAgent(DemoAgent):
         if (not self.connection_id) and message["rfc23_state"] == "invitation-received":
             self.connection_id = conn_id
 
-        if conn_id == self.connection_id:
+        print(conn_id, self.connection_id, self.reuse_connections)
+        if conn_id == self.connection_id or self.reuse_connections:
             # inviter or invitee:
             if message["rfc23_state"] in ["completed", "response-sent"]:
                 if not self._connection_ready.done():
@@ -597,6 +605,7 @@ class AriesAgent(DemoAgent):
         auto_accept: bool = True,
         display_qr: bool = False,
         reuse_connections: bool = False,
+        public_did_connections: bool = False,
         wait: bool = False,
     ):
         self._connection_ready = asyncio.Future()
@@ -609,6 +618,7 @@ class AriesAgent(DemoAgent):
                 use_did_exchange,
                 auto_accept=auto_accept,
                 reuse_connections=reuse_connections,
+                public_did_connections=public_did_connections,
             )
 
         if display_qr:
@@ -708,6 +718,7 @@ class AgentContainer:
         arg_file: str = None,
         endorser_role: str = None,
         reuse_connections: bool = False,
+        public_did_connections: bool = False,
         taa_accept: bool = False,
         anoncreds_legacy_revocation: str = None,
         log_file: str = None,
@@ -747,6 +758,7 @@ class AgentContainer:
                 self.cred_type = CRED_FORMAT_INDY
 
         self.reuse_connections = reuse_connections
+        self.public_did_connections = public_did_connections
         self.exchange_tracing = False
 
         # local agent(s)
@@ -1140,6 +1152,7 @@ class AgentContainer:
         auto_accept: bool = True,
         display_qr: bool = False,
         reuse_connections: bool = False,
+        public_did_connections: bool = False,
         wait: bool = False,
     ):
         return await self.agent.generate_invitation(
@@ -1147,6 +1160,7 @@ class AgentContainer:
             auto_accept=auto_accept,
             display_qr=display_qr,
             reuse_connections=reuse_connections,
+            public_did_connections=public_did_connections,
             wait=wait,
         )
 
@@ -1347,7 +1361,15 @@ def arg_parser(ident: str = None, port: int = 8020):
             "--reuse-connections",
             action="store_true",
             help=(
-                "Reuse connections by using Faber public key in the invite. "
+                "Reuse connections by generating a reusable invitation. "
+                "Only applicable for AIP 2.0 (OOB) connections."
+            ),
+        )
+        parser.add_argument(
+            "--public-did-connections",
+            action="store_true",
+            help=(
+                "Use Faber public key in the invite. "
                 "Only applicable for AIP 2.0 (OOB) connections."
             ),
         )
@@ -1476,6 +1498,9 @@ async def create_agent_with_args(args, ident: str = None, extra_args: list = Non
     reuse_connections = "reuse_connections" in args and args.reuse_connections
     if reuse_connections and aip != 20:
         raise Exception("Can only specify `--reuse-connections` with AIP 2.0")
+    public_did_connections = "public_did_connections" in args and args.public_did_connections
+    if public_did_connections and aip != 20:
+        raise Exception("Can only specify `--public-did-connections` with AIP 2.0")
 
     anoncreds_legacy_revocation = None
     if "anoncreds_legacy_revocation" in args and args.anoncreds_legacy_revocation:
@@ -1501,6 +1526,7 @@ async def create_agent_with_args(args, ident: str = None, extra_args: list = Non
         aip=aip,
         endorser_role=args.endorser_role,
         reuse_connections=reuse_connections,
+        public_did_connections=public_did_connections,
         taa_accept=args.taa_accept,
         anoncreds_legacy_revocation=anoncreds_legacy_revocation,
         log_file=log_file,

--- a/demo/runners/faber.py
+++ b/demo/runners/faber.py
@@ -422,6 +422,8 @@ async def main(args):
             log_file=faber_agent.log_file,
             log_config=faber_agent.log_config,
             log_level=faber_agent.log_level,
+            reuse_connections=faber_agent.reuse_connections,
+            public_did_connections=faber_agent.public_did_connections,
             extra_args=extra_args,
         )
 
@@ -453,7 +455,10 @@ async def main(args):
 
         # generate an invitation for Alice
         await faber_agent.generate_invitation(
-            display_qr=True, reuse_connections=faber_agent.reuse_connections, wait=True
+            display_qr=True,
+            reuse_connections=faber_agent.reuse_connections,
+            public_did_connections=faber_agent.public_did_connections,
+            wait=True,
         )
 
         exchange_tracing = False
@@ -721,6 +726,7 @@ async def main(args):
                 await faber_agent.generate_invitation(
                     display_qr=True,
                     reuse_connections=faber_agent.reuse_connections,
+                    public_did_connections=faber_agent.public_did_connections,
                     wait=True,
                 )
 

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -145,6 +145,8 @@ class DemoAgent:
         log_file: str = None,
         log_config: str = None,
         log_level: str = None,
+        reuse_connections: bool = False,
+        public_did_connections: bool = False,
         **params,
     ):
         self.ident = ident
@@ -179,6 +181,8 @@ class DemoAgent:
         self.log_file = log_file
         self.log_config = log_config
         self.log_level = log_level
+        self.reuse_connections = reuse_connections
+        self.public_did_connections = public_did_connections
 
         self.admin_url = f"http://{self.internal_host}:{admin_port}"
         if AGENT_ENDPOINT:
@@ -1446,16 +1450,18 @@ class DemoAgent:
         use_did_exchange: bool,
         auto_accept: bool = True,
         reuse_connections: bool = False,
+        public_did_connections: bool = False,
     ):
         self.connection_id = None
         if use_did_exchange:
             # TODO can mediation be used with DID exchange connections?
             invi_params = {
                 "auto_accept": json.dumps(auto_accept),
+                "multi_use": json.dumps(reuse_connections),
             }
             payload = {
                 "handshake_protocols": ["rfc23"],
-                "use_public_did": reuse_connections,
+                "use_public_did": public_did_connections,
             }
             if self.mediation:
                 payload["mediation_id"] = self.mediator_request_id

--- a/docs/demo/ReusingAConnection.md
+++ b/docs/demo/ReusingAConnection.md
@@ -100,7 +100,7 @@ instruction up to the point where you are about to start the Faber and Alice age
 [Alice Faber Demo]: ./README.md
 
 1. On a command line, run Faber with these parameters: `./run_demo faber
-   --reuse-connection --events`.
+   --reuse-connection --public-did-connections --events`.
 2. On a second command line, run Alice as normal, perhaps with the `events`
    option: `./run_demo alice --events`
 3. Copy the invitation from the Faber terminal and paste it into the Alice
@@ -133,6 +133,18 @@ issuer (and uses in creating the schema and Cred Def for the demo), Faber could
 use any *resolvable* (not inline) DID, including DID Peer types 2 or 4 DIDs, as
 long as the DID is the same in every invitation. It is the fact that the DID is
 always the same that tells the invitee that they can reuse an existing connection.
+
+For example, to run faber with connection reuse using a non-public DID:
+
+```
+./run_demo faber --reuse-connection --events
+```
+
+To run faber using a `did_peer` and reusable connections:
+
+```
+DEMO_EXTRA_AGENT_ARGS="[\"--emit-did-peer-2\"]" ./run_demo faber --reuse-connection --events
+```
 
 Note that the invitation does **NOT** have to be a multi-use invitation for
 reuse to be useful, as long as the other requirements (at the top of this


### PR DESCRIPTION
Separate the "connection reuse" and "use public did" configuration for the demo:

```
./run_demo faber --reuse-connection --public-did-connections
```

(Previously only the `--reuse-connection` parameter was available and it automatically set the connection to use the public DID.)

To run with a `did:peer` use:

```
DEMO_EXTRA_AGENT_ARGS="[\"--emit-did-peer-2\"]" ./run_demo faber --reuse-connection --events
```

There are some issues with `did:peer`, see discussion in issue #2703.
