### PR TITLE
:arrow_up: Upgrade codegen tools used in generate-open-api-specols

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -258,7 +258,7 @@ class ConnectionsListQueryStringSchema(OpenAPISchema):
     state = fields.Str(
         required=False,
         validate=validate.OneOf(
-            {label for state in ConnRecord.State for label in state.value}
+            sorted({label for state in ConnRecord.State for label in state.value})
         ),
         metadata={"description": "Connection state"},
     )

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -1122,7 +1122,7 @@
           "in" : "query",
           "name" : "state",
           "schema" : {
-            "enum" : [ "abandoned", "init", "active", "start", "invitation", "completed", "request", "response", "error" ],
+            "enum" : [ "abandoned", "active", "completed", "error", "init", "invitation", "request", "response", "start" ],
             "type" : "string"
           }
         }, {
@@ -7339,7 +7339,11 @@
       "ActionMenuFetchResult" : {
         "properties" : {
           "result" : {
-            "$ref" : "#/components/schemas/ActionMenuFetchResult_result"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Menu"
+            } ],
+            "description" : "Action menu",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -7508,7 +7512,11 @@
             "type" : "object"
           },
           "jws" : {
-            "$ref" : "#/components/schemas/AttachDecoratorData_jws"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/AttachDecoratorDataJWS"
+            } ],
+            "description" : "Detached Java Web Signature",
+            "type" : "object"
           },
           "links" : {
             "description" : "List of hypertext links to data",
@@ -8284,7 +8292,11 @@
       "CredDefState" : {
         "properties" : {
           "credential_definition" : {
-            "$ref" : "#/components/schemas/CredDefState_credential_definition"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/CredDef"
+            } ],
+            "description" : "credential definition",
+            "type" : "object"
           },
           "credential_definition_id" : {
             "description" : "credential definition id",
@@ -8302,10 +8314,18 @@
       "CredDefValue" : {
         "properties" : {
           "primary" : {
-            "$ref" : "#/components/schemas/CredDefValue_primary"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/CredDefValuePrimary"
+            } ],
+            "description" : "Primary value for credential definition",
+            "type" : "object"
           },
           "revocation" : {
-            "$ref" : "#/components/schemas/CredDefValue_revocation"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/CredDefValueRevocation"
+            } ],
+            "description" : "Revocation value for credential definition",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -8468,10 +8488,18 @@
       "CredDefValueSchemaAnoncreds" : {
         "properties" : {
           "primary" : {
-            "$ref" : "#/components/schemas/CredDefValueSchemaAnoncreds_primary"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/CredDefValuePrimarySchemaAnoncreds"
+            } ],
+            "description" : "Primary value for credential definition",
+            "type" : "object"
           },
           "revocation" : {
-            "$ref" : "#/components/schemas/CredDefValueSchemaAnoncreds_revocation"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/CredDefValueRevocationSchemaAnoncreds"
+            } ],
+            "description" : "Revocation value for credential definition",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -8595,7 +8623,18 @@
             "type" : "object"
           },
           "proof" : {
-            "$ref" : "#/components/schemas/Credential_proof"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/LinkedDataProof"
+            } ],
+            "description" : "The proof of the credential",
+            "example" : {
+              "created" : "2019-12-11T03:50:55",
+              "jws" : "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0JiNjQiXX0..lKJU0Df_keblRKhZAS9Qq6zybm-HqUXNVZ8vgEPNTAjQKBhQDxvXNo7nvtUBb_Eq1Ch6YBKY5qBQ",
+              "proofPurpose" : "assertionMethod",
+              "type" : "Ed25519Signature2018",
+              "verificationMethod" : "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL#z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL"
+            },
+            "type" : "object"
           },
           "type" : {
             "description" : "The JSON-LD type of the credential",
@@ -8633,7 +8672,11 @@
             "type" : "object"
           },
           "value" : {
-            "$ref" : "#/components/schemas/CredentialDefinition_value"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/CredDefValue"
+            } ],
+            "description" : "Credential definition primary and revocation values",
+            "type" : "object"
           },
           "ver" : {
             "description" : "Node protocol version",
@@ -8863,7 +8906,11 @@
             "type" : "string"
           },
           "options" : {
-            "$ref" : "#/components/schemas/DIDCreate_options"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/DIDCreateOptions"
+            } ],
+            "description" : "To define a key type and/or a did depending on chosen DID method.",
+            "type" : "object"
           },
           "seed" : {
             "description" : "Optional seed to use for DID, Must beenabled in configuration before use.",
@@ -8993,7 +9040,11 @@
             "type" : "string"
           },
           "did_doc~attach" : {
-            "$ref" : "#/components/schemas/DIDXRequest_did_doc_attach"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/AttachDecorator"
+            } ],
+            "description" : "As signed attachment, DID Doc associated with DID",
+            "type" : "object"
           },
           "goal" : {
             "description" : "A self-attested string that the receiver may want to display to the user about the context-specific goal of the out-of-band message",
@@ -9212,7 +9263,11 @@
             "type" : "object"
           },
           "options" : {
-            "$ref" : "#/components/schemas/Doc_options"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/SignatureOptions"
+            } ],
+            "description" : "Signature options",
+            "type" : "object"
           }
         },
         "required" : [ "credential", "options" ],
