### PR TITLE
:sparkles: Add pagination support for listing Connection, Cred Ex, and Pres Ex records

### DIFF
--- a/aries_cloudagent/messaging/models/paginated_query.py
+++ b/aries_cloudagent/messaging/models/paginated_query.py
@@ -1,5 +1,8 @@
 """Class for paginated query parameters."""
 
+from typing import Tuple
+
+from aiohttp.web import BaseRequest
 from marshmallow import fields
 
 from ...messaging.models.openapi import OpenAPISchema
@@ -28,3 +31,18 @@ class PaginatedQuerySchema(OpenAPISchema):
         metadata={"description": "Offset for pagination", "example": 0},
         error_messages={"validator_failed": "Value must be 0 or greater"},
     )
+
+
+def get_limit_offset(request: BaseRequest) -> Tuple[int, int]:
+    """Read the limit and offset query parameters from a request as ints, with defaults.
+
+    Args:
+        request: aiohttp request object
+
+    Returns:
+        A tuple of the limit and offset values
+    """
+
+    limit = int(request.query.get("limit", DEFAULT_PAGE_SIZE))
+    offset = int(request.query.get("offset", 0))
+    return limit, offset

--- a/aries_cloudagent/messaging/models/paginated_query.py
+++ b/aries_cloudagent/messaging/models/paginated_query.py
@@ -2,9 +2,8 @@
 
 from marshmallow import fields
 
-from aries_cloudagent.storage.base import DEFAULT_PAGE_SIZE, MAXIMUM_PAGE_SIZE
-
 from ...messaging.models.openapi import OpenAPISchema
+from ...storage.base import DEFAULT_PAGE_SIZE, MAXIMUM_PAGE_SIZE
 
 
 class PaginatedQuerySchema(OpenAPISchema):

--- a/aries_cloudagent/multitenant/admin/routes.py
+++ b/aries_cloudagent/multitenant/admin/routes.py
@@ -16,10 +16,9 @@ from ...core.error import BaseError
 from ...core.profile import ProfileManagerProvider
 from ...messaging.models.base import BaseModelError
 from ...messaging.models.openapi import OpenAPISchema
-from ...messaging.models.paginated_query import PaginatedQuerySchema
+from ...messaging.models.paginated_query import PaginatedQuerySchema, get_limit_offset
 from ...messaging.valid import UUID4_EXAMPLE, JSONWebToken
 from ...multitenant.base import BaseMultitenantManager
-from ...storage.base import DEFAULT_PAGE_SIZE
 from ...storage.error import StorageError, StorageNotFoundError
 from ...utils.endorsement_setup import attempt_auto_author_with_endorser_setup
 from ...utils.profiles import subwallet_type_not_same_as_base_wallet_raise_web_exception
@@ -382,8 +381,7 @@ async def wallets_list(request: web.BaseRequest):
     if wallet_name:
         query["wallet_name"] = wallet_name
 
-    limit = int(request.query.get("limit", DEFAULT_PAGE_SIZE))
-    offset = int(request.query.get("offset", 0))
+    limit, offset = get_limit_offset(request)
 
     try:
         async with profile.session() as session:

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -19,7 +19,7 @@ from ....cache.base import BaseCache
 from ....connections.models.conn_record import ConnRecord, ConnRecordSchema
 from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
-from ....messaging.models.paginated_query import PaginatedQuerySchema
+from ....messaging.models.paginated_query import PaginatedQuerySchema, get_limit_offset
 from ....messaging.valid import (
     ENDPOINT_EXAMPLE,
     ENDPOINT_VALIDATE,
@@ -31,7 +31,6 @@ from ....messaging.valid import (
     UUID4_EXAMPLE,
     UUID4_VALIDATE,
 )
-from ....storage.base import DEFAULT_PAGE_SIZE
 from ....storage.error import StorageError, StorageNotFoundError
 from ....wallet.error import WalletError
 from .manager import ConnectionManager, ConnectionManagerError
@@ -470,8 +469,7 @@ async def connections_list(request: web.BaseRequest):
     if request.query.get("connection_protocol"):
         post_filter["connection_protocol"] = request.query["connection_protocol"]
 
-    limit = int(request.query.get("limit", DEFAULT_PAGE_SIZE))
-    offset = int(request.query.get("offset", 0))
+    limit, offset = get_limit_offset(request)
 
     profile = context.profile
     try:

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
@@ -103,6 +103,8 @@ class TestConnectionRoutes(IsolatedAsyncioTestCase):
                         "their_public_did": "a_public_did",
                         "invitation_msg_id": "dummy_msg",
                     },
