### PR TITLE
:bug: fix IndyAttrValue bad reference in OpenAPI spec

### DIFF
--- a/aries_cloudagent/indy/models/cred.py
+++ b/aries_cloudagent/indy/models/cred.py
@@ -59,9 +59,7 @@ class DictWithIndyAttrValueSchema(fields.Dict):
         """Initialize the custom schema for a dictionary with IndyAttrValue."""
         super().__init__(
             keys=fields.Str(metadata={"description": "Attribute name"}),
-            values=fields.Nested(
-                IndyAttrValueSchema(), metadata={"description": "Attribute value"}
-            ),
+            values=fields.Nested(IndyAttrValueSchema()),
             **kwargs,
         )
 

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -9861,11 +9861,7 @@
           },
           "values" : {
             "additionalProperties" : {
-              "allOf" : [ {
-                "$ref" : "#/definitions/IndyAttrValue"
-              } ],
-              "description" : "Attribute value",
-              "type" : "object"
+              "$ref" : "#/components/schemas/IndyAttrValue"
             },
             "description" : "Credential attributes",
             "type" : "object"

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -35,6 +35,13 @@
     },
     "name" : "anoncreds - schemas"
   }, {
+    "description" : "Anoncreds wallet upgrade",
+    "externalDocs" : {
+      "description" : "Specification",
+      "url" : "https://hyperledger.github.io/anoncreds-spec"
+    },
+    "name" : "anoncreds - wallet upgrade"
+  }, {
     "description" : "Simple messaging",
     "externalDocs" : {
       "description" : "Specification",
@@ -1077,6 +1084,33 @@
         "tags" : [ "anoncreds - schemas" ]
       }
     },
+    "/anoncreds/wallet/upgrade" : {
+      "post" : {
+        "parameters" : [ {
+          "description" : "Name of wallet to upgrade to anoncreds",
+          "in" : "query",
+          "name" : "wallet_name",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UpgradeResult"
+                }
+              }
+            },
+            "description" : ""
+          }
+        },
+        "summary" : "\n        Upgrade the wallet from askar to anoncreds - Be very careful with this! You \n        cannot go back! See migration guide for more information.\n    ",
+        "tags" : [ "anoncreds - wallet upgrade" ]
+      }
+    },
     "/connections" : {
       "get" : {
         "parameters" : [ {
@@ -1110,12 +1144,28 @@
             "type" : "string"
           }
         }, {
+          "description" : "Number of results to return",
+          "in" : "query",
+          "name" : "limit",
+          "schema" : {
+            "default" : 100,
+            "type" : "integer"
+          }
+        }, {
           "description" : "My DID",
           "in" : "query",
           "name" : "my_did",
           "schema" : {
             "pattern" : "^(did:sov:)?[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}$|^did:([a-zA-Z0-9_]+):([a-zA-Z0-9_.%-]+(:[a-zA-Z0-9_.%-]+)*)((;[a-zA-Z0-9_.:%-]+=[a-zA-Z0-9_.:%-]*)*)(\\/[^#?]*)?([?][^#]*)?(\\#.*)?$$",
             "type" : "string"
+          }
+        }, {
+          "description" : "Offset for pagination",
+          "in" : "query",
+          "name" : "offset",
+          "schema" : {
+            "default" : 0,
+            "type" : "integer"
           }
         }, {
           "description" : "Connection state",
@@ -2678,6 +2728,22 @@
             "type" : "string"
           }
         }, {
+          "description" : "Number of results to return",
+          "in" : "query",
+          "name" : "limit",
+          "schema" : {
+            "default" : 100,
+            "type" : "integer"
+          }
+        }, {
+          "description" : "Offset for pagination",
+          "in" : "query",
+          "name" : "offset",
+          "schema" : {
+            "default" : 0,
+            "type" : "integer"
+          }
+        }, {
           "description" : "Role assigned in credential exchange",
           "in" : "query",
           "name" : "role",
@@ -3151,6 +3217,22 @@
           "name" : "connection_id",
           "schema" : {
             "type" : "string"
+          }
+        }, {
+          "description" : "Number of results to return",
+          "in" : "query",
+          "name" : "limit",
+          "schema" : {
+            "default" : 100,
+            "type" : "integer"
+          }
+        }, {
+          "description" : "Offset for pagination",
+          "in" : "query",
+          "name" : "offset",
+          "schema" : {
+            "default" : 0,
+            "type" : "integer"
           }
         }, {
           "description" : "Role assigned in credential exchange",
@@ -3986,7 +4068,6 @@
           "name" : "paginate_limit",
           "schema" : {
             "default" : -1,
-            "format" : "int32",
             "type" : "integer"
           }
         }, {
@@ -3995,7 +4076,6 @@
           "name" : "paginate_offset",
           "schema" : {
             "default" : 0,
-            "format" : "int32",
             "type" : "integer"
           }
         } ],
