### PR TITLE
Sonarcloud with code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,0 @@
-comment:
-  layout: "header, diff"
-  behavior: default
-  require_changes: no

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,54 @@
+name: Sonar Scan and Coverage
+
+on:
+  workflow_run:
+    workflows: [ PR Tests ]
+    types: 
+      - completed
+
+jobs:
+  SonarCloud:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+            fetch-depth: 0
+      - name: Download PR number artifact
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: Tests
+          run_id: ${{ github.event.workflow_run.id }}
+          name: PR_NUMBER
+      - name: Read PR_NUMBER
+        id: pr_number
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./PR_NUMBER
+      - name: Download Test Coverage
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: Tests
+          run_id: ${{ github.event.workflow_run.id }}
+          name: TEST_COV
+      - name: Request GitHub API for PR data
+        uses: octokit/request-action@v2.x
+        id: get_pr_data
+        with:
+          route: GET /repos/${{ github.event.repository.full_name }}/pulls/${{ steps.pr_number.outputs.content }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout base branch
+        if: github.event.workflow_run.event == 'pull_request'
+        run: |
+          echo ${{ github.event.repository.clone_url }}
+          git remote add upstream ${{ github.event.repository.clone_url }}
+          git fetch upstream
+          git checkout -B ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }} upstream/${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
+          echo ${{ github.event.workflow_run.head_branch }}
+          git checkout origin/${{ github.event.workflow_run.head_branch }}
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -25,13 +27,25 @@ jobs:
       - name: Install the project dependencies
         run: |
           pip install poetry
-          poetry install -E "askar bbs"
+          poetry install --all-extras
       - name: Tests
         run: |
-          poetry run pytest 2>&1 | tee pytest.log
+          poetry run pytest --cov --cov-report xml 2>&1 | tee pytest.log
           PYTEST_EXIT_CODE=${PIPESTATUS[0]}
           if grep -Eq "RuntimeWarning: coroutine .* was never awaited" pytest.log; then
             echo "Failure: Detected unawaited coroutine warning in pytest output."
             exit 1
           fi
           exit $PYTEST_EXIT_CODE
+      - name: Save PR number to file
+        run: echo ${{ github.event.number }} > PR_NUMBER
+      - name: Archive PR number
+        uses: actions/upload-artifact@v4
+        with:  
+          name: PR_NUMBER
+          path: PR_NUMBER
+      - name: Archive Test Results
+        uses: actions/upload-artifact@v4
+        with:  
+          name: TEST_COV
+          path: ./test-reports/coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Hyperledger Aries Cloud Agent - Python  <!-- omit in toc -->
 
 [![pypi releases](https://img.shields.io/pypi/v/aries_cloudagent)](https://pypi.org/project/aries-cloudagent/)
-[![codecov](https://codecov.io/gh/hyperledger/aries-cloudagent-python/branch/main/graph/badge.svg)](https://codecov.io/gh/hyperledger/aries-cloudagent-python)
 
 <!-- ![logo](/doc/assets/aries-cloudagent-python-logo-bw.png) -->
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=hyperledger_aries-cloudagent-python
+sonar.organization=hyperledger
+
+sonar.projectName=aries-cloudagent-python
+
+sonar.python.coverage.reportPaths=coverage.xml
+
+sonar.python.version=3.9


### PR DESCRIPTION
This is an attempt at getting code coverage working with sonarcloud with github actions from forked repos. It works by doing the testing and then uploading the results and the PR number from the pull request. The sonar workflow then fires after the testing workflow has finished where it should now have access to the token. It will download the test results and checkout the pull request branch from the forked repo to do the scan.

I can't be sure everything going to work yet because this still requires the token in secrets and for automatic analysis to be disabled. See https://github.com/hyperledger/aries-cloudagent-python/pull/2964.