### PR TITLE
Prevent revocable cred def being created without tails server

### DIFF
--- a/aries_cloudagent/anoncreds/issuer.py
+++ b/aries_cloudagent/anoncreds/issuer.py
@@ -312,6 +312,15 @@ class AnonCredsIssuer:
         if not isinstance(max_cred_num, int):
             raise ValueError("max_cred_num must be an integer")
 
+        # Don't allow revocable cred def to be created without tails server base url
+        if (
+            not self.profile.settings.get("tails_server_base_url")
+            and support_revocation
+        ):
+            raise AnonCredsIssuerError(
+                "tails_server_base_url not configured. Can't create revocable credential definition."  # noqa: E501
+            )
+
         anoncreds_registry = self.profile.inject(AnonCredsRegistry)
         schema_result = await anoncreds_registry.get_schema(self.profile, schema_id)
 

--- a/aries_cloudagent/anoncreds/routes.py
+++ b/aries_cloudagent/anoncreds/routes.py
@@ -322,6 +322,7 @@ class CredDefPostOptionsSchema(OpenAPISchema):
     revocation_registry_size = fields.Int(
         metadata={
             "description": "Maximum number of credential revocations per registry",
+            "example": 1000,
         },
         required=False,
     )

--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -14,7 +14,6 @@ from aiohttp_apispec import (
     request_schema,
     response_schema,
 )
-
 from marshmallow import fields
 
 from ...admin.request_context import AdminRequestContext
@@ -210,6 +209,12 @@ async def credential_definitions_send_credential_definition(request: web.BaseReq
     support_revocation = bool(body.get("support_revocation"))
     tag = body.get("tag")
     rev_reg_size = body.get("revocation_registry_size")
+
+    # Don't allow revocable cred def to be created without tails server base url
+    if not profile.settings.get("tails_server_base_url") and support_revocation:
+        raise web.HTTPBadRequest(
+            reason="tails_server_base_url not configured. Can't create revocable credential definition."  # noqa: E501
+        )
 
     tag_query = {"schema_id": schema_id}
     async with profile.session() as session:


### PR DESCRIPTION
Addresses https://github.com/hyperledger/aries-cloudagent-python/issues/2838.

Simply returns an error response when creating a revocable cred def without a tails file configured. 