### PR TITLE
fix: print provision messages when auto-provision is triggered

### DIFF
--- a/aries_cloudagent/config/wallet.py
+++ b/aries_cloudagent/config/wallet.py
@@ -55,6 +55,7 @@ async def wallet_config(
         except ProfileNotFoundError:
             if settings.get("auto_provision", False):
                 profile = await mgr.provision(context, profile_cfg)
+                provision = True
             else:
                 raise
 


### PR DESCRIPTION
It was recently discovered that if you set a static seed, and you have auto-provisioning enabled on the start command, there is no way to get the verkey for the created DID. The verkey is never printed out to the command line and I do not remember there being an API for retrieving the verkey (one of those, "See it once, copy it, or forever lose it" kinds of things).

After this point in the code, the only thing that "provision" enables are the print statements talking about the did/verkey being created as well as some basic profile information. It doesn't trigger any code that would make changes to the system, those lines precede the line I've added.