### PR TITLE
Allow for crids in event payload to be integers

### DIFF
--- a/aries_cloudagent/protocols/revocation_notification/v1_0/routes.py
+++ b/aries_cloudagent/protocols/revocation_notification/v1_0/routes.py
@@ -8,8 +8,8 @@ from ....core.profile import Profile
 from ....messaging.responder import BaseResponder
 from ....revocation.util import (
     REVOCATION_CLEAR_PENDING_EVENT,
-    REVOCATION_PUBLISHED_EVENT,
     REVOCATION_EVENT_PREFIX,
+    REVOCATION_PUBLISHED_EVENT,
 )
 from ....storage.error import StorageError, StorageNotFoundError
 from .models.rev_notification_record import RevNotificationRecord
@@ -31,10 +31,14 @@ def register_events(event_bus: EventBus):
 
 async def on_revocation_published(profile: Profile, event: Event):
     """Handle issuer revoke event."""
-    LOGGER.debug("Sending notification of revocation to recipient: %s", event.payload)
+    LOGGER.debug("Received notification of revocation publication: %s", event.payload)
 
+    should_notify = profile.settings.get("revocation.notify", False)
     responder = profile.inject(BaseResponder)
     crids = event.payload.get("crids") or []
+    # Allow for crids to be integers
+    if crids and isinstance(crids[0], int):
+        crids = [str(crid) for crid in crids]
 
     try:
         async with profile.session() as session:
@@ -46,9 +50,10 @@ async def on_revocation_published(profile: Profile, event: Event):
 
             for record in records:
                 await record.delete_record(session)
-                await responder.send(
-                    record.to_message(), connection_id=record.connection_id
-                )
+                if should_notify:
+                    await responder.send(
+                        record.to_message(), connection_id=record.connection_id
+                    )
 
     except StorageNotFoundError:
         LOGGER.info(

--- a/aries_cloudagent/protocols/revocation_notification/v2_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/revocation_notification/v2_0/tests/test_routes.py
@@ -1,9 +1,9 @@
 """Test routes.py"""
 
-from aries_cloudagent.tests import mock
 import pytest
 
-from .. import routes as test_module
+from aries_cloudagent.tests import mock
+
 from .....config.settings import Settings
 from .....core.event_bus import Event, MockEventBus
 from .....core.in_memory import InMemoryProfile
@@ -15,6 +15,7 @@ from .....revocation.util import (
     REVOCATION_PUBLISHED_EVENT,
 )
 from .....storage.error import StorageError, StorageNotFoundError
+from .. import routes as test_module
 
 
 @pytest.fixture
@@ -59,6 +60,28 @@ async def test_on_revocation_published(profile: Profile, responder: MockResponde
     MockRec.query_by_rev_reg_id.assert_called_once()
     mock_rec.delete_record.assert_called_once()
     assert responder.messages
+
+    # Test with integer crids
+    mock_rec.cred_rev_id = "1"
+    MockRec.query_by_rev_reg_id = mock.CoroutineMock(return_value=[mock_rec])
+    event = Event(topic, {"rev_reg_id": "mock", "crids": [1]})
+
+    with mock.patch.object(test_module, "RevNotificationRecord", MockRec):
+        await test_module.on_revocation_published(profile, event)
+
+    MockRec.query_by_rev_reg_id.assert_called_once()
+    assert mock_rec.delete_record.call_count == 2
+
+    # Test with empty crids
+    mock_rec.cred_rev_id = "1"
+    MockRec.query_by_rev_reg_id = mock.CoroutineMock(return_value=[mock_rec])
+    event = Event(topic, {"rev_reg_id": "mock", "crids": []})
+
+    with mock.patch.object(test_module, "RevNotificationRecord", MockRec):
+        await test_module.on_revocation_published(profile, event)
+
+    MockRec.query_by_rev_reg_id.assert_called_once()
+    assert mock_rec.delete_record.call_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The revocation notification not sending ended up being a simple bug. The crids from the ledger response was a list of integers but the list comprehension statement was expecting strings as thats what it gets from the wallet. I solved this by converting the list to strings to allow the payload to send integers. Think this is slightly better then making sure everywhere that ever uses this event handler is sending strings. Also added a bit better logging.

One thing I noticed is that both v1 and v2 handlers are both handling the same event. The first handler (v1 is loaded first) deletes the record so the v2 won't send the message. Not sure if this is what we want or not. Also the v1 wasn't using the `revocation.notify` config. So that is a bug as well I think. I changed v1 to recognize that config now.

Ran into a lot of things with testing traction locally against new acapy changes.