### PR TITLE
Re-enable ledger plugin when `--no-legder` is set

### DIFF
--- a/aries_cloudagent/config/default_context.py
+++ b/aries_cloudagent/config/default_context.py
@@ -122,8 +122,7 @@ class DefaultContextBuilder(ContextBuilder):
         # Currently providing admin routes only
         plugin_registry.register_plugin("aries_cloudagent.holder")
 
-        if not self.settings.get("ledger.disabled"):
-            plugin_registry.register_plugin("aries_cloudagent.ledger")
+        plugin_registry.register_plugin("aries_cloudagent.ledger")
 
         plugin_registry.register_plugin("aries_cloudagent.messaging.jsonld")
         plugin_registry.register_plugin("aries_cloudagent.resolver")


### PR DESCRIPTION
@ff137 @jamshale [in response to this](https://github.com/hyperledger/aries-cloudagent-python/pull/2990#discussion_r1654980350)