@@ -4488,6 +4568,22 @@
     "/multitenancy/wallets" : {
       "get" : {
         "parameters" : [ {
+          "description" : "Number of results to return",
+          "in" : "query",
+          "name" : "limit",
+          "schema" : {
+            "default" : 100,
+            "type" : "integer"
+          }
+        }, {
+          "description" : "Offset for pagination",
+          "in" : "query",
+          "name" : "offset",
+          "schema" : {
+            "default" : 0,
+            "type" : "integer"
+          }
+        }, {
           "description" : "Wallet name",
           "in" : "query",
           "name" : "wallet_name",
@@ -4704,6 +4800,22 @@
           "name" : "connection_id",
           "schema" : {
             "type" : "string"
+          }
+        }, {
+          "description" : "Number of results to return",
+          "in" : "query",
+          "name" : "limit",
+          "schema" : {
+            "default" : 100,
+            "type" : "integer"
+          }
+        }, {
+          "description" : "Offset for pagination",
+          "in" : "query",
+          "name" : "offset",
+          "schema" : {
+            "default" : 0,
+            "type" : "integer"
           }
         }, {
           "description" : "Role assigned in presentation exchange",
@@ -5103,6 +5215,22 @@
           "name" : "connection_id",
           "schema" : {
             "type" : "string"
+          }
+        }, {
+          "description" : "Number of results to return",
+          "in" : "query",
+          "name" : "limit",
+          "schema" : {
+            "default" : 100,
+            "type" : "integer"
+          }
+        }, {
+          "description" : "Offset for pagination",
+          "in" : "query",
+          "name" : "offset",
+          "schema" : {
+            "default" : 0,
+            "type" : "integer"
           }
         }, {
           "description" : "Role assigned in presentation exchange",
@@ -7467,7 +7595,6 @@
           "byte_count" : {
             "description" : "Byte count of data included by reference",
             "example" : 1234,
-            "format" : "int32",
             "type" : "integer"
           },
           "data" : {
@@ -8106,7 +8233,7 @@
           },
           "wallet_type" : {
             "description" : "Type of the wallet to create. Must be same as base wallet.",
-            "enum" : [ "askar", "askar-anoncreds", "in_memory", "indy" ],
+            "enum" : [ "askar", "askar-anoncreds", "in_memory" ],
             "example" : "askar",
             "type" : "string"
           },
@@ -8249,7 +8376,6 @@
           "revocation_registry_size" : {
             "description" : "Maximum number of credential revocations per registry",
             "example" : 1000,
-            "format" : "int32",
             "type" : "integer"
           },
           "support_revocation" : {
@@ -8583,6 +8709,7 @@
         "type" : "object"
       },
       "Credential" : {
+        "additionalProperties" : true,
         "properties" : {
           "@context" : {
             "description" : "The JSON-LD context of the credential",
@@ -8701,7 +8828,6 @@
           "revocation_registry_size" : {
             "description" : "Revocation registry size",
             "example" : 1000,
-            "format" : "int32",
             "maximum" : 32768,
             "minimum" : 4,
             "type" : "integer"
@@ -8849,6 +8975,7 @@
         "type" : "object"
       },
       "CredentialStatusOptions" : {
+        "additionalProperties" : true,
         "properties" : {
           "type" : {
             "description" : "Credential status method type to use for the credential. Should match status method registered in the Verifiable Credential Extension Registry",
@@ -9187,6 +9314,7 @@
         "type" : "object"
       },
       "DIFProofRequest" : {
+        "additionalProperties" : true,
         "properties" : {
           "options" : {
             "$ref" : "#/components/schemas/DIFOptions"
@@ -9366,7 +9494,6 @@
           "maxLength" : {
             "description" : "Max Length",
             "example" : 1234,
-            "format" : "int32",
             "type" : "integer"
           },
           "maximum" : {
@@ -9376,7 +9503,6 @@
           "minLength" : {
             "description" : "Min Length",
             "example" : 1234,
-            "format" : "int32",
             "type" : "integer"
           },
           "minimum" : {
@@ -9850,7 +9976,6 @@
           },
           "value" : {
             "description" : "Predicate threshold value",
-            "format" : "int32",
             "type" : "integer"
           }
         },
@@ -9908,7 +10033,6 @@
           "from" : {
             "description" : "Earliest time of interest in non-revocation interval",
             "example" : 1640995199,
-            "format" : "int32",
             "maximum" : 18446744073709551615,
             "minimum" : 0,
             "type" : "integer"
@@ -9916,7 +10040,6 @@
           "to" : {
             "description" : "Latest time of interest in non-revocation interval",
             "example" : 1640995199,
-            "format" : "int32",
             "maximum" : 18446744073709551615,
             "minimum" : 0,
             "type" : "integer"
@@ -9976,7 +10099,6 @@
           },
           "threshold" : {
             "description" : "Threshold value",
-            "format" : "int32",
             "type" : "integer"
           }
         },
@@ -10106,7 +10228,6 @@
           "timestamp" : {
             "description" : "Timestamp epoch",
             "example" : 1640995199,
-            "format" : "int32",
             "maximum" : 18446744073709551615,
             "minimum" : 0,
             "nullable" : true,
@@ -10144,7 +10265,6 @@
             "description" : "c_list value",
             "items" : {
               "items" : {
-                "format" : "int32",
                 "type" : "integer"
               },
               "type" : "array"
@@ -10185,7 +10305,7 @@
             "type" : "array"
           },
           "non_revoked" : {
-            "$ref" : "#/components/schemas/IndyProofReqAttrSpec_non_revoked"
+            "$ref" : "#/components/schemas/IndyProofReqAttrSpecNonRevoked"
           },
           "restrictions" : {
             "description" : "If present, credential must satisfy one of given restrictions: specify schema_id, schema_issuer_did, schema_name, schema_version, issuer_did, cred_def_id, and/or attr::<attribute-name>::value where <attribute-name> represents a credential attribute name",
@@ -10206,7 +10326,6 @@
           "from" : {
             "description" : "Earliest time of interest in non-revocation interval",
             "example" : 1640995199,
-            "format" : "int32",
             "maximum" : 18446744073709551615,
             "minimum" : 0,
             "type" : "integer"
@@ -10214,7 +10333,6 @@
           "to" : {
             "description" : "Latest time of interest in non-revocation interval",
             "example" : 1640995199,
-            "format" : "int32",
             "maximum" : 18446744073709551615,
             "minimum" : 0,
             "type" : "integer"
@@ -10230,7 +10348,7 @@
             "type" : "string"
           },
           "non_revoked" : {
-            "$ref" : "#/components/schemas/IndyProofReqPredSpec_non_revoked"
+            "$ref" : "#/components/schemas/IndyProofReqPredSpecNonRevoked"
           },
           "p_type" : {
             "description" : "Predicate type ('<', '<=', '>=', or '>')",
@@ -10240,7 +10358,6 @@
           },
           "p_value" : {
             "description" : "Threshold value",
-            "format" : "int32",
             "type" : "integer"
           },
           "restrictions" : {
@@ -10263,7 +10380,6 @@
           "from" : {
             "description" : "Earliest time of interest in non-revocation interval",
             "example" : 1640995199,
-            "format" : "int32",
             "maximum" : 18446744073709551615,
             "minimum" : 0,
             "type" : "integer"
@@ -10271,7 +10387,6 @@
           "to" : {
             "description" : "Latest time of interest in non-revocation interval",
             "example" : 1640995199,
-            "format" : "int32",
             "maximum" : 18446744073709551615,
             "minimum" : 0,
             "type" : "integer"
@@ -10287,7 +10402,7 @@
             "type" : "string"
           },
           "non_revoked" : {
-            "$ref" : "#/components/schemas/IndyProofRequest_non_revoked"
+            "$ref" : "#/components/schemas/IndyProofRequestNonRevoked"
           },
           "nonce" : {
             "description" : "Nonce",
@@ -10324,7 +10439,6 @@
           "from" : {
             "description" : "Earliest time of interest in non-revocation interval",
             "example" : 1640995199,
-            "format" : "int32",
             "maximum" : 18446744073709551615,
             "minimum" : 0,
             "type" : "integer"
@@ -10332,7 +10446,6 @@
           "to" : {
             "description" : "Latest time of interest in non-revocation interval",
             "example" : 1640995199,
-            "format" : "int32",
             "maximum" : 18446744073709551615,
             "minimum" : 0,
             "type" : "integer"
@@ -10382,7 +10495,6 @@
         "properties" : {
           "sub_proof_index" : {
             "description" : "Sub-proof index",
-            "format" : "int32",
             "type" : "integer"
           }
         },
@@ -10402,7 +10514,6 @@
           },
           "sub_proof_index" : {
             "description" : "Sub-proof index",
-            "format" : "int32",
             "type" : "integer"
           }
         },
@@ -10412,7 +10523,6 @@
         "properties" : {
           "sub_proof_index" : {
             "description" : "Sub-proof index",
-            "format" : "int32",
             "type" : "integer"
           },
           "values" : {
@@ -10450,7 +10560,6 @@
           "timestamp" : {
             "description" : "Epoch timestamp of interest for non-revocation proof",
             "example" : 1640995199,
-            "format" : "int32",
             "maximum" : 18446744073709551615,
             "minimum" : 0,
             "type" : "integer"
@@ -10509,7 +10618,6 @@
           "maxCredNum" : {
             "description" : "Maximum number of credentials; registry size",
             "example" : 10,
-            "format" : "int32",
             "minimum" : 1,
             "type" : "integer"
           },
@@ -10584,7 +10692,6 @@
           "revoked" : {
             "description" : "Revoked credential revocation identifiers",
             "items" : {
-              "format" : "int32",
               "type" : "integer"
             },
             "type" : "array"
@@ -10628,7 +10735,6 @@
           "maxCredNum" : {
             "description" : "Maximum number of credential revocations per registry",
             "example" : 777,
-            "format" : "int32",
             "type" : "integer"
           },
           "tag" : {
@@ -11076,7 +11182,6 @@
           "max_cred_num" : {
             "description" : "Maximum number of credentials for revocation registry",
             "example" : 1000,
-            "format" : "int32",
             "type" : "integer"
           },
           "pending_pub" : {
@@ -11270,13 +11375,11 @@
           "limit" : {
             "description" : "Limit for keylist query",
             "example" : 30,
-            "format" : "int32",
             "type" : "integer"
           },
           "offset" : {
             "description" : "Offset value for query",
             "example" : 0,
-            "format" : "int32",
             "type" : "integer"
           }
         },
@@ -11334,6 +11437,7 @@
         "type" : "object"
       },
       "LDProofVCDetail" : {
+        "additionalProperties" : true,
         "properties" : {
           "credential" : {
             "allOf" : [ {
@@ -11372,6 +11476,7 @@
         "type" : "object"
       },
       "LDProofVCOptions" : {
+        "additionalProperties" : true,
         "properties" : {
           "challenge" : {
             "description" : "A challenge to include in the proof. SHOULD be provided by the requesting party of the credential (=holder)",
@@ -11455,6 +11560,7 @@
         "type" : "object"
       },
       "LinkedDataProof" : {
+        "additionalProperties" : true,
         "properties" : {
           "challenge" : {
             "description" : "Associates a challenge with a proof, for use with a proofPurpose such as authentication",
@@ -11470,7 +11576,6 @@
           "domain" : {
             "description" : "A string value specifying the restricted domain of the signature.",
             "example" : "https://example.com",
-            "pattern" : "\\w+:(\\/?\\/?)[^\\s]+",
             "type" : "string"
           },
           "jws" : {
@@ -11908,6 +12013,7 @@
         "type" : "object"
       },
       "Presentation" : {
+        "additionalProperties" : true,
         "properties" : {
           "@context" : {
             "description" : "The JSON-LD context of the presentation",
@@ -12407,14 +12513,12 @@
             "description" : "Bit list representing revoked credentials",
             "example" : [ 0, 1, 1, 0 ],
             "items" : {
-              "format" : "int32",
               "type" : "integer"
             },
             "type" : "array"
           },
           "timestamp" : {
             "description" : "Timestamp at which revocation list is applicable",
-            "format" : "int32",
             "type" : "integer"
           }
         },
@@ -12494,7 +12598,6 @@
           "max_cred_num" : {
             "description" : "Revocation registry size",
             "example" : 1000,
-            "format" : "int32",
             "maximum" : 32768,
             "minimum" : 4,
             "type" : "integer"
@@ -12598,7 +12701,6 @@
         "properties" : {
           "maxCredNum" : {
             "example" : 777,
-            "format" : "int32",
             "type" : "integer"
           },
           "publicKeys" : {
@@ -12622,7 +12724,6 @@
           "result" : {
             "description" : "Number of credentials issued against revocation registry",
             "example" : 0,
-            "format" : "int32",
             "minimum" : 0,
             "type" : "integer"
           }
@@ -12634,7 +12735,6 @@
           "result" : {
             "description" : "Number of credentials issued against revocation registry",
             "example" : 0,
-            "format" : "int32",
             "minimum" : 0,
             "type" : "integer"
           }
@@ -13011,7 +13111,6 @@
           "seqNo" : {
             "description" : "Schema sequence number",
             "example" : 10,
-            "format" : "int32",
             "minimum" : 1,
             "type" : "integer"
           },
@@ -13293,6 +13392,7 @@
         "type" : "object"
       },
       "SignedDoc" : {
+        "additionalProperties" : true,
         "properties" : {
           "proof" : {
             "allOf" : [ {
@@ -13310,7 +13410,6 @@
           "count" : {
             "description" : "Count Value",
             "example" : 1234,
-            "format" : "int32",
             "type" : "integer"
           },
           "from" : {
@@ -13326,13 +13425,11 @@
           "max" : {
             "description" : "Max Value",
             "example" : 1234,
-            "format" : "int32",
             "type" : "integer"
           },
           "min" : {
             "description" : "Min Value",
             "example" : 1234,
-            "format" : "int32",
             "type" : "integer"
           },
           "name" : {
@@ -13372,7 +13469,6 @@
           },
           "time" : {
             "example" : 1640995199,
-            "format" : "int32",
             "maximum" : 18446744073709551615,
             "minimum" : 0,
             "type" : "integer"
@@ -13709,6 +13805,9 @@
             "type" : "array"
           }
         },
+        "type" : "object"
+      },
+      "UpgradeResult" : {
         "type" : "object"
       },
       "V10CredentialBoundOfferRequest" : {
@@ -14768,6 +14867,9 @@
           },
           "ld_proof" : {
             "$ref" : "#/components/schemas/V20CredExRecordLDProof"
+          },
+          "vc_di" : {
+            "$ref" : "#/components/schemas/V20CredExRecord"
           }
         },
         "type" : "object"
@@ -14890,6 +14992,13 @@
             } ],
             "description" : "Credential filter for linked data proof",
             "type" : "object"
+          },
+          "vc_di" : {
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/V20CredFilterVCDI"
+            } ],
+            "description" : "Credential filter for vc_di",
+            "type" : "object"
           }
         },
         "type" : "object"
@@ -14945,6 +15054,46 @@
           }
         },
         "required" : [ "ld_proof" ],
+        "type" : "object"
+      },
+      "V20CredFilterVCDI" : {
+        "properties" : {
+          "cred_def_id" : {
+            "description" : "Credential definition identifier",
+            "example" : "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+            "pattern" : "^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}):3:CL:(([1-9][0-9]*)|([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}:2:.+:[0-9.]+)):(.+)?$",
+            "type" : "string"
+          },
+          "issuer_did" : {
+            "description" : "Credential issuer DID",
+            "example" : "WgWxqztrNooG92RXvxSTWv",
+            "pattern" : "^(did:sov:)?[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}$",
+            "type" : "string"
+          },
+          "schema_id" : {
+            "description" : "Schema identifier",
+            "example" : "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+            "pattern" : "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}:2:.+:[0-9.]+$",
+            "type" : "string"
+          },
+          "schema_issuer_did" : {
+            "description" : "Schema issuer DID",
+            "example" : "WgWxqztrNooG92RXvxSTWv",
+            "pattern" : "^(did:sov:)?[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}$",
+            "type" : "string"
+          },
+          "schema_name" : {
+            "description" : "Schema name",
+            "example" : "preferences",
+            "type" : "string"
+          },
+          "schema_version" : {
+            "description" : "Schema version",
+            "example" : "1.0",
+            "pattern" : "^[0-9.]+$",
+            "type" : "string"
+          }
+        },
         "type" : "object"
       },
       "V20CredFormat" : {
@@ -15959,6 +16108,7 @@
         "type" : "object"
       },
       "VerifiableCredential" : {
+        "additionalProperties" : true,
         "properties" : {
           "@context" : {
             "description" : "The JSON-LD context of the credential",
@@ -16026,6 +16176,7 @@
         "type" : "object"
       },
       "VerifiablePresentation" : {
+        "additionalProperties" : true,
         "properties" : {
           "@context" : {
             "description" : "The JSON-LD context of the presentation",
@@ -16168,7 +16319,6 @@
           },
           "max_results" : {
             "description" : "Maximum number of results to return",
-            "format" : "int32",
             "type" : "integer"
           },
           "proof_types" : {
@@ -16291,27 +16441,6 @@
           "$ref" : "#/components/schemas/IndyNonRevocProof"
         } ],
         "description" : "Indy non-revocation proof",
-        "nullable" : true,
-        "type" : "object"
-      },
-      "IndyProofReqAttrSpec_non_revoked" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyProofReqAttrSpecNonRevoked"
-        } ],
-        "nullable" : true,
-        "type" : "object"
-      },
-      "IndyProofReqPredSpec_non_revoked" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyProofReqPredSpecNonRevoked"
-        } ],
-        "nullable" : true,
-        "type" : "object"
-      },
-      "IndyProofRequest_non_revoked" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyProofRequestNonRevoked"
-        } ],
         "nullable" : true,
         "type" : "object"
       }

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -10165,7 +10165,12 @@
       "IndyPrimaryProof" : {
         "properties" : {
           "eq_proof" : {
-            "$ref" : "#/components/schemas/IndyPrimaryProof_eq_proof"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyEQProof"
+            } ],
+            "description" : "Indy equality proof",
+            "nullable" : true,
+            "type" : "object"
           },
           "ge_proofs" : {
             "description" : "Indy GE proofs",
@@ -10277,7 +10282,12 @@
       "IndyProofProofProofsProof" : {
         "properties" : {
           "non_revoc_proof" : {
-            "$ref" : "#/components/schemas/IndyProofProofProofsProof_non_revoc_proof"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/IndyNonRevocProof"
+            } ],
+            "description" : "Indy non-revocation proof",
+            "nullable" : true,
+            "type" : "object"
           },
           "primary_proof" : {
             "allOf" : [ {
@@ -16426,22 +16436,6 @@
             "type" : "string"
           }
         },
-        "type" : "object"
-      },
-      "IndyPrimaryProof_eq_proof" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyEQProof"
-        } ],
-        "description" : "Indy equality proof",
-        "nullable" : true,
-        "type" : "object"
-      },
-      "IndyProofProofProofsProof_non_revoc_proof" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/IndyNonRevocProof"
-        } ],
-        "description" : "Indy non-revocation proof",
-        "nullable" : true,
         "type" : "object"
       }
     },

--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -29,6 +29,13 @@
       "url" : "https://hyperledger.github.io/anoncreds-spec"
     }
   }, {
+    "name" : "anoncreds - wallet upgrade",
+    "description" : "Anoncreds wallet upgrade",
+    "externalDocs" : {
+      "description" : "Specification",
+      "url" : "https://hyperledger.github.io/anoncreds-spec"
+    }
+  }, {
     "name" : "basicmessage",
     "description" : "Simple messaging",
     "externalDocs" : {
@@ -912,6 +919,28 @@
         }
       }
     },
+    "/anoncreds/wallet/upgrade" : {
+      "post" : {
+        "tags" : [ "anoncreds - wallet upgrade" ],
+        "summary" : "\n        Upgrade the wallet from askar to anoncreds - Be very careful with this! You \n        cannot go back! See migration guide for more information.\n    ",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "wallet_name",
+          "in" : "query",
+          "description" : "Name of wallet to upgrade to anoncreds",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "schema" : {
+              "$ref" : "#/definitions/UpgradeResult"
+            }
+          }
+        }
+      }
+    },
     "/connections" : {
       "get" : {
         "tags" : [ "connection" ],
@@ -944,12 +973,26 @@
           "required" : false,
           "type" : "string"
         }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of results to return",
+          "required" : false,
+          "type" : "integer",
+          "default" : 100
+        }, {
           "name" : "my_did",
           "in" : "query",
           "description" : "My DID",
           "required" : false,
           "type" : "string",
           "pattern" : "^(did:sov:)?[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}$|^did:([a-zA-Z0-9_]+):([a-zA-Z0-9_.%-]+(:[a-zA-Z0-9_.%-]+)*)((;[a-zA-Z0-9_.:%-]+=[a-zA-Z0-9_.:%-]*)*)(\\/[^#?]*)?([?][^#]*)?(\\#.*)?$$"
+        }, {
+          "name" : "offset",
+          "in" : "query",
+          "description" : "Offset for pagination",
+          "required" : false,
+          "type" : "integer",
+          "default" : 0
         }, {
           "name" : "state",
           "in" : "query",
@@ -2231,6 +2274,20 @@
           "required" : false,
           "type" : "string"
         }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of results to return",
+          "required" : false,
+          "type" : "integer",
+          "default" : 100
+        }, {
+          "name" : "offset",
+          "in" : "query",
+          "description" : "Offset for pagination",
+          "required" : false,
+          "type" : "integer",
+          "default" : 0
+        }, {
           "name" : "role",
           "in" : "query",
           "description" : "Role assigned in credential exchange",
@@ -2606,6 +2663,20 @@
           "description" : "Connection identifier",
           "required" : false,
           "type" : "string"
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of results to return",
+          "required" : false,
+          "type" : "integer",
+          "default" : 100
+        }, {
+          "name" : "offset",
+          "in" : "query",
+          "description" : "Offset for pagination",
+          "required" : false,
+          "type" : "integer",
+          "default" : 0
         }, {
           "name" : "role",
           "in" : "query",
@@ -3298,16 +3369,14 @@
           "description" : "limit number of results",
           "required" : false,
           "type" : "integer",
-          "default" : -1,
-          "format" : "int32"
+          "default" : -1
         }, {
           "name" : "paginate_offset",
           "in" : "query",
           "description" : "offset to use in pagination",
           "required" : false,
           "type" : "integer",
-          "default" : 0,
-          "format" : "int32"
+          "default" : 0
         } ],
         "responses" : {
           "201" : {
@@ -3685,6 +3754,20 @@
         "summary" : "Query subwallets",
         "produces" : [ "application/json" ],
         "parameters" : [ {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of results to return",
+          "required" : false,
+          "type" : "integer",
+          "default" : 100
+        }, {
+          "name" : "offset",
+          "in" : "query",
+          "description" : "Offset for pagination",
+          "required" : false,
+          "type" : "integer",
+          "default" : 0
+        }, {
           "name" : "wallet_name",
           "in" : "query",
           "description" : "Wallet name",
@@ -3863,6 +3946,20 @@
           "description" : "Connection identifier",
           "required" : false,
           "type" : "string"
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of results to return",
+          "required" : false,
+          "type" : "integer",
+          "default" : 100
+        }, {
+          "name" : "offset",
+          "in" : "query",
+          "description" : "Offset for pagination",
+          "required" : false,
+          "type" : "integer",
+          "default" : 0
         }, {
           "name" : "role",
           "in" : "query",
@@ -4185,6 +4282,20 @@
           "description" : "Connection identifier",
           "required" : false,
           "type" : "string"
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of results to return",
+          "required" : false,
+          "type" : "integer",
+          "default" : 100
+        }, {
+          "name" : "offset",
+          "in" : "query",
+          "description" : "Offset for pagination",
+          "required" : false,
+          "type" : "integer",
+          "default" : 0
         }, {
           "name" : "role",
           "in" : "query",
@@ -6156,7 +6267,6 @@
         },
         "byte_count" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1234,
           "description" : "Byte count of data included by reference"
         },
@@ -6792,7 +6902,7 @@
           "type" : "string",
           "example" : "askar",
           "description" : "Type of the wallet to create. Must be same as base wallet.",
-          "enum" : [ "askar", "askar-anoncreds", "in_memory", "indy" ]
+          "enum" : [ "askar", "askar-anoncreds", "in_memory" ]
         },
         "wallet_webhook_urls" : {
           "type" : "array",
@@ -6932,7 +7042,6 @@
         },
         "revocation_registry_size" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1000,
           "description" : "Maximum number of credential revocations per registry"
         },
@@ -7294,7 +7403,8 @@
             "type" : "string"
           }
         }
-      }
+      },
+      "additionalProperties" : true
     },
     "CredentialDefinition" : {
       "type" : "object",
@@ -7343,7 +7453,6 @@
       "properties" : {
         "revocation_registry_size" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1000,
           "description" : "Revocation registry size",
           "minimum" : 4,
@@ -7499,7 +7608,8 @@
           "example" : "CredentialStatusList2017",
           "description" : "Credential status method type to use for the credential. Should match status method registered in the Verifiable Credential Extension Registry"
         }
-      }
+      },
+      "additionalProperties" : true
     },
     "DID" : {
       "type" : "object",
@@ -7830,7 +7940,8 @@
         "presentation_definition" : {
           "$ref" : "#/definitions/PresentationDefinition"
         }
-      }
+      },
+      "additionalProperties" : true
     },
     "Date" : {
       "type" : "object",
@@ -7990,7 +8101,6 @@
         },
         "maxLength" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1234,
           "description" : "Max Length"
         },
