### PR TITLE
👷 Enable `linux/arm64` docker builds

### DIFF
--- a/.github/workflows/nigthly.yml
+++ b/.github/workflows/nigthly.yml
@@ -51,4 +51,4 @@ jobs:
         tag: ["nightly-${{needs.setup_and_check_pub.outputs.date}}", nightly]
     with:
       tag: ${{ matrix.tag }}
-      platforms: "linux/amd64"
+      platforms: "linux/amd64,linux/arm64"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ on:
       platforms:
         description: 'Platforms - Comma separated list of the platforms to support.'
         required: true
-        default: linux/amd64
+        default: linux/amd64,linux/arm64
         type: string
       ref:
         description: 'Optional - The branch, tag or SHA to checkout.'
@@ -26,7 +26,7 @@ on:
         type: string
       platforms:
         required: true
-        default: linux/amd64
+        default: linux/amd64,linux/arm64
         type: string
       ref:
         required: false
@@ -35,7 +35,7 @@ on:
 env:
   # linux/386 platform support has been disabled pending a permanent fix for https://github.com/hyperledger/aries-cloudagent-python/issues/2124
   # PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64,linux/386' }}
-  PLATFORMS: ${{ inputs.platforms || 'linux/amd64' }}
+  PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
 
 jobs:
   publish-image:
@@ -119,7 +119,9 @@ jobs:
             acapy_reqs=[askar,bbs,didcommv2]
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          platforms: ${{ env.PLATFORMS }}
+          # Because of BBS, only linux/amd64 is supported for the extended image
+          # https://github.com/hyperledger/aries-cloudagent-python/issues/2124#issuecomment-2293569659
+          platforms: linux/amd64
 
       # Temp fix
       # https://github.com/docker/build-push-action/issues/252


### PR DESCRIPTION
* `1.0.0rc6` resolved build issues for `linux/arm64` for the normal image
* Extended image is `linux/amd64` only due to `bbs`
* `linux/386` still appears to have issues