### PR TITLE
fix: integration tests should use didex 1.1

### DIFF
--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -1475,7 +1475,7 @@ class DemoAgent:
                 "create_unique_did": json.dumps(create_unique_did),
             }
             payload = {
-                "handshake_protocols": ["rfc23"],
+                "handshake_protocols": ["didexchange/1.1"],
                 "use_public_did": public_did_connections,
             }
             if self.mediation:


### PR DESCRIPTION
A quick fix for the integration tests. I added the `use_did_method` parameter to the `get_invite` method of the support agent class but forgot to update the `handshake_protocols` list used to did exchange 1.1. Without this change, the int tests were actually just defaulting back to 1.0 behavior of unqualified DIDs.

This is just a correction in the tests and does not impact the behavior of ACA-Py which, according to my own testing at least, is still correctly sending qualified DIDs in the appropriate circumstances.