### PR TITLE
Enable `no-transport` mode as startup parameter

### DIFF
--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -680,7 +680,9 @@ class GeneralGroup(ArgumentGroup):
         if args.storage_type:
             settings["storage_type"] = args.storage_type
 
-        if args.endpoint:
+        if args.no_transport:
+            pass
+        elif args.endpoint:
             settings["default_endpoint"] = args.endpoint[0]
             settings["additional_endpoints"] = args.endpoint[1:]
         else:
@@ -777,13 +779,13 @@ class RevocationGroup(ArgumentGroup):
         if args.notify_revocation:
             settings["revocation.notify"] = args.notify_revocation
         if args.monitor_revocation_notification:
-            settings["revocation.monitor_notification"] = (
-                args.monitor_revocation_notification
-            )
+            settings[
+                "revocation.monitor_notification"
+            ] = args.monitor_revocation_notification
         if args.anoncreds_legacy_revocation:
-            settings["revocation.anoncreds_legacy_support"] = (
-                args.anoncreds_legacy_revocation
-            )
+            settings[
+                "revocation.anoncreds_legacy_support"
+            ] = args.anoncreds_legacy_revocation
         return settings
 
 
@@ -1274,6 +1276,19 @@ class TransportGroup(ArgumentGroup):
     def add_arguments(self, parser: ArgumentParser):
         """Add transport-specific command line arguments to the parser."""
         parser.add_argument(
+            "--no-transport",
+            dest="no_transport",
+            action="store_true",
+            env_var="ACAPY_NO_TRANSPORT",
+            help=(
+                "Specifies that aca-py will run with no transport configured. "
+                "This must be set if running in no-transport mode.  Overrides any "
+                "specified transport or endpoint configurations.  "
+                "Either this parameter or the "
+                "'--endpoint' parameter MUST be specified. Default: false."
+            ),
+        )
+        parser.add_argument(
             "-it",
             "--inbound-transport",
             dest="inbound_transports",
@@ -1381,6 +1396,10 @@ class TransportGroup(ArgumentGroup):
     def get_settings(self, args: Namespace):
         """Extract transport settings."""
         settings = {}
+        if args.no_transport:
+            settings["transport.no_transport"] = args.no_transport
+            return settings
+
         if args.inbound_transports:
             settings["transport.inbound_configs"] = args.inbound_transports
         else:
@@ -1799,9 +1818,9 @@ class MultitenantGroup(ArgumentGroup):
                         )
 
                     if multitenancy_config.get("key_derivation_method"):
-                        settings["multitenant.key_derivation_method"] = (
-                            multitenancy_config.get("key_derivation_method")
-                        )
+                        settings[
+                            "multitenant.key_derivation_method"
+                        ] = multitenancy_config.get("key_derivation_method")
 
                 else:
                     for value_str in args.multitenancy_config:
@@ -1949,9 +1968,9 @@ class EndorsementGroup(ArgumentGroup):
 
         if args.endorser_endorse_with_did:
             if settings["endorser.endorser"]:
-                settings["endorser.endorser_endorse_with_did"] = (
-                    args.endorser_endorse_with_did
-                )
+                settings[
+                    "endorser.endorser_endorse_with_did"
+                ] = args.endorser_endorse_with_did
             else:
                 raise ArgsParseError(
                     "Parameter --endorser-endorse-with-did should only be set for "

--- a/aries_cloudagent/config/logging.py
+++ b/aries_cloudagent/config/logging.py
@@ -324,45 +324,47 @@ class LoggingConfigurator:
             # Title
             banner.title(agent_label or "ACA")
             # Inbound transports
-            banner.subtitle("Inbound Transports")
-            internal_in_transports = [
-                f"{transport.scheme}://{transport.host}:{transport.port}"
-                for transport in inbound_transports.values()
-                if not transport.is_external
-            ]
-            if internal_in_transports:
-                banner.list(internal_in_transports)
-            external_in_transports = [
-                f"{transport.scheme}://{transport.host}:{transport.port}"
-                for transport in inbound_transports.values()
-                if transport.is_external
-            ]
-            if external_in_transports:
-                banner.subtitle("  External Plugin")
-                banner.list(external_in_transports)
+            if inbound_transports:
+                banner.subtitle("Inbound Transports")
+                internal_in_transports = [
+                    f"{transport.scheme}://{transport.host}:{transport.port}"
+                    for transport in inbound_transports.values()
+                    if not transport.is_external
+                ]
+                if internal_in_transports:
+                    banner.list(internal_in_transports)
+                external_in_transports = [
+                    f"{transport.scheme}://{transport.host}:{transport.port}"
+                    for transport in inbound_transports.values()
+                    if transport.is_external
+                ]
+                if external_in_transports:
+                    banner.subtitle("  External Plugin")
+                    banner.list(external_in_transports)
 
             # Outbound transports
-            banner.subtitle("Outbound Transports")
-            internal_schemes = set().union(
-                *(
-                    transport.schemes
-                    for transport in outbound_transports.values()
-                    if not transport.is_external
+            if outbound_transports:
+                banner.subtitle("Outbound Transports")
+                internal_schemes = set().union(
+                    *(
+                        transport.schemes
+                        for transport in outbound_transports.values()
+                        if not transport.is_external
+                    )
                 )
-            )
-            if internal_schemes:
-                banner.list([f"{scheme}" for scheme in sorted(internal_schemes)])
+                if internal_schemes:
+                    banner.list([f"{scheme}" for scheme in sorted(internal_schemes)])
 
-            external_schemes = set().union(
-                *(
-                    transport.schemes
-                    for transport in outbound_transports.values()
-                    if transport.is_external
+                external_schemes = set().union(
+                    *(
+                        transport.schemes
+                        for transport in outbound_transports.values()
+                        if transport.is_external
+                    )
                 )
-            )
-            if external_schemes:
-                banner.subtitle("  External Plugin")
-                banner.list([f"{scheme}" for scheme in sorted(external_schemes)])
+                if external_schemes:
+                    banner.subtitle("  External Plugin")
+                    banner.list([f"{scheme}" for scheme in sorted(external_schemes)])
 
             # DID info
             if public_did:


### PR DESCRIPTION
This PR adds a `--no-transport` startup parameter for making the agent start without requiring the `--enpoint`, `--inbound-transport` and `--outbound-transport` to be set.

The idea was shared during an aca-pug meeting and there was no objection. This can greatly simplify deployment for controllers that do no require didcomm messaging.

Currently it just overrides what is required for startup.

@dbluhm @swcurran @ianco 