@@ -9366,7 +9421,11 @@
       "GetCredDefResult" : {
         "properties" : {
           "credential_definition" : {
-            "$ref" : "#/components/schemas/CredDefState_credential_definition"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/CredDef"
+            } ],
+            "description" : "credential definition",
+            "type" : "object"
           },
           "credential_definition_id" : {
             "description" : "credential definition id",
@@ -9509,7 +9568,11 @@
             "type" : "string"
           },
           "key_correctness_proof" : {
-            "$ref" : "#/components/schemas/IndyCredAbstract_key_correctness_proof"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyKeyCorrectnessProof"
+            } ],
+            "description" : "Key correctness proof",
+            "type" : "object"
           },
           "nonce" : {
             "description" : "Nonce in credential abstract",
@@ -9574,10 +9637,18 @@
       "IndyCredPrecis" : {
         "properties" : {
           "cred_info" : {
-            "$ref" : "#/components/schemas/IndyCredPrecis_cred_info"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyCredInfo"
+            } ],
+            "description" : "Credential info",
+            "type" : "object"
           },
           "interval" : {
-            "$ref" : "#/components/schemas/IndyCredPrecis_interval"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyNonRevocationInterval"
+            } ],
+            "description" : "Non-revocation interval from presentation request",
+            "type" : "object"
           },
           "presentation_referents" : {
             "items" : {
@@ -9663,7 +9734,11 @@
           },
           "values" : {
             "additionalProperties" : {
-              "$ref" : "#/components/schemas/IndyCredential_values_value"
+              "allOf" : [ {
+                "$ref" : "#/definitions/IndyAttrValue"
+              } ],
+              "description" : "Attribute value",
+              "type" : "object"
             },
             "description" : "Credential attributes",
             "type" : "object"
@@ -9990,10 +10065,18 @@
             "type" : "array"
           },
           "proof" : {
-            "$ref" : "#/components/schemas/IndyProof_proof"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyProofProof"
+            } ],
+            "description" : "Indy proof.proof content",
+            "type" : "object"
           },
           "requested_proof" : {
-            "$ref" : "#/components/schemas/IndyProof_requested_proof"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyProofRequestedProof"
+            } ],
+            "description" : "Indy proof.requested_proof content",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -10034,7 +10117,11 @@
       "IndyProofProof" : {
         "properties" : {
           "aggregated_proof" : {
-            "$ref" : "#/components/schemas/IndyProofProof_aggregated_proof"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyProofProofAggregatedProof"
+            } ],
+            "description" : "Indy proof aggregated proof",
+            "type" : "object"
           },
           "proofs" : {
             "description" : "Indy proof proofs",
@@ -10072,7 +10159,11 @@
             "$ref" : "#/components/schemas/IndyProofProofProofsProof_non_revoc_proof"
           },
           "primary_proof" : {
-            "$ref" : "#/components/schemas/IndyProofProofProofsProof_primary_proof"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyPrimaryProof"
+            } ],
+            "description" : "Indy primary proof",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -10392,7 +10483,11 @@
             "type" : "string"
           },
           "value" : {
-            "$ref" : "#/components/schemas/IndyRevRegDef_value"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyRevRegDefValue"
+            } ],
+            "description" : "Revocation registry definition value",
+            "type" : "object"
           },
           "ver" : {
             "description" : "Version of revocation registry definition",
@@ -10418,7 +10513,11 @@
             "type" : "integer"
           },
           "publicKeys" : {
-            "$ref" : "#/components/schemas/IndyRevRegDefValue_publicKeys"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyRevRegDefValuePublicKeys"
+            } ],
+            "description" : "Public keys",
+            "type" : "object"
           },
           "tailsHash" : {
             "description" : "Tails hash value",
@@ -10454,7 +10553,11 @@
       "IndyRevRegEntry" : {
         "properties" : {
           "value" : {
-            "$ref" : "#/components/schemas/IndyRevRegEntry_value"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyRevRegEntryValue"
+            } ],
+            "description" : "Revocation registry entry value",
+            "type" : "object"
           },
           "ver" : {
             "description" : "Version of revocation registry entry",
@@ -10565,7 +10668,24 @@
             "type" : "string"
           },
           "schema" : {
-            "$ref" : "#/components/schemas/InputDescriptors_schema"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/SchemasInputDescriptorFilter"
+            } ],
+            "description" : "Accepts a list of schema or a dict containing filters like oneof_filter.",
+            "example" : {
+              "oneof_filter" : [ [ {
+                "uri" : "https://www.w3.org/Test1#Test1"
+              }, {
+                "uri" : "https://www.w3.org/Test2#Test2"
+              } ], {
+                "oneof_filter" : [ [ {
+                  "uri" : "https://www.w3.org/Test1#Test1"
+                } ], [ {
+                  "uri" : "https://www.w3.org/Test2#Test2"
+                } ] ]
+              } ]
+            },
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -10742,7 +10862,11 @@
             "type" : "string"
           },
           "invitation" : {
-            "$ref" : "#/components/schemas/InvitationRecord_invitation"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/InvitationMessage"
+            } ],
+            "description" : "Out of band invitation message",
+            "type" : "object"
           },
           "invitation_id" : {
             "description" : "Invitation record identifier",
@@ -10974,10 +11098,18 @@
             "type" : "string"
           },
           "revoc_reg_def" : {
-            "$ref" : "#/components/schemas/IssuerRevRegRecord_revoc_reg_def"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyRevRegDef"
+            } ],
+            "description" : "Revocation registry definition",
+            "type" : "object"
           },
           "revoc_reg_entry" : {
-            "$ref" : "#/components/schemas/IssuerRevRegRecord_revoc_reg_entry"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyRevRegEntry"
+            } ],
+            "description" : "Revocation registry entry",
+            "type" : "object"
           },
           "revoc_reg_id" : {
             "description" : "Revocation registry identifier",
@@ -11113,7 +11245,11 @@
             "type" : "object"
           },
           "paginate" : {
-            "$ref" : "#/components/schemas/KeylistQuery_paginate"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/KeylistQueryPaginate"
+            } ],
+            "description" : "Pagination info",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -11199,10 +11335,36 @@
       "LDProofVCDetail" : {
         "properties" : {
           "credential" : {
-            "$ref" : "#/components/schemas/LDProofVCDetail_credential"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Credential"
+            } ],
+            "description" : "Detail of the JSON-LD Credential to be issued",
+            "example" : {
+              "@context" : [ "https://www.w3.org/2018/credentials/v1", "https://w3id.org/citizenship/v1" ],
+              "credentialSubject" : {
+                "familyName" : "SMITH",
+                "gender" : "Male",
+                "givenName" : "JOHN",
+                "type" : [ "PermanentResident", "Person" ]
+              },
+              "description" : "Government of Example Permanent Resident Card.",
+              "identifier" : "83627465",
+              "issuanceDate" : "2019-12-03T12:19:52Z",
+              "issuer" : "did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th",
+              "name" : "Permanent Resident Card",
+              "type" : [ "VerifiableCredential", "PermanentResidentCard" ]
+            },
+            "type" : "object"
           },
           "options" : {
-            "$ref" : "#/components/schemas/LDProofVCDetail_options"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/LDProofVCOptions"
+            } ],
+            "description" : "Options for specifying how the linked data proof is created.",
+            "example" : {
+              "proofType" : "Ed25519Signature2018"
+            },
+            "type" : "object"
           }
         },
         "required" : [ "credential", "options" ],
