### PR TITLE
Fix Snyk sarif file

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -31,6 +31,13 @@ jobs:
         image: aries-cloudagent
         args: --file=docker/Dockerfile
 
+      # Replace any "null" security severity values with 0. The null value is used in the case
+      # of license-related findings, which do not do not indicate a security vulnerability.
+      # See https://github.com/github/codeql-action/issues/2187 for more context.
+    - name: Post process snyk sarif file  
+      run: |
+        sed -i 's/"security-severity": "null"/"security-severity": "0"/g' snyk.sarif
+    
     - name: Upload result to GitHub Code Scanning
       uses: github/codeql-action/upload-sarif@v3
       with:


### PR DESCRIPTION
This PR fixes the issue with Snyk sarif file. Replace any "null" security severity values with 0. The null value is used in the case of license-related findings, which do not do not indicate a security vulnerability.

See https://github.com/github/codeql-action/issues/2187 for more context.