### PR TITLE
Add `proof_key` issuance option

### DIFF
--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -17,6 +17,7 @@ from .util import epoch_to_str
 B58 = alphabet if isinstance(alphabet, str) else alphabet.decode("ascii")
 
 EXAMPLE_TIMESTAMP = 1640995199  # 2021-12-31 23:59:59Z
+VERKEY_EXAMPLE = "3Dn1SJNPaCXcvvJvSbsFWP2xaCjMom3can8CQNhWrTRx"
 
 
 class StrOrDictField(Field):

--- a/aries_cloudagent/vc/vc_ld/manager.py
+++ b/aries_cloudagent/vc/vc_ld/manager.py
@@ -232,7 +232,8 @@ class VcLdpManager:
             if proof_type not in did_proof_types:
                 raise VcLdpManagerError(
                     f"Unable to issue credential with verkey {verkey} and proof "
-                    f"type {proof_type}. Verkey only supports proof types {did_proof_types}"
+                    f"type {proof_type}. "
+                    f"Verkey only supports proof types {did_proof_types}"
                 )
 
         except WalletNotFoundError:

--- a/aries_cloudagent/vc/vc_ld/models/options.py
+++ b/aries_cloudagent/vc/vc_ld/models/options.py
@@ -8,6 +8,7 @@ from aries_cloudagent.messaging.valid import (
     INDY_ISO8601_DATETIME_EXAMPLE,
     INDY_ISO8601_DATETIME_VALIDATE,
     UUID4_EXAMPLE,
+    VERKEY_EXAMPLE,
 )
 
 from ....messaging.models.base import BaseModel, BaseModelSchema
@@ -24,6 +25,7 @@ class LDProofVCOptions(BaseModel):
     def __init__(
         self,
         verification_method: Optional[str] = None,
+        proof_key: Optional[str] = None,
         proof_type: Optional[str] = None,
         proof_purpose: Optional[str] = None,
         created: Optional[str] = None,
@@ -34,6 +36,7 @@ class LDProofVCOptions(BaseModel):
         """Initialize the LDProofVCDetailOptions instance."""
 
         self.verification_method = verification_method
+        self.proof_key = proof_key
         self.proof_type = proof_type
         self.proof_purpose = proof_purpose
         self.created = created
@@ -95,6 +98,17 @@ class LDProofVCOptionsSchema(BaseModelSchema):
                 " verification method in the wallet"
             ),
             "example": "did:example:123456#key-1",
+        },
+    )
+
+    proof_key = fields.Str(
+        data_key="proofKey",
+        required=False,
+        metadata={
+            "description": (
+                "The verkey used for the proof." "Takes precedence over issuer did."
+            ),
+            "example": VERKEY_EXAMPLE,
         },
     )
 

--- a/aries_cloudagent/vc/vc_ld/tests/test_manager.py
+++ b/aries_cloudagent/vc/vc_ld/tests/test_manager.py
@@ -318,6 +318,26 @@ async def test_issue(
 
 
 @pytest.mark.asyncio(scope="module")
+async def test_issue_verkey(
+    profile: Profile,
+    manager: VcLdpManager,
+    vc: VerifiableCredential,
+    options: LDProofVCOptions,
+):
+    async with profile.session() as session:
+        wallet = session.inject(BaseWallet)
+        did = await wallet.create_local_did(
+            method=KEY,
+            key_type=ED25519,
+        )
+    vc.issuer = did.did
+    options.proof_key = did.verkey
+    options.proof_type = Ed25519Signature2018.signature_type
+    cred = await manager.issue(vc, options)
+    assert cred
+
+
+@pytest.mark.asyncio(scope="module")
 async def test_issue_ed25519_2020(
     profile: Profile,
     manager: VcLdpManager,


### PR DESCRIPTION
Following the discussions in PR #2348, here's my suggestion to add an optional field to specify a verkey to use when querying the wallet for the `didInfo` used in issuing credentials.

This would satisfy the requirements raised by @Jsyro and some of the work we are doing around binding `did:web` to a `did:indy`.

Please review and share some toughts @dbluhm @swcurran @jamshale @ianco @TimoGlastra .

This will also preserve this enabling feature from the deprecated `/jsonld/sign` endpoint, giving controllers flexibility while using other did methods.