@@ -7999,7 +8109,6 @@
         },
         "minLength" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1234,
           "description" : "Min Length"
         },
@@ -8457,7 +8566,6 @@
         },
         "value" : {
           "type" : "integer",
-          "format" : "int32",
           "description" : "Predicate threshold value"
         }
       }
@@ -8514,7 +8622,6 @@
       "properties" : {
         "from" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1640995199,
           "description" : "Earliest time of interest in non-revocation interval",
           "minimum" : 0,
@@ -8522,7 +8629,6 @@
         },
         "to" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1640995199,
           "description" : "Latest time of interest in non-revocation interval",
           "minimum" : 0,
@@ -8584,7 +8690,6 @@
         },
         "threshold" : {
           "type" : "integer",
-          "format" : "int32",
           "description" : "Threshold value"
         }
       }
@@ -8704,7 +8809,6 @@
         },
         "timestamp" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1640995199,
           "description" : "Timestamp epoch",
           "minimum" : 0,
@@ -8741,8 +8845,7 @@
           "items" : {
             "type" : "array",
             "items" : {
-              "type" : "integer",
-              "format" : "int32"
+              "type" : "integer"
             }
           }
         }
@@ -8776,7 +8879,7 @@
           }
         },
         "non_revoked" : {
-          "$ref" : "#/definitions/IndyProofReqAttrSpec_non_revoked"
+          "$ref" : "#/definitions/IndyProofReqAttrSpecNonRevoked"
         },
         "restrictions" : {
           "type" : "array",
@@ -8796,7 +8899,6 @@
       "properties" : {
         "from" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1640995199,
           "description" : "Earliest time of interest in non-revocation interval",
           "minimum" : 0,
@@ -8804,7 +8906,6 @@
         },
         "to" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1640995199,
           "description" : "Latest time of interest in non-revocation interval",
           "minimum" : 0,
@@ -8822,7 +8923,7 @@
           "description" : "Attribute name"
         },
         "non_revoked" : {
-          "$ref" : "#/definitions/IndyProofReqAttrSpec_non_revoked"
+          "$ref" : "#/definitions/IndyProofReqPredSpecNonRevoked"
         },
         "p_type" : {
           "type" : "string",
@@ -8832,7 +8933,6 @@
         },
         "p_value" : {
           "type" : "integer",
-          "format" : "int32",
           "description" : "Threshold value"
         },
         "restrictions" : {
@@ -8853,7 +8953,6 @@
       "properties" : {
         "from" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1640995199,
           "description" : "Earliest time of interest in non-revocation interval",
           "minimum" : 0,
@@ -8861,7 +8960,6 @@
         },
         "to" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1640995199,
           "description" : "Latest time of interest in non-revocation interval",
           "minimum" : 0,
@@ -8879,7 +8977,7 @@
           "description" : "Proof request name"
         },
         "non_revoked" : {
-          "$ref" : "#/definitions/IndyProofReqAttrSpec_non_revoked"
+          "$ref" : "#/definitions/IndyProofRequestNonRevoked"
         },
         "nonce" : {
           "type" : "string",
@@ -8914,7 +9012,6 @@
       "properties" : {
         "from" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1640995199,
           "description" : "Earliest time of interest in non-revocation interval",
           "minimum" : 0,
@@ -8922,7 +9019,6 @@
         },
         "to" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1640995199,
           "description" : "Latest time of interest in non-revocation interval",
           "minimum" : 0,
@@ -8973,7 +9069,6 @@
       "properties" : {
         "sub_proof_index" : {
           "type" : "integer",
-          "format" : "int32",
           "description" : "Sub-proof index"
         }
       }
@@ -8993,7 +9088,6 @@
         },
         "sub_proof_index" : {
           "type" : "integer",
-          "format" : "int32",
           "description" : "Sub-proof index"
         }
       }
