### PR TITLE
:adhesive_bandage: add exception handling to wallet-upgrade check

### DIFF
--- a/aries_cloudagent/core/conductor.py
+++ b/aries_cloudagent/core/conductor.py
@@ -519,7 +519,12 @@ class Conductor:
             except Exception:
                 LOGGER.exception("Error accepting mediation invitation")
 
-        await self.check_for_wallet_upgrades_in_progress()
+        try:
+            await self.check_for_wallet_upgrades_in_progress()
+        except Exception:
+            LOGGER.exception(
+                "An exception was caught while checking for wallet upgrades in progress"
+            )
 
         # notify protcols of startup status
         await self.root_profile.notify(STARTUP_EVENT_TOPIC, {})


### PR DESCRIPTION
Simple fix for non-critical issue.

Currently, if something goes wrong with the `check_for_wallet_upgrades_in_progress` method, then startup will be aborted. This PR just adds a try-except block, such that the exception is logged and startup can proceed.

Relates to #3030