### PR TITLE
Integration tests - Add retry to did registration

### DIFF
--- a/demo/bdd_support/agent_backchannel_client.py
+++ b/demo/bdd_support/agent_backchannel_client.py
@@ -4,7 +4,6 @@ import uuid
 
 from runners.agent_container import AgentContainer, create_agent_with_args_list
 
-
 ######################################################################
 # coroutine utilities
 ######################################################################
@@ -246,6 +245,7 @@ def agent_container_POST(
     data: dict = None,
     text: bool = False,
     params: dict = None,
+    raise_error: bool = True,
 ) -> dict:
     return run_coroutine(
         the_container.admin_POST,
@@ -253,6 +253,7 @@ def agent_container_POST(
         data=data,
         text=text,
         params=params,
+        raise_error=raise_error,
     )
 
 

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -7,26 +7,25 @@ import random
 import sys
 import time
 from typing import List
+
 import yaml
-
-from qrcode import QRCode
-
 from aiohttp import ClientError
+from qrcode import QRCode
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from runners.support.agent import (  # noqa:E402
-    DemoAgent,
-    default_genesis_txns,
-    start_mediator_agent,
-    connect_wallet_to_mediator,
-    start_endorser_agent,
-    connect_wallet_to_endorser,
-    WALLET_TYPE_INDY,
     CRED_FORMAT_INDY,
     CRED_FORMAT_JSON_LD,
     DID_METHOD_KEY,
     KEY_TYPE_BLS,
+    WALLET_TYPE_INDY,
+    DemoAgent,
+    connect_wallet_to_endorser,
+    connect_wallet_to_mediator,
+    default_genesis_txns,
+    start_endorser_agent,
+    start_mediator_agent,
 )
 from runners.support.utils import (  # noqa:E402
     check_requires,
@@ -35,7 +34,6 @@ from runners.support.utils import (  # noqa:E402
     log_status,
     log_timer,
 )
-
 
 CRED_PREVIEW_TYPE = "https://didcomm.org/issue-credential/2.0/credential-preview"
 SELF_ATTESTED = os.getenv("SELF_ATTESTED")
@@ -1174,7 +1172,9 @@ class AgentContainer:
         """
         return await self.agent.admin_GET(path, text=text, params=params)
 
-    async def admin_POST(self, path, data=None, text=False, params=None) -> dict:
+    async def admin_POST(
+        self, path, data=None, text=False, params=None, raise_error=True
+    ) -> dict:
         """Execute an admin POST request in the context of the current wallet.
 
         path = /path/of/request
@@ -1182,7 +1182,9 @@ class AgentContainer:
         text = True if the expected response is text, False if json data
         params = any additional parameters to pass with the request
         """
-        return await self.agent.admin_POST(path, data=data, text=text, params=params)
+        return await self.agent.admin_POST(
+            path, data=data, text=text, params=params, raise_error=raise_error
+        )
 
     async def admin_PATCH(self, path, data=None, text=False, params=None) -> dict:
         """Execute an admin PATCH request in the context of the current wallet.

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -1,6 +1,4 @@
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
-import asyncpg
 import base64
 import functools
 import json
@@ -9,17 +7,18 @@ import os
 import random
 import subprocess
 import sys
-import yaml
-
+from concurrent.futures import ThreadPoolExecutor
 from timeit import default_timer
 
+import asyncpg
+import yaml
 from aiohttp import (
-    web,
-    ClientSession,
+    ClientError,
     ClientRequest,
     ClientResponse,
-    ClientError,
+    ClientSession,
     ClientTimeout,
+    web,
 )
 
 from .utils import flatten, log_json, log_msg, log_timer, output_reader
@@ -1045,17 +1044,17 @@ class DemoAgent:
         )
 
     async def handle_endorse_transaction(self, message):
-        self.log(f"Received endorse transaction ...\n", source="stderr")
+        self.log("Received endorse transaction ...\n", source="stderr")
 
     async def handle_revocation_registry(self, message):
         reg_id = message.get("revoc_reg_id", "(undetermined)")
         self.log(f"Revocation registry: {reg_id} state: {message['state']}")
 
     async def handle_mediation(self, message):
-        self.log(f"Received mediation message ...\n")
+        self.log("Received mediation message ...\n")
 
     async def handle_keylist(self, message):
-        self.log(f"Received handle_keylist message ...\n")
+        self.log("Received handle_keylist message ...\n")
         self.log(json.dumps(message))
 
     async def taa_accept(self):
@@ -1167,7 +1166,7 @@ class DemoAgent:
             raise
 
     async def admin_POST(
-        self, path, data=None, text=False, params=None, headers=None
+        self, path, data=None, text=False, params=None, headers=None, raise_error=True
     ) -> ClientResponse:
         try:
             EVENT_LOGGER.debug(
@@ -1192,6 +1191,8 @@ class DemoAgent:
             return response
         except ClientError as e:
             self.log(f"Error during POST {path}: {str(e)}")
+            if not raise_error:
+                return None
             raise
 
     async def admin_PATCH(


### PR DESCRIPTION
I'm pretty sure this solves a majority of the problems with the endorsement integration tests. I have run the tests 9 times and not seen the DID not registered error. 

I did get one, unrelated fail about the cred_def not being in the wallet. This seems to be much less often and I will create other tickets, for the other fails, when I see them.

This fix passes an option to fail or not through the POST backchannel, which defaults to true. It will try the promote did call three times if it fails before failing the test.