### PR TITLE
Fix api schema mixup in revocation routes

### DIFF
--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -270,7 +270,7 @@ class RevokeRequestSchema(CredRevRecordQueryStringSchema):
     )
 
 
-class PublishRevocationsSchemaAnoncreds(OpenAPISchema):
+class PublishRevocationsSchema(OpenAPISchema):
     """Request and result schema for revocation publication API call."""
 
     rrid2crid = fields.Dict(
@@ -293,7 +293,7 @@ class TxnOrPublishRevocationsResultSchema(OpenAPISchema):
     """Result schema for credential definition send request."""
 
     sent = fields.Nested(
-        PublishRevocationsSchemaAnoncreds(),
+        PublishRevocationsSchema(),
         required=False,
         metadata={"definition": "Content sent"},
     )
@@ -330,7 +330,7 @@ class ClearPendingRevocationsRequestSchema(OpenAPISchema):
     )
 
 
-class CredRevRecordResultSchemaAnoncreds(OpenAPISchema):
+class CredRevRecordResultSchema(OpenAPISchema):
     """Result schema for credential revocation record request."""
 
     result = fields.Nested(IssuerCredRevRecordSchema())
@@ -613,7 +613,7 @@ async def revoke(request: web.BaseRequest):
 
 
 @docs(tags=["revocation"], summary="Publish pending revocations to ledger")
-@request_schema(PublishRevocationsSchemaAnoncreds())
+@request_schema(PublishRevocationsSchema())
 @querystring_schema(CreateRevRegTxnForEndorserOptionSchema())
 @querystring_schema(RevRegConnIdMatchInfoSchema())
 @response_schema(TxnOrPublishRevocationsResultSchema(), 200, description="")
@@ -686,7 +686,7 @@ async def publish_revocations(request: web.BaseRequest):
 
 @docs(tags=["revocation"], summary="Clear pending revocations")
 @request_schema(ClearPendingRevocationsRequestSchema())
-@response_schema(PublishRevocationsSchemaAnoncreds(), 200, description="")
+@response_schema(PublishRevocationsSchema(), 200, description="")
 async def clear_pending_revocations(request: web.BaseRequest):
     """Request handler for clearing pending revocations.
 
@@ -1070,7 +1070,7 @@ async def update_rev_reg_revoked_state(request: web.BaseRequest):
     summary="Get credential revocation status",
 )
 @querystring_schema(CredRevRecordQueryStringSchema())
-@response_schema(CredRevRecordResultSchemaAnoncreds(), 200, description="")
+@response_schema(CredRevRecordResultSchema(), 200, description="")
 async def get_cred_rev_record(request: web.BaseRequest):
     """Request handler to get credential revocation record.
 

--- a/aries_cloudagent/revocation_anoncreds/routes.py
+++ b/aries_cloudagent/revocation_anoncreds/routes.py
@@ -49,9 +49,6 @@ from ..messaging.valid import (
     WHOLE_NUM_VALIDATE,
     UUIDFour,
 )
-from ..protocols.endorse_transaction.v1_0.models.transaction_record import (
-    TransactionRecordSchema,
-)
 from ..revocation.error import RevocationError
 from ..revocation.models.issuer_rev_reg_record import (
     IssuerRevRegRecord,
@@ -78,23 +75,6 @@ class RevRegResultSchemaAnoncreds(OpenAPISchema):
     """Result schema for revocation registry creation request."""
 
     result = fields.Nested(IssuerRevRegRecordSchema())
-
-
-class TxnOrRevRegResultSchema(OpenAPISchema):
-    """Result schema for credential definition send request."""
-
-    sent = fields.Nested(
-        RevRegResultSchemaAnoncreds(),
-        required=False,
-        metadata={"definition": "Content sent"},
-    )
-    txn = fields.Nested(
-        TransactionRecordSchema(),
-        required=False,
-        metadata={
-            "description": "Revocation registry definition transaction to endorse"
-        },
-    )
 
 
 class CredRevRecordQueryStringSchema(OpenAPISchema):
@@ -173,31 +153,7 @@ class RevRegId(OpenAPISchema):
     )
 
 
-class ClearPendingRevocationsRequestSchema(OpenAPISchema):
-    """Request schema for clear pending revocations API call."""
-
-    purge = fields.Dict(
-        required=False,
-        keys=fields.Str(metadata={"example": INDY_REV_REG_ID_EXAMPLE}),
-        values=fields.List(
-            fields.Str(
-                validate=INDY_CRED_REV_ID_VALIDATE,
-                metadata={
-                    "description": "Credential revocation identifier",
-                    "example": INDY_CRED_REV_ID_EXAMPLE,
-                },
-            )
-        ),
-        metadata={
-            "description": (
-                "Credential revocation ids by revocation registry id: omit for all,"
-                " specify null or empty list for all pending per revocation registry"
-            )
-        },
-    )
-
-
-class CredRevRecordResultSchema(OpenAPISchema):
+class CredRevRecordResultSchemaAnoncreds(OpenAPISchema):
     """Result schema for credential revocation record request."""
 
     result = fields.Nested(IssuerCredRevRecordSchemaAnoncreds())
@@ -386,7 +342,7 @@ class PublishRevocationsOptions(OpenAPISchema):
     )
 
 
-class PublishRevocationsSchema(OpenAPISchema):
+class PublishRevocationsSchemaAnoncreds(OpenAPISchema):
     """Request and result schema for revocation publication API call."""
 
     rrid2crid = fields.Dict(
@@ -406,7 +362,7 @@ class PublishRevocationsSchema(OpenAPISchema):
     options = fields.Nested(PublishRevocationsOptions())
 
 
-class PublishRevocationsResultSchema(OpenAPISchema):
+class PublishRevocationsResultSchemaAnoncreds(OpenAPISchema):
     """Result schema for credential definition send request."""
 
     rrid2crid = fields.Dict(
@@ -554,8 +510,8 @@ async def revoke(request: web.BaseRequest):
 
 
 @docs(tags=[TAG_TITLE], summary="Publish pending revocations to ledger")
-@request_schema(PublishRevocationsSchema())
-@response_schema(PublishRevocationsResultSchema(), 200, description="")
+@request_schema(PublishRevocationsSchemaAnoncreds())
+@response_schema(PublishRevocationsResultSchemaAnoncreds(), 200, description="")
 async def publish_revocations(request: web.BaseRequest):
     """Request handler for publishing pending revocations to the ledger.
 
@@ -988,7 +944,7 @@ async def update_rev_reg_revoked_state(request: web.BaseRequest):
     summary="Get credential revocation status",
 )
 @querystring_schema(CredRevRecordQueryStringSchema())
-@response_schema(CredRevRecordResultSchema(), 200, description="")
+@response_schema(CredRevRecordResultSchemaAnoncreds(), 200, description="")
 async def get_cred_rev_record(request: web.BaseRequest):
     """Request handler to get credential revocation record.
 


### PR DESCRIPTION
Fixes https://github.com/hyperledger/aries-cloudagent-python/issues/2901.

I somehow mixed up the schema naming between anoncreds revocation and existing revocation modules in a couple places. Shouldn't cause problems but still needs to be fixed.

Also a couple schemas existed in anoncreds that weren't used (copy and paste error)

##### ***Note***: 
This does remind me of something. The clear pending revocations method doesn't exist in the anoncreds implementation currently. Not sure how important that is and if it should be implemented for the upcoming 1.0.0 release ?