@@ -9003,7 +9097,6 @@
       "properties" : {
         "sub_proof_index" : {
           "type" : "integer",
-          "format" : "int32",
           "description" : "Sub-proof index"
         },
         "values" : {
@@ -9041,7 +9134,6 @@
         },
         "timestamp" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1640995199,
           "description" : "Epoch timestamp of interest for non-revocation proof",
           "minimum" : 0,
@@ -9095,7 +9187,6 @@
         },
         "maxCredNum" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 10,
           "description" : "Maximum number of credentials; registry size",
           "minimum" : 1
@@ -9164,8 +9255,7 @@
           "type" : "array",
           "description" : "Revoked credential revocation identifiers",
           "items" : {
-            "type" : "integer",
-            "format" : "int32"
+            "type" : "integer"
           }
         }
       }
@@ -9206,7 +9296,6 @@
         },
         "maxCredNum" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 777,
           "description" : "Maximum number of credential revocations per registry"
         },
@@ -9632,7 +9721,6 @@
         },
         "max_cred_num" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1000,
           "description" : "Maximum number of credentials for revocation registry"
         },
@@ -9814,13 +9902,11 @@
       "properties" : {
         "limit" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 30,
           "description" : "Limit for keylist query"
         },
         "offset" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 0,
           "description" : "Offset value for query"
         }
