### PR TITLE
Use a published version of aiohttp-apispec

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -97,25 +97,21 @@ yarl = ">=1.0,<2.0"
 speedups = ["Brotli", "aiodns", "brotlicffi"]
 
 [[package]]
-name = "aiohttp-apispec"
+name = "aiohttp-apispec-acapy"
 version = "3.0.1"
 description = "Build and document REST APIs with aiohttp and apispec"
 optional = false
 python-versions = ">=3.9"
-files = []
-develop = false
+files = [
+    {file = "aiohttp-apispec-acapy-3.0.1.tar.gz", hash = "sha256:d02a32aa6a396540faa1d4fb3876f07e9b43742cc3303264c832fadeba2bf485"},
+    {file = "aiohttp_apispec_acapy-3.0.1-py3-none-any.whl", hash = "sha256:d319b10d730b2521b2bfa4814d4184757e415a5e8508d979146b53fb1bcab8d2"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9.4,<4.0"
 apispec = ">=6.6.1,<6.7.0"
 jinja2 = ">=3.1.3,<3.2.0"
 webargs = ">=8.4.0,<8.5.0"
-
-[package.source]
-type = "git"
-url = "https://github.com/ff137/aiohttp-apispec.git"
-reference = "v3.0.1"
-resolved_reference = "a2b67c0d26f6d3bf0234a8cd134f699144239eeb"
 
 [[package]]
 name = "aiohttp-cors"
@@ -2885,4 +2881,4 @@ bbs = ["ursa-bbs-signatures"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "7dbaa13873082c3ccdfdf47d5381b85d30c7c64800884148095e344955f3e27c"
+content-hash = "4fa576e802fd9ff68f5a1fce8b9b6b9b5403f92c6134ca4504ebded621a60761"

--- a/poetry.lock
+++ b/poetry.lock
@@ -98,13 +98,13 @@ speedups = ["Brotli", "aiodns", "brotlicffi"]
 
 [[package]]
 name = "aiohttp-apispec-acapy"
-version = "3.0.1"
+version = "3.0.2"
 description = "Build and document REST APIs with aiohttp and apispec"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "aiohttp-apispec-acapy-3.0.1.tar.gz", hash = "sha256:d02a32aa6a396540faa1d4fb3876f07e9b43742cc3303264c832fadeba2bf485"},
-    {file = "aiohttp_apispec_acapy-3.0.1-py3-none-any.whl", hash = "sha256:d319b10d730b2521b2bfa4814d4184757e415a5e8508d979146b53fb1bcab8d2"},
+    {file = "aiohttp-apispec-acapy-3.0.2.tar.gz", hash = "sha256:9e6946a48cb70d3f7097f51e2ce7ba8bee32fce9d654454fe300930bfa8ce542"},
+    {file = "aiohttp_apispec_acapy-3.0.2-py3-none-any.whl", hash = "sha256:93ea532afb3876685d185cc1cfe51d6d08e597cf04f79d16898a23ac4842b742"},
 ]
 
 [package.dependencies]
@@ -2881,4 +2881,4 @@ bbs = ["ursa-bbs-signatures"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "01cec6563fa3fbebbc1370af919d06b337088ee21320fb98060db260b6a9c670"
+content-hash = "5ec524034c85a7d2497fb43981a95e7d7e3cc356c2ada95f4e943c98899b07cb"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2881,4 +2881,4 @@ bbs = ["ursa-bbs-signatures"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "4fa576e802fd9ff68f5a1fce8b9b6b9b5403f92c6134ca4504ebded621a60761"
+content-hash = "01cec6563fa3fbebbc1370af919d06b337088ee21320fb98060db260b6a9c670"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/hyperledger/aries-cloudagent-python"
 [tool.poetry.dependencies]
 python = "^3.9"
 aiohttp="~3.9.4"
-aiohttp-apispec = { git = "https://github.com/ff137/aiohttp-apispec.git", tag = "v3.0.1" }
+aiohttp-apispec-acapy="~3.0.1"
 aiohttp-cors="~0.7.0"
 apispec="^6.6.0"
 async-timeout="~4.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/hyperledger/aries-cloudagent-python"
 [tool.poetry.dependencies]
 python = "^3.9"
 aiohttp="~3.9.4"
-aiohttp-apispec-acapy="~3.0.1"
+aiohttp-apispec-acapy="~3.0.2"
 aiohttp-cors="~0.7.0"
 apispec="^6.6.0"
 async-timeout="~4.0.2"


### PR DESCRIPTION
So this is my idea for the `aiohttp-apispec` library. I forked the repo from @ff137 and then published my own pypi library called `aiohttp-apispec-acapy`. This isn't really a lot better than downloading it from the forked repo as I could still delete the package. I do think it's a bit safer than using the remote repo and tag.

https://pypi.org/project/aiohttp-apispec-acapy/3.0.1/

It would be better if someone with a hyperledger account published it there instead.

I think this is a bit more solid until we come up with a long term migration plan which I think will hold up v1.0.0 release too long.

I'd need to make some adjustments to the readme file and I'm not certain if I should have the original owners information on it.

Just wanted to get others thoughts on this.