### PR TITLE
Add by_format to terse webhook for presentations

### DIFF
--- a/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_ex_record_webhook.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/messages/cred_ex_record_webhook.py
@@ -23,6 +23,7 @@ class V20CredExRecordWebhook:
         "credential_definition_id",
         "schema_id",
         "credential_id",
+        "by_format",
         "trace",
         "public_did",
         "cred_id_stored",

--- a/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
+++ b/aries_cloudagent/protocols/issue_credential/v2_0/models/cred_ex_record.py
@@ -198,11 +198,11 @@ class V20CredExRecord(BaseExchangeRecord):
         else:
             topic = f"{self.EVENT_NAMESPACE}::{self.RECORD_TOPIC}"
 
-        if session.profile.settings.get("debug.webhooks"):
-            if not payload:
-                payload = self.serialize()
+        # serialize payload before checking for webhook contents
+        if not payload:
+            payload = self.serialize()
         else:
-            payload = V20CredExRecordWebhook(**self.__dict__)
+            payload = V20CredExRecordWebhook(**payload)
             payload = payload.__dict__
 
         await session.profile.notify(topic, payload)

--- a/aries_cloudagent/protocols/present_proof/v2_0/messages/pres_webhook.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/messages/pres_webhook.py
@@ -15,6 +15,7 @@ class V20PresExRecordWebhook:
         "thread_id",
         "state",
         "trace",
+        "by_format",
         "verified",
         "verified_msgs",
         "created_at",

--- a/aries_cloudagent/protocols/present_proof/v2_0/models/pres_exchange.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/models/pres_exchange.py
@@ -197,11 +197,11 @@ class V20PresExRecord(BaseExchangeRecord):
         else:
             topic = f"{self.EVENT_NAMESPACE}::{self.RECORD_TOPIC}"
 
-        if session.profile.settings.get("debug.webhooks"):
-            if not payload:
-                payload = self.serialize()
-        else:
-            payload = V20PresExRecordWebhook(**self.__dict__)
+        # serialize payload before checking for webhook contents
+        if not payload:
+            payload = self.serialize()
+        if not session.profile.settings.get("debug.webhooks"):
+            payload = V20PresExRecordWebhook(**payload)
             payload = payload.__dict__
 
         await session.profile.notify(topic, payload)

--- a/demo/run_bdd
+++ b/demo/run_bdd
@@ -210,6 +210,9 @@ fi
 if ! [ -z "$WEBHOOK_TARGET" ]; then
   DOCKER_ENV="${DOCKER_ENV} -e WEBHOOK_TARGET=${WEBHOOK_TARGET}"
 fi
+if ! [ -z "$ACAPY_DEBUG_WEBHOOKS" ]; then
+  DOCKER_ENV="${DOCKER_ENV} -e ACAPY_DEBUG_WEBHOOKS=${ACAPY_DEBUG_WEBHOOKS}"
+fi
 # if $TAILS_NETWORK is specified it will override any previously specified $DOCKER_NET
 if ! [ -z "$TAILS_NETWORK" ]; then
   DOCKER_NET="${TAILS_NETWORK}"

--- a/demo/run_demo
+++ b/demo/run_demo
@@ -271,6 +271,9 @@ fi
 if ! [ -z "$WEBHOOK_TARGET" ]; then
   DOCKER_ENV="${DOCKER_ENV} -e WEBHOOK_TARGET=${WEBHOOK_TARGET}"
 fi
+if ! [ -z "$ACAPY_DEBUG_WEBHOOKS" ]; then
+  DOCKER_ENV="${DOCKER_ENV} -e ACAPY_DEBUG_WEBHOOKS=${ACAPY_DEBUG_WEBHOOKS}"
+fi
 # if $TAILS_NETWORK is specified it will override any previously specified $DOCKER_NET
 if ! [ -z "$TAILS_NETWORK" ]; then
   DOCKER_NET="${TAILS_NETWORK}"

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -39,6 +39,7 @@ TRACE_TAG = os.getenv("TRACE_TAG")
 TRACE_ENABLED = os.getenv("TRACE_ENABLED")
 
 WEBHOOK_TARGET = os.getenv("WEBHOOK_TARGET")
+ACAPY_DEBUG_WEBHOOKS = os.getenv("ACAPY_DEBUG_WEBHOOKS")
 
 AGENT_ENDPOINT = os.getenv("AGENT_ENDPOINT")
 
@@ -585,7 +586,8 @@ class DemoAgent:
             # turn on notifications if revocation is enabled
             result.append("--notify-revocation")
         # enable extended webhooks
-        result.append("--debug-webhooks")
+        if ACAPY_DEBUG_WEBHOOKS:
+            result.append("--debug-webhooks")
         # always enable notification webhooks
         result.append("--monitor-revocation-notification")
 

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -4,7 +4,6 @@ FROM ${from_image}
 ENV ENABLE_PTVSD 0
 ENV ENABLE_PYDEVD_PYCHARM 0
 ENV PYDEVD_PYCHARM_HOST "host.docker.internal"
-ENV ACAPY_DEBUG_WEBHOOKS 1
 
 RUN mkdir -p bin && curl -L -o bin/jq \
 	https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \


### PR DESCRIPTION
Fix for issue #3065

Note that this is for the 2.0 presentation protocol only, do we need to apply a similar fix for 1.0?

This adds the `by_format` attribute for all webhooks, not just for status `done`, however the demo requires this to work with terse webhooks (and no additional calls to the api endpoints)

Added `by_format` for issue cred as well - was failing in the demo for json-ld :-(

Makes the terse webhooks slightly less terse, but is required if we want the webhook to contain "enough" info for the controller to respond to.
