### PR TITLE
Handle failed tails server issuance [Anoncreds]

### DIFF
--- a/aries_cloudagent/anoncreds/base.py
+++ b/aries_cloudagent/anoncreds/base.py
@@ -6,11 +6,7 @@ from typing import Generic, Optional, Pattern, Sequence, TypeVar
 from ..config.injection_context import InjectionContext
 from ..core.error import BaseError
 from ..core.profile import Profile
-from .models.anoncreds_cred_def import (
-    CredDef,
-    CredDefResult,
-    GetCredDefResult,
-)
+from .models.anoncreds_cred_def import CredDef, CredDefResult, GetCredDefResult
 from .models.anoncreds_revocation import (
     GetRevListResult,
     GetRevRegDefResult,
@@ -59,10 +55,7 @@ class AnonCredsObjectAlreadyExists(AnonCredsRegistrationError, Generic[T]):
         Args:
             message: Message
             obj_id: Object ID
-            obj: Object
-
-        TODO: update this docstring - Anoncreds-break.
-
+            obj: Generic Object
         """
         super().__init__(message, obj_id, obj, *args, **kwargs)
         self._message = message

--- a/aries_cloudagent/anoncreds/default/did_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/did_indy/registry.py
@@ -7,14 +7,16 @@ from typing import Optional, Pattern, Sequence
 from ....config.injection_context import InjectionContext
 from ....core.profile import Profile
 from ...base import BaseAnonCredsRegistrar, BaseAnonCredsResolver
-from ...models.anoncreds_cred_def import (CredDef, CredDefResult,
-                                          GetCredDefResult)
-from ...models.anoncreds_revocation import (GetRevListResult,
-                                            GetRevRegDefResult, RevList,
-                                            RevListResult, RevRegDef,
-                                            RevRegDefResult)
-from ...models.anoncreds_schema import (AnonCredsSchema, GetSchemaResult,
-                                        SchemaResult)
+from ...models.anoncreds_cred_def import CredDef, CredDefResult, GetCredDefResult
+from ...models.anoncreds_revocation import (
+    GetRevListResult,
+    GetRevRegDefResult,
+    RevList,
+    RevListResult,
+    RevRegDef,
+    RevRegDefResult,
+)
+from ...models.anoncreds_schema import AnonCredsSchema, GetSchemaResult, SchemaResult
 
 LOGGER = logging.getLogger(__name__)
 

--- a/aries_cloudagent/anoncreds/default/did_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/did_indy/registry.py
@@ -7,20 +7,14 @@ from typing import Optional, Pattern, Sequence
 from ....config.injection_context import InjectionContext
 from ....core.profile import Profile
 from ...base import BaseAnonCredsRegistrar, BaseAnonCredsResolver
-from ...models.anoncreds_cred_def import (
-    CredDef,
-    CredDefResult,
-    GetCredDefResult,
-)
-from ...models.anoncreds_revocation import (
-    GetRevListResult,
-    GetRevRegDefResult,
-    RevList,
-    RevListResult,
-    RevRegDef,
-    RevRegDefResult,
-)
-from ...models.anoncreds_schema import AnonCredsSchema, GetSchemaResult, SchemaResult
+from ...models.anoncreds_cred_def import (CredDef, CredDefResult,
+                                          GetCredDefResult)
+from ...models.anoncreds_revocation import (GetRevListResult,
+                                            GetRevRegDefResult, RevList,
+                                            RevListResult, RevRegDef,
+                                            RevRegDefResult)
+from ...models.anoncreds_schema import (AnonCredsSchema, GetSchemaResult,
+                                        SchemaResult)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +26,7 @@ class DIDIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         """Initialize an instance.
 
         Args:
-        TODO: update this docstring - Anoncreds-break.
+            None
 
         """
         self._supported_identifiers_regex = re.compile(r"^did:indy:.*$")

--- a/aries_cloudagent/anoncreds/default/did_web/registry.py
+++ b/aries_cloudagent/anoncreds/default/did_web/registry.py
@@ -6,14 +6,16 @@ from typing import Optional, Pattern, Sequence
 from ....config.injection_context import InjectionContext
 from ....core.profile import Profile
 from ...base import BaseAnonCredsRegistrar, BaseAnonCredsResolver
-from ...models.anoncreds_cred_def import (CredDef, CredDefResult,
-                                          GetCredDefResult)
-from ...models.anoncreds_revocation import (GetRevListResult,
-                                            GetRevRegDefResult, RevList,
-                                            RevListResult, RevRegDef,
-                                            RevRegDefResult)
-from ...models.anoncreds_schema import (AnonCredsSchema, GetSchemaResult,
-                                        SchemaResult)
+from ...models.anoncreds_cred_def import CredDef, CredDefResult, GetCredDefResult
+from ...models.anoncreds_revocation import (
+    GetRevListResult,
+    GetRevRegDefResult,
+    RevList,
+    RevListResult,
+    RevRegDef,
+    RevRegDefResult,
+)
+from ...models.anoncreds_schema import AnonCredsSchema, GetSchemaResult, SchemaResult
 
 
 class DIDWebRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):

--- a/aries_cloudagent/anoncreds/default/did_web/registry.py
+++ b/aries_cloudagent/anoncreds/default/did_web/registry.py
@@ -6,16 +6,14 @@ from typing import Optional, Pattern, Sequence
 from ....config.injection_context import InjectionContext
 from ....core.profile import Profile
 from ...base import BaseAnonCredsRegistrar, BaseAnonCredsResolver
-from ...models.anoncreds_cred_def import CredDef, CredDefResult, GetCredDefResult
-from ...models.anoncreds_revocation import (
-    GetRevListResult,
-    GetRevRegDefResult,
-    RevList,
-    RevListResult,
-    RevRegDef,
-    RevRegDefResult,
-)
-from ...models.anoncreds_schema import AnonCredsSchema, GetSchemaResult, SchemaResult
+from ...models.anoncreds_cred_def import (CredDef, CredDefResult,
+                                          GetCredDefResult)
+from ...models.anoncreds_revocation import (GetRevListResult,
+                                            GetRevRegDefResult, RevList,
+                                            RevListResult, RevRegDef,
+                                            RevRegDefResult)
+from ...models.anoncreds_schema import (AnonCredsSchema, GetSchemaResult,
+                                        SchemaResult)
 
 
 class DIDWebRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
@@ -25,7 +23,7 @@ class DIDWebRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         """Initialize an instance.
 
         Args:
-        TODO: update this docstring - Anoncreds-break.
+            None
 
         """
         self._supported_identifiers_regex = re.compile(

--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -620,19 +620,9 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
                     write_ledger=write_ledger,
                     endorser_did=endorser_did,
                 )
-        except AnonCredsRegistrationError as err:
+        except LedgerError as err:
             LOGGER.error(
                 f"Error registering revocation registry definition {rev_reg_def_id}: {err.roll_up}"  # noqa: E501
-            )
-            return RevRegDefResult(
-                job_id=None,
-                revocation_registry_definition_state=RevRegDefState(
-                    state=RevRegDefState.STATE_FAILED,
-                    revocation_registry_definition_id=rev_reg_def_id,
-                    revocation_registry_definition=revocation_registry_definition,
-                ),
-                registration_metadata={},
-                revocation_registry_definition_metadata={},
             )
 
         # Didn't need endorsement

--- a/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
+++ b/aries_cloudagent/anoncreds/default/legacy_indy/registry.py
@@ -6,8 +6,11 @@ import re
 from asyncio import shield
 from typing import List, Optional, Pattern, Sequence, Tuple
 
-from anoncreds import (CredentialDefinition, RevocationRegistryDefinition,
-                       RevocationRegistryDefinitionPrivate)
+from anoncreds import (
+    CredentialDefinition,
+    RevocationRegistryDefinition,
+    RevocationRegistryDefinitionPrivate,
+)
 from base58 import alphabet
 from uuid_utils import uuid4
 
@@ -17,40 +20,71 @@ from ....config.injection_context import InjectionContext
 from ....core.event_bus import EventBus
 from ....core.profile import Profile, ProfileSession
 from ....ledger.base import BaseLedger
-from ....ledger.error import (LedgerError, LedgerObjectAlreadyExistsError,
-                              LedgerTransactionError)
-from ....ledger.merkel_validation.constants import (GET_REVOC_REG_DELTA,
-                                                    GET_REVOC_REG_ENTRY,
-                                                    GET_SCHEMA)
+from ....ledger.error import (
+    LedgerError,
+    LedgerObjectAlreadyExistsError,
+    LedgerTransactionError,
+)
+from ....ledger.merkel_validation.constants import (
+    GET_REVOC_REG_DELTA,
+    GET_REVOC_REG_ENTRY,
+    GET_SCHEMA,
+)
 from ....ledger.multiple_ledger.ledger_requests_executor import (
-    GET_CRED_DEF, IndyLedgerRequestsExecutor)
+    GET_CRED_DEF,
+    IndyLedgerRequestsExecutor,
+)
 from ....messaging.responder import BaseResponder
 from ....multitenant.base import BaseMultitenantManager
 from ....protocols.endorse_transaction.v1_0.manager import (
-    TransactionManager, TransactionManagerError)
+    TransactionManager,
+    TransactionManagerError,
+)
 from ....protocols.endorse_transaction.v1_0.util import is_author_role
-from ....revocation_anoncreds.models.issuer_cred_rev_record import \
-    IssuerCredRevRecord
+from ....revocation_anoncreds.models.issuer_cred_rev_record import IssuerCredRevRecord
 from ....storage.error import StorageError
 from ....utils import sentinel
 from ....wallet.did_info import DIDInfo
-from ...base import (AnonCredsObjectAlreadyExists, AnonCredsObjectNotFound,
-                     AnonCredsRegistrationError, AnonCredsResolutionError,
-                     AnonCredsSchemaAlreadyExists, BaseAnonCredsRegistrar,
-                     BaseAnonCredsResolver)
+from ...base import (
+    AnonCredsObjectAlreadyExists,
+    AnonCredsObjectNotFound,
+    AnonCredsRegistrationError,
+    AnonCredsResolutionError,
+    AnonCredsSchemaAlreadyExists,
+    BaseAnonCredsRegistrar,
+    BaseAnonCredsResolver,
+)
 from ...events import RevListFinishedEvent
 from ...issuer import CATEGORY_CRED_DEF, AnonCredsIssuer, AnonCredsIssuerError
-from ...models.anoncreds_cred_def import (CredDef, CredDefResult, CredDefState,
-                                          CredDefValue, GetCredDefResult)
-from ...models.anoncreds_revocation import (GetRevListResult,
-                                            GetRevRegDefResult, RevList,
-                                            RevListResult, RevListState,
-                                            RevRegDef, RevRegDefResult,
-                                            RevRegDefState, RevRegDefValue)
-from ...models.anoncreds_schema import (AnonCredsSchema, GetSchemaResult,
-                                        SchemaResult, SchemaState)
-from ...revocation import (CATEGORY_REV_LIST, CATEGORY_REV_REG_DEF,
-                           CATEGORY_REV_REG_DEF_PRIVATE)
+from ...models.anoncreds_cred_def import (
+    CredDef,
+    CredDefResult,
+    CredDefState,
+    CredDefValue,
+    GetCredDefResult,
+)
+from ...models.anoncreds_revocation import (
+    GetRevListResult,
+    GetRevRegDefResult,
+    RevList,
+    RevListResult,
+    RevListState,
+    RevRegDef,
+    RevRegDefResult,
+    RevRegDefState,
+    RevRegDefValue,
+)
+from ...models.anoncreds_schema import (
+    AnonCredsSchema,
+    GetSchemaResult,
+    SchemaResult,
+    SchemaState,
+)
+from ...revocation import (
+    CATEGORY_REV_LIST,
+    CATEGORY_REV_REG_DEF,
+    CATEGORY_REV_REG_DEF_PRIVATE,
+)
 from .recover import generate_ledger_rrrecovery_txn
 
 LOGGER = logging.getLogger(__name__)
@@ -1086,7 +1120,6 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
             )
 
         async with profile.session() as session:
-
             LOGGER.debug(f"revocation_list = {rev_list.revocation_list}")
             LOGGER.debug(f"rev_reg_delta = {rev_reg_delta.get('value')}")
 
@@ -1095,7 +1128,6 @@ class LegacyIndyRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
             )
 
             if not _wallet_accumalator_matches_ledger_list(rev_list, rev_reg_delta):
-
                 recovery_txn = await generate_ledger_rrrecovery_txn(
                     genesis_transactions, rev_list
                 )

--- a/aries_cloudagent/anoncreds/events.py
+++ b/aries_cloudagent/anoncreds/events.py
@@ -37,9 +37,6 @@ class CredDefFinishedEvent(Event):
 
         Args:
             payload: CredDefFinishedPayload
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         self._topic = CRED_DEF_FINISHED_EVENT
         self._payload = payload
@@ -82,9 +79,6 @@ class RevRegDefFinishedEvent(Event):
 
         Args:
             payload: RevRegDefFinishedPayload
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         self._topic = REV_REG_DEF_FINISHED_EVENT
         self._payload = payload
@@ -122,9 +116,6 @@ class RevListFinishedEvent(Event):
 
         Args:
             payload: RevListFinishedPayload
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         self._topic = REV_LIST_FINISHED_EVENT
         self._payload = payload

--- a/aries_cloudagent/anoncreds/issuer.py
+++ b/aries_cloudagent/anoncreds/issuer.py
@@ -310,7 +310,7 @@ class AnonCredsIssuer:
         if not isinstance(support_revocation, bool):
             raise ValueError("support_revocation must be a boolean")
 
-        max_cred_num = options.get("max_cred_num", DEFAULT_MAX_CRED_NUM)
+        max_cred_num = options.get("revocation_registry_size", DEFAULT_MAX_CRED_NUM)
         if not isinstance(max_cred_num, int):
             raise ValueError("max_cred_num must be an integer")
 

--- a/aries_cloudagent/anoncreds/models/anoncreds_cred_def.py
+++ b/aries_cloudagent/anoncreds/models/anoncreds_cred_def.py
@@ -34,14 +34,15 @@ class CredDefValuePrimary(BaseModel):
         """Initialize an instance.
 
         Args:
-            n: n
-            s: s
-            r: r
-            rctxt: rctxt
-            z: z
-
-        TODO: update this docstring - Anoncreds-break.
-
+            n: is a safe RSA-2048 number.
+            s: is a randomly selected quadratic residue of n.
+            r: is an object that defines a CL-RSA public key fragment 
+                for each attribute in the credential.
+            rctxt: is equal to s^(xrctxt), where xrctxt is a randomly selected integer 
+                between 2 and p'q'-1.
+            z: is equal to s^(xz), where xz is a randomly selected integer between 2 
+                and p'q'-1. This makes up part of the CL-RSA public key, independent of 
+                the message blocks being signed.
         """
         super().__init__(**kwargs)
         self.n = n
@@ -92,20 +93,20 @@ class CredDefValueRevocation(BaseModel):
         """Initialize an instance.
 
         Args:
-            g: g
-            g_dash: g_dash
-            h: h
-            h0: h0
-            h1: h1
-            h2: h2
-            htilde: htilde
-            h_cap: h_cap
-            u: u
-            pk: pk
-            y: y
-
-        TODO: update this docstring - Anoncreds-break.
-
+            g: is a generator for the elliptic curve group G1.
+            g_dash: is a generator for the elliptic curve group G2.
+            h: is an elliptic curve point selected uniformly at random from G1.
+            h0: is an elliptic curve point selected uniformly at random from G1.
+            h1: is an elliptic curve point selected uniformly at random from G1.
+            h2: is an elliptic curve point selected uniformly at random from G1.
+            htilde: is an elliptic curve point selected uniformly at random from G1.
+            h_cap: is an elliptic curve point selected uniformly at random from G2.
+            u: is an elliptic curve point selected uniformly at random from G2.
+            pk: is the public key in G1 for the issuer with respect to this accumulator, 
+                computed as g^sk (in multiplicative notation), where sk is from 
+                r_key above.
+            y: is the an elliptic curve point in G2. computed as h_cap^x 
+                (in multiplicative notation), where x is from r_key above
         """
         self.g = g
         self.g_dash = g_dash
@@ -171,9 +172,6 @@ class CredDefValue(BaseModel):
         Args:
             primary: Cred Def value primary
             revocation: Cred Def value revocation
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         super().__init__(**kwargs)
         self.primary = primary
@@ -225,9 +223,6 @@ class CredDef(BaseModel):
             type: Type
             tag: Tag
             value: Cred Def value
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         super().__init__(**kwargs)
         self.issuer_id = issuer_id
@@ -307,9 +302,6 @@ class CredDefState(BaseModel):
             state: State
             credential_definition_id: Cred Def ID
             credential_definition: Cred Def
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         self.state = state
         self.credential_definition_id = credential_definition_id
@@ -370,9 +362,6 @@ class CredDefResult(BaseModel):
             credential_definition_state: Cred Def state
             registration_metadata: Registration metadata
             credential_definition_metadata: Cred Def metadata
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         super().__init__(**kwargs)
         self.job_id = job_id
@@ -420,9 +409,6 @@ class GetCredDefResult(BaseModel):
             credential_definition: Cred Def
             resolution_metadata: Resolution metadata
             credential_definition_metadata: Cred Def metadata
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         super().__init__(**kwargs)
         self.credential_definition_id = credential_definition_id

--- a/aries_cloudagent/anoncreds/models/anoncreds_cred_def.py
+++ b/aries_cloudagent/anoncreds/models/anoncreds_cred_def.py
@@ -36,12 +36,12 @@ class CredDefValuePrimary(BaseModel):
         Args:
             n: is a safe RSA-2048 number.
             s: is a randomly selected quadratic residue of n.
-            r: is an object that defines a CL-RSA public key fragment 
+            r: is an object that defines a CL-RSA public key fragment
                 for each attribute in the credential.
-            rctxt: is equal to s^(xrctxt), where xrctxt is a randomly selected integer 
+            rctxt: is equal to s^(xrctxt), where xrctxt is a randomly selected integer
                 between 2 and p'q'-1.
-            z: is equal to s^(xz), where xz is a randomly selected integer between 2 
-                and p'q'-1. This makes up part of the CL-RSA public key, independent of 
+            z: is equal to s^(xz), where xz is a randomly selected integer between 2
+                and p'q'-1. This makes up part of the CL-RSA public key, independent of
                 the message blocks being signed.
         """
         super().__init__(**kwargs)
@@ -102,10 +102,10 @@ class CredDefValueRevocation(BaseModel):
             htilde: is an elliptic curve point selected uniformly at random from G1.
             h_cap: is an elliptic curve point selected uniformly at random from G2.
             u: is an elliptic curve point selected uniformly at random from G2.
-            pk: is the public key in G1 for the issuer with respect to this accumulator, 
-                computed as g^sk (in multiplicative notation), where sk is from 
+            pk: is the public key in G1 for the issuer with respect to this accumulator,
+                computed as g^sk (in multiplicative notation), where sk is from
                 r_key above.
-            y: is the an elliptic curve point in G2. computed as h_cap^x 
+            y: is the an elliptic curve point in G2. computed as h_cap^x
                 (in multiplicative notation), where x is from r_key above
         """
         self.g = g

--- a/aries_cloudagent/anoncreds/models/anoncreds_revocation.py
+++ b/aries_cloudagent/anoncreds/models/anoncreds_revocation.py
@@ -7,11 +7,13 @@ from marshmallow import EXCLUDE, fields
 from marshmallow.validate import OneOf
 from typing_extensions import Literal
 
-from aries_cloudagent.messaging.valid import (INDY_CRED_DEF_ID_EXAMPLE,
-                                              INDY_ISO8601_DATETIME_EXAMPLE,
-                                              INDY_OR_KEY_DID_EXAMPLE,
-                                              INDY_RAW_PUBLIC_KEY_EXAMPLE,
-                                              INDY_REV_REG_ID_EXAMPLE)
+from aries_cloudagent.messaging.valid import (
+    INDY_CRED_DEF_ID_EXAMPLE,
+    INDY_ISO8601_DATETIME_EXAMPLE,
+    INDY_OR_KEY_DID_EXAMPLE,
+    INDY_RAW_PUBLIC_KEY_EXAMPLE,
+    INDY_REV_REG_ID_EXAMPLE,
+)
 
 from ...messaging.models.base import BaseModel, BaseModelSchema
 

--- a/aries_cloudagent/anoncreds/models/anoncreds_revocation.py
+++ b/aries_cloudagent/anoncreds/models/anoncreds_revocation.py
@@ -7,13 +7,11 @@ from marshmallow import EXCLUDE, fields
 from marshmallow.validate import OneOf
 from typing_extensions import Literal
 
-from aries_cloudagent.messaging.valid import (
-    INDY_CRED_DEF_ID_EXAMPLE,
-    INDY_ISO8601_DATETIME_EXAMPLE,
-    INDY_OR_KEY_DID_EXAMPLE,
-    INDY_RAW_PUBLIC_KEY_EXAMPLE,
-    INDY_REV_REG_ID_EXAMPLE,
-)
+from aries_cloudagent.messaging.valid import (INDY_CRED_DEF_ID_EXAMPLE,
+                                              INDY_ISO8601_DATETIME_EXAMPLE,
+                                              INDY_OR_KEY_DID_EXAMPLE,
+                                              INDY_RAW_PUBLIC_KEY_EXAMPLE,
+                                              INDY_REV_REG_ID_EXAMPLE)
 
 from ...messaging.models.base import BaseModel, BaseModelSchema
 
@@ -41,9 +39,6 @@ class RevRegDefValue(BaseModel):
             max_cred_num: Max. number of Creds
             tails_location: Tails file location
             tails_hash: Tails file hash
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         super().__init__(**kwargs)
         self.public_keys = public_keys
@@ -102,9 +97,6 @@ class RevRegDef(BaseModel):
             cred_def_id: Cred Def ID
             tag: Tag
             value: Rev Reg Def Value
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         super().__init__(**kwargs)
         self.issuer_id = issuer_id
@@ -183,9 +175,6 @@ class RevRegDefState(BaseModel):
             state: State
             revocation_registry_definition_id: Rev Reg Definition ID
             revocation_registry_definition: Rev Reg Definition
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         self.state = state
         self.revocation_registry_definition_id = revocation_registry_definition_id
@@ -247,9 +236,6 @@ class RevRegDefResult(BaseModel):
             revocation_registry_definition_state: Rev Reg Def state
             registration_metadata: Registration metadata
             revocation_registry_definition_metadata: Rev Reg Def metadata
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         super().__init__(**kwargs)
         self.job_id = job_id
@@ -311,9 +297,6 @@ class GetRevRegDefResult(BaseModel):
             revocation_registry_id: Revocation Registry ID
             resolution_metadata: Resolution metadata
             revocation_registry_metadata: Revocation Registry metadata
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         super().__init__(**kwargs)
         self.revocation_registry = revocation_registry
@@ -362,9 +345,6 @@ class RevList(BaseModel):
             revocation_list: Revocation list
             current_accumulator: Current accumulator
             timestamp: Timestamp
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         super().__init__(**kwargs)
         self.issuer_id = issuer_id
@@ -453,9 +433,6 @@ class RevListState(BaseModel):
         Args:
             state: State
             revocation_list: Revocation list
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         self.state = state
         self.revocation_list = revocation_list
@@ -508,9 +485,6 @@ class RevListResult(BaseModel):
             revocation_list_state: Revocation list state
             registration_metadata: Registration metadata
             revocation_list_metadata: Revocation list metadata
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         super().__init__(**kwargs)
         self.job_id = job_id
@@ -561,9 +535,6 @@ class GetRevListResult(BaseModel):
             revocation_list: Revocation list
             resolution_metadata: Resolution metadata
             revocation_registry_metadata: Rev Reg metadata
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         super().__init__(**kwargs)
         self.revocation_list = revocation_list

--- a/aries_cloudagent/anoncreds/models/anoncreds_schema.py
+++ b/aries_cloudagent/anoncreds/models/anoncreds_schema.py
@@ -7,10 +7,7 @@ from marshmallow import EXCLUDE, fields
 from marshmallow.validate import OneOf
 
 from ...messaging.models.base import BaseModel, BaseModelSchema
-from ...messaging.valid import (
-    INDY_OR_KEY_DID_EXAMPLE,
-    INDY_SCHEMA_ID_EXAMPLE,
-)
+from ...messaging.valid import INDY_OR_KEY_DID_EXAMPLE, INDY_SCHEMA_ID_EXAMPLE
 
 
 class AnonCredsSchema(BaseModel):
@@ -31,9 +28,6 @@ class AnonCredsSchema(BaseModel):
             attr_names: Schema Attribute Name list
             name: Schema name
             version: Schema version
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         super().__init__(**kwargs)
         self.issuer_id = issuer_id
@@ -106,9 +100,6 @@ class GetSchemaResult(BaseModel):
             schema_id: Schema ID
             resolution_metadata: Resolution Metdata
             schema_metadata: Schema Metadata
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         super().__init__(**kwargs)
         self.schema_value = schema
@@ -221,9 +212,6 @@ class SchemaResult(BaseModel):
             schema_state: Schema state
             registration_metadata: Registration Metdata
             schema_metadata: Schema Metadata
-
-        TODO: update this docstring - Anoncreds-break.
-
         """
         super().__init__(**kwargs)
         self.job_id = job_id

--- a/aries_cloudagent/anoncreds/tests/test_issuer.py
+++ b/aries_cloudagent/anoncreds/tests/test_issuer.py
@@ -471,7 +471,7 @@ class TestAnonCredsIssuer(IsolatedAsyncioTestCase):
                 issuer_id="issuer-id",
                 schema_id="schema-id",
                 signature_type="CL",
-                options={"max_cred_num": "100"},  # requires integer
+                options={"support_revocation": "100"},  # requires integer
             )
 
     @mock.patch.object(test_module.AnonCredsIssuer, "notify")

