### PR TITLE
chore: propose official deprecations of a couple of features

### DIFF
--- a/aries_cloudagent/config/logging.py
+++ b/aries_cloudagent/config/logging.py
@@ -327,15 +327,26 @@ class LoggingConfigurator:
     @classmethod
     def print_notices(cls, settings: Settings):
         """Print notices and warnings."""
-        if settings.get("wallet.type", "in_memory").lower() == "indy":
-            with Banner(border=":", length=80, file=sys.stderr) as banner:
-                banner.centered("⚠ DEPRECATION NOTICE: ⚠")
-                banner.hr()
+        with Banner(border=":", length=80, file=sys.stderr) as banner:
+            banner.centered("⚠ DEPRECATION NOTICE: ⚠")
+            banner.hr()
+            if settings.get("wallet.type", "in_memory").lower() == "indy":
                 banner.print(
                     "The Indy wallet type is deprecated, use Askar instead; see: "
                     "https://aca-py.org/main/deploying/IndySDKtoAskarMigration/",
                 )
-            print()
+                banner.hr()
+            banner.print(
+                "Aries RFC 0160: Connection Protocol is deprecated and support will be "
+                "removed in a future version; use RFC 0023: DID Exchange instead."
+            )
+            banner.hr()
+            banner.print(
+                "Using `did:sov:BzCbsNYhMrjHiqZDTUASHg;spec` in protocols is deprecated "
+                "and support will be removed in a future version; use "
+                "https://didcomm.org/ instead."
+            )
+        print()
 
 
 ######################################################################

--- a/aries_cloudagent/config/logging.py
+++ b/aries_cloudagent/config/logging.py
@@ -342,9 +342,11 @@ class LoggingConfigurator:
             )
             banner.hr()
             banner.print(
-                "Using `did:sov:BzCbsNYhMrjHiqZDTUASHg;spec` in protocols is deprecated "
-                "and support will be removed in a future version; use "
-                "https://didcomm.org/ instead."
+                "Receiving a core DIDComm protocol with the "
+                "`did:sov:BzCbsNYhMrjHiqZDTUASHg;spec` prefix is deprecated. All parties "
+                "sending this prefix should be notified that support for receiving such "
+                "messages will be removed in an upcoming ACA-Py release. "
+                "Use https://didcomm.org/ instead."
             )
         print()
 

--- a/aries_cloudagent/config/logging.py
+++ b/aries_cloudagent/config/logging.py
@@ -337,16 +337,26 @@ class LoggingConfigurator:
                 )
                 banner.hr()
             banner.print(
-                "Aries RFC 0160: Connection Protocol is deprecated and support will be "
-                "removed in a future version; use RFC 0023: DID Exchange instead."
-            )
-            banner.hr()
-            banner.print(
                 "Receiving a core DIDComm protocol with the "
                 "`did:sov:BzCbsNYhMrjHiqZDTUASHg;spec` prefix is deprecated. All parties "
                 "sending this prefix should be notified that support for receiving such "
-                "messages will be removed in an upcoming ACA-Py release. "
+                "messages will be removed in a future release. "
                 "Use https://didcomm.org/ instead."
+            )
+            banner.hr()
+            banner.print(
+                "Aries RFC 0160: Connection Protocol is deprecated and support will be "
+                "removed in a future release; use RFC 0023: DID Exchange instead."
+            )
+            banner.hr()
+            banner.print(
+                "Aries RFC 0036: Issue Credential 1.0 is deprecated and support will be "
+                "removed in a future release; use RFC 0453: Issue Credential 2.0 instead."
+            )
+            banner.hr()
+            banner.print(
+                "Aries RFC 0037: Present Proof 1.0 is deprecated and support will be "
+                "removed in a future release; use RFC 0454: Present Proof 2.0 instead."
             )
         print()
 

--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -292,14 +292,14 @@ class Dispatcher:
                 "Received a core DIDComm protocol with the deprecated "
                 "`did:sov:BzCbsNYhMrjHiqZDTUASHg;spec` prefix. The sending party should "
                 "be notified that support for receiving such messages will be removed in "
-                "an upcoming ACA-Py release. Use https://didcomm.org/ instead.",
+                "a future release. Use https://didcomm.org/ instead.",
                 DeprecationWarning,
             )
             self.logger.warning(
                 "Received a core DIDComm protocol with the deprecated "
                 "`did:sov:BzCbsNYhMrjHiqZDTUASHg;spec` prefix. The sending party should "
                 "be notified that support for receiving such messages will be removed in "
-                "an upcoming ACA-Py release. Use https://didcomm.org/ instead.",
+                "a future release. Use https://didcomm.org/ instead.",
             )
 
         message_type_rec_version = get_version_from_message_type(message_type)