@@ -9887,7 +9973,8 @@
         "options" : {
           "$ref" : "#/definitions/LDProofVCDetail_options"
         }
-      }
+      },
+      "additionalProperties" : true
     },
     "LDProofVCOptions" : {
       "type" : "object",
@@ -9926,7 +10013,8 @@
           "example" : "did:example:123456#key-1",
           "description" : "The verification method to use for the proof. Should match a verification method in the wallet"
         }
-      }
+      },
+      "additionalProperties" : true
     },
     "LedgerConfigInstance" : {
       "type" : "object",
@@ -9986,8 +10074,7 @@
         "domain" : {
           "type" : "string",
           "example" : "https://example.com",
-          "description" : "A string value specifying the restricted domain of the signature.",
-          "pattern" : "\\w+:(\\/?\\/?)[^\\s]+"
+          "description" : "A string value specifying the restricted domain of the signature."
         },
         "jws" : {
           "type" : "string",
@@ -10020,7 +10107,8 @@
           "description" : "Information used for proof verification",
           "pattern" : "\\w+:(\\/?\\/?)[^\\s]+"
         }
-      }
+      },
+      "additionalProperties" : true
     },
     "ListCredentialsResponse" : {
       "type" : "object"
@@ -10455,7 +10543,8 @@
             "properties" : { }
           }
         }
