### PR TITLE
Add functionality for building and running agents seprately

### DIFF
--- a/demo/run_demo
+++ b/demo/run_demo
@@ -4,8 +4,16 @@ shopt -s nocasematch
 
 cd $(dirname $0)
 
-AGENT="$1"
-shift
+RESOLUTION="$1"
+# Check if RESOLUTION is not provided or not a valid option
+if [ -z "$RESOLUTION" ] || [ "$RESOLUTION" != "build" -a "$RESOLUTION" != "run" ]; then
+  echo "Resolution not specified or invalid."
+  AGENT="$1"  # If RESOLUTION is not provided or invalid, assume argument is AGENT
+else
+  shift  # Shift only if RESOLUTION is provided and valid
+  AGENT="$1"
+fi
+shift  # Shift again to remove AGENT from the arguments
 ARGS=""
 
 TRACE_ENABLED=""
@@ -107,8 +115,9 @@ do
     cat <<EOF
 
 Usage:
-   ./demo_run <agent> [OPTIONS]
+   ./demo_run <resolution> <agent> [OPTIONS]
 
+   - <resolution> is one of the docker option to build or run.
    - <agent> is one of alice, faber, acme, performance.
    - Options:
       --events - display on the terminal the webhook events from the ACA-Py agent.
@@ -127,6 +136,19 @@ EOF
   esac
   ARGS="${ARGS:+$ARGS }$i"
 done
+
+if [ -z "$RESOLUTION" ]; then
+  echo "Resolution not specified."
+elif [ "$RESOLUTION" = "build" ]; then
+  DOCKER_RESOLUTION="build"
+  echo "Agent will be build."
+elif [ "$RESOLUTION" = "run" ]; then
+  DOCKER_RESOLUTION="run"
+  echo "Agent will be run."
+else
+  echo "You can utilize the 'build' option to build the agent or the 'run' option to run the agent."
+fi
+
 
 if [ "$AGENT" = "faber" ]; then
   AGENT_MODULE="faber"
@@ -155,9 +177,18 @@ if [ ! -z "$AGENT_PORT_OVERRIDE" ]; then
   AGENT_PORT_RANGE="$AGENT_PORT-$AGENT_PORT_END"
 fi
 
-echo "Preparing agent image..."
-docker build -t acapy-base -f ../docker/Dockerfile .. || exit 1
-docker build -t faber-alice-demo -f ../docker/Dockerfile.demo --build-arg from_image=acapy-base .. || exit 1
+# 1. Build the agent image
+if [ -z "$DOCKER_RESOLUTION" ] || [ "$DOCKER_RESOLUTION" = "build" ]; then
+  echo "Preparing agent image..."
+  docker build -t acapy-base -f ../docker/Dockerfile .. || exit 1
+  docker build -t faber-alice-demo -f ../docker/Dockerfile.demo --build-arg from_image=acapy-base .. || exit 1
+fi
+
+if [ "$DOCKER_RESOLUTION" = "build" ]; then
+  exit 1
+else
+  echo "You can utilize the 'build' option to build the agent or the 'run' option to run the agent."
+fi
 
 if [ ! -z "$DOCKERHOST" ]; then
   # provided via APPLICATION_URL environment variable
@@ -263,8 +294,13 @@ fi
 DOCKER=${DOCKER:-docker}
 
 $DOCKER run --name $AGENT --rm -it ${DOCKER_OPTS} \
-  --network=${DOCKER_NET} \
-  -p 0.0.0.0:$AGENT_PORT_RANGE:$AGENT_PORT_RANGE \
-  ${DOCKER_VOL} \
-  $DOCKER_ENV \
-  faber-alice-demo $AGENT_MODULE --port $AGENT_PORT $ARGS
+    --network=${DOCKER_NET} \
+    -p 0.0.0.0:$AGENT_PORT_RANGE:$AGENT_PORT_RANGE \
+    ${DOCKER_VOL} \
+    $(if [ "$DOCKER_RESOLUTION" = "run" ]; then
+      echo "-v $(pwd)/../aries_cloudagent:/home/aries/aries_cloudagent \
+      -v $(pwd)/../scripts:/home/aries/scripts \
+      -v $(pwd)/../demo:/home/aries/demo"
+    fi) \
+    $DOCKER_ENV \
+    faber-alice-demo $AGENT_MODULE --port $AGENT_PORT $ARGS

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -419,6 +419,18 @@ To pass extra arguements to the agent (for example):
 DEMO_EXTRA_AGENT_ARGS="[\"--emit-did-peer-2\"]" ./run_demo faber --did-exchange --reuse-connections
 ```
 
+Additionally, separating the build and run functionalities in the script allows for smoother development and debugging processes. With the mounting of volumes from the host into the Docker container, code changes can be automatically reloaded without the need to repeatedly restart the demo.
+
+Build Command:
+```bash
+./demo/run_demo build alice --wallet-type askar-anoncreds --events
+```
+
+Run Command:
+```bash
+./demo/run_demo run alice --wallet-type askar-anoncreds --events
+```
+
 ## Learning about the Alice/Faber code
 
 These Alice and Faber scripts (in the `demo/runners` folder) implement the controller and run the agent as a sub-process (see the documentation for `aca-py`). The controller publishes a REST service to receive web hook callbacks from their agent. Note that this architecture, running the agent as a sub-process, is a variation on the documented architecture of running the controller and agent as separate processes/containers.

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -419,7 +419,7 @@ To pass extra arguements to the agent (for example):
 DEMO_EXTRA_AGENT_ARGS="[\"--emit-did-peer-2\"]" ./run_demo faber --did-exchange --reuse-connections
 ```
 
-Additionally, separating the build and run functionalities in the script allows for smoother development and debugging processes. With the mounting of volumes from the host into the Docker container, code changes can be automatically reloaded without the need to repeatedly restart the demo.
+Additionally, separating the build and run functionalities in the script allows for smoother development and debugging processes. With the mounting of volumes from the host into the Docker container, code changes can be automatically reloaded without the need to repeatedly build the demo.
 
 Build Command:
 ```bash


### PR DESCRIPTION
1. Added support for building the agent image using 'build'
2. Implemented the ability to start the agent container with 'start' with host files mounted into docker container
3. Updated the script to handle the 'resolution' command with its options(build & run)

Build
`./demo/run_demo build alice --wallet-type askar-anoncreds --events
`
Run
`./demo/run_demo run alice --wallet-type askar-anoncreds --events
`