+                    limit=100,
+                    offset=0,
                     post_filter_positive={
                         "their_role": list(ConnRecord.Role.REQUESTER.value),
                         "connection_protocol": "connections/1.0",

--- a/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
@@ -22,7 +22,7 @@ from ....ledger.error import LedgerError
 from ....messaging.credential_definitions.util import CRED_DEF_TAGS
 from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
-from ....messaging.models.paginated_query import PaginatedQuerySchema
+from ....messaging.models.paginated_query import PaginatedQuerySchema, get_limit_offset
 from ....messaging.valid import (
     INDY_CRED_DEF_ID_EXAMPLE,
     INDY_CRED_DEF_ID_VALIDATE,
@@ -35,7 +35,6 @@ from ....messaging.valid import (
     UUID4_EXAMPLE,
     UUID4_VALIDATE,
 )
-from ....storage.base import DEFAULT_PAGE_SIZE
 from ....storage.error import StorageError, StorageNotFoundError
 from ....utils.tracing import AdminAPIMessageTracingSchema, get_timer, trace_event
 from ....wallet.util import default_did_from_verkey
@@ -405,8 +404,7 @@ async def credential_exchange_list(request: web.BaseRequest):
         if request.query.get(k, "") != ""
     }
 
-    limit = int(request.query.get("limit", DEFAULT_PAGE_SIZE))
-    offset = int(request.query.get("offset", 0))
+    limit, offset = get_limit_offset(request)
 
     try:
         async with context.profile.session() as session:

--- a/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/routes.py
@@ -26,7 +26,7 @@ from ....ledger.error import LedgerError
 from ....messaging.decorators.attach_decorator import AttachDecorator
 from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
-from ....messaging.models.paginated_query import PaginatedQuerySchema
+from ....messaging.models.paginated_query import PaginatedQuerySchema, get_limit_offset
 from ....messaging.valid import (
     INDY_CRED_DEF_ID_EXAMPLE,
     INDY_CRED_DEF_ID_VALIDATE,
@@ -39,7 +39,6 @@ from ....messaging.valid import (
     UUID4_EXAMPLE,
     UUID4_VALIDATE,
 )
-from ....storage.base import DEFAULT_PAGE_SIZE
 from ....storage.error import StorageError, StorageNotFoundError
 from ....utils.tracing import AdminAPIMessageTracingSchema, get_timer, trace_event
 from ....vc.ld_proofs.error import LinkedDataProofException
@@ -568,8 +567,7 @@ async def credential_exchange_list(request: web.BaseRequest):
         if request.query.get(k, "") != ""
     }
 
-    limit = int(request.query.get("limit", DEFAULT_PAGE_SIZE))
-    offset = int(request.query.get("offset", 0))
+    limit, offset = get_limit_offset(request)
 
     try:
         async with profile.session() as session:

--- a/aries_cloudagent/protocols/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/routes.py
@@ -25,7 +25,7 @@ from ....ledger.error import LedgerError
 from ....messaging.decorators.attach_decorator import AttachDecorator
 from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
-from ....messaging.models.paginated_query import PaginatedQuerySchema
+from ....messaging.models.paginated_query import PaginatedQuerySchema, get_limit_offset
 from ....messaging.valid import (
     INDY_EXTRA_WQL_EXAMPLE,
     INDY_EXTRA_WQL_VALIDATE,
@@ -36,7 +36,6 @@ from ....messaging.valid import (
     UUID4_EXAMPLE,
     UUID4_VALIDATE,
 )
-from ....storage.base import DEFAULT_PAGE_SIZE
 from ....storage.error import StorageError, StorageNotFoundError
 from ....utils.tracing import AdminAPIMessageTracingSchema, get_timer, trace_event
 from ....wallet.error import WalletNotFoundError
@@ -312,8 +311,7 @@ async def presentation_exchange_list(request: web.BaseRequest):
         if request.query.get(k, "") != ""
     }
 
-    limit = int(request.query.get("limit", DEFAULT_PAGE_SIZE))
-    offset = int(request.query.get("offset", 0))
+    limit, offset = get_limit_offset(request)
 
     try:
         async with context.profile.session() as session:

--- a/aries_cloudagent/protocols/present_proof/v2_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/routes.py
@@ -26,7 +26,7 @@ from ....ledger.error import LedgerError
 from ....messaging.decorators.attach_decorator import AttachDecorator
 from ....messaging.models.base import BaseModelError
 from ....messaging.models.openapi import OpenAPISchema
-from ....messaging.models.paginated_query import PaginatedQuerySchema
+from ....messaging.models.paginated_query import PaginatedQuerySchema, get_limit_offset
 from ....messaging.valid import (
     INDY_EXTRA_WQL_EXAMPLE,
     INDY_EXTRA_WQL_VALIDATE,
@@ -37,7 +37,7 @@ from ....messaging.valid import (
     UUID4_EXAMPLE,
     UUID4_VALIDATE,
 )
-from ....storage.base import DEFAULT_PAGE_SIZE, BaseStorage
+from ....storage.base import BaseStorage
 from ....storage.error import StorageError, StorageNotFoundError
 from ....storage.vc_holder.base import VCHolder
 from ....storage.vc_holder.vc_record import VCRecord
@@ -449,8 +449,7 @@ async def present_proof_list(request: web.BaseRequest):
         if request.query.get(k, "") != ""
     }
 
-    limit = int(request.query.get("limit", DEFAULT_PAGE_SIZE))
-    offset = int(request.query.get("offset", 0))
+    limit, offset = get_limit_offset(request)
 
     try:
         async with profile.session() as session:


### PR DESCRIPTION
Marking as draft to first confirm functionality works as expected

Edit: Success! I've written a local test to assert that limit/offset does indeed work as expected, and that unique records are returned across pages. 
___

This adds `limit` and `offset` query parameters to:
- listing connection records (in v1 connections API)
- listing credential exchange records (in v1 and v2 issue_credentials API)
- listing presentation exchange records (in v1 and v2 present_proof API)

As with #3000: the default behavior is now changed to no longer attempt to fetch all records for these endpoints. A default page size of 100 is used, with a maximum allowable page size of 10'000.

As you can see, adding the functionality is as simple as extending `PaginatedQuerySchema` for the query parameter schemas, and then to read limit and offset, and passing it to the Records.query method.

There are probably more endpoints where this functionality can be added, so I'm open for suggestions to apply the same elsewhere, but it should be straight forward enough for other contributors to add too.

These are just what I believe to be the essential endpoints, such that issuers/verifiers listing connections or exchange records won't try to read potentially millions of records.