### PR TITLE
Switch Snyk Container scan back to on push.

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,6 +1,6 @@
 name: Snyk Container
 on:
-  pull_request:
+  push:
     branches:
       - main
     paths:


### PR DESCRIPTION
- The Snyk Container scan relies on a token, which is not available to PRs from external forks.
- Switch back to running the scan on push until we can get things sorted on how to run the scans on PRs securely.