-      }
+      },
+      "additionalProperties" : true
     },
     "PresentationDefinition" : {
       "type" : "object",
@@ -10905,13 +10994,11 @@
           "example" : [ 0, 1, 1, 0 ],
           "description" : "Bit list representing revoked credentials",
           "items" : {
-            "type" : "integer",
-            "format" : "int32"
+            "type" : "integer"
           }
         },
         "timestamp" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : "2021-12-31T23:59:59Z",
           "description" : "Timestamp at which revocation list is applicable"
         }
@@ -10987,7 +11074,6 @@
         },
         "max_cred_num" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1000,
           "description" : "Revocation registry size",
           "minimum" : 4,
@@ -11088,7 +11174,6 @@
       "properties" : {
         "maxCredNum" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 777
         },
         "publicKeys" : {
@@ -11111,7 +11196,6 @@
       "properties" : {
         "result" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 0,
           "description" : "Number of credentials issued against revocation registry",
           "minimum" : 0
@@ -11123,7 +11207,6 @@
       "properties" : {
         "result" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 0,
           "description" : "Number of credentials issued against revocation registry",
           "minimum" : 0
@@ -11498,7 +11581,6 @@
         },
         "seqNo" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 10,
           "description" : "Schema sequence number",
           "minimum" : 1
@@ -11778,14 +11860,14 @@
         "proof" : {
           "$ref" : "#/definitions/SignedDoc_proof"
         }
-      }
+      },
+      "additionalProperties" : true
     },
     "SubmissionRequirements" : {
       "type" : "object",
       "properties" : {
         "count" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1234,
           "description" : "Count Value"
         },
@@ -11801,13 +11883,11 @@
         },
         "max" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1234,
           "description" : "Max Value"
         },
         "min" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1234,
           "description" : "Min Value"
         },