--- a/aries_cloudagent/anoncreds/tests/test_revocation.py
+++ b/aries_cloudagent/anoncreds/tests/test_revocation.py
@@ -12,10 +12,6 @@ from anoncreds import (
     RevocationStatusList,
     Schema,
 )
-
-# AnoncredsError,
-# W3cCredential,
-# CredentialRevocationConfig,
 from aries_askar import AskarError, AskarErrorCode
 from requests import RequestException, Session
 
@@ -35,13 +31,9 @@ from aries_cloudagent.anoncreds.models.anoncreds_schema import (
     GetSchemaResult,
 )
 from aries_cloudagent.anoncreds.registry import AnonCredsRegistry
-from aries_cloudagent.anoncreds.tests.mock_objects import (
-    MOCK_REV_REG_DEF,
-)
+from aries_cloudagent.anoncreds.tests.mock_objects import MOCK_REV_REG_DEF
 from aries_cloudagent.anoncreds.tests.test_issuer import MockCredDefEntry
-from aries_cloudagent.askar.profile_anon import (
-    AskarAnoncredsProfile,
-)
+from aries_cloudagent.askar.profile_anon import AskarAnoncredsProfile
 from aries_cloudagent.core.event_bus import Event, EventBus, MockEventBus
 from aries_cloudagent.core.in_memory.profile import (
     InMemoryProfile,

--- a/aries_cloudagent/ledger/indy_vdr.py
+++ b/aries_cloudagent/ledger/indy_vdr.py
@@ -1169,13 +1169,18 @@ class IndyVdrLedger(BaseLedger):
                 rev_reg_def_req.set_endorser(endorser_did)
 
             legacy_indy_registry = LegacyIndyRegistry()
-            resp = await legacy_indy_registry.txn_submit(
-                self,
-                rev_reg_def_req,
-                sign=True,
-                sign_did=did_info,
-                write_ledger=write_ledger,
-            )
+            try:
+                resp = await legacy_indy_registry.txn_submit(
+                    self,
+                    rev_reg_def_req,
+                    sign=True,
+                    sign_did=did_info,
+                    write_ledger=write_ledger,
+                )
+            except LedgerError as err:
+                raise LedgerError(
+                    "Exception when sending revocation registry definition"
+                ) from err
 
             if not write_ledger:
                 return revoc_reg_def["id"], {"signed_txn": resp}

--- a/aries_cloudagent/protocols/endorse_transaction/v1_0/manager.py
+++ b/aries_cloudagent/protocols/endorse_transaction/v1_0/manager.py
@@ -425,8 +425,10 @@ class TransactionManager:
                 )
 
                 legacy_indy_registry = LegacyIndyRegistry()
