### PR TITLE
Fix run_tests script

### DIFF
--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -42,4 +42,4 @@ fi
 $CONTAINER_RUNTIME run --rm -ti --name aries-cloudagent-runner \
   --platform linux/amd64 \
 	-v "$(pwd)/../test-reports:/usr/src/app/test-reports:z" \
-	$DOCKER_ARGS localhost/aries-cloudagent-test "$@"
+	$DOCKER_ARGS aries-cloudagent-test "$@"


### PR DESCRIPTION
Fix a change that I think @dbluhm did awhile back, which is now causing issues when trying to run tests locally.

@dbluhm  what was the reason for the fix?  This PR removes your change but maybe there is an alternative that addresses your reasons without breaking local tests ...
