### PR TITLE
Update `TxnOrPublishRevocationsResultSchema`

### DIFF
--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -700,7 +700,7 @@ async def _process_publish_response_for_endorsement(
                 raise web.HTTPBadRequest(reason=err.roll_up) from err
 
             await outbound_handler(transaction_request, connection_id=endorser_conn_id)
-            
+
         txn_responses.append(transaction.serialize())
 
     return txn_responses

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -298,12 +298,14 @@ class TxnOrPublishRevocationsResultSchema(OpenAPISchema):
         required=False,
         metadata={"definition": "Content sent"},
     )
-    txn = fields.Nested(
-        TransactionRecordSchema(),
-        required=False,
-        metadata={
-            "description": "Revocation registry revocations transaction to endorse"
-        },
+    txn = fields.List(
+        fields.Nested(
+            TransactionRecordSchema(),
+            required=False,
+            metadata={
+                "description": "Revocation registry revocations transaction to endorse"
+            },
+        )
     )
 
 

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -661,13 +661,10 @@ async def publish_revocations(request: web.BaseRequest):
         raise web.HTTPBadRequest(reason=err.roll_up) from err
 
     if create_transaction_for_endorser:
-        return web.json_response(
-            (
-                await _process_publish_response_for_endorsement(
-                    profile, rev_reg_responses, outbound_handler, endorser_conn_id
-                )
-            )
+        list_of_txns = await _process_publish_response_for_endorsement(
+            profile, rev_reg_responses, outbound_handler, endorser_conn_id
         )
+        return web.json_response({"txn": list_of_txns})
 
     return web.json_response({"rrid2crid": result})
 
@@ -702,7 +699,7 @@ async def _process_publish_response_for_endorsement(
 
             await outbound_handler(transaction_request, connection_id=endorser_conn_id)
 
-        txn_responses.append({"txn": transaction.serialize()})
+        txn_responses.append(transaction.serialize())
 
     return txn_responses
 

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -668,7 +668,7 @@ async def publish_revocations(request: web.BaseRequest):
         )
         return web.json_response({"txn": list_of_txns})
 
-    return web.json_response({"rrid2crid": result})
+    return web.json_response({"sent": {"rrid2crid": result}})
 
 
 async def _process_publish_response_for_endorsement(

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -698,7 +698,7 @@ async def _process_publish_response_for_endorsement(
                 raise web.HTTPBadRequest(reason=err.roll_up) from err
 
             await outbound_handler(transaction_request, connection_id=endorser_conn_id)
-
+        LOGGER.error(">>> transaction: %s", transaction.serialize())
         txn_responses.append(transaction.serialize())
 
     return txn_responses

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -700,7 +700,7 @@ async def _process_publish_response_for_endorsement(
                 raise web.HTTPBadRequest(reason=err.roll_up) from err
 
             await outbound_handler(transaction_request, connection_id=endorser_conn_id)
-        LOGGER.error(">>> transaction: %s", transaction.serialize())
+            
         txn_responses.append(transaction.serialize())
 
     return txn_responses

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -290,14 +290,9 @@ class PublishRevocationsSchema(OpenAPISchema):
     )
 
 
-class TxnOrPublishRevocationsResultSchema(OpenAPISchema):
+class TxnOrPublishRevocationsResultSchema(PublishRevocationsSchema):
     """Result schema for credential definition send request."""
 
-    sent = fields.Nested(
-        PublishRevocationsSchema(),
-        required=False,
-        metadata={"definition": "Content sent"},
-    )
     txn = fields.List(
         fields.Nested(
             TransactionRecordSchema(),

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -663,7 +663,7 @@ async def publish_revocations(request: web.BaseRequest):
         )
         return web.json_response({"txn": list_of_txns})
 
-    return web.json_response({"sent": {"rrid2crid": result}})
+    return web.json_response({"rrid2crid": result})
 
 
 async def _process_publish_response_for_endorsement(

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -13707,11 +13707,14 @@
             "$ref" : "#/components/schemas/PublishRevocations"
           },
           "txn" : {
-            "allOf" : [ {
-              "$ref" : "#/components/schemas/TransactionRecord"
-            } ],
-            "description" : "Revocation registry revocations transaction to endorse",
-            "type" : "object"
+            "items" : {
+              "allOf" : [ {
+                "$ref" : "#/components/schemas/TransactionRecord"
+              } ],
+              "description" : "Revocation registry revocations transaction to endorse",
+              "type" : "object"
+            },
+            "type" : "array"
           }
         },
         "type" : "object"

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -13703,8 +13703,18 @@
       },
       "TxnOrPublishRevocationsResult" : {
         "properties" : {
-          "sent" : {
-            "$ref" : "#/components/schemas/PublishRevocations"
+          "rrid2crid" : {
+            "additionalProperties" : {
+              "items" : {
+                "description" : "Credential revocation identifier",
+                "example" : "12345",
+                "pattern" : "^[1-9][0-9]*$",
+                "type" : "string"
+              },
+              "type" : "array"
+            },
+            "description" : "Credential revocation ids by revocation registry id",
+            "type" : "object"
           },
           "txn" : {
             "items" : {

--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -12148,8 +12148,18 @@
     "TxnOrPublishRevocationsResult" : {
       "type" : "object",
       "properties" : {
-        "sent" : {
-          "$ref" : "#/definitions/PublishRevocations"
+        "rrid2crid" : {
+          "type" : "object",
+          "description" : "Credential revocation ids by revocation registry id",
+          "additionalProperties" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "example" : "12345",
+              "description" : "Credential revocation identifier",
+              "pattern" : "^[1-9][0-9]*$"
+            }
+          }
         },
         "txn" : {
           "type" : "array",

--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -12152,7 +12152,14 @@
           "$ref" : "#/definitions/PublishRevocations"
         },
         "txn" : {
-          "$ref" : "#/definitions/TxnOrPublishRevocationsResult_txn"
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "description" : "Revocation registry revocations transaction to endorse",
+            "allOf" : [ {
+              "$ref" : "#/definitions/TransactionRecord"
+            } ]
+          }
         }
       }
     },
@@ -14802,10 +14809,6 @@
     "TxnOrCredentialDefinitionSendResult_txn" : {
       "type" : "object",
       "description" : "Credential definition transaction to endorse"
-    },
-    "TxnOrPublishRevocationsResult_txn" : {
-      "type" : "object",
-      "description" : "Revocation registry revocations transaction to endorse"
     },
     "TxnOrRegisterLedgerNymResponse_txn" : {
       "type" : "object",


### PR DESCRIPTION
Update `TxnOrPublishRevocationsResultSchema` to accommodate changes made in PR #3107

Tweak return values from `publish_revocations` to match response model.

Ran the script `generate-open-api-spec` to update `openapi.json` and `swagger.json` files