-                ledger_response_json = await legacy_indy_registry.txn_submit(
-                    ledger, ledger_transaction, sign=False, taa_accept=False
+                ledger_response_json = await shield(
+                    legacy_indy_registry.txn_submit(
+                        ledger, ledger_transaction, sign=False, taa_accept=False
+                    )
                 )
             else:
                 async with ledger:

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -7,8 +7,8 @@ import os
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from timeit import default_timer
 from secrets import token_hex
+from timeit import default_timer
 
 import asyncpg
 import yaml
@@ -464,7 +464,7 @@ class DemoAgent:
             },
             "options": {
                 "support_revocation": support_revocation,
-                "max_cred_num": max_cred_num,
+                "revocation_registry_size": max_cred_num,
             },
         }
         credential_definition_response = await self.admin_POST(


### PR DESCRIPTION
- Handles the scenario where the tails server isn't available during revocation rotation.
- Fixes a bug with the openapi verse expected value for `max_cred_num`
- Refactors the create_credential function
- Removes some TODO's. Most with documentation that I think is good enough.

Keeps the revocation list in a failed state if the revocation registry has never been uploaded to the tails server. During issuance it will check for a failed state and try to upload and finish the revocation list. Issuance will not occur until a successful tails server and connection occurs.

Thought about keeping the revocation registry definition itself in a failed state but seemed to make sense to have it this way so the registry will still handle the full registry scenario.