@@ -11222,7 +11384,11 @@
             "type" : "string"
           },
           "credentialStatus" : {
-            "$ref" : "#/components/schemas/LDProofVCOptions_credentialStatus"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/CredentialStatusOptions"
+            } ],
+            "description" : "The credential status mechanism to use for the credential. Omitting the property indicates the issued credential will not include a credential status",
+            "type" : "object"
           },
           "domain" : {
             "description" : "The intended domain of validity for the proof",
@@ -11653,7 +11819,11 @@
             "type" : "string"
           },
           "invitation" : {
-            "$ref" : "#/components/schemas/InvitationRecord_invitation"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/InvitationMessage"
+            } ],
+            "description" : "Out of band invitation message",
+            "type" : "object"
           },
           "multi_use" : {
             "description" : "Allow for multiple uses of the oobinvitation",
@@ -11757,7 +11927,18 @@
             "type" : "string"
           },
           "proof" : {
-            "$ref" : "#/components/schemas/Presentation_proof"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/LinkedDataProof"
+            } ],
+            "description" : "The proof of the presentation",
+            "example" : {
+              "created" : "2019-12-11T03:50:55",
+              "jws" : "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0JiNjQiXX0..lKJU0Df_keblRKhZAS9Qq6zybm-HqUXNVZ8vgEPNTAjQKBhQDxvXNo7nvtUBb_Eq1Ch6YBKY5qBQ",
+              "proofPurpose" : "assertionMethod",
+              "type" : "Ed25519Signature2018",
+              "verificationMethod" : "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL#z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL"
+            },
+            "type" : "object"
           },
           "type" : {
             "description" : "The JSON-LD type of the presentation",
@@ -12287,7 +12468,11 @@
       "RevListState" : {
         "properties" : {
           "revocation_list" : {
-            "$ref" : "#/components/schemas/RevListState_revocation_list"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/RevList"
+            } ],
+            "description" : "revocation list",
+            "type" : "object"
           },
           "state" : {
             "enum" : [ "finished", "failed", "action", "wait" ],
@@ -12389,7 +12574,11 @@
       "RevRegDefState" : {
         "properties" : {
           "revocation_registry_definition" : {
-            "$ref" : "#/components/schemas/RevRegDefState_revocation_registry_definition"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/RevRegDef"
+            } ],
+            "description" : "revocation registry definition",
+            "type" : "object"
           },
           "revocation_registry_definition_id" : {
             "description" : "revocation registry definition id",
@@ -12934,7 +13123,11 @@
       "SchemaSendResult" : {
         "properties" : {
           "schema" : {
-            "$ref" : "#/components/schemas/SchemaSendResult_schema"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Schema"
+            } ],
+            "description" : "Schema definition",
+            "type" : "object"
           },
           "schema_id" : {
             "description" : "Schema identifier",
@@ -12998,7 +13191,11 @@
       "SendMenu" : {
         "properties" : {
           "menu" : {
-            "$ref" : "#/components/schemas/SendMenu_menu"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/MenuJson"
+            } ],
+            "description" : "Menu to send to connection",
+            "type" : "object"
           }
         },
         "required" : [ "menu" ],
@@ -13096,7 +13293,11 @@
       "SignedDoc" : {
         "properties" : {
           "proof" : {
-            "$ref" : "#/components/schemas/SignedDoc_proof"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/SignatureOptions"
+            } ],
+            "description" : "Linked data proof",
+            "type" : "object"
           }
         },
         "required" : [ "proof" ],
@@ -13383,7 +13584,11 @@
             "$ref" : "#/components/schemas/CredentialDefinitionSendResult"
           },
           "txn" : {
-            "$ref" : "#/components/schemas/TxnOrCredentialDefinitionSendResult_txn"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/TransactionRecord"
+            } ],
+            "description" : "Credential definition transaction to endorse",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -13394,7 +13599,11 @@
             "$ref" : "#/components/schemas/PublishRevocationsSchemaAnoncreds"
           },
           "txn" : {
-            "$ref" : "#/components/schemas/TxnOrPublishRevocationsResult_txn"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/TransactionRecord"
+            } ],
+            "description" : "Revocation registry revocations transaction to endorse",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -13407,7 +13616,11 @@
             "type" : "boolean"
           },
           "txn" : {
-            "$ref" : "#/components/schemas/TxnOrRegisterLedgerNymResponse_txn"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/TransactionRecord"
+            } ],
+            "description" : "DID transaction to endorse",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -13418,7 +13631,11 @@
             "$ref" : "#/components/schemas/RevRegResult"
           },
           "txn" : {
-            "$ref" : "#/components/schemas/TxnOrRevRegResult_txn"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/TransactionRecord"
+            } ],
+            "description" : "Revocation registry definition transaction to endorse",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -13426,10 +13643,18 @@
       "TxnOrSchemaSendResult" : {
         "properties" : {
           "sent" : {
-            "$ref" : "#/components/schemas/TxnOrSchemaSendResult_sent"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/SchemaSendResult"
+            } ],
+            "description" : "Content sent",
+            "type" : "object"
           },
           "txn" : {
-            "$ref" : "#/components/schemas/TxnOrSchemaSendResult_txn"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/TransactionRecord"
+            } ],
+            "description" : "Schema transaction to endorse",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -13487,7 +13712,11 @@
       "V10CredentialBoundOfferRequest" : {
         "properties" : {
           "counter_proposal" : {
-            "$ref" : "#/components/schemas/V10CredentialBoundOfferRequest_counter_proposal"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/CredentialProposal"
+            } ],
+            "description" : "Optional counter-proposal",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -13610,7 +13839,11 @@
             "type" : "string"
           },
           "credential" : {
-            "$ref" : "#/components/schemas/V10CredentialExchange_credential"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyCredInfo"
+            } ],
+            "description" : "Credential as stored",
+            "type" : "object"
           },
           "credential_definition_id" : {
             "description" : "Credential definition identifier",
@@ -13629,16 +13862,32 @@
             "type" : "string"
           },
           "credential_offer" : {
-            "$ref" : "#/components/schemas/V10CredentialExchange_credential_offer"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyCredAbstract"
+            } ],
+            "description" : "(Indy) credential offer",
+            "type" : "object"
           },
           "credential_offer_dict" : {
-            "$ref" : "#/components/schemas/V10CredentialExchange_credential_offer_dict"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/CredentialOffer"
+            } ],
+            "description" : "Credential offer message",
+            "type" : "object"
           },
           "credential_proposal_dict" : {
-            "$ref" : "#/components/schemas/V10CredentialExchange_credential_proposal_dict"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/CredentialProposal"
+            } ],
+            "description" : "Credential proposal message",
+            "type" : "object"
           },
           "credential_request" : {
-            "$ref" : "#/components/schemas/V10CredentialExchange_credential_request"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyCredRequest"
+            } ],
+            "description" : "(Indy) credential request",
+            "type" : "object"
           },
           "credential_request_metadata" : {
             "description" : "(Indy) credential request metadata",
@@ -13662,7 +13911,11 @@
             "type" : "string"
           },
           "raw_credential" : {
-            "$ref" : "#/components/schemas/V10CredentialExchange_raw_credential"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyCredential"
+            } ],
+            "description" : "Credential as received, prior to storage in holder wallet",
+            "type" : "object"
           },
           "revoc_reg_id" : {
             "description" : "Revocation registry identifier",
@@ -13920,7 +14173,11 @@
         "properties" : {
           "results" : {
             "items" : {
-              "$ref" : "#/components/schemas/V10DiscoveryExchangeListResult_results_inner"
+              "allOf" : [ {
+                "$ref" : "#/components/schemas/V10DiscoveryRecord"
+              } ],
+              "description" : "Discover Features v1.0 exchange record",
+              "type" : "object"
             },
             "type" : "array"
           }
@@ -13941,7 +14198,11 @@
             "type" : "string"
           },
           "disclose" : {
-            "$ref" : "#/components/schemas/V10DiscoveryRecord_disclose"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Disclose"
+            } ],
+            "description" : "Disclose message",
+            "type" : "object"
           },
           "discovery_exchange_id" : {
             "description" : "Credential exchange identifier",
@@ -13949,7 +14210,11 @@
             "type" : "string"
           },
           "query_msg" : {
-            "$ref" : "#/components/schemas/V10DiscoveryRecord_query_msg"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Query"
+            } ],
+            "description" : "Query message",
+            "type" : "object"
           },
           "state" : {
             "description" : "Current record state",
@@ -14043,7 +14308,11 @@
             "type" : "string"
           },
           "presentation" : {
-            "$ref" : "#/components/schemas/V10PresentationExchange_presentation"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyProof"
+            } ],
+            "description" : "(Indy) presentation (also known as proof)",
+            "type" : "object"
           },
           "presentation_exchange_id" : {
             "description" : "Presentation exchange identifier",
@@ -14051,13 +14320,25 @@
             "type" : "string"
           },
           "presentation_proposal_dict" : {
-            "$ref" : "#/components/schemas/V10PresentationExchange_presentation_proposal_dict"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/PresentationProposal"
+            } ],
+            "description" : "Presentation proposal message",
+            "type" : "object"
           },
           "presentation_request" : {
-            "$ref" : "#/components/schemas/V10PresentationExchange_presentation_request"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyProofRequest"
+            } ],
+            "description" : "(Indy) presentation request (also known as proof request)",
+            "type" : "object"
           },
           "presentation_request_dict" : {
-            "$ref" : "#/components/schemas/V10PresentationExchange_presentation_request_dict"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/PresentationRequest"
+            } ],
+            "description" : "Presentation request message",
+            "type" : "object"
           },
           "role" : {
             "description" : "Present-proof exchange role: prover or verifier",
@@ -14268,10 +14549,18 @@
       "V20CredBoundOfferRequest" : {
         "properties" : {
           "counter_preview" : {
-            "$ref" : "#/components/schemas/V20CredBoundOfferRequest_counter_preview"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredPreview"
+            } ],
+            "description" : "Optional content for counter-proposal",
+            "type" : "object"
           },
           "filter" : {
-            "$ref" : "#/components/schemas/V20CredBoundOfferRequest_filter"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredFilter"
+            } ],
+            "description" : "Credential specification criteria by format",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -14296,7 +14585,11 @@
             "$ref" : "#/components/schemas/V20CredPreview"
           },
           "filter" : {
-            "$ref" : "#/components/schemas/V20CredBoundOfferRequest_filter"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredFilter"
+            } ],
+            "description" : "Credential specification criteria by format",
+            "type" : "object"
           },
           "replacement_id" : {
             "description" : "Optional identifier used to manage credential replacement",
@@ -14335,7 +14628,11 @@
             "type" : "boolean"
           },
           "by_format" : {
-            "$ref" : "#/components/schemas/V20CredExRecord_by_format"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredExRecordByFormat"
+            } ],
+            "description" : "Attachment content by format for proposal, offer, request, and issue",
+            "type" : "object"
           },
           "connection_id" : {
             "description" : "Connection identifier",
@@ -14354,19 +14651,39 @@
             "type" : "string"
           },
           "cred_issue" : {
-            "$ref" : "#/components/schemas/V20CredExRecord_cred_issue"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredIssue"
+            } ],
+            "description" : "Serialized credential issue message",
+            "type" : "object"
           },
           "cred_offer" : {
-            "$ref" : "#/components/schemas/V20CredExRecord_cred_offer"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredOffer"
+            } ],
+            "description" : "Credential offer message",
+            "type" : "object"
           },
           "cred_preview" : {
-            "$ref" : "#/components/schemas/V20CredExRecord_cred_preview"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredPreview"
+            } ],
+            "description" : "Credential preview from credential proposal",
+            "type" : "object"
           },
           "cred_proposal" : {
-            "$ref" : "#/components/schemas/V20CredExRecord_cred_proposal"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredProposal"
+            } ],
+            "description" : "Credential proposal message",
+            "type" : "object"
           },
           "cred_request" : {
-            "$ref" : "#/components/schemas/V20CredExRecord_cred_request"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredRequest"
+            } ],
+            "description" : "Serialized credential request message",
+            "type" : "object"
           },
           "error_msg" : {
             "description" : "Error message",
@@ -14438,7 +14755,11 @@
       "V20CredExRecordDetail" : {
         "properties" : {
           "cred_ex_record" : {
-            "$ref" : "#/components/schemas/V20CredExRecordDetail_cred_ex_record"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredExRecord"
+            } ],
+            "description" : "Credential exchange record",
+            "type" : "object"
           },
           "indy" : {
             "$ref" : "#/components/schemas/V20CredExRecordIndy"
@@ -14555,10 +14876,18 @@
       "V20CredFilter" : {
         "properties" : {
           "indy" : {
-            "$ref" : "#/components/schemas/V20CredFilter_indy"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredFilterIndy"
+            } ],
+            "description" : "Credential filter for indy",
+            "type" : "object"
           },
           "ld_proof" : {
-            "$ref" : "#/components/schemas/V20CredFilter_ld_proof"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/LDProofVCDetail"
+            } ],
+            "description" : "Credential filter for linked data proof",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -14606,7 +14935,11 @@
       "V20CredFilterLDProof" : {
         "properties" : {
           "ld_proof" : {
-            "$ref" : "#/components/schemas/V20CredFilter_ld_proof"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/LDProofVCDetail"
+            } ],
+            "description" : "Credential filter for linked data proof",
+            "type" : "object"
           }
         },
         "required" : [ "ld_proof" ],