--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -286,6 +286,20 @@ class Dispatcher:
 
         if not message_type:
             raise MessageParseError("Message does not contain '@type' parameter")
+
+        if message_type.startswith("did:sov"):
+            warnings.warn(
+                "Using `did:sov:BzCbsNYhMrjHiqZDTUASHg;spec` in protocols is deprecated "
+                "and support will be removed in a future version; use "
+                "https://didcomm.org/ instead.",
+                DeprecationWarning,
+            )
+            self.logger.warning(
+                "Using `did:sov:BzCbsNYhMrjHiqZDTUASHg;spec` in protocols is deprecated "
+                "and support will be removed in a future version; use "
+                "https://didcomm.org/ instead.",
+            )
+
         message_type_rec_version = get_version_from_message_type(message_type)
 
         registry: ProtocolRegistry = self.profile.inject(ProtocolRegistry)

--- a/aries_cloudagent/core/dispatcher.py
+++ b/aries_cloudagent/core/dispatcher.py
@@ -289,15 +289,17 @@ class Dispatcher:
 
         if message_type.startswith("did:sov"):
             warnings.warn(
-                "Using `did:sov:BzCbsNYhMrjHiqZDTUASHg;spec` in protocols is deprecated "
-                "and support will be removed in a future version; use "
-                "https://didcomm.org/ instead.",
+                "Received a core DIDComm protocol with the deprecated "
+                "`did:sov:BzCbsNYhMrjHiqZDTUASHg;spec` prefix. The sending party should "
+                "be notified that support for receiving such messages will be removed in "
+                "an upcoming ACA-Py release. Use https://didcomm.org/ instead.",
                 DeprecationWarning,
             )
             self.logger.warning(
-                "Using `did:sov:BzCbsNYhMrjHiqZDTUASHg;spec` in protocols is deprecated "
-                "and support will be removed in a future version; use "
-                "https://didcomm.org/ instead.",
+                "Received a core DIDComm protocol with the deprecated "
+                "`did:sov:BzCbsNYhMrjHiqZDTUASHg;spec` prefix. The sending party should "
+                "be notified that support for receiving such messages will be removed in "
+                "an upcoming ACA-Py release. Use https://didcomm.org/ instead.",
             )
 
         message_type_rec_version = get_version_from_message_type(message_type)

--- a/aries_cloudagent/protocols/connections/v1_0/manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/manager.py
@@ -2,6 +2,7 @@
 
 import logging
 from typing import Optional, Sequence, Tuple, Union, cast
+import warnings
 
 from ....connections.base_manager import BaseConnectionManager
 from ....connections.models.conn_record import ConnRecord
@@ -51,6 +52,18 @@ class ConnectionManager(BaseConnectionManager):
 
         """
         return self._profile
+
+    def deprecation_warning(self):
+        """Log a deprecation warning."""
+        warnings.warn(
+            "Aries RFC 0160: Connection Protocol is deprecated and support will be "
+            "removed in a future version; use RFC 0023: DID Exchange instead.",
+            DeprecationWarning,
+        )
+        self._logger.warning(
+            "Aries RFC 0160: Connection Protocol is deprecated and support will be "
+            "removed in a future version; use RFC 0023: DID Exchange instead."
+        )
 
     async def create_invitation(
         self,
@@ -107,6 +120,7 @@ class ConnectionManager(BaseConnectionManager):
             A tuple of the new `ConnRecord` and `ConnectionInvitation` instances
 
         """
