### PR TITLE
fix: didexchange manager not checking the did-rotate content correctly

### DIFF
--- a/aries_cloudagent/protocols/didexchange/v1_0/manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/manager.py
@@ -973,10 +973,10 @@ class DIDXManager(BaseConnectionManager):
                 signed_did = await self.verify_rotate(
                     wallet, response.did_rotate_attach, conn_rec.invitation_key
                 )
-                if their_did != response.did:
+                if their_did != signed_did:
                     raise DIDXManagerError(
                         f"Connection DID {their_did} "
-                        f"does not match singed DID rotate {signed_did}"
+                        f"does not match signed DID rotate {signed_did}"
                     )
 
             self._logger.debug(

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -2014,7 +2014,9 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
         mock_response.did = TestConfig.test_target_did
         mock_response.did_doc_attach = None
         mock_response.did_rotate_attach.data.verify = mock.AsyncMock(return_value=True)
-        mock_response.did_rotate_attach.data.signed = TestConfig.test_target_did.encode()
+        mock_response.did_rotate_attach.data.signed = (
+            TestConfig.test_target_did.encode()
+        )
 
         receipt = MessageReceipt(
             recipient_did=TestConfig.test_did,

--- a/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/didexchange/v1_0/tests/test_manager.py
@@ -2014,6 +2014,7 @@ class TestDidExchangeManager(IsolatedAsyncioTestCase, TestConfig):
         mock_response.did = TestConfig.test_target_did
         mock_response.did_doc_attach = None
         mock_response.did_rotate_attach.data.verify = mock.AsyncMock(return_value=True)
+        mock_response.did_rotate_attach.data.signed = TestConfig.test_target_did.encode()
 
         receipt = MessageReceipt(
             recipient_did=TestConfig.test_did,


### PR DESCRIPTION
minor error i noticed while browsing acapy code whilst working on aries-vcx: https://github.com/hyperledger/aries-vcx/issues/1226.

if statement was not correcting the correct data, resulting in it always being `true`