### PR TITLE
fix: fixes a regression that requires a log file in multi-tenant mode

### DIFF
--- a/aries_cloudagent/config/default_multitenant_logging_config.ini
+++ b/aries_cloudagent/config/default_multitenant_logging_config.ini
@@ -21,7 +21,7 @@ args = (sys.stderr,)
 class = logging.handlers.TimedRotatingFileMultiProcessHandler
 level = DEBUG
 formatter = formatter
-args = ('test.log', 'd', 7, 1)
+args = ('agent.log', 'd', 7, 1)
 
 [formatter_formatter]
 format = %(asctime)s %(wallet_id)s %(levelname)s %(pathname)s:%(lineno)d %(message)s

--- a/aries_cloudagent/config/logging.py
+++ b/aries_cloudagent/config/logging.py
@@ -170,15 +170,15 @@ class LoggingConfigurator:
             # location if --log-file is specified on startup and a config file is not.
             if not log_config_path and write_to_log_file:
                 log_config_path = cls.default_multitenant_config_path_ini
-  
+
             cls._configure_multitenant_logging(
                 log_config_path=log_config_path,
                 log_level=log_level,
-                log_file=log_file, 
+                log_file=log_file,
             )
         else:
             # The default config for single-tenant mode does not specify a log file
-            # location. This is a check that requires a log file path to be provided if 
+            # location. This is a check that requires a log file path to be provided if
             # --log-file is specified on startup and a config file is not.
             if not log_config_path and write_to_log_file and not log_file:
                 raise ValueError(

--- a/aries_cloudagent/config/logging.py
+++ b/aries_cloudagent/config/logging.py
@@ -168,8 +168,13 @@ class LoggingConfigurator:
         if multitenant:
             # The default logging config for multi-tenant mode specifies a log file
             # location if --log-file is specified on startup and a config file is not.
-            if not log_config_path and write_to_log_file:
-                log_config_path = cls.default_multitenant_config_path_ini
+            # When all else fails, the default single-tenant config file is used.
+            if not log_config_path:
+                log_config_path = (
+                    cls.default_multitenant_config_path_ini
+                    if write_to_log_file
+                    else cls.default_config_path_ini
+                )
 
             cls._configure_multitenant_logging(
                 log_config_path=log_config_path,


### PR DESCRIPTION
This fixes a regression introduced by #2870 that required a log file to be present on file when using the default config setup for multi-tenant mode. The log file is only required if the user specifically sets the `--log-file` startup param.