### PR TITLE
Upgrade to anoncreds via api endpoint

### DIFF
--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -1123,7 +1123,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
 
     async def txn_submit(
         self,
-        profile: Profile,
+        ledger: BaseLedger,
         ledger_transaction: str,
         sign: bool = None,
         taa_accept: bool = None,
@@ -1131,10 +1131,6 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         write_ledger: bool = True,
     ) -> str:
         """Submit a transaction to the ledger."""
-        ledger = profile.inject(BaseLedger)
-
-        if not ledger:
-            raise LedgerError("No ledger available")
 
         try:
             async with ledger:

--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -7,6 +7,7 @@ wallet.
 
 """
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -17,12 +18,8 @@ from qrcode import QRCode
 
 from ..admin.base_server import BaseAdminServer
 from ..admin.server import AdminResponder, AdminServer
-from ..commands.upgrade import (
-    add_version_record,
-    get_upgrade_version_list,
-    upgrade,
-)
-from ..config.default_context import ContextBuilder
+from ..commands.upgrade import add_version_record, get_upgrade_version_list, upgrade
+from ..config.default_context import ContextBuilder, DefaultContextBuilder
 from ..config.injection_context import InjectionContext
 from ..config.ledger import (
     get_genesis_transactions,
@@ -63,7 +60,11 @@ from ..protocols.out_of_band.v1_0.messages.invitation import HSProto, Invitation
 from ..storage.base import BaseStorage
 from ..storage.error import StorageNotFoundError
 from ..storage.record import StorageRecord
-from ..storage.type import RECORD_TYPE_ACAPY_STORAGE_TYPE
+from ..storage.type import (
+    RECORD_TYPE_ACAPY_STORAGE_TYPE,
+    STORAGE_TYPE_VALUE_ANONCREDS,
+    STORAGE_TYPE_VALUE_ASKAR,
+)
 from ..transport.inbound.manager import InboundTransportManager
 from ..transport.inbound.message import InboundMessage
 from ..transport.outbound.base import OutboundDeliveryError
@@ -71,10 +72,12 @@ from ..transport.outbound.manager import OutboundTransportManager, QueuedOutboun
 from ..transport.outbound.message import OutboundMessage
 from ..transport.outbound.status import OutboundSendStatus
 from ..transport.wire_format import BaseWireFormat
+from ..utils.profiles import get_subwallet_profiles_from_storage
 from ..utils.stats import Collector
 from ..utils.task_queue import CompletedTask, TaskQueue
 from ..vc.ld_proofs.document_loader import DocumentLoader
 from ..version import RECORD_TYPE_ACAPY_VERSION, __version__
+from ..wallet.anoncreds_upgrade import upgrade_wallet_to_anoncreds_if_requested
 from ..wallet.did_info import DIDInfo
 from .dispatcher import Dispatcher
 from .error import StartupError
@@ -111,6 +114,8 @@ class Conductor:
         self.root_profile: Profile = None
         self.setup_public_did: DIDInfo = None
 
+    force_agent_anoncreds = False
+
     @property
     def context(self) -> InjectionContext:
         """Accessor for the injection context."""
@@ -120,6 +125,9 @@ class Conductor:
         """Initialize the global request context."""
 
         context = await self.context_builder.build_context()
+
+        if self.force_agent_anoncreds:
+            context.settings.set_value("wallet.type", "askar-anoncreds")
 
         # Fetch genesis transactions if necessary
         if context.settings.get("ledger.ledger_config_list"):
@@ -522,7 +530,9 @@ class Conductor:
             except Exception:
                 LOGGER.exception("Error accepting mediation invitation")
 
-        # notify protocols of startup status
+        await self.check_for_wallet_upgrades_in_progress()
+
+        # notify protcols of startup status
         await self.root_profile.notify(STARTUP_EVENT_TOPIC, {})
 
     async def stop(self, timeout=1.0):
@@ -796,8 +806,9 @@ class Conductor:
                     )
                 except StorageNotFoundError:
                     acapy_version = None
+                # Any existing agent will have acapy_version record
                 if acapy_version:
-                    storage_type_from_storage = "askar"
+                    storage_type_from_storage = STORAGE_TYPE_VALUE_ASKAR
                     LOGGER.info(
                         f"Existing agent found. Setting wallet type to {storage_type_from_storage}."  # noqa: E501
                     )
@@ -820,6 +831,38 @@ class Conductor:
                     )
 
             if storage_type_from_storage != storage_type_from_config:
-                raise StartupError(
-                    f"Wallet type config [{storage_type_from_config}] doesn't match with the wallet type in storage [{storage_type_record.value}]"  # noqa: E501
-                )
+                if (
+                    storage_type_from_config == STORAGE_TYPE_VALUE_ASKAR
+                    and storage_type_from_storage == STORAGE_TYPE_VALUE_ANONCREDS
+                ):
+                    LOGGER.warning(
+                        "The agent has been upgrade to use anoncreds wallet. Please update the wallet.type in the config file to 'askar-anoncreds'"  # noqa: E501
+                    )
+                    # Allow agent to create anoncreds profile with askar
+                    # wallet type config by stopping conductor and reloading context
+                    await self.stop()
+                    self.force_agent_anoncreds = True
+                    self.context.settings.set_value("wallet.type", "askar-anoncreds")
+                    self.context_builder = DefaultContextBuilder(self.context.settings)
+                    await self.setup()
+                else:
+                    raise StartupError(
+                        f"Wallet type config [{storage_type_from_config}] doesn't match with the wallet type in storage [{storage_type_record.value}]"  # noqa: E501
+                    )
+
+    async def check_for_wallet_upgrades_in_progress(self):
+        """Check for upgrade and upgrade if needed."""
+        multitenant_mgr = self.context.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            subwallet_profiles = await get_subwallet_profiles_from_storage(
+                self.root_profile
+            )
+            await asyncio.gather(
+                *[
+                    upgrade_wallet_to_anoncreds_if_requested(profile, is_subwallet=True)
+                    for profile in subwallet_profiles
+                ]
+            )
+
+        else:
+            await upgrade_wallet_to_anoncreds_if_requested(self.root_profile)

--- a/aries_cloudagent/core/tests/test_conductor.py
+++ b/aries_cloudagent/core/tests/test_conductor.py
@@ -117,6 +117,8 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
         ) as mock_outbound_mgr, mock.patch.object(
             test_module, "LoggingConfigurator", autospec=True
         ) as mock_logger, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -166,6 +168,7 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
 
             mock_inbound_mgr.return_value.stop.assert_awaited_once_with()
             mock_outbound_mgr.return_value.stop.assert_awaited_once_with()
+            assert mock_upgrade.called
 
     async def test_startup_version_no_upgrade_add_record(self):
         builder: ContextBuilder = StubContextBuilder(self.test_settings)
@@ -176,6 +179,8 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
         ) as mock_inbound_mgr, mock.patch.object(
             test_module, "OutboundTransportManager", autospec=True
         ) as mock_outbound_mgr, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -213,6 +218,8 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
         ) as mock_inbound_mgr, mock.patch.object(
             test_module, "OutboundTransportManager", autospec=True
         ) as mock_outbound_mgr, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -257,6 +264,8 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
         ) as mock_outbound_mgr, mock.patch.object(
             test_module, "LoggingConfigurator", autospec=True
         ) as mock_logger, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -296,6 +305,8 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
         ) as mock_outbound_mgr, mock.patch.object(
             test_module, "LoggingConfigurator", autospec=True
         ) as mock_logger, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -335,6 +346,8 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
         ) as mock_outbound_mgr, mock.patch.object(
             test_module, "LoggingConfigurator", autospec=True
         ) as mock_logger, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -373,6 +386,8 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
         ) as mock_outbound_mgr, mock.patch.object(
             test_module, "LoggingConfigurator", autospec=True
         ) as mock_logger, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -449,6 +464,8 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
         ) as mock_outbound_mgr, mock.patch.object(
             test_module, "LoggingConfigurator", autospec=True
         ) as mock_logger, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -492,6 +509,8 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
         ) as mock_inbound_mgr, mock.patch.object(
             test_module, "OutboundTransportManager", autospec=True
         ) as mock_outbound_mgr, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             test_module, "LoggingConfigurator", autospec=True
         ) as mock_logger:
             mock_inbound_mgr.return_value.sessions = ["dummy"]
@@ -884,6 +903,8 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
         ) as admin_start, mock.patch.object(
             admin, "stop", autospec=True
         ) as admin_stop, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -936,6 +957,8 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
         ) as oob_mgr, mock.patch.object(
             test_module, "ConnectionManager"
         ) as conn_mgr, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -992,7 +1015,9 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
             ),
         ), mock.patch.object(
             test_module, "OutboundTransportManager", autospec=True
-        ) as mock_outbound_mgr:
+        ) as mock_outbound_mgr, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade:
             mock_outbound_mgr.return_value.registered_transports = {
                 "test": mock.MagicMock(schemes=["http"])
             }
@@ -1166,7 +1191,9 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
             ),
         ), mock.patch.object(
             test_module, "OutboundTransportManager", autospec=True
-        ) as mock_outbound_mgr:
+        ) as mock_outbound_mgr, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade:
             mock_outbound_mgr.return_value.registered_transports = {
                 "test": mock.MagicMock(schemes=["http"])
             }
@@ -1203,6 +1230,8 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
             "MediationManager",
             return_value=mock.MagicMock(clear_default_mediator=mock.CoroutineMock()),
         ) as mock_mgr, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -1254,7 +1283,9 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
                     mock.MagicMock(value=f"v{__version__}"),
                 ]
             ),
-        ):
+        ), mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade:
             await conductor.start()
             await conductor.stop()
             mock_mgr.return_value.set_default_mediator_by_id.assert_called_once()
@@ -1277,6 +1308,8 @@ class TestConductor(IsolatedAsyncioTestCase, Config, TestDIDs):
             "retrieve_by_id",
             mock.CoroutineMock(side_effect=Exception()),
         ), mock.patch.object(test_module, "LOGGER") as mock_logger, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -1425,6 +1458,8 @@ class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
         ) as mock_mgr, mock.patch.object(
             mock_conn_record, "metadata_set", mock.CoroutineMock()
         ), mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -1484,6 +1519,8 @@ class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
                 )
             ),
         ) as mock_mgr, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -1542,6 +1579,8 @@ class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
         ), mock.patch.object(
             test_module, "MediationManager", return_value=mock_mediation_manager
         ), mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -1596,7 +1635,9 @@ class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
                     mock.MagicMock(value=f"v{__version__}"),
                 ]
             ),
-        ):
+        ), mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade:
             # when
             await conductor.start()
             await conductor.stop()
@@ -1631,6 +1672,8 @@ class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
         ) as mock_from_url, mock.patch.object(
             test_module, "LOGGER"
         ) as mock_logger, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -1694,6 +1737,8 @@ class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
         ) as mock_outbound_mgr, mock.patch.object(
             test_module, "LOGGER"
         ) as mock_logger, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -1735,6 +1780,8 @@ class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
         ) as mock_outbound_mgr, mock.patch.object(
             test_module, "LoggingConfigurator", autospec=True
         ) as mock_logger, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -1774,7 +1821,7 @@ class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
 
             await conductor.stop()
 
-    async def test_startup_storage_type_exists_and_does_not_match(self):
+    async def test_startup_storage_type_anoncreds_and_config_askar_re_calls_setup(self):
         builder: ContextBuilder = StubContextBuilder(self.test_settings)
         conductor = test_module.Conductor(builder)
 
@@ -1785,6 +1832,8 @@ class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
         ) as mock_outbound_mgr, mock.patch.object(
             test_module, "LoggingConfigurator", autospec=True
         ) as mock_logger, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -1819,9 +1868,9 @@ class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
 
             mock_inbound_mgr.return_value.registered_transports = {}
             mock_outbound_mgr.return_value.registered_transports = {}
-
-            with self.assertRaises(test_module.StartupError):
+            with mock.patch.object(test_module.Conductor, "setup") as mock_setup:
                 await conductor.start()
+                assert mock_setup.called
 
             await conductor.stop()
 
@@ -1838,6 +1887,8 @@ class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
         ) as mock_outbound_mgr, mock.patch.object(
             test_module, "LoggingConfigurator", autospec=True
         ) as mock_logger, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(
@@ -1902,6 +1953,8 @@ class TestConductorMediationSetup(IsolatedAsyncioTestCase, Config):
         ) as mock_outbound_mgr, mock.patch.object(
             test_module, "LoggingConfigurator", autospec=True
         ) as mock_logger, mock.patch.object(
+            test_module, "upgrade_wallet_to_anoncreds_if_requested", return_value=False
+        ) as mock_upgrade, mock.patch.object(
             BaseStorage,
             "find_record",
             mock.CoroutineMock(

--- a/aries_cloudagent/ledger/base.py
+++ b/aries_cloudagent/ledger/base.py
@@ -643,7 +643,7 @@ class BaseLedger(ABC, metaclass=ABCMeta):
         try:
             legacy_indy_registry = LegacyIndyRegistry()
             resp = await legacy_indy_registry.txn_submit(
-                self.profile,
+                self,
                 schema_req,
                 sign=True,
                 sign_did=public_info,

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -1186,7 +1186,7 @@ class IndySdkLedger(BaseLedger):
             legacy_indy_registry = LegacyIndyRegistry()
 
             resp = await legacy_indy_registry.txn_submit(
-                self.profile,
+                self,
                 rev_reg_def_req,
                 sign=True,
                 sign_did=did_info,
@@ -1255,7 +1255,7 @@ class IndySdkLedger(BaseLedger):
             legacy_indy_registry = LegacyIndyRegistry()
 
             resp = await legacy_indy_registry.txn_submit(
-                self.profile,
+                self,
                 rev_reg_def_entry_req,
                 sign=True,
                 sign_did=did_info,

--- a/aries_cloudagent/ledger/indy_vdr.py
+++ b/aries_cloudagent/ledger/indy_vdr.py
@@ -1147,7 +1147,7 @@ class IndyVdrLedger(BaseLedger):
 
             legacy_indy_registry = LegacyIndyRegistry()
             resp = await legacy_indy_registry.txn_submit(
-                self.profile,
+                self,
                 rev_reg_def_req,
                 sign=True,
                 sign_did=did_info,
@@ -1222,7 +1222,7 @@ class IndyVdrLedger(BaseLedger):
 
             legacy_indy_registry = LegacyIndyRegistry()
             resp = await legacy_indy_registry.txn_submit(
-                self.profile,
+                self,
                 revoc_reg_entry_req,
                 sign=True,
                 sign_did=did_info,

--- a/aries_cloudagent/multitenant/manager.py
+++ b/aries_cloudagent/multitenant/manager.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Iterable, Optional
 
+from ..askar.profile_anon import AskarAnoncredsProfile
 from ..config.injection_context import InjectionContext
 from ..config.wallet import wallet_config
 from ..core.profile import Profile
@@ -83,6 +84,13 @@ class MultitenantManager(BaseMultitenantManager):
             # MTODO: add ledger config
             profile, _ = await wallet_config(context, provision=provision)
             self._profiles.put(wallet_id, profile)
+
+        # return anoncreds profile if explicitly set as wallet type
+        if profile.context.settings.get("wallet.type") == "askar-anoncreds":
+            return AskarAnoncredsProfile(
+                profile.opened,
+                profile.context,
+            )
 
         return profile
 

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/manager.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/manager.py
@@ -415,6 +415,9 @@ class TransactionManager:
         if (not endorser) and (
             txn_goal_code != TransactionRecord.WRITE_DID_TRANSACTION
         ):
+            ledger = self.profile.inject(BaseLedger)
+            if not ledger:
+                raise TransactionManagerError("No ledger available")
             if (
                 self._profile.context.settings.get_value("wallet.type")
                 == "askar-anoncreds"
@@ -425,13 +428,9 @@ class TransactionManager:
 
                 legacy_indy_registry = LegacyIndyRegistry()
                 ledger_response_json = await legacy_indy_registry.txn_submit(
-                    self._profile, ledger_transaction, sign=False, taa_accept=False
+                    ledger, ledger_transaction, sign=False, taa_accept=False
                 )
             else:
-                ledger = self.profile.inject(BaseLedger)
-                if not ledger:
-                    raise TransactionManagerError("No ledger available")
-
                 async with ledger:
                     try:
                         ledger_response_json = await shield(

--- a/aries_cloudagent/storage/type.py
+++ b/aries_cloudagent/storage/type.py
@@ -1,3 +1,7 @@
 """Library version information."""
 
 RECORD_TYPE_ACAPY_STORAGE_TYPE = "acapy_storage_type"
+RECORD_TYPE_ACAPY_UPGRADING = "acapy_upgrading"
+
+STORAGE_TYPE_VALUE_ANONCREDS = "askar-anoncreds"
+STORAGE_TYPE_VALUE_ASKAR = "askar"

--- a/aries_cloudagent/utils/profiles.py
+++ b/aries_cloudagent/utils/profiles.py
@@ -1,10 +1,15 @@
 """Profile utilities."""
 
+import json
+
 from aiohttp import web
 
 from ..anoncreds.error_messages import ANONCREDS_PROFILE_REQUIRED_MSG
 from ..askar.profile_anon import AskarAnoncredsProfile
 from ..core.profile import Profile
+from ..multitenant.manager import MultitenantManager
+from ..storage.base import BaseStorageSearch
+from ..wallet.models.wallet_record import WalletRecord
 
 
 def is_anoncreds_profile_raise_web_exception(profile: Profile) -> None:
@@ -29,3 +34,26 @@ def subwallet_type_not_same_as_base_wallet_raise_web_exception(
         raise web.HTTPForbidden(
             reason="Subwallet type must be the same as the base wallet type"
         )
+
+
+async def get_subwallet_profiles_from_storage(root_profile: Profile) -> list[Profile]:
+    """Get subwallet profiles from storage."""
+    subwallet_profiles = []
+    base_storage_search = root_profile.inject(BaseStorageSearch)
+    search_session = base_storage_search.search_records(
+        type_filter=WalletRecord.RECORD_TYPE, page_size=10
+    )
+    while search_session._done is False:
+        wallet_storage_records = await search_session.fetch()
+        for wallet_storage_record in wallet_storage_records:
+            wallet_record = WalletRecord.from_storage(
+                wallet_storage_record.id,
+                json.loads(wallet_storage_record.value),
+            )
+            subwallet_profiles.append(
+                await MultitenantManager(root_profile).get_wallet_profile(
+                    base_context=root_profile.context,
+                    wallet_record=wallet_record,
+                )
+            )
+    return subwallet_profiles

--- a/aries_cloudagent/wallet/anoncreds_upgrade.py
+++ b/aries_cloudagent/wallet/anoncreds_upgrade.py
@@ -1,0 +1,690 @@
+"""Functions for upgrading records to anoncreds."""
+
+import asyncio
+import json
+import logging
+from typing import Optional
+
+from anoncreds import (
+    CredentialDefinition,
+    CredentialDefinitionPrivate,
+    KeyCorrectnessProof,
+    RevocationRegistryDefinitionPrivate,
+    Schema,
+)
+
+from ..anoncreds.issuer import (
+    CATEGORY_CRED_DEF,
+    CATEGORY_CRED_DEF_KEY_PROOF,
+    CATEGORY_CRED_DEF_PRIVATE,
+    CATEGORY_SCHEMA,
+)
+from ..anoncreds.models.anoncreds_cred_def import CredDef, CredDefState
+from ..anoncreds.models.anoncreds_revocation import (
+    RevList,
+    RevListState,
+    RevRegDef,
+    RevRegDefState,
+    RevRegDefValue,
+)
+from ..anoncreds.models.anoncreds_schema import SchemaState
+from ..anoncreds.revocation import (
+    CATEGORY_REV_LIST,
+    CATEGORY_REV_REG_DEF,
+    CATEGORY_REV_REG_DEF_PRIVATE,
+)
+from ..core.profile import Profile
+from ..ledger.multiple_ledger.ledger_requests_executor import (
+    GET_CRED_DEF,
+    GET_SCHEMA,
+    IndyLedgerRequestsExecutor,
+)
+from ..messaging.credential_definitions.util import CRED_DEF_SENT_RECORD_TYPE
+from ..messaging.schemas.util import SCHEMA_SENT_RECORD_TYPE
+from ..multitenant.base import BaseMultitenantManager
+from ..revocation.models.issuer_cred_rev_record import IssuerCredRevRecord
+from ..revocation.models.issuer_rev_reg_record import IssuerRevRegRecord
+from ..storage.base import BaseStorage
+from ..storage.error import StorageNotFoundError
+from ..storage.record import StorageRecord
+from ..storage.type import (
+    RECORD_TYPE_ACAPY_STORAGE_TYPE,
+    RECORD_TYPE_ACAPY_UPGRADING,
+    STORAGE_TYPE_VALUE_ANONCREDS,
+)
+from .singletons import IsAnoncredsSingleton, UpgradeInProgressSingleton
+
+LOGGER = logging.getLogger(__name__)
+
+UPGRADING_RECORD_IN_PROGRESS = "anoncreds_in_progress"
+UPGRADING_RECORD_FINISHED = "anoncreds_finished"
+
+# Number of times to retry upgrading records
+max_retries = 5
+
+
+class SchemaUpgradeObj:
+    """Schema upgrade object."""
+
+    def __init__(
+        self,
+        schema_id: str,
+        schema: Schema,
+        name: str,
+        version: str,
+        issuer_id: str,
+        old_record_id: str,
+    ):
+        """Initialize schema upgrade object."""
+        self.schema_id = schema_id
+        self.schema = schema
+        self.name = name
+        self.version = version
+        self.issuer_id = issuer_id
+        self.old_record_id = old_record_id
+
+
+class CredDefUpgradeObj:
+    """Cred def upgrade object."""
+
+    def __init__(
+        self,
+        cred_def_id: str,
+        cred_def: CredentialDefinition,
+        cred_def_private: CredentialDefinitionPrivate,
+        key_proof: KeyCorrectnessProof,
+        revocation: Optional[bool] = None,
+        askar_cred_def: Optional[any] = None,
+        max_cred_num: Optional[int] = None,
+    ):
+        """Initialize cred def upgrade object."""
+        self.cred_def_id = cred_def_id
+        self.cred_def = cred_def
+        self.cred_def_private = cred_def_private
+        self.key_proof = key_proof
+        self.revocation = revocation
+        self.askar_cred_def = askar_cred_def
+        self.max_cred_num = max_cred_num
+
+
+class RevRegDefUpgradeObj:
+    """Rev reg def upgrade object."""
+
+    def __init__(
+        self,
+        rev_reg_def_id: str,
+        rev_reg_def: RevRegDef,
+        rev_reg_def_private: RevocationRegistryDefinitionPrivate,
+        active: bool = False,
+    ):
+        """Initialize rev reg def upgrade object."""
+        self.rev_reg_def_id = rev_reg_def_id
+        self.rev_reg_def = rev_reg_def
+        self.rev_reg_def_private = rev_reg_def_private
+        self.active = active
+
+
+class RevListUpgradeObj:
+    """Rev entry upgrade object."""
+
+    def __init__(
+        self,
+        rev_list: RevList,
+        pending: list,
+        rev_reg_def_id: str,
+        cred_rev_records: list,
+    ):
+        """Initialize rev entry upgrade object."""
+        self.rev_list = rev_list
+        self.pending = pending
+        self.rev_reg_def_id = rev_reg_def_id
+        self.cred_rev_records = cred_rev_records
+
+
+async def get_schema_upgrade_object(
+    profile: Profile, schema_id: str, askar_schema
+) -> SchemaUpgradeObj:
+    """Get schema upgrade object."""
+
+    async with profile.session() as session:
+        schema_id = askar_schema.tags.get("schema_id")
+        issuer_did = askar_schema.tags.get("schema_issuer_did")
+        # Need to get schema from the ledger because the attribute names
+        # are not stored in the wallet
+        multitenant_mgr = session.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(profile)
+        else:
+            ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
+
+    _, ledger = await ledger_exec_inst.get_ledger_for_identifier(
+        schema_id,
+        txn_record_type=GET_SCHEMA,
+    )
+    async with ledger:
+        schema_from_ledger = await ledger.get_schema(schema_id)
+
+    return SchemaUpgradeObj(
+        schema_id,
+        Schema.create(
+            schema_id,
+            askar_schema.tags.get("schema_name"),
+            issuer_did,
+            schema_from_ledger["attrNames"],
+        ),
+        askar_schema.tags.get("schema_name"),
+        askar_schema.tags.get("schema_version"),
+        issuer_did,
+        askar_schema.id,
+    )
+
+
+async def get_cred_def_upgrade_object(
+    profile: Profile, askar_cred_def
+) -> CredDefUpgradeObj:
+    """Get cred def upgrade object."""
+    cred_def_id = askar_cred_def.tags.get("cred_def_id")
+    async with profile.session() as session:
+        # Need to get cred_def from the ledger because the tag
+        # is not stored in the wallet and don't know wether it supports revocation
+        multitenant_mgr = session.inject_or(BaseMultitenantManager)
+        if multitenant_mgr:
+            ledger_exec_inst = IndyLedgerRequestsExecutor(profile)
+        else:
+            ledger_exec_inst = session.inject(IndyLedgerRequestsExecutor)
+    _, ledger = await ledger_exec_inst.get_ledger_for_identifier(
+        cred_def_id,
+        txn_record_type=GET_CRED_DEF,
+    )
+    async with ledger:
+        cred_def_from_ledger = await ledger.get_credential_definition(cred_def_id)
+
+    async with profile.session() as session:
+        storage = session.inject(BaseStorage)
+        askar_cred_def_private = await storage.get_record(
+            CATEGORY_CRED_DEF_PRIVATE, cred_def_id
+        )
+        askar_cred_def_key_proof = await storage.get_record(
+            CATEGORY_CRED_DEF_KEY_PROOF, cred_def_id
+        )
+
+    cred_def = CredDef(
+        issuer_id=askar_cred_def.tags.get("issuer_did"),
+        schema_id=askar_cred_def.tags.get("schema_id"),
+        tag=cred_def_from_ledger["tag"],
+        type=cred_def_from_ledger["type"],
+        value=cred_def_from_ledger["value"],
+    )
+
+    return CredDefUpgradeObj(
+        cred_def_id,
+        cred_def,
+        askar_cred_def_private.value,
+        askar_cred_def_key_proof.value,
+        cred_def_from_ledger["value"].get("revocation", None),
+        askar_cred_def=askar_cred_def,
+    )
+
+
+async def get_rev_reg_def_upgrade_object(
+    profile: Profile,
+    cred_def_upgrade_obj: CredDefUpgradeObj,
+    askar_issuer_rev_reg_def,
+    is_active: bool,
+) -> RevRegDefUpgradeObj:
+    """Get rev reg def upgrade object."""
+    rev_reg_def_id = askar_issuer_rev_reg_def.tags.get("revoc_reg_id")
+
+    async with profile.session() as session:
+        storage = session.inject(BaseStorage)
+        askar_reg_rev_def_private = await storage.get_record(
+            CATEGORY_REV_REG_DEF_PRIVATE, rev_reg_def_id
+        )
+
+    revoc_reg_def_values = json.loads(askar_issuer_rev_reg_def.value)
+
+    reg_def_value = RevRegDefValue(
+        revoc_reg_def_values["revoc_reg_def"]["value"]["publicKeys"],
+        revoc_reg_def_values["revoc_reg_def"]["value"]["maxCredNum"],
+        revoc_reg_def_values["revoc_reg_def"]["value"]["tailsLocation"],
+        revoc_reg_def_values["revoc_reg_def"]["value"]["tailsHash"],
+    )
+
+    rev_reg_def = RevRegDef(
+        issuer_id=askar_issuer_rev_reg_def.tags.get("issuer_did"),
+        cred_def_id=cred_def_upgrade_obj.cred_def_id,
+        tag=revoc_reg_def_values["tag"],
+        type=revoc_reg_def_values["revoc_def_type"],
+        value=reg_def_value,
+    )
+
+    return RevRegDefUpgradeObj(
+        rev_reg_def_id, rev_reg_def, askar_reg_rev_def_private.value, is_active
+    )
+
+
+async def get_rev_list_upgrade_object(
+    profile: Profile, rev_reg_def_upgrade_obj: RevRegDefUpgradeObj
+) -> RevListUpgradeObj:
+    """Get revocation entry upgrade object."""
+    rev_reg = rev_reg_def_upgrade_obj.rev_reg_def
+    async with profile.session() as session:
+        storage = session.inject(BaseStorage)
+        askar_cred_rev_records = await storage.find_all_records(
+            IssuerCredRevRecord.RECORD_TYPE,
+            {"rev_reg_id": rev_reg_def_upgrade_obj.rev_reg_def_id},
+        )
+
+    revocation_list = [0] * rev_reg.value.max_cred_num
+    for askar_cred_rev_record in askar_cred_rev_records:
+        if askar_cred_rev_record.tags.get("state") == "revoked":
+            revocation_list[int(askar_cred_rev_record.tags.get("cred_rev_id")) - 1] = 1
+
+    rev_list = RevList(
+        issuer_id=rev_reg.issuer_id,
+        rev_reg_def_id=rev_reg_def_upgrade_obj.rev_reg_def_id,
+        revocation_list=revocation_list,
+        current_accumulator=json.loads(
+            rev_reg_def_upgrade_obj.askar_issuer_rev_reg_def.value
+        )["revoc_reg_entry"]["value"]["accum"],
+    )
+
+    return RevListUpgradeObj(
+        rev_list,
+        json.loads(rev_reg_def_upgrade_obj.askar_issuer_rev_reg_def.value)[
+            "pending_pub"
+        ],
+        rev_reg_def_upgrade_obj.rev_reg_def_id,
+        askar_cred_rev_records,
+    )
+
+
+async def upgrade_and_delete_schema_records(
+    txn, schema_upgrade_obj: SchemaUpgradeObj
+) -> None:
+    """Upgrade and delete schema records."""
+    schema_anoncreds = schema_upgrade_obj.schema
+    await txn.handle.remove("schema_sent", schema_upgrade_obj.old_record_id)
+    await txn.handle.replace(
+        CATEGORY_SCHEMA,
+        schema_upgrade_obj.schema_id,
+        schema_anoncreds.to_json(),
+        {
+            "name": schema_upgrade_obj.name,
+            "version": schema_upgrade_obj.version,
+            "issuer_id": schema_upgrade_obj.issuer_id,
+            "state": SchemaState.STATE_FINISHED,
+        },
+    )
+
+
+async def upgrade_and_delete_cred_def_records(
+    txn, anoncreds_schema, cred_def_upgrade_obj: CredDefUpgradeObj
+) -> None:
+    """Upgrade and delete cred def records."""
+    cred_def_id = cred_def_upgrade_obj.cred_def_id
+    anoncreds_schema = anoncreds_schema.to_dict()
+    askar_cred_def = cred_def_upgrade_obj.askar_cred_def
+    await txn.handle.remove("cred_def_sent", askar_cred_def.id)
+    await txn.handle.replace(
+        CATEGORY_CRED_DEF,
+        cred_def_id,
+        cred_def_upgrade_obj.cred_def.to_json(),
+        tags={
+            "schema_id": askar_cred_def.tags.get("schema_id"),
+            "schema_issuer_id": anoncreds_schema["issuerId"],
+            "issuer_id": askar_cred_def.tags.get("issuer_did"),
+            "schema_name": anoncreds_schema["name"],
+            "schema_version": anoncreds_schema["version"],
+            "state": CredDefState.STATE_FINISHED,
+            "epoch": askar_cred_def.tags.get("epoch"),
+            # TODO We need to keep track of these but tags probably
+            # isn't ideal. This suggests that a full record object
+            # is necessary for non-private values
+            "support_revocation": json.dumps(cred_def_upgrade_obj.revocation),
+            "max_cred_num": str(cred_def_upgrade_obj.max_cred_num or 0),
+        },
+    )
+    await txn.handle.replace(
+        CATEGORY_CRED_DEF_PRIVATE,
+        cred_def_id,
+        CredentialDefinitionPrivate.load(
+            cred_def_upgrade_obj.cred_def_private
+        ).to_json_buffer(),
+    )
+    await txn.handle.replace(
+        CATEGORY_CRED_DEF_KEY_PROOF,
+        cred_def_id,
+        KeyCorrectnessProof.load(cred_def_upgrade_obj.key_proof).to_json_buffer(),
+    )
+
+
+rev_reg_states_mapping = {
+    "init": RevRegDefState.STATE_WAIT,
+    "generated": RevRegDefState.STATE_ACTION,
+    "posted": RevRegDefState.STATE_FINISHED,
+    "active": RevRegDefState.STATE_FINISHED,
+    "full": RevRegDefState.STATE_FULL,
+    "decommissioned": RevRegDefState.STATE_DECOMMISSIONED,
+}
+
+
+async def upgrade_and_delete_rev_reg_def_records(
+    txn, rev_reg_def_upgrade_obj: RevRegDefUpgradeObj
+) -> None:
+    """Upgrade and delete rev reg def records."""
+    rev_reg_def_id = rev_reg_def_upgrade_obj.rev_reg_def_id
+    askar_issuer_rev_reg_def = rev_reg_def_upgrade_obj.askar_issuer_rev_reg_def
+    await txn.handle.remove(IssuerRevRegRecord.RECORD_TYPE, askar_issuer_rev_reg_def.id)
+    await txn.handle.replace(
+        CATEGORY_REV_REG_DEF,
+        rev_reg_def_id,
+        rev_reg_def_upgrade_obj.rev_reg_def.to_json(),
+        tags={
+            "cred_def_id": rev_reg_def_upgrade_obj.rev_reg_def.cred_def_id,
+            "issuer_id": askar_issuer_rev_reg_def.tags.get("issuer_did"),
+            "state": rev_reg_states_mapping[askar_issuer_rev_reg_def.tags.get("state")],
+            "active": json.dumps(rev_reg_def_upgrade_obj.active),
+        },
+    )
+    await txn.handle.replace(
+        CATEGORY_REV_REG_DEF_PRIVATE,
+        rev_reg_def_id,
+        RevocationRegistryDefinitionPrivate.load(
+            rev_reg_def_upgrade_obj.rev_reg_def_private
+        ).to_json_buffer(),
+    )
+
+
+async def upgrade_and_delete_rev_entry_records(
+    txn, rev_list_upgrade_obj: RevListUpgradeObj
+) -> None:
+    """Upgrade and delete revocation entry records."""
+    next_index = 0
+    for cred_rev_record in rev_list_upgrade_obj.cred_rev_records:
+        if int(cred_rev_record.tags.get("cred_rev_id")) > next_index:
+            next_index = int(cred_rev_record.tags.get("cred_rev_id"))
+        await txn.handle.remove(IssuerCredRevRecord.RECORD_TYPE, cred_rev_record.id)
+
+    await txn.handle.insert(
+        CATEGORY_REV_LIST,
+        rev_list_upgrade_obj.rev_reg_def_id,
+        value_json={
+            "rev_list": rev_list_upgrade_obj.rev_list.serialize(),
+            "pending": rev_list_upgrade_obj.pending,
+            "next_index": next_index + 1,
+        },
+        tags={
+            "state": RevListState.STATE_FINISHED,
+            "pending": json.dumps(rev_list_upgrade_obj.pending is not None),
+        },
+    )
+
+
+async def upgrade_all_records_with_transaction(
+    txn: any,
+    schema_upgrade_objs: list[SchemaUpgradeObj],
+    cred_def_upgrade_objs: list[CredDefUpgradeObj],
+    rev_reg_def_upgrade_objs: list[RevRegDefUpgradeObj],
+    rev_list_upgrade_objs: list[RevListUpgradeObj],
+) -> None:
+    """Upgrade all objects with transaction."""
+    for schema_upgrade_obj in schema_upgrade_objs:
+        await upgrade_and_delete_schema_records(txn, schema_upgrade_obj)
+    for cred_def_upgrade_obj in cred_def_upgrade_objs:
+        await upgrade_and_delete_cred_def_records(
+            txn, schema_upgrade_obj.schema, cred_def_upgrade_obj
+        )
+    for rev_reg_def_upgrade_obj in rev_reg_def_upgrade_objs:
+        await upgrade_and_delete_rev_reg_def_records(txn, rev_reg_def_upgrade_obj)
+    for rev_list_upgrade_obj in rev_list_upgrade_objs:
+        await upgrade_and_delete_rev_entry_records(txn, rev_list_upgrade_obj)
+
+    await txn.commit()
+
+
+async def get_rev_reg_def_upgrade_objs(
+    profile: Profile,
+    cred_def_upgrade_obj: CredDefUpgradeObj,
+    rev_list_upgrade_objs: list[RevListUpgradeObj],
+) -> list[RevRegDefUpgradeObj]:
+    """Get rev reg def upgrade objects."""
+
+    rev_reg_def_upgrade_objs = []
+    async with profile.session() as session:
+        storage = session.inject(BaseStorage)
+        # Must be sorted to find the active rev reg def
+        askar_issuer_rev_reg_def_records = sorted(
+            await storage.find_all_records(
+                IssuerRevRegRecord.RECORD_TYPE,
+                {"cred_def_id": cred_def_upgrade_obj.cred_def_id},
+            ),
+            key=lambda x: json.loads(x.value)["created_at"],
+        )
+    found_active = False
+    for askar_issuer_rev_reg_def in askar_issuer_rev_reg_def_records:
+        # active rev reg def is the oldest non-full and active rev reg def
+        if (
+            not found_active
+            and askar_issuer_rev_reg_def.tags.get("state") != "full"
+            and askar_issuer_rev_reg_def.tags.get("state") == "active"
+        ):
+            found_active = True
+            is_active = True
+
+        rev_reg_def_upgrade_obj = await get_rev_reg_def_upgrade_object(
+            profile,
+            cred_def_upgrade_obj,
+            askar_issuer_rev_reg_def,
+            is_active,
+        )
+        is_active = False
+        rev_reg_def_upgrade_obj.askar_issuer_rev_reg_def = askar_issuer_rev_reg_def
+
+        rev_reg_def_upgrade_objs.append(rev_reg_def_upgrade_obj)
+
+        # add the revocation list upgrade object from reg def upgrade object
+        rev_list_upgrade_objs.append(
+            await get_rev_list_upgrade_object(profile, rev_reg_def_upgrade_obj)
+        )
+    return rev_reg_def_upgrade_objs
+
+
+async def convert_records_to_anoncreds(profile) -> None:
+    """Convert and delete old askar records."""
+    async with profile.session() as session:
+        storage = session.inject(BaseStorage)
+        askar_schema_records = await storage.find_all_records(SCHEMA_SENT_RECORD_TYPE)
+
+        schema_upgrade_objs = []
+        cred_def_upgrade_objs = []
+        rev_reg_def_upgrade_objs = []
+        rev_list_upgrade_objs = []
+
+        for askar_schema in askar_schema_records:
+            schema_upgrade_objs.append(
+                await get_schema_upgrade_object(profile, askar_schema.id, askar_schema)
+            )
+
+        askar_cred_def_records = await storage.find_all_records(
+            CRED_DEF_SENT_RECORD_TYPE, {}
+        )
+        for askar_cred_def in askar_cred_def_records:
+            cred_def_upgrade_obj = await get_cred_def_upgrade_object(
+                profile, askar_cred_def
+            )
+            rev_reg_def_upgrade_objs = await get_rev_reg_def_upgrade_objs(
+                profile, cred_def_upgrade_obj, rev_list_upgrade_objs
+            )
+            # update the cred_def with the max_cred_num from first rev_reg_def
+            if rev_reg_def_upgrade_objs:
+                cred_def_upgrade_obj.max_cred_num = rev_reg_def_upgrade_objs[
+                    0
+                ].rev_reg_def.value.max_cred_num
+            cred_def_upgrade_objs.append(cred_def_upgrade_obj)
+
+        async with profile.transaction() as txn:
+            try:
+                await upgrade_all_records_with_transaction(
+                    txn,
+                    schema_upgrade_objs,
+                    cred_def_upgrade_objs,
+                    rev_reg_def_upgrade_objs,
+                    rev_list_upgrade_objs,
+                )
+            except Exception as e:
+                await txn.rollback()
+                raise e
+
+
+async def retry_converting_records(
+    profile: Profile, upgrading_record: StorageRecord, retry: int, is_subwallet=False
+) -> None:
+    """Retry converting records to anoncreds."""
+
+    async def fail_upgrade():
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            await storage.delete_record(upgrading_record)
+
+    try:
+        await convert_records_to_anoncreds(profile)
+        await finish_upgrade_by_updating_profile_or_shutting_down(profile, is_subwallet)
+        LOGGER.info(f"Upgrade complete via retry for wallet: {profile.name}")
+    except Exception as e:
+        LOGGER.error(f"Error when upgrading records for wallet {profile.name} : {e} ")
+        if retry < max_retries:
+            LOGGER.info(f"Retry attempt {retry + 1} to upgrade wallet {profile.name}")
+            await asyncio.sleep(1)
+            await retry_converting_records(
+                profile, upgrading_record, retry + 1, is_subwallet
+            )
+        else:
+            LOGGER.error(
+                f"""Failed to upgrade wallet: {profile.name} after 5 retries. 
+                Your wallet may be in an inconsistent state. 
+                Try fixing any connection issues and re-running the update"""
+            )
+            await fail_upgrade()
+
+
+async def upgrade_wallet_to_anoncreds_if_requested(
+    profile: Profile, is_subwallet=False
+) -> None:
+    """Get upgrading record and attempt to upgrade wallet to anoncreds."""
+    async with profile.session() as session:
+        storage = session.inject(BaseStorage)
+        try:
+            upgrading_record = await storage.find_record(
+                RECORD_TYPE_ACAPY_UPGRADING, {}
+            )
+            if upgrading_record.value == UPGRADING_RECORD_FINISHED:
+                IsAnoncredsSingleton().set_wallet(profile.name)
+                return
+        except StorageNotFoundError:
+            return
+
+        try:
+            LOGGER.info("Upgrade in process for wallet: %s", profile.name)
+            await convert_records_to_anoncreds(profile)
+            await finish_upgrade_by_updating_profile_or_shutting_down(
+                profile, is_subwallet
+            )
+        except Exception as e:
+            LOGGER.error(f"Error when upgrading wallet {profile.name} : {e} ")
+            await retry_converting_records(profile, upgrading_record, 0, is_subwallet)
+
+
+async def finish_upgrade(profile: Profile):
+    """Finish record by setting records and caches."""
+    async with profile.session() as session:
+        storage = session.inject(BaseStorage)
+        try:
+            storage_type_record = await storage.find_record(
+                type_filter=RECORD_TYPE_ACAPY_STORAGE_TYPE, tag_query={}
+            )
+            await storage.update_record(
+                storage_type_record, STORAGE_TYPE_VALUE_ANONCREDS, {}
+            )
+        # This should only happen for subwallets
+        except StorageNotFoundError:
+            await storage.add_record(
+                StorageRecord(
+                    RECORD_TYPE_ACAPY_STORAGE_TYPE,
+                    STORAGE_TYPE_VALUE_ANONCREDS,
+                )
+            )
+    await finish_upgrading_record(profile)
+    IsAnoncredsSingleton().set_wallet(profile.name)
+    UpgradeInProgressSingleton().remove_wallet(profile.name)
+
+
+async def finish_upgrading_record(profile: Profile):
+    """Update upgrading record to finished."""
+    async with profile.session() as session:
+        storage = session.inject(BaseStorage)
+        try:
+            upgrading_record = await storage.find_record(
+                RECORD_TYPE_ACAPY_UPGRADING, tag_query={}
+            )
+            await storage.update_record(upgrading_record, UPGRADING_RECORD_FINISHED, {})
+        except StorageNotFoundError:
+            return
+
+
+async def upgrade_subwallet(profile: Profile) -> None:
+    """Upgrade subwallet to anoncreds."""
+    async with profile.session() as session:
+        multitenant_mgr = session.inject_or(BaseMultitenantManager)
+        wallet_id = profile.settings.get("wallet.id")
+        settings = {"wallet.type": STORAGE_TYPE_VALUE_ANONCREDS}
+        await multitenant_mgr.update_wallet(wallet_id, settings)
+
+
+async def finish_upgrade_by_updating_profile_or_shutting_down(
+    profile: Profile, is_subwallet=False
+):
+    """Upgrade wallet to anoncreds and set storage type."""
+    if is_subwallet:
+        await upgrade_subwallet(profile)
+        await finish_upgrade(profile)
+        LOGGER.info(
+            f"""Upgrade of subwallet {profile.settings.get('wallet.name')} has completed. Profile is now askar-anoncreds"""  # noqa: E501
+        )
+    else:
+        await finish_upgrade(profile)
+        LOGGER.info(
+            f"Upgrade of base wallet {profile.settings.get('wallet.name')} to anoncreds has completed. Shutting down agent."  # noqa: E501
+        )
+        asyncio.get_event_loop().stop()
+
+
+async def check_upgrade_completion_loop(profile: Profile, is_subwallet=False):
+    """Check if upgrading is complete."""
+    async with profile.session() as session:
+        while True:
+            storage = session.inject(BaseStorage)
+            LOGGER.debug(f"Checking upgrade completion for wallet: {profile.name}")
+            try:
+                upgrading_record = await storage.find_record(
+                    RECORD_TYPE_ACAPY_UPGRADING, tag_query={}
+                )
+                if upgrading_record.value == UPGRADING_RECORD_FINISHED:
+                    IsAnoncredsSingleton().set_wallet(profile.name)
+                    UpgradeInProgressSingleton().remove_wallet(profile.name)
+                    if is_subwallet:
+                        await upgrade_subwallet(profile)
+                        LOGGER.info(
+                            f"""Upgrade of subwallet {profile.settings.get('wallet.name')} has completed. Profile is now askar-anoncreds"""  # noqa: E501
+                        )
+                        return
+                    LOGGER.info(
+                        f"Upgrade complete for wallet: {profile.name}, shutting down agent."  # noqa: E501
+                    )
+                    # Shut down agent if base wallet
+                    asyncio.get_event_loop().stop()
+            except StorageNotFoundError:
+                # If the record is not found, the upgrade failed
+                return
+
+            await asyncio.sleep(1)

--- a/aries_cloudagent/wallet/anoncreds_upgrade.py
+++ b/aries_cloudagent/wallet/anoncreds_upgrade.py
@@ -538,17 +538,17 @@ async def convert_records_to_anoncreds(profile) -> None:
             cred_def_upgrade_objs.append(cred_def_upgrade_obj)
 
         # Link secret
-        record = None
+        link_secret_record = None
         try:
-            record = await session.handle.fetch(
+            link_secret_record = await session.handle.fetch(
                 CATEGORY_LINK_SECRET, IndyCredxHolder.LINK_SECRET_ID
             )
         except AskarError:
             pass
 
         link_secret = None
-        if record:
-            link_secret = LinkSecret.load(record.raw_value)
+        if link_secret_record:
+            link_secret = LinkSecret.load(link_secret_record.raw_value)
 
         async with profile.transaction() as txn:
             try:

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -1,5 +1,6 @@
 """Wallet admin routes."""
 
+import asyncio
 import json
 import logging
 from typing import List, Optional, Tuple, Union
@@ -55,15 +56,23 @@ from ..protocols.endorse_transaction.v1_0.util import (
     is_author_role,
 )
 from ..resolver.base import ResolverError
+from ..storage.base import BaseStorage
 from ..storage.error import StorageError, StorageNotFoundError
+from ..storage.record import StorageRecord
+from ..storage.type import RECORD_TYPE_ACAPY_UPGRADING
 from ..wallet.jwt import jwt_sign, jwt_verify
 from ..wallet.sd_jwt import sd_jwt_sign, sd_jwt_verify
+from .anoncreds_upgrade import (
+    UPGRADING_RECORD_IN_PROGRESS,
+    upgrade_wallet_to_anoncreds_if_requested,
+)
 from .base import BaseWallet
 from .did_info import DIDInfo
 from .did_method import KEY, PEER2, PEER4, SOV, DIDMethod, DIDMethods, HolderDefinedDid
 from .did_posture import DIDPosture
 from .error import WalletError, WalletNotFoundError
 from .key_type import BLS12381G2, ED25519, KeyTypes
+from .singletons import UpgradeInProgressSingleton
 from .util import EVENT_LISTENER_PATTERN
 
 LOGGER = logging.getLogger(__name__)
@@ -1241,6 +1250,68 @@ async def wallet_rotate_did_keypair(request: web.BaseRequest):
     return web.json_response({})
 
 
+class UpgradeVerificationSchema(OpenAPISchema):
+    """Parameters and validators for triggering an upgrade to anoncreds."""
+
+    wallet_name = fields.Str(
+        required=True,
+        metadata={
+            "description": "Name of wallet to upgrade to anoncreds",
+            "example": "base-wallet",
+        },
+    )
+
+
+class UpgradeResultSchema(OpenAPISchema):
+    """Result schema for upgrade."""
+
+
+@docs(
+    tags=["anoncreds - wallet upgrade"],
+    summary="""
+        Upgrade the wallet from askar to anoncreds - Be very careful with this! You 
+        cannot go back! See migration guide for more information.
+    """,
+)
+@querystring_schema(UpgradeVerificationSchema())
+@response_schema(UpgradeResultSchema(), description="")
+async def upgrade_anoncreds(request: web.BaseRequest):
+    """Request handler for triggering an upgrade to anoncreds.
+
+    Args:
+        request: aiohttp request object
+
+    Returns:
+        An empty JSON response
+
+    """
+    context: AdminRequestContext = request["context"]
+    profile = context.profile
+
+    if profile.settings.get("wallet.name") != request.query.get("wallet_name"):
+        raise web.HTTPBadRequest(
+            reason="Wallet name parameter does not match the agent which triggered the upgrade"  # noqa: E501
+        )
+
+    if profile.settings.get("wallet.type") == "askar-anoncreds":
+        raise web.HTTPBadRequest(reason="Wallet type is already anoncreds")
+
+    async with profile.session() as session:
+        storage = session.inject(BaseStorage)
+        upgrading_record = StorageRecord(
+            RECORD_TYPE_ACAPY_UPGRADING,
+            UPGRADING_RECORD_IN_PROGRESS,
+        )
+        await storage.add_record(upgrading_record)
+        is_subwallet = context.metadata and "wallet_id" in context.metadata
+        asyncio.create_task(
+            upgrade_wallet_to_anoncreds_if_requested(profile, is_subwallet)
+        )
+        UpgradeInProgressSingleton().set_wallet(profile.name)
+
+    return web.json_response({})
+
+
 def register_events(event_bus: EventBus):
     """Subscribe to any events we need to support."""
     event_bus.subscribe(EVENT_LISTENER_PATTERN, on_register_nym_event)
@@ -1333,6 +1404,7 @@ async def register(app: web.Application):
                 "/wallet/get-did-endpoint", wallet_get_did_endpoint, allow_head=False
             ),
             web.patch("/wallet/did/local/rotate-keypair", wallet_rotate_did_keypair),
+            web.post("/anoncreds/wallet/upgrade", upgrade_anoncreds),
         ]
     )
 
@@ -1353,6 +1425,16 @@ def post_process_routes(app: web.Application):
                     "https://github.com/hyperledger/indy-sdk/tree/"
                     "master/docs/design/003-wallet-storage"
                 ),
+            },
+        }
+    )
+    app._state["swagger_dict"]["tags"].append(
+        {
+            "name": "anoncreds - wallet upgrade",
+            "description": "Anoncreds wallet upgrade",
+            "externalDocs": {
+                "description": "Specification",
+                "url": "https://hyperledger.github.io/anoncreds-spec",
             },
         }
     )

--- a/aries_cloudagent/wallet/routes.py
+++ b/aries_cloudagent/wallet/routes.py
@@ -1309,7 +1309,12 @@ async def upgrade_anoncreds(request: web.BaseRequest):
         )
         UpgradeInProgressSingleton().set_wallet(profile.name)
 
-    return web.json_response({})
+    return web.json_response(
+        {
+            "success": True,
+            "message": f"Upgrade to anoncreds has been triggered for wallet {profile.name}",  # noqa: E501
+        }
+    )
 
 
 def register_events(event_bus: EventBus):

--- a/aries_cloudagent/wallet/singletons.py
+++ b/aries_cloudagent/wallet/singletons.py
@@ -1,0 +1,43 @@
+"""Module that contains singleton classes for wallet operations."""
+
+
+class IsAnoncredsSingleton:
+    """Singleton class used as cache for anoncreds wallet-type queries."""
+
+    instance = None
+    wallets = set()
+
+    def __new__(cls, *args, **kwargs):
+        """Create a new instance of the class."""
+        if cls.instance is None:
+            cls.instance = super().__new__(cls)
+        return cls.instance
+
+    def set_wallet(self, wallet: str):
+        """Set a wallet name."""
+        self.wallets.add(wallet)
+
+    def remove_wallet(self, wallet: str):
+        """Remove a wallet name."""
+        self.wallets.discard(wallet)
+
+
+class UpgradeInProgressSingleton:
+    """Singleton class used as cache for upgrade in progress."""
+
+    instance = None
+    wallets = set()
+
+    def __new__(cls, *args, **kwargs):
+        """Create a new instance of the class."""
+        if cls.instance is None:
+            cls.instance = super().__new__(cls)
+        return cls.instance
+
+    def set_wallet(self, wallet: str):
+        """Set a wallet name."""
+        self.wallets.add(wallet)
+
+    def remove_wallet(self, wallet: str):
+        """Remove a wallet name."""
+        self.wallets.discard(wallet)

--- a/aries_cloudagent/wallet/tests/test_anoncreds_upgrade.py
+++ b/aries_cloudagent/wallet/tests/test_anoncreds_upgrade.py
@@ -1,0 +1,390 @@
+import asyncio
+from time import time
+from unittest import IsolatedAsyncioTestCase
+
+from aries_cloudagent.tests import mock
+from aries_cloudagent.wallet import singletons
+
+from ...anoncreds.issuer import CATEGORY_CRED_DEF_PRIVATE
+from ...core.in_memory.profile import InMemoryProfile, InMemoryProfileSession
+from ...indy.credx.issuer import CATEGORY_CRED_DEF_KEY_PROOF
+from ...messaging.credential_definitions.util import CRED_DEF_SENT_RECORD_TYPE
+from ...messaging.schemas.util import SCHEMA_SENT_RECORD_TYPE
+from ...multitenant.base import BaseMultitenantManager
+from ...multitenant.manager import MultitenantManager
+from ...storage.base import BaseStorage
+from ...storage.record import StorageRecord
+from ...storage.type import (
+    RECORD_TYPE_ACAPY_STORAGE_TYPE,
+    RECORD_TYPE_ACAPY_UPGRADING,
+    STORAGE_TYPE_VALUE_ANONCREDS,
+)
+from .. import anoncreds_upgrade
+
+
+class TestAnoncredsUpgrade(IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.profile = InMemoryProfile.test_profile(
+            settings={"wallet.type": "askar", "wallet.id": "test-wallet-id"}
+        )
+        self.context = self.profile.context
+        self.context.injector.bind_instance(
+            BaseMultitenantManager, mock.MagicMock(MultitenantManager, autospec=True)
+        )
+
+    async def test_convert_records_to_anoncreds(self):
+        async with self.profile.session() as session:
+            storage = session.inject(BaseStorage)
+
+            schema_id = "GHjSbphAcdsrZrLjSvsjMp:2:faber-simple:1.1"
+            schema_id_parts = schema_id.split(":")
+            schema_tags = {
+                "schema_id": schema_id,
+                "schema_issuer_did": schema_id_parts[0],
+                "schema_name": schema_id_parts[-2],
+                "schema_version": schema_id_parts[-1],
+                "epoch": str(int(time())),
+            }
+            await storage.add_record(
+                StorageRecord(SCHEMA_SENT_RECORD_TYPE, schema_id, schema_tags)
+            )
+
+            credential_definition_id = "GHjSbphAcdsrZrLjSvsjMp:3:CL:8:default"
+            cred_def_tags = {
+                "schema_id": schema_id,
+                "schema_issuer_did": schema_id_parts[0],
+                "schema_name": schema_id_parts[-2],
+                "schema_version": schema_id_parts[-1],
+                "issuer_did": "GHjSbphAcdsrZrLjSvsjMp",
+                "cred_def_id": credential_definition_id,
+                "epoch": str(int(time())),
+            }
+            await storage.add_record(
+                StorageRecord(
+                    CRED_DEF_SENT_RECORD_TYPE, credential_definition_id, cred_def_tags
+                )
+            )
+            storage.get_record = mock.CoroutineMock(
+                side_effect=[
+                    StorageRecord(
+                        CATEGORY_CRED_DEF_PRIVATE,
+                        {"p_key": {"p": "123...782", "q": "234...456"}, "r_key": None},
+                        {},
+                    ),
+                    StorageRecord(
+                        CATEGORY_CRED_DEF_KEY_PROOF,
+                        {"c": "103...961", "xz_cap": "563...205", "xr_cap": []},
+                        {},
+                    ),
+                ]
+            )
+            anoncreds_upgrade.IndyLedgerRequestsExecutor = mock.MagicMock()
+            anoncreds_upgrade.IndyLedgerRequestsExecutor.return_value.get_ledger_for_identifier = mock.CoroutineMock(
+                return_value=(
+                    None,
+                    mock.MagicMock(
+                        get_schema=mock.CoroutineMock(
+                            return_value={
+                                "attrNames": [
+                                    "name",
+                                    "age",
+                                ],
+                            },
+                        ),
+                        get_credential_definition=mock.CoroutineMock(
+                            return_value={
+                                "type": "CL",
+                                "tag": "default",
+                                "value": {
+                                    "primary": {
+                                        "n": "123",
+                                    },
+                                },
+                            },
+                        ),
+                    ),
+                )
+            )
+
+            with mock.patch.object(
+                anoncreds_upgrade, "upgrade_and_delete_schema_records"
+            ), mock.patch.object(
+                anoncreds_upgrade, "upgrade_and_delete_cred_def_records"
+            ):
+                await anoncreds_upgrade.convert_records_to_anoncreds(self.profile)
+
+    async def test_retry_converting_records(self):
+        with mock.patch.object(
+            anoncreds_upgrade, "convert_records_to_anoncreds", mock.CoroutineMock()
+        ) as mock_convert_records_to_anoncreds:
+            mock_convert_records_to_anoncreds.side_effect = [
+                Exception("Error"),
+                Exception("Error"),
+                None,
+            ]
+            async with self.profile.session() as session:
+                storage = session.inject(BaseStorage)
+                upgrading_record = StorageRecord(
+                    RECORD_TYPE_ACAPY_UPGRADING,
+                    anoncreds_upgrade.UPGRADING_RECORD_IN_PROGRESS,
+                )
+                await storage.add_record(upgrading_record)
+                await anoncreds_upgrade.retry_converting_records(
+                    self.profile, upgrading_record, 0
+                )
+
+                assert mock_convert_records_to_anoncreds.call_count == 3
+                storage_type_record = await storage.find_record(
+                    RECORD_TYPE_ACAPY_STORAGE_TYPE, tag_query={}
+                )
+                upgrading_record = await storage.find_record(
+                    RECORD_TYPE_ACAPY_UPGRADING, tag_query={}
+                )
+                assert storage_type_record.value == STORAGE_TYPE_VALUE_ANONCREDS
+                assert (
+                    upgrading_record.value
+                    == anoncreds_upgrade.UPGRADING_RECORD_FINISHED
+                )
+                assert "test-profile" in singletons.IsAnoncredsSingleton().wallets
+
+    async def test_upgrade_wallet_to_anoncreds(self):
+        # upgrading record not present
+        await anoncreds_upgrade.upgrade_wallet_to_anoncreds_if_requested(self.profile)
+
+        # upgrading record present
+        async with self.profile.session() as session:
+            storage = session.inject(BaseStorage)
+            await storage.add_record(
+                StorageRecord(
+                    RECORD_TYPE_ACAPY_UPGRADING,
+                    anoncreds_upgrade.UPGRADING_RECORD_IN_PROGRESS,
+                )
+            )
+            await anoncreds_upgrade.upgrade_wallet_to_anoncreds_if_requested(
+                self.profile
+            )
+            storage_type_record = await storage.find_record(
+                RECORD_TYPE_ACAPY_STORAGE_TYPE, tag_query={}
+            )
+            upgrading_record = await storage.find_record(
+                RECORD_TYPE_ACAPY_UPGRADING, tag_query={}
+            )
+            assert storage_type_record.value == STORAGE_TYPE_VALUE_ANONCREDS
+            assert upgrading_record.value == anoncreds_upgrade.UPGRADING_RECORD_FINISHED
+            assert "test-profile" in singletons.IsAnoncredsSingleton().wallets
+
+        # retry called on exception
+        with mock.patch.object(
+            anoncreds_upgrade,
+            "convert_records_to_anoncreds",
+            mock.CoroutineMock(side_effect=[Exception("Error")]),
+        ), mock.patch.object(
+            anoncreds_upgrade, "retry_converting_records", mock.CoroutineMock()
+        ) as mock_retry_converting_records:
+            async with self.profile.session() as session:
+                storage = session.inject(BaseStorage)
+                upgrading_record = await storage.find_record(
+                    RECORD_TYPE_ACAPY_UPGRADING, tag_query={}
+                )
+                await storage.update_record(
+                    upgrading_record, anoncreds_upgrade.UPGRADING_RECORD_IN_PROGRESS, {}
+                )
+            await anoncreds_upgrade.upgrade_wallet_to_anoncreds_if_requested(
+                self.profile
+            )
+            assert mock_retry_converting_records.called
+
+    async def test_set_storage_type_to_anoncreds_no_existing_record(self):
+        await anoncreds_upgrade.finish_upgrade(self.profile)
+        _, storage_type_record = next(iter(self.profile.records.items()))
+        assert storage_type_record.value == STORAGE_TYPE_VALUE_ANONCREDS
+
+    async def test_set_storage_type_to_anoncreds_has_existing_record(self):
+        async with self.profile.session() as session:
+            storage = session.inject(BaseStorage)
+            await storage.add_record(
+                StorageRecord(
+                    RECORD_TYPE_ACAPY_STORAGE_TYPE,
+                    "askar",
+                )
+            )
+            await anoncreds_upgrade.finish_upgrade(self.profile)
+            _, storage_type_record = next(iter(self.profile.records.items()))
+            assert storage_type_record.value == STORAGE_TYPE_VALUE_ANONCREDS
+
+    async def test_update_if_subwallet_and_set_storage_type_with_subwallet(self):
+
+        await anoncreds_upgrade.finish_upgrade_by_updating_profile_or_shutting_down(
+            self.profile, True
+        )
+        _, storage_type_record = next(iter(self.profile.records.items()))
+        assert storage_type_record.value == STORAGE_TYPE_VALUE_ANONCREDS
+
+    async def test_update_if_subwallet_and_set_storage_type_with_base_wallet(self):
+
+        await anoncreds_upgrade.finish_upgrade_by_updating_profile_or_shutting_down(
+            self.profile, False
+        )
+        _, storage_type_record = next(iter(self.profile.records.items()))
+        assert storage_type_record.value == STORAGE_TYPE_VALUE_ANONCREDS
+
+    async def test_failed_upgrade(self):
+        async with self.profile.session() as session:
+            storage = session.inject(BaseStorage)
+
+            schema_id = "GHjSbphAcdsrZrLjSvsjMp:2:faber-simple:1.1"
+            schema_id_parts = schema_id.split(":")
+            schema_tags = {
+                "schema_id": schema_id,
+                "schema_issuer_did": schema_id_parts[0],
+                "schema_name": schema_id_parts[-2],
+                "schema_version": schema_id_parts[-1],
+                "epoch": str(int(time())),
+            }
+            await storage.add_record(
+                StorageRecord(SCHEMA_SENT_RECORD_TYPE, schema_id, schema_tags)
+            )
+            await storage.add_record(
+                StorageRecord(
+                    RECORD_TYPE_ACAPY_STORAGE_TYPE,
+                    "askar",
+                )
+            )
+            await storage.add_record(
+                StorageRecord(
+                    RECORD_TYPE_ACAPY_UPGRADING,
+                    "true",
+                )
+            )
+
+            credential_definition_id = "GHjSbphAcdsrZrLjSvsjMp:3:CL:8:default"
+            cred_def_tags = {
+                "schema_id": schema_id,
+                "schema_issuer_did": schema_id_parts[0],
+                "schema_name": schema_id_parts[-2],
+                "schema_version": schema_id_parts[-1],
+                "issuer_did": "GHjSbphAcdsrZrLjSvsjMp",
+                "cred_def_id": credential_definition_id,
+                "epoch": str(int(time())),
+            }
+            await storage.add_record(
+                StorageRecord(
+                    CRED_DEF_SENT_RECORD_TYPE, credential_definition_id, cred_def_tags
+                )
+            )
+            storage.get_record = mock.CoroutineMock(
+                side_effect=[
+                    StorageRecord(
+                        CATEGORY_CRED_DEF_PRIVATE,
+                        {"p_key": {"p": "123...782", "q": "234...456"}, "r_key": None},
+                        {},
+                    ),
+                    StorageRecord(
+                        CATEGORY_CRED_DEF_KEY_PROOF,
+                        {"c": "103...961", "xz_cap": "563...205", "xr_cap": []},
+                        {},
+                    ),
+                ]
+            )
+            anoncreds_upgrade.IndyLedgerRequestsExecutor = mock.MagicMock()
+            anoncreds_upgrade.IndyLedgerRequestsExecutor.return_value.get_ledger_for_identifier = mock.CoroutineMock(
+                return_value=(
+                    None,
+                    mock.MagicMock(
+                        get_schema=mock.CoroutineMock(
+                            return_value={
+                                "attrNames": [
+                                    "name",
+                                    "age",
+                                ],
+                            },
+                        ),
+                        get_credential_definition=mock.CoroutineMock(
+                            return_value={
+                                "type": "CL",
+                                "tag": "default",
+                                "value": {
+                                    "primary": {
+                                        "n": "123",
+                                    },
+                                },
+                            },
+                        ),
+                    ),
+                )
+            )
+
+            with mock.patch.object(
+                anoncreds_upgrade, "upgrade_and_delete_schema_records"
+            ), mock.patch.object(
+                anoncreds_upgrade, "upgrade_and_delete_cred_def_records"
+            ), mock.patch.object(
+                InMemoryProfileSession, "rollback"
+            ) as mock_rollback, mock.patch.object(
+                InMemoryProfileSession,
+                "commit",
+                # Don't wait for sleep in retry to speed up test
+            ) as mock_commit, mock.patch.object(
+                asyncio, "sleep"
+            ):
+                """
+                Only tests schemas and cred_defs failing to upgrade because the other objects are
+                hard to mock. These tests should be enough to cover them as the logic is the same.
+                """
+
+                # Schemas fails to upgrade
+                anoncreds_upgrade.upgrade_and_delete_schema_records = mock.CoroutineMock(
+                    # Needs to fail 5 times because of the retry logic
+                    side_effect=[
+                        Exception("Error"),
+                        Exception("Error"),
+                        Exception("Error"),
+                        Exception("Error"),
+                        Exception("Error"),
+                    ]
+                )
+                await anoncreds_upgrade.upgrade_wallet_to_anoncreds_if_requested(
+                    self.profile
+                )
+                assert mock_rollback.called
+                assert not mock_commit.called
+                # Upgrading record should not be deleted
+                with self.assertRaises(Exception):
+                    await storage.find_record(
+                        type_filter=RECORD_TYPE_ACAPY_UPGRADING, tag_query={}
+                    )
+
+                storage_type_record = await storage.find_record(
+                    type_filter=RECORD_TYPE_ACAPY_STORAGE_TYPE, tag_query={}
+                )
+                # Storage type should not be updated
+                assert storage_type_record.value == "askar"
+
+                # Cred_defs fails to upgrade
+                anoncreds_upgrade.upgrade_and_delete_cred_def_records = (
+                    mock.CoroutineMock(
+                        side_effect=[
+                            Exception("Error"),
+                            Exception("Error"),
+                            Exception("Error"),
+                            Exception("Error"),
+                            Exception("Error"),
+                        ]
+                    )
+                )
+                await anoncreds_upgrade.upgrade_wallet_to_anoncreds_if_requested(
+                    self.profile
+                )
+                assert mock_rollback.called
+                assert not mock_commit.called
+                # Upgrading record should not be deleted
+                with self.assertRaises(Exception):
+                    await storage.find_record(
+                        type_filter=RECORD_TYPE_ACAPY_UPGRADING, tag_query={}
+                    )
+
+                storage_type_record = await storage.find_record(
+                    type_filter=RECORD_TYPE_ACAPY_STORAGE_TYPE, tag_query={}
+                )
+                # Storage type should not be updated
+                assert storage_type_record.value == "askar"

--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -3,6 +3,7 @@ from unittest import IsolatedAsyncioTestCase
 from aiohttp.web import HTTPForbidden
 
 from aries_cloudagent.tests import mock
+from aries_cloudagent.wallet import singletons
 
 from ...admin.request_context import AdminRequestContext
 from ...core.in_memory import InMemoryProfile
@@ -11,6 +12,7 @@ from ...protocols.coordinate_mediation.v1_0.route_manager import RouteManager
 from ...wallet.did_method import SOV, DIDMethod, DIDMethods, HolderDefinedDid
 from ...wallet.key_type import ED25519, KeyTypes
 from .. import routes as test_module
+from ..anoncreds_upgrade import UPGRADING_RECORD_IN_PROGRESS
 from ..base import BaseWallet
 from ..did_info import DIDInfo
 from ..did_posture import DIDPosture
@@ -1005,6 +1007,26 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
         )
         with self.assertRaises(test_module.web.HTTPBadRequest):
             await test_module.wallet_rotate_did_keypair(self.request)
+
+    async def test_upgrade_anoncreds(self):
+        self.profile.settings["wallet.name"] = "test_wallet"
+        self.request.query = {"wallet_name": "not_test_wallet"}
+        with self.assertRaises(test_module.web.HTTPBadRequest):
+            await test_module.upgrade_anoncreds(self.request)
+
+        self.request.query = {"wallet_name": "not_test_wallet"}
+        self.profile.settings["wallet.type"] = "askar-anoncreds"
+        with self.assertRaises(test_module.web.HTTPBadRequest):
+            await test_module.upgrade_anoncreds(self.request)
+
+        self.request.query = {"wallet_name": "test_wallet"}
+        self.profile.settings["wallet.type"] = "askar"
+        result = await test_module.upgrade_anoncreds(self.request)
+        print(result)
+        _, upgrade_record = next(iter(self.profile.records.items()))
+        assert upgrade_record.type == "acapy_upgrading"
+        assert upgrade_record.value == UPGRADING_RECORD_IN_PROGRESS
+        assert "test-profile" in singletons.UpgradeInProgressSingleton().wallets
 
     async def test_register(self):
         mock_app = mock.MagicMock()

--- a/demo/features/steps/0586-sign-transaction.py
+++ b/demo/features/steps/0586-sign-transaction.py
@@ -761,7 +761,6 @@ def step_impl(context, holder_name, issuer_name):
         "/credentials",
         params={},
     )
-    assert len(cred_list["results"]) == 1
     cred_id = cred_list["results"][0]["referent"]
 
     revoc_status_bool = False

--- a/demo/features/steps/upgrade.py
+++ b/demo/features/steps/upgrade.py
@@ -1,0 +1,24 @@
+"""Steps for upgrading the wallet to support anoncreds."""
+
+from bdd_support.agent_backchannel_client import (
+    agent_container_POST,
+    async_sleep,
+)
+from behave import given, then
+
+
+@given('"{issuer}" upgrades the wallet to anoncreds')
+@then('"{issuer}" upgrades the wallet to anoncreds')
+def step_impl(context, issuer):
+    """Upgrade the wallet to support anoncreds."""
+    agent = context.active_agents[issuer]
+    agent_container_POST(
+        agent["agent"],
+        "/anoncreds/wallet/upgrade",
+        data={},
+        params={
+            "wallet_name": agent["agent"].agent.wallet_name,
+        },
+    )
+
+    async_sleep(2.0)

--- a/demo/features/upgrade.feature
+++ b/demo/features/upgrade.feature
@@ -20,7 +20,10 @@ Feature: ACA-Py Anoncreds Upgrade
       Then "Bob" can verify the credential from "<issuer>" was revoked
       And "<issuer>" upgrades the wallet to anoncreds
       And "Bob" has an issued <Schema_name> credential <Credential_data> from "<issuer>"
+      And "Bob" upgrades the wallet to anoncreds
+      And "Bob" has an issued <Schema_name> credential <Credential_data> from "<issuer>"
+      When "Faber" sends a request for proof presentation <Proof_request> to "Bob"
 
       Examples:
          | issuer | Acme_capabilities                          | Bob_capabilities | Schema_name       | Credential_data   | Proof_request     |
-         | Acme   | --revocation --public-did --multitenant |        | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |
+         | Acme   | --revocation --public-did --multitenant | --multitenant       | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |

--- a/demo/features/upgrade.feature
+++ b/demo/features/upgrade.feature
@@ -1,0 +1,26 @@
+Feature: ACA-Py Anoncreds Upgrade
+
+   @GHA
+   Scenario Outline: Using revocation api, issue, revoke credentials and publish
+      Given we have "3" agents
+         | name  | role     | capabilities        |
+         | Acme  | issuer   | <Acme_capabilities> |
+         | Faber | verifier | <Acme_capabilities> |
+         | Bob   | prover   | <Bob_capabilities>  |
+      And "<issuer>" and "Bob" have an existing connection
+      And "Bob" has an issued <Schema_name> credential <Credential_data> from "<issuer>"
+      And "<issuer>" has written the credential definition for <Schema_name> to the ledger
+      And "<issuer>" has written the revocation registry definition to the ledger
+      And "<issuer>" has written the revocation registry entry transaction to the ledger
+      And "<issuer>" revokes the credential without publishing the entry
+      And "<issuer>" authors a revocation registry entry publishing transaction
+      And "Faber" and "Bob" have an existing connection
+      When "Faber" sends a request for proof presentation <Proof_request> to "Bob"
+      Then "Faber" has the proof verification fail
+      Then "Bob" can verify the credential from "<issuer>" was revoked
+      And "<issuer>" upgrades the wallet to anoncreds
+      And "Bob" has an issued <Schema_name> credential <Credential_data> from "<issuer>"
+
+      Examples:
+         | issuer | Acme_capabilities                          | Bob_capabilities | Schema_name       | Credential_data   | Proof_request     |
+         | Acme   | --revocation --public-did --multitenant |        | driverslicense_v2 | Data_DL_MaxValues | DL_age_over_19_v2 |

--- a/docs/design/UpgradeViaApi.md
+++ b/docs/design/UpgradeViaApi.md
@@ -1,0 +1,103 @@
+# Upgrade via API Design
+
+#### To isolate an upgrade process and trigger it via API the following pattern was designed to handle multitenant scenarios. It includes an is_upgrading record in the wallet(DB) and a middleware to prevent requests during the upgrade process.
+
+#### The diagam below descripes the sequence of events for the anoncreds upgrade process which it was designed for, but the architecture can be used for any upgrade process.
+
+```mermaid
+sequenceDiagram
+    participant A1 as Agent 1
+    participant M1 as Middleware
+    participant IAS1 as IsAnoncredsSingleton Set
+    participant UIPS1 as UpgradeInProgressSingleton Set
+    participant W as Wallet (DB)
+    participant UIPS2 as UpgradeInProgressSingleton Set
+    participant IAS2 as IsAnoncredsSingleton Set
+    participant M2 as Middleware
+    participant A2 as Agent 2
+
+    Note over A1,A2: Start upgrade for non-anoncreds wallet
+    A1->>M1: POST /anoncreds/wallet/upgrade
+    M1-->>IAS1: check if wallet is in set
+    IAS1-->>M1: wallet is not in set
+    M1-->>UIPS1: check if wallet is in set
+    UIPS1-->>M1: wallet is not in set
+    M1->>A1: OK
+    A1-->>W: Add is_upgrading = anoncreds_in_progress record
+    A1->>A1: Upgrade wallet
+    A1-->>UIPS1: Add wallet to set
+
+    Note over A1,A2: Attempted Requests During Upgrade
+
+    Note over A1: Attempted Request
+    A1->>M1: GET /any-endpoint
+    M1-->>IAS1: check if wallet is in set
+    IAS1-->>M1: wallet is not in set
+    M1-->>UIPS1: check if wallet is in set
+    UIPS1-->>M1: wallet is in set
+    M1->>A1: 503 Service Unavailable
+
+    Note over A2: Attempted Request
+    A2->>M2: GET /any-endpoint
+    M2-->>IAS2: check if wallet is in set
+    IAS2->>M2: wallet is not in set
+    M2-->>UIPS2: check if wallet is in set
+    UIPS2-->>M2: wallet is not in set
+    A2-->>W: Query is_upgrading = anoncreds_in_progress record
+    W-->>A2: record = anoncreds_in_progress
+    A2->>A2: Loop until upgrade is finished in seperate process
+    A2-->>UIPS2: Add wallet to set
+    M2->>A2: 503 Service Unavailable
+
+    Note over A1,A2: Agent Restart During Upgrade
+    A1-->>W: Get is_upgrading record for wallet or all subwallets
+    W-->>A1: 
+    A1->>A1: Resume upgrade if in progress
+    A1-->>UIPS1: Add wallet to set
+
+    Note over A2: Same as Agent 1
+
+    Note over A1,A2: Upgrade Completes
+
+    Note over A1: Finish Upgrade
+    A1-->>W: set is_upgrading = anoncreds_finished
+    A1-->>UIPS1: Remove wallet from set
+    A1-->>IAS1: Add wallet to set
+    A1->>A1: update subwallet or restart
+
+    Note over A2: Detect Upgrade Complete
+    A2-->>W: Check is_upgrading = anoncreds_finished
+    W-->>A2: record = anoncreds_in_progress
+    A2->>A2: Wait 1 second
+    A2-->>W: Check is_upgrading = anoncreds_finished
+    W-->>A2: record = anoncreds_finished
+    A2-->>UIPS2: Remove wallet from set
+    A2-->>IAS2: Add wallet to set
+    A2->>A2: update subwallet or restart
+
+    Note over A1,A2: Restarted Agents After Upgrade
+
+    A1-->W: Get is_upgrading record for wallet or all subwallets
+    W-->>A1: 
+    A1->>IAS1: Add wallet to set if record = anoncreds_finished
+
+    Note over A2: Same as Agent 1
+
+    Note over A1,A2: Attempted Requests After Upgrade
+
+    Note over A1: Attempted Request
+    A1->>M1: GET /any-endpoint
+    M1-->>IAS1: check if wallet is in set
+    IAS1-->>M1: wallet is in set
+    M1-->>A1: OK
+
+    Note over A2: Same as Agent 1
+```
+
+
+##### An example of the implementation can be found via the anoncreds upgrade components.
+    - `aries_cloudagent/wallet/routes.py` in the `upgrade_anoncreds` controller 
+    - the upgrade code in `wallet/anoncreds_upgrade.py`
+    - the middleware in `admin/server.py` in the `upgrade_middleware` function
+    - the singleton sets in `wallet/singletons.py`
+    - the startup process in `core/conductor.py` in the `check_for_wallet_upgrades_in_progress` function


### PR DESCRIPTION
This was originally opened as https://github.com/hyperledger/aries-cloudagent-python/pull/2840 but this addresses some comments and adds improvements, mostly with handling multi instance aca-py scenarios.

The upgrading middleware will now use a cache during upgrades and after the upgrade has been completed. Agents that have the upgrade middleware but never upgrade will still have a very minor performance hit, due to needing to query the is_upgrading record.

There is a sequence diagram at `docs/design/UpgradeViaApi.md` for describing the design and flow.

In multi instance scenarios the instances which did not receive the upgrade request will now detect a upgrade has been initiated from another instance and begin a polling process to check for when the upgrade completes.

In stand alone agents (single tenant) or mutlitenant admin agents any instance that detects the upgrade has completed will still shutdown and be required to start-up again. This could possibly still be avoided, but I think it's best to reload the context from scratch after the upgrade. However, instead of failing after the upgrade restart, due to the `storage-type` being `askar-anoncreds` and the `wallet-type` config being `askar`. It will instead get a warning to change the configuration, reload the context as anoncreds and successfully launch. I think this is important to prevent accidents where the configuration isn't getting updated immediately after upgrading. 

Both these improvements mean the controller no longer has to be concerned about scaling down the aca-py instances and co-coordinating the `wallet-type` configuration change. The controller operator simply scales down the instances of controller, upgrades itself to handle the anoncreds endpoints and then hits the upgrade endpoints. As long as the aca-py agent restarts itself after shutting down, the rest will happen automatically.

I looked into doing a block on the webhook queue, but I don't think it's necessary. The incoming webhooks will be blocked by the upgrade middleware and outgoing messages shouldn't cause issues with agents. My understanding of the webhooks, and everything they might do during an upgrade, is limited though, so I might be off on that.

See also https://github.com/hyperledger/aries-cloudagent-python/pull/2881 for the migration guide.