@@ -11848,7 +11928,6 @@
         },
         "time" : {
           "type" : "integer",
-          "format" : "int32",
           "example" : 1640995199,
           "minimum" : 0,
           "maximum" : 18446744073709551615
@@ -12161,6 +12240,9 @@
           }
         }
       }
+    },
+    "UpgradeResult" : {
+      "type" : "object"
     },
     "V10CredentialBoundOfferRequest" : {
       "type" : "object",
@@ -13128,6 +13210,9 @@
         },
         "ld_proof" : {
           "$ref" : "#/definitions/V20CredExRecordLDProof"
+        },
+        "vc_di" : {
+          "$ref" : "#/definitions/V20CredExRecord"
         }
       }
     },
@@ -13242,6 +13327,9 @@
         },
         "ld_proof" : {
           "$ref" : "#/definitions/V20CredFilter_ld_proof"
+        },
+        "vc_di" : {
+          "$ref" : "#/definitions/V20CredFilter_vc_di"
         }
       }
     },
@@ -13291,6 +13379,46 @@
       "properties" : {
         "ld_proof" : {
           "$ref" : "#/definitions/V20CredFilter_ld_proof"
+        }
+      }
+    },
+    "V20CredFilterVCDI" : {
+      "type" : "object",
+      "properties" : {
+        "cred_def_id" : {
+          "type" : "string",
+          "example" : "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+          "description" : "Credential definition identifier",
+          "pattern" : "^([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}):3:CL:(([1-9][0-9]*)|([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}:2:.+:[0-9.]+)):(.+)?$"
+        },
+        "issuer_did" : {
+          "type" : "string",
+          "example" : "WgWxqztrNooG92RXvxSTWv",
+          "description" : "Credential issuer DID",
+          "pattern" : "^(did:sov:)?[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}$"
+        },
+        "schema_id" : {
+          "type" : "string",
+          "example" : "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+          "description" : "Schema identifier",
+          "pattern" : "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}:2:.+:[0-9.]+$"
+        },
+        "schema_issuer_did" : {
+          "type" : "string",
+          "example" : "WgWxqztrNooG92RXvxSTWv",
+          "description" : "Schema issuer DID",
+          "pattern" : "^(did:sov:)?[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21,22}$"
+        },
+        "schema_name" : {
+          "type" : "string",
+          "example" : "preferences",
+          "description" : "Schema name"
+        },
+        "schema_version" : {
+          "type" : "string",
+          "example" : "1.0",
+          "description" : "Schema version",
+          "pattern" : "^[0-9.]+$"
         }
       }
     },
