### PR TITLE
:sparkles: Faster uuid generation

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -3,7 +3,6 @@
 import asyncio
 import logging
 import re
-import uuid
 import warnings
 import weakref
 from typing import Callable, Coroutine, Optional, Pattern, Sequence, cast
@@ -15,6 +14,7 @@ from aiohttp_apispec import (
     setup_aiohttp_apispec,
     validation_middleware,
 )
+from uuid_utils import uuid4
 
 from aries_cloudagent.wallet import singletons
 
@@ -548,7 +548,7 @@ class AdminServer(BaseAdminServer):
 
         ws = web.WebSocketResponse()
         await ws.prepare(request)
-        socket_id = str(uuid.uuid4())
+        socket_id = str(uuid4())
         queue = BasicMessageQueue()
         loop = asyncio.get_event_loop()
 

--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -10,10 +10,7 @@ from typing import Callable, Coroutine, Optional, Pattern, Sequence, cast
 import aiohttp_cors
 import jwt
 from aiohttp import web
-from aiohttp_apispec import (
-    setup_aiohttp_apispec,
-    validation_middleware,
-)
+from aiohttp_apispec import setup_aiohttp_apispec, validation_middleware
 from uuid_utils import uuid4
 
 from aries_cloudagent.wallet import singletons

--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -32,9 +32,7 @@ from ....protocols.endorse_transaction.v1_0.manager import (
     TransactionManagerError,
 )
 from ....protocols.endorse_transaction.v1_0.util import is_author_role
-from ....revocation_anoncreds.models.issuer_cred_rev_record import (
-    IssuerCredRevRecord,
-)
+from ....revocation_anoncreds.models.issuer_cred_rev_record import IssuerCredRevRecord
 from ....revocation_anoncreds.recover import generate_ledger_rrrecovery_txn
 from ....storage.error import StorageError
 from ....utils import sentinel

--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -3,11 +3,11 @@
 import json
 import logging
 import re
-import uuid
 from asyncio import shield
 from typing import List, Optional, Pattern, Sequence, Tuple
 
 from base58 import alphabet
+from uuid_utils import uuid4
 
 from ....anoncreds.default.legacy_indy.author import get_endorser_info
 from ....cache.base import BaseCache
@@ -267,7 +267,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         # Need endorsement, so execute transaction flow
         (schema_id, schema_def) = result
 
-        job_id = uuid.uuid4().hex
+        job_id = uuid4().hex
         meta_data = {"context": {"job_id": job_id, "schema_id": schema_id}}
 
         transaction_manager = TransactionManager(profile)
@@ -445,7 +445,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
             )
 
         # Need endorsement, so execute transaction flow
