### PR TITLE
For proof problem handler, allow no connection record (OOB cases), prevent unhandled exception

### DIFF
--- a/aries_cloudagent/protocols/present_proof/v2_0/handlers/pres_problem_report_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/handlers/pres_problem_report_handler.py
@@ -29,7 +29,11 @@ class V20PresProblemReportHandler(BaseHandler):
         try:
             await pres_manager.receive_problem_report(
                 context.message,
-                context.connection_record.connection_id,
+                (
+                    context.connection_record.connection_id
+                    if context.connection_record is not None
+                    else None
+                ),
             )
         except (StorageError, StorageNotFoundError):
             self._logger.exception(


### PR DESCRIPTION
Details in https://github.com/hyperledger/aries-cloudagent-python/issues/3069

Just add a conditional to handle the case where there's no connection record. Already did this for v1.0 here https://github.com/hyperledger/aries-cloudagent-python/pull/2723 but missed this was done in a different place for 2.0