@@ -14749,7 +15082,11 @@
             "$ref" : "#/components/schemas/V20CredPreview"
           },
           "filter" : {
-            "$ref" : "#/components/schemas/V20CredBoundOfferRequest_filter"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredFilter"
+            } ],
+            "description" : "Credential specification criteria by format",
+            "type" : "object"
           },
           "replacement_id" : {
             "description" : "Optional identifier used to manage credential replacement",
@@ -14789,7 +15126,11 @@
             "$ref" : "#/components/schemas/V20CredPreview"
           },
           "filter" : {
-            "$ref" : "#/components/schemas/V20CredBoundOfferRequest_filter"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredFilter"
+            } ],
+            "description" : "Credential specification criteria by format",
+            "type" : "object"
           },
           "replacement_id" : {
             "description" : "Optional identifier used to manage credential replacement",
@@ -14840,7 +15181,11 @@
             "type" : "string"
           },
           "credential_preview" : {
-            "$ref" : "#/components/schemas/V20CredProposal_credential_preview"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredPreview"
+            } ],
+            "description" : "Credential preview",
+            "type" : "object"
           },
           "filters~attach" : {
             "description" : "Credential filter per acceptable format on corresponding identifier",
@@ -14912,7 +15257,11 @@
             "type" : "string"
           },
           "filter" : {
-            "$ref" : "#/components/schemas/V20CredRequestFree_filter"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredFilterLDProof"
+            } ],
+            "description" : "Credential specification criteria by format",
+            "type" : "object"
           },
           "holder_did" : {
             "description" : "Holder DID to substitute for the credentialSubject.id",
@@ -14956,7 +15305,11 @@
         "properties" : {
           "results" : {
             "items" : {
-              "$ref" : "#/components/schemas/V20DiscoveryExchangeListResult_results_inner"
+              "allOf" : [ {
+                "$ref" : "#/components/schemas/V20DiscoveryRecord"
+              } ],
+              "description" : "Discover Features v2.0 exchange record",
+              "type" : "object"
             },
             "type" : "array"
           }
@@ -14966,7 +15319,11 @@
       "V20DiscoveryExchangeResult" : {
         "properties" : {
           "results" : {
-            "$ref" : "#/components/schemas/V20DiscoveryExchangeListResult_results_inner"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20DiscoveryRecord"
+            } ],
+            "description" : "Discover Features v2.0 exchange record",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -14985,7 +15342,11 @@
             "type" : "string"
           },
           "disclosures" : {
-            "$ref" : "#/components/schemas/V20DiscoveryRecord_disclosures"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Disclosures"
+            } ],
+            "description" : "Disclosures message",
+            "type" : "object"
           },
           "discovery_exchange_id" : {
             "description" : "Credential exchange identifier",
@@ -14993,7 +15354,11 @@
             "type" : "string"
           },
           "queries_msg" : {
-            "$ref" : "#/components/schemas/V20DiscoveryRecord_queries_msg"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Queries"
+            } ],
+            "description" : "Queries message",
+            "type" : "object"
           },
           "state" : {
             "description" : "Current record state",
@@ -15033,7 +15398,11 @@
             "$ref" : "#/components/schemas/V20CredPreview"
           },
           "filter" : {
-            "$ref" : "#/components/schemas/V20CredBoundOfferRequest_filter"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredFilter"
+            } ],
+            "description" : "Credential specification criteria by format",
+            "type" : "object"
           },
           "replacement_id" : {
             "description" : "Optional identifier used to manage credential replacement",
@@ -15130,7 +15499,11 @@
             "type" : "boolean"
           },
           "by_format" : {
-            "$ref" : "#/components/schemas/V20PresExRecord_by_format"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20PresExRecordByFormat"
+            } ],
+            "description" : "Attachment content by format for proposal, request, and presentation",
+            "type" : "object"
           },
           "connection_id" : {
             "description" : "Connection identifier",
@@ -15155,7 +15528,11 @@
             "type" : "string"
           },
           "pres" : {
-            "$ref" : "#/components/schemas/V20PresExRecord_pres"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20Pres"
+            } ],
+            "description" : "Presentation message",
+            "type" : "object"
           },
           "pres_ex_id" : {
             "description" : "Presentation exchange identifier",
@@ -15163,10 +15540,18 @@
             "type" : "string"
           },
           "pres_proposal" : {
-            "$ref" : "#/components/schemas/V20PresExRecord_pres_proposal"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20PresProposal"
+            } ],
+            "description" : "Presentation proposal message",
+            "type" : "object"
           },
           "pres_request" : {
-            "$ref" : "#/components/schemas/V20PresExRecord_pres_request"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20PresRequest"
+            } ],
+            "description" : "Presentation request message",
+            "type" : "object"
           },
           "role" : {
             "description" : "Present-proof exchange role: prover or verifier",
@@ -15300,10 +15685,18 @@
       "V20PresProposalByFormat" : {
         "properties" : {
           "dif" : {
-            "$ref" : "#/components/schemas/V20PresProposalByFormat_dif"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/DIFProofProposal"
+            } ],
+            "description" : "Presentation proposal for DIF",
+            "type" : "object"
           },
           "indy" : {
-            "$ref" : "#/components/schemas/V20PresProposalByFormat_indy"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyProofRequest"
+            } ],
+            "description" : "Presentation proposal for indy",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -15380,10 +15773,18 @@
       "V20PresRequestByFormat" : {
         "properties" : {
           "dif" : {
-            "$ref" : "#/components/schemas/V20PresRequestByFormat_dif"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/DIFProofRequest"
+            } ],
+            "description" : "Presentation request for DIF",
+            "type" : "object"
           },
           "indy" : {
-            "$ref" : "#/components/schemas/V20PresRequestByFormat_indy"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyProofRequest"
+            } ],
+            "description" : "Presentation request for indy",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -15427,10 +15828,18 @@
             "type" : "boolean"
           },
           "dif" : {
-            "$ref" : "#/components/schemas/V20PresSpecByFormatRequest_dif"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/DIFPresSpec"
+            } ],
+            "description" : "Optional Presentation specification for DIF, overrides the PresentionExchange record's PresRequest",
+            "type" : "object"
           },
           "indy" : {
-            "$ref" : "#/components/schemas/V20PresSpecByFormatRequest_indy"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyPresSpec"
+            } ],
+            "description" : "Presentation specification for indy",
+            "type" : "object"
           },
           "trace" : {
             "description" : "Record trace information, based on agent configuration",
@@ -15586,7 +15995,18 @@
             "type" : "object"
           },
           "proof" : {
-            "$ref" : "#/components/schemas/Credential_proof"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/LinkedDataProof"
+            } ],
+            "description" : "The proof of the credential",
+            "example" : {
+              "created" : "2019-12-11T03:50:55",
+              "jws" : "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0JiNjQiXX0..lKJU0Df_keblRKhZAS9Qq6zybm-HqUXNVZ8vgEPNTAjQKBhQDxvXNo7nvtUBb_Eq1Ch6YBKY5qBQ",
+              "proofPurpose" : "assertionMethod",
+              "type" : "Ed25519Signature2018",
+              "verificationMethod" : "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL#z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL"
+            },
+            "type" : "object"
           },
           "type" : {
             "description" : "The JSON-LD type of the credential",
@@ -15621,7 +16041,18 @@
             "type" : "string"
           },
           "proof" : {
-            "$ref" : "#/components/schemas/Presentation_proof"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/LinkedDataProof"
+            } ],
+            "description" : "The proof of the presentation",
+            "example" : {
+              "created" : "2019-12-11T03:50:55",
+              "jws" : "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0JiNjQiXX0..lKJU0Df_keblRKhZAS9Qq6zybm-HqUXNVZ8vgEPNTAjQKBhQDxvXNo7nvtUBb_Eq1Ch6YBKY5qBQ",
+              "proofPurpose" : "assertionMethod",
+              "type" : "Ed25519Signature2018",
+              "verificationMethod" : "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL#z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL"
+            },
+            "type" : "object"
           },
           "type" : {
             "description" : "The JSON-LD type of the presentation",
@@ -15683,7 +16114,11 @@
       "VerifyRequest" : {
         "properties" : {
           "doc" : {
-            "$ref" : "#/components/schemas/VerifyRequest_doc"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/SignedDoc"
+            } ],
+            "description" : "Signed document",
+            "type" : "object"
           },
           "verkey" : {
             "description" : "Verkey to use for doc verification",
@@ -15837,125 +16272,6 @@
         },
         "type" : "object"
       },
