### PR TITLE
Fix - only run integration tests on opened PR's

### DIFF
--- a/.github/workflows/integrationtests.yml
+++ b/.github/workflows/integrationtests.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,7 +20,7 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'pull_request' && !github.event.pull_request.draft && github.repository == 'hyperledger/aries-cloudagent-python') || (github.event_name != 'pull_request')
+    if: (github.event_name == 'pull_request' && github.repository == 'hyperledger/aries-cloudagent-python') || (github.event_name != 'pull_request')
     outputs:
       is_release: ${{ steps.check_if_release.outputs.is_release }}
     steps:


### PR DESCRIPTION
The `don't run integration tests on draft PR's` was added a little while ago on this unrelated PR https://github.com/hyperledger/aries-cloudagent-python/pull/3000.

However, the way it was done skips the integration tests after you move a draft PR into ready for review.

Because it has `synchronize` and `reopen` set as well. The integration tests will run if you rebase a draft PR with main or when you reopen a draft PR. Don't really think this is a big deal, but can try to make it a bit better if we want.