@@ -14282,7 +14410,8 @@
             "type" : "string"
           }
         }
-      }
+      },
+      "additionalProperties" : true
     },
     "VerifiablePresentation" : {
       "type" : "object",
@@ -14322,7 +14451,8 @@
             "properties" : { }
           }
         }
-      }
+      },
+      "additionalProperties" : true
     },
     "VerifyCredentialRequest" : {
       "type" : "object",
@@ -14410,7 +14540,6 @@
         },
         "max_results" : {
           "type" : "integer",
-          "format" : "int32",
           "description" : "Maximum number of results to return"
         },
         "proof_types" : {
@@ -14598,10 +14727,6 @@
       "type" : "object",
       "description" : "Indy primary proof"
     },
-    "IndyProofReqAttrSpec_non_revoked" : {
-      "type" : "object",
-      "x-nullable" : true
-    },
     "IndyRevRegDef_value" : {
       "type" : "object",
       "description" : "Revocation registry definition value"
@@ -14785,6 +14910,10 @@
     "V20CredFilter_ld_proof" : {
       "type" : "object",
       "description" : "Credential filter for linked data proof"
+    },
+    "V20CredFilter_vc_di" : {
+      "type" : "object",
+      "description" : "Credential filter for vc_di"
     },
     "V20CredProposal_credential_preview" : {
       "type" : "object",

--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -8454,11 +8454,7 @@
           "type" : "object",
           "description" : "Credential attributes",
           "additionalProperties" : {
-            "type" : "object",
-            "description" : "Attribute value",
-            "allOf" : [ {
-              "$ref" : "#/definitions/IndyAttrValue"
-            } ]
+            "$ref" : "#/definitions/IndyAttrValue"
           }
         },
         "witness" : {

--- a/scripts/generate-open-api-spec
+++ b/scripts/generate-open-api-spec
@@ -6,8 +6,8 @@
 #
 ##########################################################################################
 
-SWAGGER_GEN_CONTAINER="docker.io/swaggerapi/swagger-codegen-cli:2.4.39"
-OPENAPI_GEN_CONTAINER="docker.io/openapitools/openapi-generator-cli:v7.5.0"
+SWAGGER_GEN_CONTAINER="docker.io/swaggerapi/swagger-codegen-cli:2.4.41"
+OPENAPI_GEN_CONTAINER="docker.io/openapitools/openapi-generator-cli:v7.7.0"
 
 # Ensure the script is running from the directory containing this script
 cd $(dirname $0)


### PR DESCRIPTION
Resolves #3086

See comment for detail: https://github.com/hyperledger/aries-cloudagent-python/issues/3086#issuecomment-2213956023

___

You'll see in the commit logs I first regenerated the OpenAPI spec, to capture all the latest changes since 0.12.1.
Then I upgraded the openapi gen tools to latest versions, which just improves the default model names in a couple cases:
- `IndyProofProofProofsProof_non_revoc_proof` -> `IndyNonRevocProof` 
- `IndyPrimaryProof_eq_proof` -> `IndyEQProof`

No other changes from upgrading the openapi generators to latest versions.

Then, I removed the description metadata from the `IndyAttrValue` field in `DictWithIndyAttrValueSchema`, and regenerated the spec. That solves the bad reference.