### PR TITLE
Anoncreds - Send full registry list when getting revocation states

### DIFF
--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -692,7 +692,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
 
     def _indexes_to_bit_array(self, indexes: List[int], size: int) -> List[int]:
         """Turn a sequence of indexes into a full state bit array."""
-        return [1 if index in indexes else 0 for index in range(1, size + 1)]
+        return [1 if index in indexes else 0 for index in range(0, size + 1)]
 
     async def _get_ledger(self, profile: Profile, rev_reg_def_id: str):
         async with profile.session() as session:


### PR DESCRIPTION
See https://github.com/hyperledger/aries-cloudagent-python/issues/2934.

So this ended up being a one line fix. The anoncreds legacy_indy implementation for the holder, was getting the revocation list (registry) from the ledger. Then it was removing index 0, which doesn't actually represent a credential but is expected by anoncreds-rs when getting the revocation state. See https://github.com/hyperledger/anoncreds-rs/issues/336.

This is a bit weird and will need to be remembered when other implementations get added.

I have tested with the demo and manually. I still want to make an integration test for this scenario.