### PR TITLE
Sonarcloud with code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,0 @@
-comment:
-  layout: "header, diff"
-  behavior: default
-  require_changes: no

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -11,6 +11,7 @@ jobs:
   tests:
     name: Tests
     uses: ./.github/workflows/tests.yml
+    secrets: inherit
     with:
       python-version: "3.9"
       os: "ubuntu-latest"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -25,13 +27,18 @@ jobs:
       - name: Install the project dependencies
         run: |
           pip install poetry
-          poetry install -E "askar bbs"
+          poetry install --all-extras
       - name: Tests
         run: |
-          poetry run pytest 2>&1 | tee pytest.log
+          poetry run pytest --cov --cov-report xml 2>&1 | tee pytest.log
           PYTEST_EXIT_CODE=${PIPESTATUS[0]}
           if grep -Eq "RuntimeWarning: coroutine .* was never awaited" pytest.log; then
             echo "Failure: Detected unawaited coroutine warning in pytest output."
             exit 1
           fi
           exit $PYTEST_EXIT_CODE
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Hyperledger Aries Cloud Agent - Python  <!-- omit in toc -->
 
 [![pypi releases](https://img.shields.io/pypi/v/aries_cloudagent)](https://pypi.org/project/aries-cloudagent/)
-[![codecov](https://codecov.io/gh/hyperledger/aries-cloudagent-python/branch/main/graph/badge.svg)](https://codecov.io/gh/hyperledger/aries-cloudagent-python)
 
 <!-- ![logo](/doc/assets/aries-cloudagent-python-logo-bw.png) -->
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=hyperledger_aries-cloudagent-python
+sonar.organization=hyperledger
+
+sonar.projectName=aries-cloudagent-python
+
+sonar.python.coverage.reportPaths=test-reports/coverage.xml
+
+sonar.python.version=3.9


### PR DESCRIPTION
This will add code coverage and duplication reporting to the sonarcloud comment and have details in the sonarcloud UI.

![image](https://github.com/hyperledger/aries-cloudagent-python/assets/31809382/ce0acb67-3790-40a8-badf-eb3cff0d698c)

The admin of the sonarcloud account need to do 2 things for the project. 

1. Turn off automatic analysis. The upload needs to happen after the unit tests complete and doing it automatically isn't supported yet.
![image](https://github.com/hyperledger/aries-cloudagent-python/assets/31809382/4429ee97-053e-467c-83ca-071d62fb1d07)

![image](https://github.com/hyperledger/aries-cloudagent-python/assets/31809382/a197b193-ea38-4d24-913d-cd87bd9ecf0a)

The github action will initialize the analysis now and should look like the image.

2. Create a token in my account --> security, and add it to the repo's secrets called `SONAR_TOKEN`

![image](https://github.com/hyperledger/aries-cloudagent-python/assets/31809382/28b91ab2-b063-4b4c-842d-31f8fb39deba)

![image](https://github.com/hyperledger/aries-cloudagent-python/assets/31809382/2fd0caa6-491f-4c42-9b1e-477d1c31d9e5)


 