### PR TITLE
Add descriptive error for issuance without RevRegRecord

### DIFF
--- a/aries_cloudagent/revocation/indy.py
+++ b/aries_cloudagent/revocation/indy.py
@@ -258,7 +258,12 @@ class IndyRevocation:
                     await IssuerRevRegRecord.query_by_cred_def_id(
                         session, cred_def_id, limit=1
                     )
-                )[0]
+                )
+                if not any_registry:
+                    raise RevocationError(
+                        f"No revocation registry record found in issuer wallet for cred def id {cred_def_id}"
+                    )
+                any_registry = any_registry[0]
                 await self.init_issuer_registry(
                     cred_def_id,
                     max_cred_num=any_registry.max_cred_num,

--- a/aries_cloudagent/revocation/indy.py
+++ b/aries_cloudagent/revocation/indy.py
@@ -237,9 +237,7 @@ class IndyRevocation:
         triggered and the caller should retry after a delay.
         """
         try:
-            active_rev_reg_rec = await self.get_active_issuer_rev_reg_record(
-                cred_def_id
-            )
+            active_rev_reg_rec = await self.get_active_issuer_rev_reg_record(cred_def_id)
             rev_reg = active_rev_reg_rec.get_registry()
             await rev_reg.get_or_fetch_local_tails_path()
             return active_rev_reg_rec, rev_reg
@@ -254,14 +252,12 @@ class IndyRevocation:
             # all registries are full, create a new one
             if not full_registries:
                 # Use any registry to get max cred num
-                any_registry = (
-                    await IssuerRevRegRecord.query_by_cred_def_id(
-                        session, cred_def_id, limit=1
-                    )
+                any_registry = await IssuerRevRegRecord.query_by_cred_def_id(
+                    session, cred_def_id, limit=1
                 )
                 if not any_registry:
                     raise RevocationError(
-                        f"No revocation registry record found in issuer wallet for cred def id {cred_def_id}"
+                        f"No revocation registry record found in issuer wallet for cred def id {cred_def_id}"  # noqa: E501
                     )
                 any_registry = any_registry[0]
                 await self.init_issuer_registry(


### PR DESCRIPTION
This just raises an exception with a descriptive message when revocable credential issuance is attempted but there is no RevRegRecord in the issuer wallet.

Can happen when there is issues with the tails server.