+        self.deprecation_warning()
         # Mediation Record can still be None after this operation if no
         # mediation id passed and no default
         mediation_record = await self._route_manager.mediation_record_if_id(
@@ -257,6 +271,7 @@ class ConnectionManager(BaseConnectionManager):
             The new `ConnRecord` instance
 
         """
+        self.deprecation_warning()
         if not invitation.did:
             if not invitation.recipient_keys:
                 raise ConnectionManagerError(
@@ -338,6 +353,7 @@ class ConnectionManager(BaseConnectionManager):
             A new `ConnectionRequest` message to send to the other agent
 
         """
+        self.deprecation_warning()
 
         mediation_records = await self._route_manager.mediation_records_for_connection(
             self.profile,
@@ -411,6 +427,7 @@ class ConnectionManager(BaseConnectionManager):
             The new or updated `ConnRecord` instance
 
         """
+        self.deprecation_warning()
         ConnRecord.log_state(
             "Receiving connection request",
             {"request": request},
@@ -575,6 +592,7 @@ class ConnectionManager(BaseConnectionManager):
             A tuple of the updated `ConnRecord` new `ConnectionResponse` message
 
         """
+        self.deprecation_warning()
         ConnRecord.log_state(
             "Creating connection response",
             {"connection_id": connection.connection_id},
@@ -686,6 +704,7 @@ class ConnectionManager(BaseConnectionManager):
                 at the request or response stage
 
         """
+        self.deprecation_warning()
         connection = None
         if response._thread:
             # identify the request by the thread ID
@@ -765,6 +784,7 @@ class ConnectionManager(BaseConnectionManager):
         report: ConnectionProblemReport,
     ):
         """Receive problem report."""
+        self.deprecation_warning()
         if not report.description:
             raise ConnectionManagerError("Missing description in problem report")
 

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -594,6 +594,7 @@ async def connections_metadata_set(request: web.BaseRequest):
 @docs(
     tags=["connection"],
     summary="Create a new connection invitation",
+    deprecated=True,
 )
 @querystring_schema(CreateInvitationQueryStringSchema())
 @request_schema(CreateInvitationRequestSchema())
@@ -667,6 +668,7 @@ async def connections_create_invitation(request: web.BaseRequest):
 @docs(
     tags=["connection"],
     summary="Receive a new connection invitation",
+    deprecated=True,
 )
 @querystring_schema(ReceiveInvitationQueryStringSchema())
 @request_schema(ReceiveInvitationRequestSchema())
@@ -708,6 +710,7 @@ async def connections_receive_invitation(request: web.BaseRequest):
 @docs(
     tags=["connection"],
     summary="Accept a stored connection invitation",
+    deprecated=True,
 )
 @match_info_schema(ConnectionsConnIdMatchInfoSchema())
 @querystring_schema(AcceptInvitationQueryStringSchema())
@@ -758,6 +761,7 @@ async def connections_accept_invitation(request: web.BaseRequest):
 @docs(
     tags=["connection"],
     summary="Accept a stored connection request",
+    deprecated=True,
 )
 @match_info_schema(ConnectionsConnIdMatchInfoSchema())
 @querystring_schema(AcceptRequestQueryStringSchema())

--- a/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
@@ -377,6 +377,7 @@ class V10CredentialExchangeAutoRemoveRequestSchema(OpenAPISchema):
 @docs(
     tags=["issue-credential v1.0"],
     summary="Fetch all credential exchange records",
+    deprecated=True,
 )
 @querystring_schema(V10CredentialExchangeListQueryStringSchema)
 @response_schema(V10CredentialExchangeListResultSchema(), 200, description="")
@@ -417,6 +418,7 @@ async def credential_exchange_list(request: web.BaseRequest):
 @docs(
     tags=["issue-credential v1.0"],
     summary="Fetch a single credential exchange record",
+    deprecated=True,
 )
 @match_info_schema(CredExIdMatchInfoSchema())
 @response_schema(V10CredentialExchangeSchema(), 200, description="")
@@ -463,6 +465,7 @@ async def credential_exchange_retrieve(request: web.BaseRequest):
         "Create a credential record without "
         "sending (generally for use with Out-Of-Band)"
     ),
+    deprecated=True,
 )
 @request_schema(V10CredentialCreateSchema())
 @response_schema(V10CredentialExchangeSchema(), 200, description="")
@@ -541,6 +544,7 @@ async def credential_exchange_create(request: web.BaseRequest):
 @docs(
     tags=["issue-credential v1.0"],
     summary="Send holder a credential, automating entire flow",
+    deprecated=True,
 )
 @request_schema(V10CredentialProposalRequestMandSchema())
 @response_schema(V10CredentialExchangeSchema(), 200, description="")
@@ -642,6 +646,7 @@ async def credential_exchange_send(request: web.BaseRequest):
 @docs(
     tags=["issue-credential v1.0"],
     summary="Send issuer a credential proposal",
+    deprecated=True,
 )
 @request_schema(V10CredentialProposalRequestOptSchema())
 @response_schema(V10CredentialExchangeSchema(), 200, description="")
@@ -764,6 +769,7 @@ async def _create_free_offer(
 @docs(
     tags=["issue-credential v1.0"],
     summary="Create a credential offer, independent of any proposal or connection",
+    deprecated=True,
 )
 @request_schema(V10CredentialConnFreeOfferRequestSchema())
 @response_schema(V10CredentialExchangeSchema(), 200, description="")
@@ -837,6 +843,7 @@ async def credential_exchange_create_free_offer(request: web.BaseRequest):
 @docs(
     tags=["issue-credential v1.0"],
     summary="Send holder a credential offer, independent of any proposal",
+    deprecated=True,
 )
 @request_schema(V10CredentialFreeOfferRequestSchema())
 @response_schema(V10CredentialExchangeSchema(), 200, description="")
@@ -925,6 +932,7 @@ async def credential_exchange_send_free_offer(request: web.BaseRequest):
 @docs(
     tags=["issue-credential v1.0"],
     summary="Send holder a credential offer in reference to a proposal with preview",
+    deprecated=True,
 )
 @match_info_schema(CredExIdMatchInfoSchema())
 @request_schema(V10CredentialBoundOfferRequestSchema())
@@ -1024,6 +1032,7 @@ async def credential_exchange_send_bound_offer(request: web.BaseRequest):
 @docs(
     tags=["issue-credential v1.0"],
     summary="Send issuer a credential request",
+    deprecated=True,
 )
 @match_info_schema(CredExIdMatchInfoSchema())
 @request_schema(V10CredentialExchangeAutoRemoveRequestSchema())
@@ -1139,6 +1148,7 @@ async def credential_exchange_send_request(request: web.BaseRequest):
 @docs(
     tags=["issue-credential v1.0"],
     summary="Send holder a credential",
+    deprecated=True,
 )
 @match_info_schema(CredExIdMatchInfoSchema())
 @request_schema(V10CredentialIssueRequestSchema())
@@ -1234,6 +1244,7 @@ async def credential_exchange_issue(request: web.BaseRequest):
 @docs(
     tags=["issue-credential v1.0"],
     summary="Store a received credential",
+    deprecated=True,
 )
 @match_info_schema(CredExIdMatchInfoSchema())
 @request_schema(V10CredentialStoreRequestSchema())
@@ -1338,6 +1349,7 @@ async def credential_exchange_store(request: web.BaseRequest):
 @docs(
     tags=["issue-credential v1.0"],
     summary="Send a problem report for credential exchange",
+    deprecated=True,
 )
 @match_info_schema(CredExIdMatchInfoSchema())
 @request_schema(V10CredentialProblemReportRequestSchema())
@@ -1384,6 +1396,7 @@ async def credential_exchange_problem_report(request: web.BaseRequest):
 @docs(
     tags=["issue-credential v1.0"],
     summary="Remove an existing credential exchange record",
+    deprecated=True,
 )
 @match_info_schema(CredExIdMatchInfoSchema())
 @response_schema(IssueCredentialModuleResponseSchema(), 200, description="")

--- a/aries_cloudagent/protocols/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/routes.py
@@ -282,7 +282,11 @@ class V10PresExIdMatchInfoSchema(OpenAPISchema):
     )
 
 
-@docs(tags=["present-proof v1.0"], summary="Fetch all present-proof exchange records")
+@docs(
+    tags=["present-proof v1.0"],
+    summary="Fetch all present-proof exchange records",
+    deprecated=True,
+)
 @querystring_schema(V10PresentationExchangeListQueryStringSchema)
 @response_schema(V10PresentationExchangeListSchema(), 200, description="")
 async def presentation_exchange_list(request: web.BaseRequest):
@@ -322,6 +326,7 @@ async def presentation_exchange_list(request: web.BaseRequest):
 @docs(
     tags=["present-proof v1.0"],
     summary="Fetch a single presentation exchange record",
+    deprecated=True,
 )
 @match_info_schema(V10PresExIdMatchInfoSchema())
 @response_schema(V10PresentationExchangeSchema(), 200, description="")
@@ -369,6 +374,7 @@ async def presentation_exchange_retrieve(request: web.BaseRequest):
 @docs(
     tags=["present-proof v1.0"],
     summary="Fetch credentials for a presentation request from wallet",
+    deprecated=True,
 )
 @match_info_schema(V10PresExIdMatchInfoSchema())
 @querystring_schema(CredentialsFetchQueryStringSchema())
@@ -446,7 +452,11 @@ async def presentation_exchange_credentials_list(request: web.BaseRequest):
     return web.json_response(credentials)
 
 
-@docs(tags=["present-proof v1.0"], summary="Sends a presentation proposal")
+@docs(
+    tags=["present-proof v1.0"],
+    summary="Sends a presentation proposal",
+    deprecated=True,
+)
 @request_schema(V10PresentationProposalRequestSchema())
 @response_schema(V10PresentationExchangeSchema(), 200, description="")
 async def presentation_exchange_send_proposal(request: web.BaseRequest):
@@ -529,6 +539,7 @@ async def presentation_exchange_send_proposal(request: web.BaseRequest):
 @docs(
     tags=["present-proof v1.0"],
     summary="Creates a presentation request not bound to any proposal or connection",
+    deprecated=True,
 )
 @request_schema(V10PresentationCreateRequestRequestSchema())
 @response_schema(V10PresentationExchangeSchema(), 200, description="")
@@ -606,6 +617,7 @@ async def presentation_exchange_create_request(request: web.BaseRequest):
 @docs(
     tags=["present-proof v1.0"],
     summary="Sends a free presentation request not bound to any proposal",
+    deprecated=True,
 )
 @request_schema(V10PresentationSendRequestRequestSchema())
 @response_schema(V10PresentationExchangeSchema(), 200, description="")
@@ -693,6 +705,7 @@ async def presentation_exchange_send_free_request(request: web.BaseRequest):
 @docs(
     tags=["present-proof v1.0"],
     summary="Sends a presentation request in reference to a proposal",
+    deprecated=True,
 )
 @match_info_schema(V10PresExIdMatchInfoSchema())
 @request_schema(V10PresentationSendRequestToProposalSchema())
@@ -785,7 +798,11 @@ async def presentation_exchange_send_bound_request(request: web.BaseRequest):
     return web.json_response(result)
 
 
-@docs(tags=["present-proof v1.0"], summary="Sends a proof presentation")
+@docs(
+    tags=["present-proof v1.0"],
+    summary="Sends a proof presentation",
+    deprecated=True,
+)
 @match_info_schema(V10PresExIdMatchInfoSchema())
 @request_schema(V10PresentationSendRequestSchema())
 @response_schema(V10PresentationExchangeSchema(), description="")
@@ -899,7 +916,11 @@ async def presentation_exchange_send_presentation(request: web.BaseRequest):
     return web.json_response(result)
 
 
-@docs(tags=["present-proof v1.0"], summary="Verify a received presentation")
+@docs(
+    tags=["present-proof v1.0"],
+    summary="Verify a received presentation",
+    deprecated=True,
+)
 @match_info_schema(V10PresExIdMatchInfoSchema())
 @response_schema(V10PresentationExchangeSchema(), description="")
 async def presentation_exchange_verify_presentation(request: web.BaseRequest):
@@ -972,6 +993,7 @@ async def presentation_exchange_verify_presentation(request: web.BaseRequest):
 @docs(
     tags=["present-proof v1.0"],
     summary="Send a problem report for presentation exchange",
+    deprecated=True,
 )
 @match_info_schema(V10PresExIdMatchInfoSchema())
 @request_schema(V10PresentationProblemReportRequestSchema())
@@ -1013,6 +1035,7 @@ async def presentation_exchange_problem_report(request: web.BaseRequest):
 @docs(
     tags=["present-proof v1.0"],
     summary="Remove an existing presentation exchange record",
+    deprecated=True,
 )
 @match_info_schema(V10PresExIdMatchInfoSchema())
 @response_schema(V10PresentProofModuleResponseSchema(), description="")


### PR DESCRIPTION
With this PR I'd like to propose that we move the following features to deprecated status:

- Aries RFC 160: Connection Protocol
- Aries RFC 0036: Issue Credential 1.0
- Aries RFC 0037: Present Proof 1.0
- `did:sov:...` as Protocol Doc URI

By moving these to deprecated status, we inform the community that these are features that should no longer be used and steer them to DID Exchange and using didcomm.org as the doc uri in their projects.

These items should more or less already be considered deprecated but there are some final efforts that need to be made to tie up loose ends. With the introduction of qualified DIDs in the pending 0.12.0 release and automatically always emitting https://didcomm.org (by setting the flag for it to be permanently set to `true`), we move close enough to these loose ends being tied off to, in my opinion, move these features to official deprecated status.

In practice, this PR affects the code in the following ways:

- Prints a deprecation notice on startup (to stderr) that these features are now deprecated.
- When a message with type starting with `did:sov:` is received, log a deprecation warning
- When a connection protocol operation is taken, log a warning message (this one might be a bit aggressive; I'd be happy to tone this back if it's too much)
- Mark the Admin API endpoints as deprecated in the OpenAPI/Swagger spec and UI. The endpoints are still usable but are greyed out.
  - To clarify, only the Admin API endpoints triggering connection protocol specific operations are marked as deprecated. Other connection management endpoints are NOT marked as deprecated (e.g. listing connections, deleting a connection, etc.).

Let me know your thoughts.