### PR TITLE
patch for #2781: User Agent header in doc loader

### DIFF
--- a/aries_cloudagent/vc/ld_proofs/document_downloader.py
+++ b/aries_cloudagent/vc/ld_proofs/document_downloader.py
@@ -9,6 +9,7 @@ import string
 from typing import Dict, Optional
 import urllib.parse as urllib_parse
 from importlib import resources
+from ...version import __version__
 
 import requests
 from pyld import jsonld
@@ -122,6 +123,7 @@ class JsonLdDocumentDownloader:
             headers = options.get("headers")
             if headers is None:
                 headers = {"Accept": "application/ld+json, application/json"}
+            headers["User-Agent"] = f"AriesCloudAgent/{__version__}"
             response = requests.get(url, headers=headers, **kwargs)
 
             content_type = response.headers.get("content-type")


### PR DESCRIPTION
a patch for #2781 (see issue description). Longer term acapy may consider making a User Agent header globally for all requests, and perhaps configurable. however this one gets us by