### PR TITLE
Add explicit write permission to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,9 @@ jobs:
 
     name: Publish ACA-Py Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
This should fix the publish workflows. Worked with my forked repo.