-      "ActionMenuFetchResult_result" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/Menu"
-        } ],
-        "description" : "Action menu",
-        "type" : "object"
-      },
-      "AttachDecoratorData_jws" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/AttachDecoratorDataJWS"
-        } ],
-        "description" : "Detached Java Web Signature",
-        "type" : "object"
-      },
-      "CredDefState_credential_definition" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/CredDef"
-        } ],
-        "description" : "credential definition",
-        "type" : "object"
-      },
-      "CredDefValue_primary" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/CredDefValuePrimary"
-        } ],
-        "description" : "Primary value for credential definition",
-        "type" : "object"
-      },
-      "CredDefValue_revocation" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/CredDefValueRevocation"
-        } ],
-        "description" : "Revocation value for credential definition",
-        "type" : "object"
-      },
-      "CredDefValueSchemaAnoncreds_primary" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/CredDefValuePrimarySchemaAnoncreds"
-        } ],
-        "description" : "Primary value for credential definition",
-        "type" : "object"
-      },
-      "CredDefValueSchemaAnoncreds_revocation" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/CredDefValueRevocationSchemaAnoncreds"
-        } ],
-        "description" : "Revocation value for credential definition",
-        "type" : "object"
-      },
-      "Credential_proof" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/LinkedDataProof"
-        } ],
-        "description" : "The proof of the credential",
-        "example" : {
-          "created" : "2019-12-11T03:50:55",
-          "jws" : "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0JiNjQiXX0..lKJU0Df_keblRKhZAS9Qq6zybm-HqUXNVZ8vgEPNTAjQKBhQDxvXNo7nvtUBb_Eq1Ch6YBKY5qBQ",
-          "proofPurpose" : "assertionMethod",
-          "type" : "Ed25519Signature2018",
-          "verificationMethod" : "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL#z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL"
-        },
-        "type" : "object"
-      },
-      "CredentialDefinition_value" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/CredDefValue"
-        } ],
-        "description" : "Credential definition primary and revocation values",
-        "type" : "object"
-      },
-      "DIDCreate_options" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/DIDCreateOptions"
-        } ],
-        "description" : "To define a key type and/or a did depending on chosen DID method.",
-        "type" : "object"
-      },
-      "DIDXRequest_did_doc_attach" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/AttachDecorator"
-        } ],
-        "description" : "As signed attachment, DID Doc associated with DID",
-        "type" : "object"
-      },
-      "Doc_options" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/SignatureOptions"
-        } ],
-        "description" : "Signature options",
-        "type" : "object"
-      },
-      "IndyCredAbstract_key_correctness_proof" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyKeyCorrectnessProof"
-        } ],
-        "description" : "Key correctness proof",
-        "type" : "object"
-      },
-      "IndyCredPrecis_cred_info" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyCredInfo"
-        } ],
-        "description" : "Credential info",
-        "type" : "object"
-      },
-      "IndyCredPrecis_interval" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyNonRevocationInterval"
-        } ],
-        "description" : "Non-revocation interval from presentation request",
-        "type" : "object"
-      },
-      "IndyCredential_values_value" : {
-        "allOf" : [ {
-          "$ref" : "#/definitions/IndyAttrValue"
-        } ],
-        "description" : "Attribute value",
-        "type" : "object"
-      },
       "IndyPrimaryProof_eq_proof" : {
         "allOf" : [ {
           "$ref" : "#/components/schemas/IndyEQProof"
@@ -15964,40 +16280,12 @@
         "nullable" : true,
         "type" : "object"
       },
-      "IndyProof_proof" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyProofProof"
-        } ],
-        "description" : "Indy proof.proof content",
-        "type" : "object"
-      },
-      "IndyProof_requested_proof" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyProofRequestedProof"
-        } ],
-        "description" : "Indy proof.requested_proof content",
-        "type" : "object"
-      },
-      "IndyProofProof_aggregated_proof" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyProofProofAggregatedProof"
-        } ],
-        "description" : "Indy proof aggregated proof",
-        "type" : "object"
-      },
       "IndyProofProofProofsProof_non_revoc_proof" : {
         "allOf" : [ {
           "$ref" : "#/components/schemas/IndyNonRevocProof"
         } ],
         "description" : "Indy non-revocation proof",
         "nullable" : true,
-        "type" : "object"
-      },
-      "IndyProofProofProofsProof_primary_proof" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyPrimaryProof"
-        } ],
-        "description" : "Indy primary proof",
         "type" : "object"
       },
       "IndyProofReqAttrSpec_non_revoked" : {
@@ -16019,492 +16307,6 @@
           "$ref" : "#/components/schemas/IndyProofRequestNonRevoked"
         } ],
         "nullable" : true,
