### PR TITLE
:bug: Fix ServiceDecorator parsing in oob record handling

### DIFF
--- a/aries_cloudagent/core/oob_processor.py
+++ b/aries_cloudagent/core/oob_processor.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional
 
 from ..messaging.agent_message import AgentMessage
 from ..connections.models.conn_record import ConnRecord

--- a/aries_cloudagent/core/oob_processor.py
+++ b/aries_cloudagent/core/oob_processor.py
@@ -91,7 +91,7 @@ class OobMessageProcessor:
                     oob_record.their_service,
                 )
 
-                their_service = ServiceDecorator.deserialize(oob_record.their_service)
+                their_service = oob_record.their_service
 
                 # Attach ~service decorator so other message can respond
                 message = json.loads(outbound_message.payload)
@@ -100,7 +100,7 @@ class OobMessageProcessor:
                         "Setting our service on the message ~service %s",
                         oob_record.our_service,
                     )
-                    message["~service"] = oob_record.our_service
+                    message["~service"] = oob_record.our_service.serialize()
 
                 message["~thread"] = {
                     **message.get("~thread", {}),
@@ -256,14 +256,7 @@ class OobMessageProcessor:
             )
             return None
 
-        their_service = (
-            cast(
-                ServiceDecorator,
-                ServiceDecorator.deserialize(oob_record.their_service),
-            )
-            if oob_record.their_service
-            else None
-        )
+        their_service = oob_record.their_service
 
         # Verify the sender key is present in their service in our record
         # If we don't have the sender verkey stored yet we can allow any key

--- a/aries_cloudagent/core/tests/test_oob_processor.py
+++ b/aries_cloudagent/core/tests/test_oob_processor.py
@@ -31,11 +31,11 @@ class TestOobProcessor(IsolatedAsyncioTestCase):
         self.oob_record = mock.MagicMock(
             connection_id="a-connection-id",
             attach_thread_id="the-thid",
-            their_service={
-                "recipientKeys": ["9WCgWKUaAJj3VWxxtzvvMQN3AoFxoBtBDo9ntwJnVVCC"],
-                "routingKeys": ["6QSduYdf8Bi6t8PfNm5vNomGWDtXhmMmTRzaciudBXYJ"],
-                "serviceEndpoint": "http://their-service-endpoint.com",
-            },
+            their_service=ServiceDecorator(
+                recipient_keys=["9WCgWKUaAJj3VWxxtzvvMQN3AoFxoBtBDo9ntwJnVVCC"],
+                routing_keys=["6QSduYdf8Bi6t8PfNm5vNomGWDtXhmMmTRzaciudBXYJ"],
+                endpoint="http://their-service-endpoint.com",
+            ),
             emit_event=mock.CoroutineMock(),
             delete_record=mock.CoroutineMock(),
             save=mock.CoroutineMock(),
@@ -121,16 +121,16 @@ class TestOobProcessor(IsolatedAsyncioTestCase):
             invitation=mock.MagicMock(requests_attach=[]),
             invi_msg_id="the-pthid",
             our_recipient_key="3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx",
-            their_service={
-                "recipientKeys": ["9WCgWKUaAJj3VWxxtzvvMQN3AoFxoBtBDo9ntwJnVVCC"],
-                "serviceEndpoint": "http://their-service-endpoint.com",
-                "routingKeys": ["6QSduYdf8Bi6t8PfNm5vNomGWDtXhmMmTRzaciudBXYJ"],
-            },
-            our_service={
-                "recipientKeys": ["3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"],
-                "serviceEndpoint": "http://our-service-endpoint.com",
-                "routingKeys": [],
-            },
+            their_service=ServiceDecorator(
+                recipient_keys=["9WCgWKUaAJj3VWxxtzvvMQN3AoFxoBtBDo9ntwJnVVCC"],
+                endpoint="http://their-service-endpoint.com",
+                routing_keys=["6QSduYdf8Bi6t8PfNm5vNomGWDtXhmMmTRzaciudBXYJ"],
+            ),
+            our_service=ServiceDecorator(
+                recipient_keys=["3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"],
+                endpoint="http://our-service-endpoint.com",
+                routing_keys=[],
+            ),
         )
 
         message = json.dumps({"~thread": {"thid": "the-thid"}})
@@ -196,16 +196,16 @@ class TestOobProcessor(IsolatedAsyncioTestCase):
             invitation=mock.MagicMock(requests_attach=[]),
             invi_msg_id="the-pthid",
             our_recipient_key="3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx",