-        job_id = uuid.uuid4().hex
+        job_id = uuid4().hex
 
         meta_data = {
             "context": {
@@ -616,7 +616,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         # Need endorsement, so execute transaction flow
         (rev_reg_def_id, reg_rev_def) = result
 
-        job_id = uuid.uuid4().hex
+        job_id = uuid4().hex
         meta_data = {
             "context": {
                 "job_id": job_id,
@@ -874,7 +874,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
 
         (rev_reg_def_id, requested_txn) = result
 
-        job_id = uuid.uuid4().hex
+        job_id = uuid4().hex
         meta_data = {
             "context": {
                 "job_id": job_id,
@@ -987,7 +987,7 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
 
         (rev_reg_def_id, requested_txn) = result
 
-        job_id = uuid.uuid4().hex
+        job_id = uuid4().hex
         meta_data = {
             "context": {
                 "job_id": job_id,

--- a/aries_cloudagent/anoncreds/holder.py
+++ b/aries_cloudagent/anoncreds/holder.py
@@ -13,8 +13,8 @@ from anoncreds import (
     CredentialRevocationState,
     Presentation,
     PresentCredentials,
-    create_link_secret,
     W3cCredential,
+    create_link_secret,
 )
 from aries_askar import AskarError, AskarErrorCode
 from uuid_utils import uuid4

--- a/aries_cloudagent/anoncreds/holder.py
+++ b/aries_cloudagent/anoncreds/holder.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import logging
 import re
-import uuid
 from typing import Dict, Optional, Sequence, Tuple, Union
 
 from anoncreds import (
@@ -18,6 +17,7 @@ from anoncreds import (
     W3cCredential,
 )
 from aries_askar import AskarError, AskarErrorCode
+from uuid_utils import uuid4
 
 from ..anoncreds.models.anoncreds_schema import AnonCredsSchema
 from ..askar.profile_anon import AskarAnoncredsProfile
@@ -238,7 +238,7 @@ class AnonCredsHolder:
                 f"Error parsing credential definition ID: {cred_def_id}"
             )
 
-        credential_id = credential_id or str(uuid.uuid4())
+        credential_id = credential_id or str(uuid4())
         tags = {
             "schema_id": schema_id,
             "schema_issuer_did": schema_id_parts[1],

--- a/aries_cloudagent/anoncreds/revocation.py
+++ b/aries_cloudagent/anoncreds/revocation.py
@@ -26,10 +26,7 @@ from uuid_utils import uuid4
 
 from aries_cloudagent.anoncreds.models.anoncreds_cred_def import CredDef
 
-from ..askar.profile_anon import (
-    AskarAnoncredsProfile,
-    AskarAnoncredsProfileSession,
-)
+from ..askar.profile_anon import AskarAnoncredsProfile, AskarAnoncredsProfileSession
 from ..core.error import BaseError
 from ..core.event_bus import Event, EventBus
 from ..core.profile import Profile, ProfileSession

--- a/aries_cloudagent/anoncreds/revocation.py
+++ b/aries_cloudagent/anoncreds/revocation.py
@@ -10,7 +10,6 @@ import time
 from pathlib import Path
 from typing import List, NamedTuple, Optional, Sequence, Tuple
 from urllib.parse import urlparse
-from uuid import uuid4
 
 import base58
 from anoncreds import (
@@ -23,6 +22,7 @@ from anoncreds import (
 )
 from aries_askar.error import AskarError
 from requests import RequestException, Session
+from uuid_utils import uuid4
 
 from aries_cloudagent.anoncreds.models.anoncreds_cred_def import CredDef
 

--- a/aries_cloudagent/config/ledger.py
+++ b/aries_cloudagent/config/ledger.py
@@ -5,12 +5,12 @@ import logging
 import re
 import sys
 from typing import Optional
-import uuid
 
 import markdown
 import prompt_toolkit
 from prompt_toolkit.eventloop.defaults import use_asyncio_event_loop
 from prompt_toolkit.formatted_text import HTML
+from uuid_utils import uuid4
 
 from ..config.settings import Settings
 from ..core.profile import Profile
@@ -88,7 +88,7 @@ async def load_multiple_genesis_transactions_from_config(settings: Settings):
         is_write_ledger = (
             False if config.get("is_write") is None else config.get("is_write")
         )
-        ledger_id = config.get("id") or str(uuid.uuid4())
+        ledger_id = config.get("id") or str(uuid4())
         if is_write_ledger:
             write_ledger_set = True
         config_item = {

--- a/aries_cloudagent/config/ledger.py
+++ b/aries_cloudagent/config/ledger.py
@@ -1,9 +1,9 @@
 """Ledger configuration."""
 
-from collections import OrderedDict
 import logging
 import re
 import sys
+from collections import OrderedDict
 from typing import Optional
 
 import markdown
@@ -17,9 +17,8 @@ from ..core.profile import Profile
 from ..ledger.base import BaseLedger
 from ..ledger.endpoint_type import EndpointType
 from ..ledger.error import LedgerError
-from ..utils.http import fetch, FetchError
+from ..utils.http import FetchError, fetch
 from ..wallet.base import BaseWallet
-
 from .base import ConfigError
 
 LOGGER = logging.getLogger(__name__)

--- a/aries_cloudagent/indy/credx/holder.py
+++ b/aries_cloudagent/indy/credx/holder.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import logging
 import re
-import uuid
 from typing import Dict, Optional, Sequence, Tuple, Union
 
 from aries_askar import AskarError, AskarErrorCode
@@ -17,6 +16,7 @@ from indy_credx import (
     Presentation,
     PresentCredentials,
 )
+from uuid_utils import uuid4
 
 from ...askar.profile import AskarProfile
 from ...ledger.base import BaseLedger
@@ -195,7 +195,7 @@ class IndyCredxHolder(IndyHolder):
                 f"Error parsing credential definition ID: {cred_def_id}"
             )
 
-        credential_id = credential_id or str(uuid.uuid4())
+        credential_id = credential_id or str(uuid4())
         tags = {
             "schema_id": schema_id,
             "schema_issuer_did": schema_id_parts[1],

--- a/aries_cloudagent/ledger/multiple_ledger/ledger_config_schema.py
+++ b/aries_cloudagent/ledger/multiple_ledger/ledger_config_schema.py
@@ -1,8 +1,7 @@
 """Schema for configuring multiple ledgers."""
 
-import uuid
-
 from marshmallow import EXCLUDE, fields, pre_load
+from uuid_utils import uuid4
 
 from ...messaging.models.base import BaseModel, BaseModelSchema
 from ...messaging.models.openapi import OpenAPISchema
@@ -56,7 +55,7 @@ class LedgerConfigInstanceSchema(BaseModelSchema):
     def validate_id(self, data, **kwargs):
         """Check if id is present, if not then set to UUID4."""
         if "id" not in data:
-            data["id"] = str(uuid.uuid4())
+            data["id"] = str(uuid4())
         return data
 
 

--- a/aries_cloudagent/messaging/agent_message.py
+++ b/aries_cloudagent/messaging/agent_message.py
@@ -2,7 +2,6 @@
 
 from collections import OrderedDict
 from typing import Mapping, Optional, Text, Union
-import uuid
 
 from marshmallow import (
     EXCLUDE,
@@ -13,6 +12,7 @@ from marshmallow import (
     pre_dump,
     pre_load,
 )
+from uuid_utils import uuid4
 
 from ..protocols.didcomm_prefix import DIDCommPrefix
 from ..wallet.base import BaseWallet
@@ -75,7 +75,7 @@ class AgentMessage(BaseModel, BaseMessage):
             self._message_id = _id
             self._message_new_id = False
         else:
-            self._message_id = str(uuid.uuid4())
+            self._message_id = str(uuid4())
             self._message_new_id = True
         self._message_decorators = (
             _decorators if _decorators is not None else DecoratorSet()

--- a/aries_cloudagent/messaging/decorators/attach_decorator.py
+++ b/aries_cloudagent/messaging/decorators/attach_decorator.py
@@ -5,10 +5,10 @@ An attach decorator embeds content or specifies appended content.
 
 import copy
 import json
-import uuid
 from typing import Any, Mapping, Sequence, Tuple, Union
 
 from marshmallow import EXCLUDE, fields, pre_load
+from uuid_utils import uuid4
 
 from ...did.did_key import DIDKey
 from ...wallet.base import BaseWallet
@@ -620,7 +620,7 @@ class AttachDecorator(BaseModel):
             byte_count: optional attachment byte count
         """
         return AttachDecorator(
-            ident=ident or str(uuid.uuid4()),
+            ident=ident or str(uuid4()),
             description=description,
             filename=filename,
             mime_type="text/string",
@@ -655,7 +655,7 @@ class AttachDecorator(BaseModel):
 
         """
         return AttachDecorator(
-            ident=ident or str(uuid.uuid4()),
+            ident=ident or str(uuid4()),
             description=description,
             filename=filename,
             mime_type="application/json",
@@ -692,7 +692,7 @@ class AttachDecorator(BaseModel):
 
         """
         return AttachDecorator(
-            ident=ident or str(uuid.uuid4()),
+            ident=ident or str(uuid4()),
             description=description,
             filename=filename,
             mime_type="application/json",
@@ -731,7 +731,7 @@ class AttachDecorator(BaseModel):
 
         """
         return AttachDecorator(
-            ident=ident or str(uuid.uuid4()),
+            ident=ident or str(uuid4()),
             description=description,
             filename=filename,
             mime_type=mime_type or "application/json",

--- a/aries_cloudagent/messaging/decorators/tests/test_attach_decorator.py
+++ b/aries_cloudagent/messaging/decorators/tests/test_attach_decorator.py
@@ -1,10 +1,10 @@
 import json
-import uuid
 from copy import deepcopy
 from datetime import datetime, timezone
 from unittest import TestCase
 
 import pytest
+from uuid_utils import uuid4
 
 from aries_cloudagent.wallet.base import BaseWallet
 
@@ -54,7 +54,7 @@ INDY_CRED = {
     "rev_reg": None,
     "witness": None,
 }
-IDENT = str(uuid.uuid4())
+IDENT = str(uuid4())
 DESCRIPTION = 'To one trained by "Bob," Truth can be found in a potato'
 FILENAME = "potato.png"
 MIME_TYPE = "image/png"

--- a/aries_cloudagent/messaging/models/base_record.py
+++ b/aries_cloudagent/messaging/models/base_record.py
@@ -3,11 +3,11 @@
 import json
 import logging
 import sys
-import uuid
 from datetime import datetime
 from typing import Any, Mapping, Optional, Sequence, Type, TypeVar, Union
 
 from marshmallow import fields
+from uuid_utils import uuid4
 
 from ...cache.base import BaseCache
 from ...config.settings import BaseSettings
@@ -355,7 +355,7 @@ class BaseRecord(BaseModel):
                 new_record = False
             else:
                 if not self._id:
-                    self._id = str(uuid.uuid4())
+                    self._id = str(uuid4())
                 self.created_at = self.updated_at
                 await storage.add_record(self.storage_record)
                 new_record = True

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/manager.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/manager.py
@@ -23,10 +23,7 @@ from ....revocation.util import (
 from ....storage.error import StorageError, StorageNotFoundError
 from ....transport.inbound.receipt import MessageReceipt
 from ....wallet.base import BaseWallet
-from ....wallet.util import (
-    notify_endorse_did_attrib_event,
-    notify_endorse_did_event,
-)
+from ....wallet.util import notify_endorse_did_attrib_event, notify_endorse_did_event
 from .messages.cancel_transaction import CancelTransaction
 from .messages.endorsed_transaction_response import EndorsedTransactionResponse
 from .messages.refused_transaction_response import RefusedTransactionResponse

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/manager.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/manager.py
@@ -2,8 +2,9 @@
 
 import json
 import logging
-import uuid
 from asyncio import shield
+
+from uuid_utils import uuid4
 
 from ....anoncreds.issuer import AnonCredsIssuer
 from ....anoncreds.revocation import AnonCredsRevocation
@@ -78,7 +79,7 @@ class TransactionManager:
         """
 
         messages_attach_dict = {
-            "@id": str(uuid.uuid4()),
+            "@id": str(uuid4()),
             "mime-type": "application/json",
             "data": {"json": messages_attach},
         }

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/tests/test_manager.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
-import uuid
 from unittest import IsolatedAsyncioTestCase
+
+from uuid_utils import uuid4
 
 from .....admin.request_context import AdminRequestContext
 from .....anoncreds.default.legacy_indy.registry import LegacyIndyRegistry
@@ -278,7 +279,7 @@ class TestTransactionManager(IsolatedAsyncioTestCase):
             "author_goal_code": TransactionRecord.WRITE_TRANSACTION,
         }
         mock_request.messages_attach = {
-            "@id": str(uuid.uuid4()),
+            "@id": str(uuid4()),
             "mime-type": "application/json",
             "data": {"json": self.test_messages_attach},
         }

--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_format.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_format.py
@@ -3,9 +3,9 @@
 from collections import namedtuple
 from enum import Enum
 from typing import TYPE_CHECKING, Mapping, Sequence, Type, Union
-from uuid import uuid4
 
 from marshmallow import EXCLUDE, fields
+from uuid_utils import uuid4
 
 from .....messaging.decorators.attach_decorator import AttachDecorator
 from .....messaging.models.base import BaseModel, BaseModelSchema

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -4,7 +4,8 @@ import asyncio
 import logging
 import re
 from typing import List, Mapping, NamedTuple, Optional, Sequence, Text, Union
-import uuid
+
+from uuid_utils import uuid4
 
 from aries_cloudagent.protocols.coordinate_mediation.v1_0.route_manager import (
     RouteManager,
@@ -145,7 +146,7 @@ class InvitationCreator:
         self.route_manager = route_manager
         self.oob = oob
 
-        self.msg_id = str(uuid.uuid4())
+        self.msg_id = str(uuid4())
         self.attachments = attachments
 
         self.handshake_protocols = [

--- a/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/manager.py
@@ -43,8 +43,8 @@ from .messages.invitation import HSProto, InvitationMessage
 from .messages.problem_report import OOBProblemReport
 from .messages.reuse import HandshakeReuse
 from .messages.reuse_accept import HandshakeReuseAccept
-from .messages.service import Service as ServiceMessage
 from .messages.service import Service
+from .messages.service import Service as ServiceMessage
 from .models.invitation import InvitationRecord
 from .models.oob_record import OobRecord
 

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -8,17 +8,17 @@ merge [return applicable credential list and descriptor_map for presentation_sub
 returns VerifiablePresentation
 """
 
-import pytz
-import re
 import logging
-
+import re
 from datetime import datetime
-from dateutil.parser import parse as dateutil_parser
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+import pytz
 from dateutil.parser import ParserError
+from dateutil.parser import parse as dateutil_parser
 from jsonpath_ng import parse
 from pyld import jsonld
 from pyld.jsonld import JsonLdProcessor
-from typing import Sequence, Optional, Tuple, Union, Dict, List
 from unflatten import unflatten
 from uuid_utils import uuid4
 
@@ -26,37 +26,34 @@ from ....core.error import BaseError
 from ....core.profile import Profile
 from ....storage.vc_holder.vc_record import VCRecord
 from ....vc.ld_proofs import (
-    Ed25519Signature2018,
-    Ed25519Signature2020,
     BbsBlsSignature2020,
     BbsBlsSignatureProof2020,
-    WalletKeyPair,
     DocumentLoader,
+    Ed25519Signature2018,
+    Ed25519Signature2020,
+    WalletKeyPair,
 )
 from ....vc.ld_proofs.constants import (
-    SECURITY_CONTEXT_BBS_URL,
     EXPANDED_TYPE_CREDENTIALS_CONTEXT_V1_VC_TYPE,
+    SECURITY_CONTEXT_BBS_URL,
 )
-from ....vc.vc_ld.prove import sign_presentation, create_presentation, derive_credential
+from ....vc.vc_ld.prove import create_presentation, derive_credential, sign_presentation
 from ....wallet.base import BaseWallet, DIDInfo
-from ....wallet.default_verification_key_strategy import (
-    BaseVerificationKeyStrategy,
-)
+from ....wallet.default_verification_key_strategy import BaseVerificationKeyStrategy
 from ....wallet.error import WalletError, WalletNotFoundError
 from ....wallet.key_type import BLS12381G2, ED25519
-
 from .pres_exch import (
-    PresentationDefinition,
-    InputDescriptors,
+    Constraints,
     DIFField,
     Filter,
-    Constraints,
-    SubmissionRequirements,
+    InputDescriptorMapping,
+    InputDescriptors,
+    PresentationDefinition,
+    PresentationSubmission,
     Requirement,
     SchemaInputDescriptor,
     SchemasInputDescriptorFilter,
-    InputDescriptorMapping,
-    PresentationSubmission,
+    SubmissionRequirements,
 )
 
 PRESENTATION_SUBMISSION_JSONLD_CONTEXT = (

--- a/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_exch_handler.py
@@ -20,7 +20,7 @@ from pyld import jsonld
 from pyld.jsonld import JsonLdProcessor
 from typing import Sequence, Optional, Tuple, Union, Dict, List
 from unflatten import unflatten
-from uuid import uuid4
+from uuid_utils import uuid4
 
 from ....core.error import BaseError
 from ....core.profile import Profile

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
@@ -1,10 +1,10 @@
 from copy import deepcopy
 from datetime import datetime
 from typing import Sequence
-from uuid import uuid4
 
 from aries_cloudagent.tests import mock
 import pytest
+from uuid_utils import uuid4
 
 from aries_cloudagent.wallet.key_type import BLS12381G2, ED25519
 

--- a/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
+++ b/aries_cloudagent/protocols/present_proof/dif/tests/test_pres_exch_handler.py
@@ -2,62 +2,53 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Sequence
 
-from aries_cloudagent.tests import mock
 import pytest
 from uuid_utils import uuid4
 
+from aries_cloudagent.tests import mock
 from aries_cloudagent.wallet.key_type import BLS12381G2, ED25519
 
 from .....core.in_memory import InMemoryProfile
 from .....resolver.did_resolver import DIDResolver
 from .....storage.vc_holder.vc_record import VCRecord
-from .....wallet.base import BaseWallet, DIDInfo
-from .....wallet.default_verification_key_strategy import (
-    DefaultVerificationKeyStrategy,
-    BaseVerificationKeyStrategy,
-)
-from .....wallet.did_method import SOV, KEY, DIDMethods
-from .....wallet.error import WalletNotFoundError
-from .....vc.ld_proofs import (
-    BbsBlsSignature2020,
-)
+from .....vc.ld_proofs import BbsBlsSignature2020
+from .....vc.ld_proofs.constants import SECURITY_CONTEXT_BBS_URL
 from .....vc.ld_proofs.document_loader import DocumentLoader
 from .....vc.ld_proofs.error import LinkedDataProofException
-from .....vc.ld_proofs.constants import SECURITY_CONTEXT_BBS_URL
+from .....vc.tests.data import BBS_SIGNED_VC_MATTR
 from .....vc.tests.document_loader import custom_document_loader
-from .....vc.tests.data import (
-    BBS_SIGNED_VC_MATTR,
+from .....wallet.base import BaseWallet, DIDInfo
+from .....wallet.default_verification_key_strategy import (
+    BaseVerificationKeyStrategy,
+    DefaultVerificationKeyStrategy,
 )
-
+from .....wallet.did_method import KEY, SOV, DIDMethods
+from .....wallet.error import WalletNotFoundError
 from .. import pres_exch_handler as test_module
 from ..pres_exch import (
-    PresentationDefinition,
-    Requirement,
-    Filter,
-    SchemaInputDescriptor,
-    SchemasInputDescriptorFilter,
     Constraints,
     DIFField,
+    Filter,
+    PresentationDefinition,
+    Requirement,
+    SchemaInputDescriptor,
+    SchemasInputDescriptorFilter,
 )
-from ..pres_exch_handler import (
-    DIFPresExchHandler,
-    DIFPresExchError,
-)
-
+from ..pres_exch_handler import DIFPresExchError, DIFPresExchHandler
 from .test_data import (
-    get_test_data,
-    edd_jsonld_creds,
-    bbs_bls_number_filter_creds,
-    bbs_signed_cred_no_credsubjectid,
-    bbs_signed_cred_credsubjectid,
-    creds_with_no_id,
-    is_holder_pd,
-    is_holder_pd_multiple_fields_excluded,
-    is_holder_pd_multiple_fields_included,
     EXPANDED_CRED_FHIR_TYPE_1,
     EXPANDED_CRED_FHIR_TYPE_2,
     TEST_CRED_DICT,
     TEST_CRED_WILDCARD,
+    bbs_bls_number_filter_creds,
+    bbs_signed_cred_credsubjectid,
+    bbs_signed_cred_no_credsubjectid,
+    creds_with_no_id,
+    edd_jsonld_creds,
+    get_test_data,
+    is_holder_pd,
+    is_holder_pd_multiple_fields_excluded,
+    is_holder_pd_multiple_fields_included,
 )
 
 

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
@@ -3,8 +3,8 @@
 import json
 import logging
 from typing import Mapping, Optional, Sequence, Tuple
-from uuid import uuid4
 
+from uuid_utils import uuid4
 
 from ......messaging.base_handler import BaseResponder
 from ......messaging.decorators.attach_decorator import AttachDecorator

--- a/aries_cloudagent/protocols/present_proof/v2_0/messages/pres_format.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/messages/pres_format.py
@@ -3,9 +3,9 @@
 from collections import namedtuple
 from enum import Enum
 from typing import TYPE_CHECKING, Mapping, Sequence, Type, Union
-from uuid import uuid4
 
 from marshmallow import EXCLUDE, fields
+from uuid_utils import uuid4
 
 from .....messaging.decorators.attach_decorator import AttachDecorator
 from .....messaging.models.base import BaseModel, BaseModelSchema

--- a/aries_cloudagent/revocation/indy.py
+++ b/aries_cloudagent/revocation/indy.py
@@ -2,7 +2,8 @@
 
 import logging
 from typing import Optional, Sequence, Tuple
-from uuid import uuid4
+
+from uuid_utils import uuid4
 
 from ..core.profile import Profile
 from ..ledger.base import BaseLedger

--- a/aries_cloudagent/revocation/indy.py
+++ b/aries_cloudagent/revocation/indy.py
@@ -18,7 +18,6 @@ from ..protocols.endorse_transaction.v1_0.util import (
     is_author_role,
 )
 from ..storage.base import StorageNotFoundError
-
 from .error import (
     RevocationError,
     RevocationInvalidStateValueError,

--- a/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
+++ b/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
@@ -3,7 +3,6 @@
 import json
 import importlib
 import logging
-import uuid
 from functools import total_ordering
 from os.path import join
 from pathlib import Path
@@ -12,6 +11,7 @@ from typing import Any, Mapping, Sequence, Tuple, Union
 from urllib.parse import urlparse
 
 from marshmallow import fields, validate
+from uuid_utils import uuid4
 
 from ...core.profile import Profile, ProfileSession
 from ...indy.credx.issuer import (
@@ -190,7 +190,7 @@ class IssuerRevRegRecord(BaseRecord):
     async def generate_registry(self, profile: Profile):
         """Create the revocation registry definition and tails file."""
         if not self.tag:
-            self.tag = self._id or str(uuid.uuid4())
+            self.tag = self._id or str(uuid4())
 
         if self.state != IssuerRevRegRecord.STATE_INIT:
             raise RevocationError(

--- a/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
+++ b/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
@@ -1,7 +1,7 @@
 """Issuer revocation registry storage handling."""
 
-import json
 import importlib
+import json
 import logging
 from functools import total_ordering
 from os.path import join
@@ -14,10 +14,7 @@ from marshmallow import fields, validate
 from uuid_utils import uuid4
 
 from ...core.profile import Profile, ProfileSession
-from ...indy.credx.issuer import (
-    CATEGORY_CRED_DEF,
-    CATEGORY_REV_REG_DEF_PRIVATE,
-)
+from ...indy.credx.issuer import CATEGORY_CRED_DEF, CATEGORY_REV_REG_DEF_PRIVATE
 from ...indy.issuer import IndyIssuer, IndyIssuerError
 from ...indy.models.revocation import (
     IndyRevRegDef,

--- a/aries_cloudagent/revocation_anoncreds/routes.py
+++ b/aries_cloudagent/revocation_anoncreds/routes.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import uuid
 
 from aiohttp import web
 from aiohttp_apispec import (
@@ -14,6 +13,7 @@ from aiohttp_apispec import (
 )
 from marshmallow import fields, validate, validates_schema
 from marshmallow.exceptions import ValidationError
+from uuid_utils import uuid4
 
 from ..admin.decorators.auth import tenant_authentication
 from ..admin.request_context import AdminRequestContext
@@ -636,7 +636,7 @@ async def _get_issuer_rev_reg_record(
 
     # transform
     result = IssuerRevRegRecord(
-        record_id=uuid.uuid4(),
+        record_id=uuid4(),
         state=state,
         cred_def_id=rev_reg_def.cred_def_id,
         error_msg=None,

--- a/aries_cloudagent/revocation_anoncreds/tests/test_routes.py
+++ b/aries_cloudagent/revocation_anoncreds/tests/test_routes.py
@@ -8,10 +8,7 @@ from aiohttp.web import HTTPNotFound
 from aries_cloudagent.tests import mock
 
 from ...admin.request_context import AdminRequestContext
-from ...anoncreds.models.anoncreds_revocation import (
-    RevRegDef,
-    RevRegDefValue,
-)
+from ...anoncreds.models.anoncreds_revocation import RevRegDef, RevRegDefValue
 from ...askar.profile import AskarProfile
 from ...askar.profile_anon import AskarAnoncredsProfile
 from ...core.in_memory import InMemoryProfile

--- a/aries_cloudagent/revocation_anoncreds/tests/test_routes.py
+++ b/aries_cloudagent/revocation_anoncreds/tests/test_routes.py
@@ -199,7 +199,7 @@ class TestRevocationRoutes(IsolatedAsyncioTestCase):
         with mock.patch.object(
             test_module, "AnonCredsRevocation", autospec=True
         ) as mock_anon_creds_revoc, mock.patch.object(
-            test_module.uuid, "uuid4", mock.Mock()
+            test_module, "uuid4", mock.Mock()
         ) as mock_uuid, mock.patch.object(
             test_module.web, "json_response", mock.Mock()
         ) as mock_json_response:
@@ -446,7 +446,7 @@ class TestRevocationRoutes(IsolatedAsyncioTestCase):
         with mock.patch.object(
             test_module, "AnonCredsRevocation", autospec=True
         ) as mock_anon_creds_revoc, mock.patch.object(
-            test_module.uuid, "uuid4", mock.Mock()
+            test_module, "uuid4", mock.Mock()
         ) as mock_uuid, mock.patch.object(
             test_module.web, "json_response", mock.Mock()
         ) as mock_json_response:

--- a/aries_cloudagent/storage/record.py
+++ b/aries_cloudagent/storage/record.py
@@ -2,7 +2,8 @@
 
 from collections import namedtuple
 from typing import Optional
-from uuid import uuid4
+
+from uuid_utils import uuid4
 
 
 class StorageRecord(namedtuple("StorageRecord", "type value tags id")):

--- a/aries_cloudagent/storage/vc_holder/vc_record.py
+++ b/aries_cloudagent/storage/vc_holder/vc_record.py
@@ -2,9 +2,9 @@
 
 import logging
 from typing import Mapping, Sequence
-from uuid import uuid4
 
 from marshmallow import EXCLUDE, fields
+from uuid_utils import uuid4
 
 from ...messaging.models.base import BaseModel, BaseModelSchema
 from ...messaging.valid import ENDPOINT_EXAMPLE, ENDPOINT_VALIDATE, UUID4_EXAMPLE

--- a/aries_cloudagent/transport/inbound/manager.py
+++ b/aries_cloudagent/transport/inbound/manager.py
@@ -1,9 +1,10 @@
 """Inbound transport manager."""
 
 import logging
-import uuid
 from collections import OrderedDict
 from typing import Callable, Coroutine
+
+from uuid_utils import uuid4
 
 from ...core.profile import Profile
 from ...utils.classloader import ClassLoader, ModuleLoadError, ClassNotFoundError
@@ -164,7 +165,7 @@ class InboundTransportManager:
             client_info=client_info,
             close_handler=self.closed_session,
             inbound_handler=self.receive_inbound,
-            session_id=str(uuid.uuid4()),
+            session_id=str(uuid4()),
             transport_type=transport_type,
             wire_format=wire_format,
         )

--- a/aries_cloudagent/transport/inbound/manager.py
+++ b/aries_cloudagent/transport/inbound/manager.py
@@ -7,12 +7,10 @@ from typing import Callable, Coroutine
 from uuid_utils import uuid4
 
 from ...core.profile import Profile
-from ...utils.classloader import ClassLoader, ModuleLoadError, ClassNotFoundError
+from ...utils.classloader import ClassLoader, ClassNotFoundError, ModuleLoadError
 from ...utils.task_queue import CompletedTask, TaskQueue
-
 from ..outbound.message import OutboundMessage
 from ..wire_format import BaseWireFormat
-
 from .base import (
     BaseInboundTransport,
     InboundTransportConfiguration,

--- a/aries_cloudagent/vc/routes.py
+++ b/aries_cloudagent/vc/routes.py
@@ -1,10 +1,9 @@
 """VC-API Routes."""
 
-import uuid
-
 from aiohttp import web
 from aiohttp_apispec import docs, request_schema, response_schema
 from marshmallow.exceptions import ValidationError
+from uuid_utils import uuid4
 
 from ..admin.decorators.auth import tenant_authentication
 from ..admin.request_context import AdminRequestContext
@@ -151,7 +150,7 @@ async def store_credential_route(request: web.BaseRequest):
 
     try:
         vc = body["verifiableCredential"]
-        cred_id = vc["id"] if "id" in vc else f"urn:uuid:{str(uuid.uuid4())}"
+        cred_id = vc["id"] if "id" in vc else f"urn:uuid:{str(uuid4())}"
         options = {} if "options" not in body else body["options"]
 
         vc = VerifiableCredential.deserialize(vc)

--- a/aries_cloudagent/vc/routes.py
+++ b/aries_cloudagent/vc/routes.py
@@ -15,13 +15,9 @@ from ..wallet.base import BaseWallet
 from ..wallet.error import WalletError
 from .vc_ld.manager import VcLdpManager, VcLdpManagerError
 from .vc_ld.models import web_schemas
-from .vc_ld.models.credential import (
-    VerifiableCredential,
-)
+from .vc_ld.models.credential import VerifiableCredential
 from .vc_ld.models.options import LDProofVCOptions
-from .vc_ld.models.presentation import (
-    VerifiablePresentation,
-)
+from .vc_ld.models.presentation import VerifiablePresentation
 
 
 @docs(tags=["vc-api"], summary="List credentials")

--- a/aries_cloudagent/wallet/key_pair.py
+++ b/aries_cloudagent/wallet/key_pair.py
@@ -1,8 +1,9 @@
 """Key pair storage manager."""
 
 import json
-import uuid
 from typing import List, Mapping, Optional, Sequence
+
+from uuid_utils import uuid4
 
 from ..storage.base import BaseStorage
 from ..storage.record import StorageRecord
@@ -53,7 +54,7 @@ class KeyPairStorageManager:
             KEY_PAIR_STORAGE_TYPE,
             json.dumps(data),
             {**tags, "verkey": verkey, "key_type": key_type.key_type},
-            uuid.uuid4().hex,
+            uuid4().hex,
         )
 
         await self._store.add_record(record)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2610,6 +2610,98 @@ files = [
 ]
 
 [[package]]
+name = "uuid-utils"
+version = "0.7.0"
+description = "Drop-in replacement for Python UUID in Rust"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "uuid_utils-0.7.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:1813869ffbf82ebe5fbe749cf0d5e580c605b0fd65d5e738e44439578280f993"},
+    {file = "uuid_utils-0.7.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:afb6d3cea6f8b1d9692a1c5d7a93aa6189f973509ea272f4c070399e88cea36b"},
+    {file = "uuid_utils-0.7.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38af087e1804774f563ff5f9f043022274dfce110b721ca272f89c0de4ee44e1"},
+    {file = "uuid_utils-0.7.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:183603176b65401492db51a16526360997c91e32bc1ffe20ee527337fc57f634"},
+    {file = "uuid_utils-0.7.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cebc0e99853c6c12f42e509c27af6131ef36b29e6f381d53c6d81eb1bd21a5f4"},
+    {file = "uuid_utils-0.7.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:49e0a42bd9c3825f10d38dcc49bafe5b6543b6c107e4b614e96abf8a7cd58a6f"},
+    {file = "uuid_utils-0.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a0f978aa8a51ca05142e4e81767d67de08b35ce7db28bc2e600d0c317472013"},
+    {file = "uuid_utils-0.7.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3d2d02868c73334e84d80a7ad60e6c7506c72c059508e9a38db453e4110a652"},
+    {file = "uuid_utils-0.7.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:03f710c032d903f273c720dfc080b68fead1ed543de8ad53c4c8dde64c6edd56"},
+    {file = "uuid_utils-0.7.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b60c49becd9ff3844fe6e0e87319df9c84dd65bb86c36ad3514981f64e7a737a"},
+    {file = "uuid_utils-0.7.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c7ae618dbe27eb5c681a09bec4554d8da8264130a083657fcb80033bbf1c6114"},
+    {file = "uuid_utils-0.7.0-cp310-none-win32.whl", hash = "sha256:fb73e36a209c2b585e878748615c0410d2422908ad86fc12b5ae66fedd7e326d"},
+    {file = "uuid_utils-0.7.0-cp310-none-win_amd64.whl", hash = "sha256:8e30075e257184328356436a8a6b0e5a0c2b097c224a1e7f9d98a4c350ae5f21"},
+    {file = "uuid_utils-0.7.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:ca41e673b807405c0c5aa97ff8959b80884734b1eb55428c7285de245aa3e101"},
+    {file = "uuid_utils-0.7.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:cac7e2cf5b40ef297a998fc3ede146f171f99b18210e1237f01002c7e3fa6b0b"},
+    {file = "uuid_utils-0.7.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9bad486bcb3b1bd1f6a6e02d9627c51b993305bd2efd3eb4acd0aff529cd7d43"},
+    {file = "uuid_utils-0.7.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd9d769f85bd24a558e8d1aee93400811e3f734199acc5410617f67b1041e0f4"},
+    {file = "uuid_utils-0.7.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5c99930f6d51efd15b6c2feb73b386bffccfc82c535eb7d8229e4fb6467f5c6c"},
+    {file = "uuid_utils-0.7.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c68ba81b63e23032beda93eeab084f76f141017a26cb895c65777cf3c6c3474"},
+    {file = "uuid_utils-0.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaa67667584aba2096292607e2f2e4485df1d1fb2594b2390227cf18df057f0"},
+    {file = "uuid_utils-0.7.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6506fedaacd814b50cb62745b058796612c0ddd818a35a70082ea76f8b484931"},
+    {file = "uuid_utils-0.7.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eaa55deae8fd4e7ff30a31f1661e953d70705efa3b09d0fc33576a8eaa589910"},
+    {file = "uuid_utils-0.7.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0d4e7cd2f45e9a3dd371abb8532c6fcbb9befa1551522336095b02369e9144a9"},
+    {file = "uuid_utils-0.7.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d6a35a2205318cff201e76cbc6ad428c58e4d9d9ce9c83fd600c5295538be60e"},
+    {file = "uuid_utils-0.7.0-cp311-none-win32.whl", hash = "sha256:a7c82f88158f0693cfbc769536d7c09a7cd3c58b22a1b2a041374db1ba03e2d3"},
+    {file = "uuid_utils-0.7.0-cp311-none-win_amd64.whl", hash = "sha256:df8f82270295726d1f7d1e26026c29d33a2b40e6dcf8723cf7f5809909eaf6d6"},
+    {file = "uuid_utils-0.7.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:53e5d6703f6a38aa1ba59cf8ac0486ac9a847e816e638cf9d6a2a4da4e9f6247"},
+    {file = "uuid_utils-0.7.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:c29183a8baedb39fc89e3d98ed2427d49e97ff3680f6832bffe73568d594970d"},
+    {file = "uuid_utils-0.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:253fd6e8962008484e02fd4ff4a77ffbddd3867c0c3c24a6919eb4fefc3a2297"},
+    {file = "uuid_utils-0.7.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:de53537159212608eb15d4948d0e0098d2fa2b30d453f93d83fe737f0fd7188b"},
+    {file = "uuid_utils-0.7.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:116c4b2ff774ce552324b196a3222302a2e78479a301fdb11c2aa1d294ab0f4d"},
+    {file = "uuid_utils-0.7.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2eafb4fe02270e22a3bdb03c2107604cf68589a965667cabb71789beed318497"},
+    {file = "uuid_utils-0.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6ab7a012a1514e498f3f537852257ad2ec9402d1cc165865108dc6d9496bbd4"},
+    {file = "uuid_utils-0.7.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:08d58f7de04f3c43a4da05eece58002f4028a7275775ad5013e010abd51d7238"},
+    {file = "uuid_utils-0.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e349d43a969f696dbc7acd002b64952b71674eaf948043a4c6dd1ab65d7c462"},
+    {file = "uuid_utils-0.7.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:53f4c96e7fd1dab33dd56a885d9cffb5aaf21a9064115743e2cee1ff03cb359b"},
+    {file = "uuid_utils-0.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c145629c4e48cda275310955632a8231c031f5e9b2eb93b9ab8a081dc6ab6681"},
+    {file = "uuid_utils-0.7.0-cp312-none-win_amd64.whl", hash = "sha256:2ca368440148049475ff94f62d5011c34cd7954fe36247698fc05658d04ad9a1"},
+    {file = "uuid_utils-0.7.0-cp38-cp38-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:48ed8e59c6fdcc8f825e9fa58afc7f98ba37f744a401ff28a47e7042a761b373"},
+    {file = "uuid_utils-0.7.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:bb2777eb2837fc88aceb09addb45bfc7bc8dd0058d19627867b459dac3101a4b"},
+    {file = "uuid_utils-0.7.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:070254d2435e9f187e0e8c0626fc6ed108d308cdec669c6d1493dd117bfbedd1"},
+    {file = "uuid_utils-0.7.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:424abbbf7e8bdfe78ab552d838efeb9fd033cfe2208f00aadee2704169a1ebad"},
+    {file = "uuid_utils-0.7.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:884a72b5f87f7534b685382221d872058bb743294cdb0f2215056b6cc85350fb"},
+    {file = "uuid_utils-0.7.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ab1509e21c74feb68b4a3e309bde8c64a8fce2e4552b79cb14058d6bc17a6129"},
+    {file = "uuid_utils-0.7.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e6d70efc5e3449f0be3184a6925d0feb29fe40bdcd24ee2611a9021ee9b2580"},
+    {file = "uuid_utils-0.7.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:411e29b3a2de713c4a3f3edc653599fb17ef3f38b6a788fecef62c3f229b7b0e"},
+    {file = "uuid_utils-0.7.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:3bf10bd5a898d72f50183718ca18bd61b8830c9134469b4d7b9f73f176f06c9f"},
+    {file = "uuid_utils-0.7.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:247af7258004f497ec927fcf463914df5447eb691d7e9c23528280c471d6e830"},
+    {file = "uuid_utils-0.7.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:01f7c73860b3cef024f9f57515dae5d52a554c3d2480d8410174ec5b609e20f5"},
+    {file = "uuid_utils-0.7.0-cp38-none-win32.whl", hash = "sha256:d90d432c85bb2d9b3d67c8483b1134cf4363a39fa3273b8f05dcfde2bdddfc5d"},
+    {file = "uuid_utils-0.7.0-cp38-none-win_amd64.whl", hash = "sha256:d31ebe0e6d5d1210da259de4d04ee31dfd5407296302bc2dfcca941e3e8f7bee"},
+    {file = "uuid_utils-0.7.0-cp39-cp39-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:076fe5f6e5295a5d47b240ece6047d25ce15e8a114f60acc51b4025c3b973ed9"},
+    {file = "uuid_utils-0.7.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:997f4d4f505391b69373c852662b5fe0af8c17b71fe401fea7687261464b9aa5"},
+    {file = "uuid_utils-0.7.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:59fc7ce3dddb5694f6ecd427d557a342f44075cdaf836cd99033fd0cc500e592"},
+    {file = "uuid_utils-0.7.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:463b98c24c5f6f4d0b46174c1068c19007fe6414c38fbd58d5cb6c8d29cdd1ef"},
+    {file = "uuid_utils-0.7.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65c5d33fd056517d0ab1624168359371b012cc6e3a0fd6029d212d3973032e90"},
+    {file = "uuid_utils-0.7.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:da47c5c4348a5f88749ac8fd54715bdfa18c1317ebf709121721e9b5fb338c66"},
+    {file = "uuid_utils-0.7.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:04f39fd90656770422cc7ec46467c2eb758e19d70c5844770bd67834ebae40ea"},
+    {file = "uuid_utils-0.7.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a5817e38d497ae643c68044c5c84153fa47557df1f8c1661c17bd1e26bda1058"},
+    {file = "uuid_utils-0.7.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:407c15bbde425bc4df829771ef601260eda8617ac5adc6f1eb924d916674c34f"},
+    {file = "uuid_utils-0.7.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:d4ac00e7f3bbb578e20fadf81468f28b63d1b29930192d8285e9d01b2f75f270"},
+    {file = "uuid_utils-0.7.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6d937d37b696a2e3346171367a6ecf69519af4f2a5325e8e7f9a7cfb61597387"},
+    {file = "uuid_utils-0.7.0-cp39-none-win32.whl", hash = "sha256:a4fd826bc2c260716b53db90b2e4c8a0f752aae053fbfbd1860e6e450bcf6ae9"},
+    {file = "uuid_utils-0.7.0-cp39-none-win_amd64.whl", hash = "sha256:c1aa084a1b4842c49526ed1189122a96a8cdd73f66ef4219956279044bf6721f"},
+    {file = "uuid_utils-0.7.0-pp38-pypy38_pp73-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:15eb3621d24fb6aab7f8e7b315356171795ca0f226ba9c31490fb9c08712c201"},
+    {file = "uuid_utils-0.7.0-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:bd0dac47317dcdefafe493428237019582ba8adb91c3ec80e033ee631c173f6d"},
+    {file = "uuid_utils-0.7.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a7b555e485f17ab1ab0cb963ff48c6404b93dd491aef7f52a8ae8c52f7f51841"},
+    {file = "uuid_utils-0.7.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e66bddd9a469645ede16f0abde5db4dd1a75bc9628ab0b68cad0b848de8494aa"},
+    {file = "uuid_utils-0.7.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ad6957427be8f2e48d2f128b3382b3c8e33b4b26542d757e5957c9593773082"},
+    {file = "uuid_utils-0.7.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4c753f5b690a481d31f13668a57610a4ee9805d0bd4515ab74a3766bea3b0e66"},
+    {file = "uuid_utils-0.7.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e99615eb01550e1f883b5b251a04e8afe053dd30fb6c1af823bd14841bd9290"},
+    {file = "uuid_utils-0.7.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cb241970c10cccd37ecac5b3759276ca499cb5b639b832167f91b0a98383e89d"},
+    {file = "uuid_utils-0.7.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:14b672b950e792545fde222cf08f9ba9e30ac69399c2ca34b91d4fa457ce1528"},
+    {file = "uuid_utils-0.7.0-pp39-pypy39_pp73-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:1229b9849a239714899040f8af9c7b3b7ad790483ac0bdf06982eb03383e7a93"},
+    {file = "uuid_utils-0.7.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:2b6c56101e5dedf06c81c5f3e3dc9d542feb4a5443b01a100c14eef6ae7e9ec4"},
+    {file = "uuid_utils-0.7.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77c7f5e54fad8d761e019122080b14fae9568dd09cbb908f349284efa8f9a792"},
+    {file = "uuid_utils-0.7.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b429a906f0dff1c35d55ca17c5f7fedf3149cb405808b43ba4f3a6d21732c31"},
+    {file = "uuid_utils-0.7.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:06608c7d643149dee92ceebc73a84bb736d4394f200ecb794541a79e10bc482d"},
+    {file = "uuid_utils-0.7.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:655e505c4e7c321e7f60572fdd594bdfdd96556a9699f697045e3d0b4699f30a"},
+    {file = "uuid_utils-0.7.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1e59447b45d5988572e450f43de5546e1d2f6643d2e0137d83b5fdad204fd05"},
+    {file = "uuid_utils-0.7.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3010bdaff5c2a78980849aa6b082e7a0013949c8e4d317934f4aaacf14a2d22"},
+    {file = "uuid_utils-0.7.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:ec25fadeeb34c41ef95a8b849a3e4dcc39e96eb39367323ba873bc1732d6516a"},
+    {file = "uuid_utils-0.7.0.tar.gz", hash = "sha256:015aa22711ffd57c5001c2477c6a40121db2794ae3be181a0bf79eef80e28943"},
+]
+
+[[package]]
 name = "virtualenv"
 version = "20.26.2"
 description = "Virtual Python Environment builder"
@@ -2767,18 +2859,18 @@ multidict = ">=4.0"
 
 [[package]]
 name = "zipp"
-version = "3.19.0"
+version = "3.19.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.19.0-py3-none-any.whl", hash = "sha256:96dc6ad62f1441bcaccef23b274ec471518daf4fbbc580341204936a5a3dddec"},
-    {file = "zipp-3.19.0.tar.gz", hash = "sha256:952df858fb3164426c976d9338d3961e8e8b3758e2e059e0f754b8c4262625ee"},
+    {file = "zipp-3.19.1-py3-none-any.whl", hash = "sha256:2828e64edb5386ea6a52e7ba7cdb17bb30a73a858f5eb6eb93d8d36f5ea26091"},
+    {file = "zipp-3.19.1.tar.gz", hash = "sha256:35427f6d5594f4acf82d25541438348c26736fa9b3afa2754bcd63cdb99d8e8f"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [extras]
 askar = ["anoncreds", "aries-askar", "indy-credx", "indy-vdr"]
@@ -2787,4 +2879,4 @@ bbs = ["ursa-bbs-signatures"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "9a42f2f61071cb81905db7bd6e92150482c1b4093b04c997190a2485b060ea74"
+content-hash = "bf0b2f518093be63b64b345c7164cd735f81bbc8020bd286dad2fe2754992b64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ unflatten="~0.1"
 sd-jwt = "^0.10.3"
 did-peer-2 = "^0.1.2"
 did-peer-4 = "^0.1.4"
+uuid_utils = "^0.7.0"
 
 # askar
 aries-askar= { version = "~0.3.0", optional = true }


### PR DESCRIPTION
Next up on the list of improvements that nobody asked for :-) faster uuid generation!

I noticed in the StorageRecord class that a new uuid4 is always generated when one isn't provided. This seemed important. So I wondered what is the fastest way to generate a uuid, and unsurprisingly, there is a python-rust binding that claims to be 10x faster than the default python uuid library.

https://github.com/aminalaee/uuid-utils

I verified the benchmarks with a timeit script, comparing that with another rust-binding library `fastuuid`:
```py
import timeit
import uuid

from fastuuid import uuid4 as fastuuid4
from uuid_utils import uuid4 as utiluuid4


def uuid4_hex():
    return uuid.uuid4().hex


def fastuuid4_hex():
    return fastuuid4().hex


def utiluuid4_hex():
    return utiluuid4().hex


if __name__ == "__main__":
    number = 1000000  # Number of executions for timeit

    uuid4_time = timeit.timeit("uuid4_hex()", globals=globals(), number=number)
    print(f"uuid4_hex().hex: {uuid4_time:.6f} seconds")

    fastuuid4_time = timeit.timeit("fastuuid4_hex()", globals=globals(), number=number)
    print(f"fastuuid4().hex: {fastuuid4_time:.6f} seconds")

    utiluuid4_hex_time = timeit.timeit(
        "utiluuid4_hex()", globals=globals(), number=number
    )
    print(f"utiluuid4_hex().hex: {utiluuid4_hex_time:.6f} seconds")
```

My results:
```sh
uuid4_hex().hex: 2.518658 seconds
fastuuid4().hex: 1.306156 seconds
utiluuid4_hex().hex: 0.280322 seconds
```

0.28 seconds vs 2.5 seconds. That's 9 StorageRecords that can now be generated in the time that it previously took for 1!

It's a drop-in replacement. If maintainers like it as well, maybe it'll make ACA-Py a lil bit faster :-)