-        "type" : "object"
-      },
-      "IndyRevRegDef_value" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyRevRegDefValue"
-        } ],
-        "description" : "Revocation registry definition value",
-        "type" : "object"
-      },
-      "IndyRevRegDefValue_publicKeys" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyRevRegDefValuePublicKeys"
-        } ],
-        "description" : "Public keys",
-        "type" : "object"
-      },
-      "IndyRevRegEntry_value" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyRevRegEntryValue"
-        } ],
-        "description" : "Revocation registry entry value",
-        "type" : "object"
-      },
-      "InputDescriptors_schema" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/SchemasInputDescriptorFilter"
-        } ],
-        "description" : "Accepts a list of schema or a dict containing filters like oneof_filter.",
-        "example" : {
-          "oneof_filter" : [ [ {
-            "uri" : "https://www.w3.org/Test1#Test1"
-          }, {
-            "uri" : "https://www.w3.org/Test2#Test2"
-          } ], {
-            "oneof_filter" : [ [ {
-              "uri" : "https://www.w3.org/Test1#Test1"
-            } ], [ {
-              "uri" : "https://www.w3.org/Test2#Test2"
-            } ] ]
-          } ]
-        },
-        "type" : "object"
-      },
-      "InvitationRecord_invitation" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/InvitationMessage"
-        } ],
-        "description" : "Out of band invitation message",
-        "type" : "object"
-      },
-      "IssuerRevRegRecord_revoc_reg_def" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyRevRegDef"
-        } ],
-        "description" : "Revocation registry definition",
-        "type" : "object"
-      },
-      "IssuerRevRegRecord_revoc_reg_entry" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyRevRegEntry"
-        } ],
-        "description" : "Revocation registry entry",
-        "type" : "object"
-      },
-      "KeylistQuery_paginate" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/KeylistQueryPaginate"
-        } ],
-        "description" : "Pagination info",
-        "type" : "object"
-      },
-      "LDProofVCDetail_credential" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/Credential"
-        } ],
-        "description" : "Detail of the JSON-LD Credential to be issued",
-        "example" : {
-          "@context" : [ "https://www.w3.org/2018/credentials/v1", "https://w3id.org/citizenship/v1" ],
-          "credentialSubject" : {
-            "familyName" : "SMITH",
-            "gender" : "Male",
-            "givenName" : "JOHN",
-            "type" : [ "PermanentResident", "Person" ]
-          },
-          "description" : "Government of Example Permanent Resident Card.",
-          "identifier" : "83627465",
-          "issuanceDate" : "2019-12-03T12:19:52Z",
-          "issuer" : "did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th",
-          "name" : "Permanent Resident Card",
-          "type" : [ "VerifiableCredential", "PermanentResidentCard" ]
-        },
-        "type" : "object"
-      },
-      "LDProofVCDetail_options" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/LDProofVCOptions"
-        } ],
-        "description" : "Options for specifying how the linked data proof is created.",
-        "example" : {
-          "proofType" : "Ed25519Signature2018"
-        },
-        "type" : "object"
-      },
-      "LDProofVCOptions_credentialStatus" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/CredentialStatusOptions"
-        } ],
-        "description" : "The credential status mechanism to use for the credential. Omitting the property indicates the issued credential will not include a credential status",
-        "type" : "object"
-      },
-      "Presentation_proof" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/LinkedDataProof"
-        } ],
-        "description" : "The proof of the presentation",
-        "example" : {
-          "created" : "2019-12-11T03:50:55",
-          "jws" : "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0JiNjQiXX0..lKJU0Df_keblRKhZAS9Qq6zybm-HqUXNVZ8vgEPNTAjQKBhQDxvXNo7nvtUBb_Eq1Ch6YBKY5qBQ",
-          "proofPurpose" : "assertionMethod",
-          "type" : "Ed25519Signature2018",
-          "verificationMethod" : "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL#z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL"
-        },
-        "type" : "object"
-      },
-      "RevListState_revocation_list" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/RevList"
-        } ],
-        "description" : "revocation list",
-        "type" : "object"
-      },
-      "RevRegDefState_revocation_registry_definition" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/RevRegDef"
-        } ],
-        "description" : "revocation registry definition",
-        "type" : "object"
-      },
-      "SchemaSendResult_schema" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/Schema"
-        } ],
-        "description" : "Schema definition",
-        "type" : "object"
-      },
-      "SendMenu_menu" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/MenuJson"
-        } ],
-        "description" : "Menu to send to connection",
-        "type" : "object"
-      },
-      "SignedDoc_proof" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/SignatureOptions"
-        } ],
-        "description" : "Linked data proof",
-        "type" : "object"
-      },
-      "TxnOrCredentialDefinitionSendResult_txn" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/TransactionRecord"
-        } ],
-        "description" : "Credential definition transaction to endorse",
-        "type" : "object"
-      },
-      "TxnOrPublishRevocationsResult_txn" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/TransactionRecord"
-        } ],
-        "description" : "Revocation registry revocations transaction to endorse",
-        "type" : "object"
-      },
-      "TxnOrRegisterLedgerNymResponse_txn" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/TransactionRecord"
-        } ],
-        "description" : "DID transaction to endorse",
-        "type" : "object"
-      },
-      "TxnOrRevRegResult_txn" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/TransactionRecord"
-        } ],
-        "description" : "Revocation registry definition transaction to endorse",
-        "type" : "object"
-      },
-      "TxnOrSchemaSendResult_sent" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/SchemaSendResult"
-        } ],
-        "description" : "Content sent",
-        "type" : "object"
-      },
-      "TxnOrSchemaSendResult_txn" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/TransactionRecord"
-        } ],
-        "description" : "Schema transaction to endorse",
-        "type" : "object"
-      },
-      "V10CredentialBoundOfferRequest_counter_proposal" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/CredentialProposal"
-        } ],
-        "description" : "Optional counter-proposal",
-        "type" : "object"
-      },
-      "V10CredentialExchange_credential" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyCredInfo"
-        } ],
-        "description" : "Credential as stored",
-        "type" : "object"
-      },
-      "V10CredentialExchange_credential_offer" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyCredAbstract"
-        } ],
-        "description" : "(Indy) credential offer",
-        "type" : "object"
-      },
-      "V10CredentialExchange_credential_offer_dict" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/CredentialOffer"
-        } ],
-        "description" : "Credential offer message",
-        "type" : "object"
-      },
-      "V10CredentialExchange_credential_proposal_dict" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/CredentialProposal"
-        } ],
-        "description" : "Credential proposal message",
-        "type" : "object"
-      },
-      "V10CredentialExchange_credential_request" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyCredRequest"
-        } ],
-        "description" : "(Indy) credential request",
-        "type" : "object"
-      },
-      "V10CredentialExchange_raw_credential" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyCredential"
-        } ],
-        "description" : "Credential as received, prior to storage in holder wallet",
-        "type" : "object"
-      },
-      "V10DiscoveryExchangeListResult_results_inner" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V10DiscoveryRecord"
-        } ],
-        "description" : "Discover Features v1.0 exchange record",
-        "type" : "object"
-      },
-      "V10DiscoveryRecord_disclose" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/Disclose"
-        } ],
-        "description" : "Disclose message",
-        "type" : "object"
-      },
-      "V10DiscoveryRecord_query_msg" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/Query"
-        } ],
-        "description" : "Query message",
-        "type" : "object"
-      },
-      "V10PresentationExchange_presentation" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyProof"
-        } ],
-        "description" : "(Indy) presentation (also known as proof)",
-        "type" : "object"
-      },
-      "V10PresentationExchange_presentation_proposal_dict" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/PresentationProposal"
-        } ],
-        "description" : "Presentation proposal message",
-        "type" : "object"
-      },
-      "V10PresentationExchange_presentation_request" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyProofRequest"
-        } ],
-        "description" : "(Indy) presentation request (also known as proof request)",
-        "type" : "object"
-      },
-      "V10PresentationExchange_presentation_request_dict" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/PresentationRequest"
-        } ],
-        "description" : "Presentation request message",
-        "type" : "object"
-      },
-      "V20CredBoundOfferRequest_counter_preview" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20CredPreview"
-        } ],
-        "description" : "Optional content for counter-proposal",
-        "type" : "object"
-      },
-      "V20CredBoundOfferRequest_filter" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20CredFilter"
-        } ],
-        "description" : "Credential specification criteria by format",
-        "type" : "object"
-      },
-      "V20CredExRecord_by_format" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20CredExRecordByFormat"
-        } ],
-        "description" : "Attachment content by format for proposal, offer, request, and issue",
-        "type" : "object"
-      },
-      "V20CredExRecord_cred_issue" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20CredIssue"
-        } ],
-        "description" : "Serialized credential issue message",
-        "type" : "object"
-      },
-      "V20CredExRecord_cred_offer" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20CredOffer"
-        } ],
-        "description" : "Credential offer message",
-        "type" : "object"
-      },
-      "V20CredExRecord_cred_preview" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20CredPreview"
-        } ],
-        "description" : "Credential preview from credential proposal",
-        "type" : "object"
-      },
-      "V20CredExRecord_cred_proposal" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20CredProposal"
-        } ],
-        "description" : "Credential proposal message",
-        "type" : "object"
-      },
-      "V20CredExRecord_cred_request" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20CredRequest"
-        } ],
-        "description" : "Serialized credential request message",
-        "type" : "object"
-      },
-      "V20CredExRecordDetail_cred_ex_record" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20CredExRecord"
-        } ],
-        "description" : "Credential exchange record",
-        "type" : "object"
-      },
-      "V20CredFilter_indy" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20CredFilterIndy"
-        } ],
-        "description" : "Credential filter for indy",
-        "type" : "object"
-      },
-      "V20CredFilter_ld_proof" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/LDProofVCDetail"
-        } ],
-        "description" : "Credential filter for linked data proof",
-        "type" : "object"
-      },
-      "V20CredProposal_credential_preview" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20CredPreview"
-        } ],
-        "description" : "Credential preview",
-        "type" : "object"
-      },
-      "V20CredRequestFree_filter" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20CredFilterLDProof"
-        } ],
-        "description" : "Credential specification criteria by format",
-        "type" : "object"
-      },
-      "V20DiscoveryExchangeListResult_results_inner" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20DiscoveryRecord"
-        } ],
-        "description" : "Discover Features v2.0 exchange record",
-        "type" : "object"
-      },
-      "V20DiscoveryRecord_disclosures" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/Disclosures"
-        } ],
-        "description" : "Disclosures message",
-        "type" : "object"
-      },
-      "V20DiscoveryRecord_queries_msg" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/Queries"
-        } ],
-        "description" : "Queries message",
-        "type" : "object"
-      },
-      "V20PresExRecord_by_format" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20PresExRecordByFormat"
-        } ],
-        "description" : "Attachment content by format for proposal, request, and presentation",
-        "type" : "object"
-      },
-      "V20PresExRecord_pres" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20Pres"
-        } ],
-        "description" : "Presentation message",
-        "type" : "object"
-      },
-      "V20PresExRecord_pres_proposal" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20PresProposal"
-        } ],
-        "description" : "Presentation proposal message",
-        "type" : "object"
-      },
-      "V20PresExRecord_pres_request" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/V20PresRequest"
-        } ],
-        "description" : "Presentation request message",
-        "type" : "object"
-      },
-      "V20PresProposalByFormat_dif" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/DIFProofProposal"
-        } ],
-        "description" : "Presentation proposal for DIF",
-        "type" : "object"
-      },
-      "V20PresProposalByFormat_indy" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyProofRequest"
-        } ],
-        "description" : "Presentation proposal for indy",
-        "type" : "object"
-      },
-      "V20PresRequestByFormat_dif" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/DIFProofRequest"
-        } ],
-        "description" : "Presentation request for DIF",
-        "type" : "object"
-      },
-      "V20PresRequestByFormat_indy" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyProofRequest"
-        } ],
-        "description" : "Presentation request for indy",
-        "type" : "object"
-      },
-      "V20PresSpecByFormatRequest_dif" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/DIFPresSpec"
-        } ],
-        "description" : "Optional Presentation specification for DIF, overrides the PresentionExchange record's PresRequest",
-        "type" : "object"
-      },
-      "V20PresSpecByFormatRequest_indy" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyPresSpec"
-        } ],
-        "description" : "Presentation specification for indy",
-        "type" : "object"
-      },
-      "VerifyRequest_doc" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/SignedDoc"
-        } ],
-        "description" : "Signed document",
         "type" : "object"
       }
     },

