### PR TITLE
Change interop tests to critical on PRs

### DIFF
--- a/.github/workflows/bdd-interop-tests.yml
+++ b/.github/workflows/bdd-interop-tests.yml
@@ -42,5 +42,5 @@ jobs:
           cat aries-agent-test-harness/aries-backchannels/acapy/requirements-main.txt
           cd aries-agent-test-harness
           ./manage build -a acapy-main
-          NO_TTY=1 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -t @AcceptanceTest -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound
+          NO_TTY=1 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -t @critical -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound
 


### PR DESCRIPTION
This changes the tag for interop tests on PR's to critical to run less edge case testing.