### PR TITLE
Add missing verificaiton method option

### DIFF
--- a/aries_cloudagent/vc/routes.py
+++ b/aries_cloudagent/vc/routes.py
@@ -186,7 +186,7 @@ async def prove_presentation_route(request: web.BaseRequest):
         options = {} if "options" not in body else body["options"]
 
         # We derive the proofType from the holder DID if not provided in options
-        if not options.get("type", None):
+        if not options.get("proofType", None):
             holder = presentation["holder"]
             did = holder if isinstance(holder, str) else holder["id"]
             async with context.session() as session:
@@ -198,8 +198,6 @@ async def prove_presentation_route(request: web.BaseRequest):
                 options["proofType"] = "Ed25519Signature2020"
             elif key_type == "bls12381g2":
                 options["proofType"] = "BbsBlsSignature2020"
-        else:
-            options["proofType"] = options.pop("type")
 
         presentation = VerifiablePresentation.deserialize(presentation)
         options = LDProofVCOptions.deserialize(options)

--- a/aries_cloudagent/vc/routes.py
+++ b/aries_cloudagent/vc/routes.py
@@ -81,7 +81,7 @@ async def issue_credential_route(request: web.BaseRequest):
         options = {} if "options" not in body else body["options"]
 
         # We derive the proofType from the issuer DID if not provided in options
-        if not options.get("type", None) and not options.get("proofType", None):
+        if not options.get("proofType", None):
             issuer = credential["issuer"]
             did = issuer if isinstance(issuer, str) else issuer["id"]
             async with context.session() as session:
@@ -93,10 +93,6 @@ async def issue_credential_route(request: web.BaseRequest):
                 options["proofType"] = "Ed25519Signature2020"
             elif key_type == "bls12381g2":
                 options["proofType"] = "BbsBlsSignature2020"
-        else:
-            options["proofType"] = (
-                options.pop("type") if "type" in options else options["proofType"]
-            )
 
         credential = VerifiableCredential.deserialize(credential)
         options = LDProofVCOptions.deserialize(options)

--- a/aries_cloudagent/vc/vc_ld/models/web_schemas.py
+++ b/aries_cloudagent/vc/vc_ld/models/web_schemas.py
@@ -1,12 +1,8 @@
 """VC-API routes web requests schemas."""
 
-from marshmallow import fields, Schema
+from marshmallow import fields
 from ....messaging.models.openapi import OpenAPISchema
 
-from ....messaging.valid import (
-    RFC3339_DATETIME_EXAMPLE,
-    UUID4_EXAMPLE,
-)
 from ..validation_result import (
     PresentationVerificationResultSchema,
 )
@@ -19,36 +15,6 @@ from .presentation import (
     PresentationSchema,
     VerifiablePresentationSchema,
 )
-
-
-class IssuanceOptionsSchema(Schema):
-    """Linked data proof verifiable credential options schema."""
-
-    proof_type = fields.Str(
-        data_key="proofType",
-        required=False, 
-        metadata={"example": "Ed25519Signature2020"}
-        )
-    proof_purpose = fields.Str(
-        data_key="proofPurpose",
-        required=False, 
-        metadata={"example": "assertionMethod"}
-        )
-    verification_method = fields.Str(
-        data_key="verificationMethod",
-        required=False,
-        metadata={
-            "example": "did:example:123456#key-1",
-        },
-    )
-    created = fields.Str(required=False, metadata={"example": RFC3339_DATETIME_EXAMPLE})
-    domain = fields.Str(required=False, metadata={"example": "website.example"})
-    challenge = fields.Str(required=False, metadata={"example": UUID4_EXAMPLE})
-    # credential_status = fields.Dict(
-    #     data_key="credentialStatus",
-    #     required=False,
-    #     metadata={"example": {"type": "StatusList2021"}},
-    # )
 
 
 class ListCredentialsResponse(OpenAPISchema):
@@ -67,7 +33,7 @@ class IssueCredentialRequest(OpenAPISchema):
     """Request schema for issuing a credential."""
 
     credential = fields.Nested(CredentialSchema)
-    options = fields.Nested(IssuanceOptionsSchema)
+    options = fields.Nested(LDProofVCOptionsSchema)
 
 
 class IssueCredentialResponse(OpenAPISchema):
@@ -93,7 +59,7 @@ class ProvePresentationRequest(OpenAPISchema):
     """Request schema for proving a presentation."""
 
     presentation = fields.Nested(PresentationSchema)
-    options = fields.Nested(IssuanceOptionsSchema)
+    options = fields.Nested(LDProofVCOptionsSchema)
 
 
 class ProvePresentationResponse(OpenAPISchema):

--- a/aries_cloudagent/vc/vc_ld/models/web_schemas.py
+++ b/aries_cloudagent/vc/vc_ld/models/web_schemas.py
@@ -24,11 +24,26 @@ from .presentation import (
 class IssuanceOptionsSchema(Schema):
     """Linked data proof verifiable credential options schema."""
 
-    type = fields.Str(required=False, metadata={"example": "Ed25519Signature2020"})
+    proof_type = fields.Str(
+        data_key="proofType",
+        required=False, 
+        metadata={"example": "Ed25519Signature2020"}
+        )
+    proof_purpose = fields.Str(
+        data_key="proofPurpose",
+        required=False, 
+        metadata={"example": "assertionMethod"}
+        )
+    verification_method = fields.Str(
+        data_key="verificationMethod",
+        required=False,
+        metadata={
+            "example": "did:example:123456#key-1",
+        },
+    )
     created = fields.Str(required=False, metadata={"example": RFC3339_DATETIME_EXAMPLE})
     domain = fields.Str(required=False, metadata={"example": "website.example"})
     challenge = fields.Str(required=False, metadata={"example": UUID4_EXAMPLE})
-    # TODO, implement status list publication through a plugin
     # credential_status = fields.Dict(
     #     data_key="credentialStatus",
     #     required=False,


### PR DESCRIPTION
I replaced the custom `IssuanceOptionsSchema` schema on the vc/issue endpoint with the previous `LDProofOptionsSchema`. The idea will be to revisit the idea of having custom options field for different endpoints in a post 1.0 version. The verificationMethod option is necessary when issuing using unconventional did methods, such as did:web where the wallet can't correlate a verificationMethod with a specific did