### PR TITLE
Prevent 500 error when re-promoting DID with endorsement

### DIFF
--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -757,8 +757,11 @@ async def wallet_set_public_did(request: web.BaseRequest):
 
     if not create_transaction_for_endorser:
         return web.json_response({"result": format_did_info(info)})
-
     else:
+        # DID is already posted to ledger
+        if not attrib_def:
+            return web.json_response({"result": format_did_info(info)})
+
         transaction_mgr = TransactionManager(context.profile)
         try:
             transaction = await transaction_mgr.create_record(


### PR DESCRIPTION
See https://github.com/hyperledger/aries-cloudagent-python/issues/2884

Just decided to fix this when I saw it. Doesn't cause any issues but prevents an unwanted 500 error.