### PR TITLE
CodeCov report on PR's

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,7 @@
 comment:
-  layout: "header, diff"
+  layout: " diff, flags, files"
   behavior: default
-  require_changes: no
+  require_changes: false
+  require_base: false
+  require_head: true
+  hide_project_coverage: false

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -14,3 +14,4 @@ jobs:
     with:
       python-version: "3.9"
       os: "ubuntu-latest"
+    secrets: inherit

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -14,4 +14,3 @@ jobs:
     with:
       python-version: "3.9"
       os: "ubuntu-latest"
-    secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ on:
       os:
         required: true
         type: string
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
 jobs:
   tests:
@@ -28,10 +31,14 @@ jobs:
           poetry install -E "askar bbs"
       - name: Tests
         run: |
-          poetry run pytest 2>&1 | tee pytest.log
+          poetry run pytest --cov=./ --cov-report=xml 2>&1 | tee pytest.log
           PYTEST_EXIT_CODE=${PIPESTATUS[0]}
           if grep -Eq "RuntimeWarning: coroutine .* was never awaited" pytest.log; then
             echo "Failure: Detected unawaited coroutine warning in pytest output."
             exit 1
           fi
           exit $PYTEST_EXIT_CODE
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,6 @@ on:
       os:
         required: true
         type: string
-    secrets:
-      CODECOV_TOKEN:
-        required: true
 
 jobs:
   tests:
@@ -39,6 +36,4 @@ jobs:
           fi
           exit $PYTEST_EXIT_CODE
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
This will bring back `codecov` reporting on PR's and add comments like:

![image](https://github.com/hyperledger/aries-cloudagent-python/assets/31809382/1d4c9db8-a5af-4ec0-9c90-8ef8248b9040)

The warning only happened because I forced pushed.

The readme badge should also start working again.

There is a bit of setup for the repo admin. I'm hoping the covecov account that was used a year ago can be used again. The repo admin has to setup a token. It's really easy. The instructions are here https://docs.codecov.com/docs/github-2-getting-a-codecov-account-and-uploading-coverage.

Note: The unit tests for this PR won't pass until the token is available. 
![image](https://github.com/hyperledger/aries-cloudagent-python/assets/31809382/ab6fa794-396c-4d5c-8f72-75ed65a25799)
