### PR TITLE
:bug: Fix IndyAttrValue model that was dropped from openapi spec

### DIFF
--- a/aries_cloudagent/indy/models/cred.py
+++ b/aries_cloudagent/indy/models/cred.py
@@ -55,6 +55,16 @@ class IndyAttrValueSchema(BaseModelSchema):
 class DictWithIndyAttrValueSchema(fields.Dict):
     """Dict with indy attribute value schema."""
 
+    def __init__(self, **kwargs):
+        """Initialize the custom schema for a dictionary with IndyAttrValue."""
+        super().__init__(
+            keys=fields.Str(metadata={"description": "Attribute name"}),
+            values=fields.Nested(
+                IndyAttrValueSchema(), metadata={"description": "Attribute value"}
+            ),
+            **kwargs,
+        )
+
     def _deserialize(self, value, attr, data, **kwargs):
         """Deserialize dict with indy attribute value."""
         if not isinstance(value, dict):

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -9484,6 +9484,22 @@
       "HolderModuleResponse" : {
         "type" : "object"
       },
+      "IndyAttrValue" : {
+        "properties" : {
+          "encoded" : {
+            "description" : "Attribute encoded value",
+            "example" : "-1",
+            "pattern" : "^-?[0-9]*$",
+            "type" : "string"
+          },
+          "raw" : {
+            "description" : "Attribute raw value",
+            "type" : "string"
+          }
+        },
+        "required" : [ "encoded", "raw" ],
+        "type" : "object"
+      },
       "IndyCredAbstract" : {
         "properties" : {
           "cred_def_id" : {
@@ -9646,8 +9662,10 @@
             "type" : "object"
           },
           "values" : {
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/IndyCredential_values_value"
+            },
             "description" : "Credential attributes",
-            "properties" : { },
             "type" : "object"
           },
           "witness" : {
@@ -15929,6 +15947,13 @@
           "$ref" : "#/components/schemas/IndyNonRevocationInterval"
         } ],
         "description" : "Non-revocation interval from presentation request",
+        "type" : "object"
+      },
+      "IndyCredential_values_value" : {
+        "allOf" : [ {
+          "$ref" : "#/definitions/IndyAttrValue"
+        } ],
+        "description" : "Attribute value",
         "type" : "object"
       },
       "IndyPrimaryProof_eq_proof" : {

--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -8161,6 +8161,22 @@
     "HolderModuleResponse" : {
       "type" : "object"
     },
+    "IndyAttrValue" : {
+      "type" : "object",
+      "required" : [ "encoded", "raw" ],
+      "properties" : {
+        "encoded" : {
+          "type" : "string",
+          "example" : "-1",
+          "description" : "Attribute encoded value",
+          "pattern" : "^-?[0-9]*$"
+        },
+        "raw" : {
+          "type" : "string",
+          "description" : "Attribute raw value"
+        }
+      }
+    },
     "IndyCredAbstract" : {
       "type" : "object",
       "required" : [ "cred_def_id", "key_correctness_proof", "nonce", "schema_id" ],
@@ -8327,7 +8343,13 @@
         "values" : {
           "type" : "object",
           "description" : "Credential attributes",
-          "properties" : { }
+          "additionalProperties" : {
+            "type" : "object",
+            "description" : "Attribute value",
+            "allOf" : [ {
+              "$ref" : "#/definitions/IndyAttrValue"
+            } ]
+          }
         },
         "witness" : {
           "type" : "object",


### PR DESCRIPTION
A previous refactoring, which introduced a `DictWithIndyAttrValueSchema` class ([^](https://github.com/hyperledger/aries-cloudagent-python/commit/d8a6f3f5a4b9d9b58e9e64916fef23da0c130587)), caused the `IndyAttrValue` model to drop from the openapi spec.

This PR re-adds the model to the spec

Signed-off-by: ff137 <ff137@proton.me>