### PR TITLE
Update GHA so that broken image links work on docs site - without breaking them on GitHub

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -41,6 +41,10 @@ jobs:
           for i in *.md; do sed -e "s#docs/#./#g" $i >docs/$i; done
           # Fix references in DevReadMe.md to moved files
           sed -e "s#\.\./\.\./#../#" docs/features/DevReadMe.md >tmp.md; mv tmp.md docs/features/DevReadMe.md
+          # Fix image references in demo documents so they work in GitHub and mkdocs
+          grep collateral docs/demo/AriesOpenAPIDemo.md
+          for i in docs/demo/AriesOpenAPIDemo.md docs/demo/AliceGetsAPhone.md; do sed -e "s#src=.collateral#src=\"../collateral#" $i >$i.tmp; mv $i.tmp $i; done
+          grep collateral docs/demo/AriesOpenAPIDemo.md
           # Populate overrides for the current version, and then remove to not apply if VERSION is main branch
           OVERRIDE=overrides/main.html
           echo -e "{% extends \"base.html\" %}\n\n{% block outdated %}\n  You are viewing the documentation for ACA-Py Release $VERSION.\n{% endblock %}" >$OVERRIDE

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -42,9 +42,7 @@ jobs:
           # Fix references in DevReadMe.md to moved files
           sed -e "s#\.\./\.\./#../#" docs/features/DevReadMe.md >tmp.md; mv tmp.md docs/features/DevReadMe.md
           # Fix image references in demo documents so they work in GitHub and mkdocs
-          grep collateral docs/demo/AriesOpenAPIDemo.md
           for i in docs/demo/AriesOpenAPIDemo.md docs/demo/AliceGetsAPhone.md; do sed -e "s#src=.collateral#src=\"../collateral#" $i >$i.tmp; mv $i.tmp $i; done
-          grep collateral docs/demo/AriesOpenAPIDemo.md
           # Populate overrides for the current version, and then remove to not apply if VERSION is main branch
           OVERRIDE=overrides/main.html
           echo -e "{% extends \"base.html\" %}\n\n{% block outdated %}\n  You are viewing the documentation for ACA-Py Release $VERSION.\n{% endblock %}" >$OVERRIDE


### PR DESCRIPTION
Links to images are different when the markdown page is displayed by GitHub vs. when deployed as documentation. Fix the links on the fly as the mkdocs site is created.
