### PR TITLE
:construction_worker: Add pip to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
- # For details on how this file works refer to:
- #   - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# For details on how this file works refer to:
+#   - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
   # Maintain dependencies for GitHub Actions
@@ -11,4 +11,18 @@ updates:
       interval: weekly
     groups:
       all-actions:
-        patterns: [ "*" ]
+        patterns: ["*"]
+
+  # Maintain dependencies for Python
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    update-types:
+      - "minor"
+      - "major"
+    commit-message:
+      prefix: "chore(deps): "
+    labels:
+      - "dependencies"
+      - "python"


### PR DESCRIPTION
Configures pip dependency management with dependabot

I've specified:
```yml
    schedule:
      interval: daily
    update-types:
      - "minor"
      - "major"
    commit-message:
      prefix: "chore(deps): "
    labels:
      - "dependencies"
      - "python"
```

Let me know if there are any desired changes.

`update-types` specifies to ignore patch releases, so it doesn't spam too much (and because ~ or ^ versioning already would include patch releases when lock file is updated)
Then, `commit-message: prefix` and `labels` is to match the existing dependabot PR style (which I assume is currently created manually)