### PR TITLE
Send revocation list instead of rev_list object - Anoncreds

### DIFF
--- a/aries_cloudagent/anoncreds/revocation.py
+++ b/aries_cloudagent/anoncreds/revocation.py
@@ -494,7 +494,9 @@ class AnonCredsRevocation:
 
             if result.revocation_list_state.state == STATE_FINISHED:
                 await self.notify(
-                    RevListFinishedEvent.with_payload(rev_list.rev_reg_def_id, rev_list)
+                    RevListFinishedEvent.with_payload(
+                        rev_list.rev_reg_def_id, rev_list.revocation_list
+                    )
                 )
 
         except AskarError as err:

--- a/aries_cloudagent/protocols/revocation_notification/v1_0/routes.py
+++ b/aries_cloudagent/protocols/revocation_notification/v1_0/routes.py
@@ -54,6 +54,10 @@ async def on_revocation_published(profile: Profile, event: Event):
                     await responder.send(
                         record.to_message(), connection_id=record.connection_id
                     )
+                    LOGGER.info(
+                        "Sent revocation notification for credential to %s",
+                        record.connection_id,
+                    )
 
     except StorageNotFoundError:
         LOGGER.info(


### PR DESCRIPTION
Fixes anoncreds specific problem on initial rev_list. Was sending the rev_list object to the event handler instead of the actual list.

Added a log message to v1 handler for after the message has been sent.