--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -956,7 +956,7 @@
           "description" : "Connection state",
           "required" : false,
           "type" : "string",
-          "enum" : [ "abandoned", "init", "active", "start", "invitation", "completed", "request", "response", "error" ]
+          "enum" : [ "abandoned", "active", "completed", "error", "init", "invitation", "request", "response", "start" ]
         }, {
           "name" : "their_did",
           "in" : "query",

--- a/scripts/generate-open-api-spec
+++ b/scripts/generate-open-api-spec
@@ -6,7 +6,7 @@
 #
 ##########################################################################################
 
-SWAGGER_GEN_CONTAINER="docker.io/swaggerapi/swagger-codegen-cli:2.4.32"
+SWAGGER_GEN_CONTAINER="docker.io/swaggerapi/swagger-codegen-cli:2.4.39"
 OPENAPI_GEN_CONTAINER="docker.io/openapitools/openapi-generator-cli:v6.6.0"
 
 # Ensure the script is running from the directory containing this script

--- a/scripts/generate-open-api-spec
+++ b/scripts/generate-open-api-spec
@@ -7,7 +7,7 @@
 ##########################################################################################
 
 SWAGGER_GEN_CONTAINER="docker.io/swaggerapi/swagger-codegen-cli:2.4.39"
-OPENAPI_GEN_CONTAINER="docker.io/openapitools/openapi-generator-cli:v6.6.0"
+OPENAPI_GEN_CONTAINER="docker.io/openapitools/openapi-generator-cli:v7.5.0"
 
 # Ensure the script is running from the directory containing this script
 cd $(dirname $0)


### PR DESCRIPTION
Upgrades `swagger-codegen-cli` and `openapi-generator-cli` to latest releases.

The swagger one makes no difference to the spec, but the openapi one has some improvements.

e.g. nested models used to reference to subschemas:
```
      "InvitationRecord" : {
        "properties" : {
...
          "invitation" : {
            "$ref" : "#/components/schemas/InvitationRecord_invitation"
          },

...

      "InvitationRecord_invitation" : {
        "allOf" : [ {
          "$ref" : "#/components/schemas/InvitationMessage"
        } ],
        "description" : "Out of band invitation message",
        "type" : "object"
      },
```

which now references directly:
```
      "InvitationRecord" : {
        "properties" : {
...
          "invitation" : {
            "allOf" : [ {
              "$ref" : "#/components/schemas/InvitationMessage"
            } ],
            "description" : "Out of band invitation message",
            "type" : "object"
          },
```

Note: there's a "Connection state" enum field which was defined from a python set, so its ordering would vary every time the spec is regenerated. I converted that to a sorted list, so its ordering will remain consistent.