-            their_service={
-                "recipientKeys": ["9WCgWKUaAJj3VWxxtzvvMQN3AoFxoBtBDo9ntwJnVVCC"],
-                "serviceEndpoint": "http://their-service-endpoint.com",
-                "routingKeys": ["6QSduYdf8Bi6t8PfNm5vNomGWDtXhmMmTRzaciudBXYJ"],
-            },
-            our_service={
-                "recipientKeys": ["3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"],
-                "serviceEndpoint": "http://our-service-endpoint.com",
-                "routingKeys": [],
-            },
+            their_service=ServiceDecorator(
+                recipient_keys=["9WCgWKUaAJj3VWxxtzvvMQN3AoFxoBtBDo9ntwJnVVCC"],
+                endpoint="http://their-service-endpoint.com",
+                routing_keys=["6QSduYdf8Bi6t8PfNm5vNomGWDtXhmMmTRzaciudBXYJ"],
+            ),
+            our_service=ServiceDecorator(
+                recipient_keys=["3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"],
+                endpoint="http://our-service-endpoint.com",
+                routing_keys=[],
+            ),
         )
 
         with mock.patch.object(
@@ -303,7 +303,7 @@ class TestOobProcessor(IsolatedAsyncioTestCase):
             self.context.message_receipt = MessageReceipt(
                 thread_id="the-thid",
                 recipient_verkey="our-recipient-key",
-                sender_verkey=self.oob_record.their_service["recipientKeys"][0],
+                sender_verkey=self.oob_record.their_service.recipient_keys[0],
             )
 
             assert await self.oob_processor.find_oob_record_for_inbound_message(

--- a/aries_cloudagent/core/tests/test_oob_processor.py
+++ b/aries_cloudagent/core/tests/test_oob_processor.py
@@ -728,7 +728,7 @@ class TestOobProcessor(IsolatedAsyncioTestCase):
         )
 
         assert oob_record.attach_thread_id == "4a580490-a9d8-44f5-a3f6-14e0b8a219b0"
-        assert oob_record.their_service == {
+        assert oob_record.their_service.serialize() == {
             "serviceEndpoint": "http://their-service-endpoint.com",
             "recipientKeys": ["9WCgWKUaAJj3VWxxtzvvMQN3AoFxoBtBDo9ntwJnVVCC"],
             "routingKeys": ["6QSduYdf8Bi6t8PfNm5vNomGWDtXhmMmTRzaciudBXYJ"],


### PR DESCRIPTION
Fixes `find_oob_target_for_outbound_message` and `find_oob_record_for_inbound_message` in OobMessageProcessor

Context:
Attempting to upgrade to 0.12 in https://github.com/didx-xyz/aries-cloudapi-python

Our existing OOB test workflows would raise an error from the following line in `find_oob_record_for_inbound_message`:
```py
        their_service = (
            cast(
                ServiceDecorator,
                ServiceDecorator.deserialize(oob_record.their_service),
            )
            if oob_record.their_service
            else None
        )
```

The error:
```py
Traceback (most recent call last):
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/messaging/models/base.py", line 196, in deserialize
    schema.loads(obj) if isinstance(obj, str) else schema.load(obj),
  File "/home/aries/.local/lib/python3.9/site-packages/marshmallow/schema.py", line 723, in load
    return self._do_load(
  File "/home/aries/.local/lib/python3.9/site-packages/marshmallow/schema.py", line 910, in _do_load
    raise exc
marshmallow.exceptions.ValidationError: {'_schema': ['Invalid input type.']
```

I noticed that according to the compiler, `oob_record.their_service` was already of type ServiceDecorator ... so `cast(ServiceDecorator, ServiceDecorator.deserialize(...` is especially code-smelly!

Resolving that to simply be `their_service = oob_record.their_service` led to the following exception:

```py
...
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/admin/server.py", line 148, in send_outbound
    return await self._send(profile, message)
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/core/conductor.py", line 647, in outbound_message_router
    status: OutboundSendStatus = await self._outbound_message_router(
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/core/conductor.py", line 674, in _outbound_message_router
    return await self.queue_outbound(profile, outbound, inbound)
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/core/conductor.py", line 722, in queue_outbound
    outbound.target = await self.dispatcher.run_task(
  File "/usr/local/lib/python3.9/asyncio/futures.py", line 284, in __await__
    yield self  # This tells Task to wait for completion.
  File "/usr/local/lib/python3.9/asyncio/tasks.py", line 328, in __wakeup
    future.result()
  File "/usr/local/lib/python3.9/asyncio/futures.py", line 201, in result
    raise self._exception
  File "/usr/local/lib/python3.9/asyncio/tasks.py", line 256, in __step
    result = coro.send(None)
  File "/home/aries/.local/lib/python3.9/site-packages/aries_cloudagent/core/oob_processor.py", line 110, in find_oob_target_for_outbound_message
    outbound_message.payload = json.dumps(message)
...
TypeError: Object of type ServiceDecorator is not JSON serializable
```

The above was fixed by adding `.serialize()` to `message["~service"] = oob_record.our_service.serialize()` 
Tada! With this modification, our previous OOB test workflow is passing again.

This appears to come from some type inconsistencies ... where services are references as either dictionaries or ServiceDecorator types.

Some tests were failing due to mocking their/our_service as dictionaries. Resolved that by using the correct model.