### PR TITLE
Fix anoncreds non-endorsement revocation

### DIFF
--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -12,6 +12,7 @@ from base58 import alphabet
 from ....anoncreds.default.legacy_indy.author import get_endorser_info
 from ....cache.base import BaseCache
 from ....config.injection_context import InjectionContext
+from ....core.event_bus import EventBus
 from ....core.profile import Profile
 from ....ledger.base import BaseLedger
 from ....ledger.error import (
@@ -967,10 +968,12 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         )
 
         if write_ledger:
-            await self.notify(
+            event_bus = profile.inject(EventBus)
+            await event_bus.notify(
+                profile,
                 RevListFinishedEvent.with_payload(
                     curr_list.rev_reg_def_id, newly_revoked_indices
-                )
+                ),
             )
             return RevListResult(
                 job_id=None,

--- a/demo/features/revocation-api.feature
+++ b/demo/features/revocation-api.feature
@@ -39,7 +39,7 @@ Feature: ACA-Py Revocation API
       Then "Bob" can verify the credential from "<issuer>" was revoked
       Examples:
          | issuer | Acme_capabilities                          | Bob_capabilities | Schema_name       | Credential_data   | Proof_request     |
-         #| Acme   | --revocation --public-did                  |                  | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
+         | Acme   | --revocation --public-did                  |                  | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
          | Acme   | --revocation --public-did --wallet-type askar-anoncreds | --wallet-type askar-anoncreds | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
 
    @Revoc-api.x @GHA-Anoncreds-break


### PR DESCRIPTION
Sorry. I should have blocked the last PR from getting merged for a bit. I forgot to test the anoncreds non-endorsement scenario. Integration tests caught it and I fixed the problem with this PR. Tested the failing integration tests locally.

Also, enabled a test that was commented out for askar wallet revoke and then publish scenarios.