### PR TITLE
Adjust nightly and release workflows

### DIFF
--- a/.github/actions/is-release/action.yml
+++ b/.github/actions/is-release/action.yml
@@ -1,6 +1,11 @@
 name: Check if PR is a release
 description: "Checks if the PR is a release"
 
+outputs:
+  is_release:
+    description: "Is this a release?"
+    value: ${{ steps.check_if_release.outputs.is_release }}
+
 runs:
   using: "composite"
   steps:

--- a/.github/actions/is-release/action.yml
+++ b/.github/actions/is-release/action.yml
@@ -1,0 +1,34 @@
+name: Check if PR is a release
+description: "Checks if the PR is a release"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check if PR is a release
+      shell: bash
+      id: check_if_release
+      continue-on-error: true
+      run: |
+        # Get the diff between the current commit and the last merge commit on the upstream/main branch
+        git remote add upstream https://github.com/hyperledger/aries-cloudagent-python.git
+        git fetch upstream
+        
+        last_merge=$(git rev-list --no-merges -n 1 upstream/main)
+        
+        echo event = ${{ github.event_name }}
+
+        echo last upstream commit = "$last_merge"
+        echo current pr commit = "${{ github.sha }}"
+
+        echo Will exit with code 1 if the pull request is not a release
+
+        changes=$(git diff "${{ github.sha }}" "$last_merge" pyproject.toml)
+
+        # Extract the version of aries-cloudagent from the diff of pyproject.toml
+        version=$(echo "$changes" | grep -A1 'name = "aries_cloudagent"' | head -n 2 | tail -n 1 | awk '{print $3}' | tr -d '"')
+
+        echo "$version"
+        if [ "$version" ]; then
+          echo "This is a release because the aries-cloudagent version in pyproject.toml has changes"
+          echo is_release=true >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/bdd-integration-tests.yml
+++ b/.github/workflows/bdd-integration-tests.yml
@@ -29,37 +29,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check if PR is a release
+        uses: ./.github/actions/is-release
         id: check_if_release
-        continue-on-error: true
-        run: |
-          # Get the diff between the current commit and the last merge commit on the upstream/main branch
-          git remote add upstream https://github.com/hyperledger/aries-cloudagent-python.git
-          git fetch upstream
-          
-          last_merge=$(git rev-list --no-merges -n 1 upstream/main)
-          
-          echo event = ${{ github.event_name }}
-
-          echo last upstream commit = "$last_merge"
-          echo current pr commit = "${{ github.sha }}"
-
-          echo Will exit with code 1 if the pull request is not a release
-
-          changes=$(git diff "${{ github.sha }}" "$last_merge" pyproject.toml)
-
-          # Extract the version of aries-cloudagent from the diff of pyproject.toml
-          version=$(echo "$changes" | grep -A1 'name = "aries_cloudagent"' | head -n 2 | tail -n 1 | awk '{print $3}' | tr -d '"')
-
-          echo "$version"
-          if [ "$version" ]; then
-            echo "This is a release because the aries-cloudagent version in pyproject.toml has changes"
-            echo is_release=true >> $GITHUB_OUTPUT
-          fi
       - name: run-pr-integration-tests
         uses: ./.github/actions/run-integration-tests
-        if: (steps.check_if_release.outputs.is_release != 'true' && github.event_name == 'pull_request')
+        if: (steps.check_if_release.outputs.is_release != 'true')
       - name: run-release-or-cron-integration-tests
-        if: (steps.check_if_release.outputs.is_release == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        if: (steps.check_if_release.outputs.is_release == 'true')
         uses: ./.github/actions/run-integration-tests
         with:
           TEST_SCOPE: "-t @Release -t ~@BBS"

--- a/.github/workflows/bdd-integration-tests.yml
+++ b/.github/workflows/bdd-integration-tests.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Check if PR is a release
         uses: ./.github/actions/is-release
         id: check_if_release
-      - name: run-pr-integration-tests
+      - name: Run PR or Nightly Integration Tests
         uses: ./.github/actions/run-integration-tests
         if: (steps.check_if_release.outputs.is_release != 'true')
-      - name: run-release-or-cron-integration-tests
+      - name: Run Release Integration Tests
         if: (steps.check_if_release.outputs.is_release == 'true')
         uses: ./.github/actions/run-integration-tests
         with:

--- a/.github/workflows/bdd-interop-tests.yml
+++ b/.github/workflows/bdd-interop-tests.yml
@@ -1,6 +1,9 @@
 name: BDD Interop Integration Tests
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -25,6 +28,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Check if PR is a release
+        uses: ./.github/actions/is-release
+        id: check_if_release
       - name: Request GitHub API for PR data
         uses: octokit/request-action@v2.x
         env:
@@ -32,7 +38,7 @@ jobs:
         id: get_pr_data
         with:
           route: GET /repos/${{ github.event.repository.full_name }}/pulls/${{ github.event.number }}
-      - name: Run BDD Interop Tests
+      - name: Prepare Interop Tests
         run: |
           # Get AATH 
           git clone https://github.com/hyperledger/aries-agent-test-harness.git
@@ -42,5 +48,14 @@ jobs:
           cat aries-agent-test-harness/aries-backchannels/acapy/requirements-main.txt
           cd aries-agent-test-harness
           ./manage build -a acapy-main
+      - name: Run PR Interop Tests
+        if: (steps.check_if_release.outputs.is_release != 'true' && github.event_name == 'pull_request')
+        run: |
+          cd aries-agent-test-harness
           NO_TTY=1 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -t @critical -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound
+      - name: Run Release or Nightly Interop Tests
+        if: (steps.check_if_release.outputs.is_release != 'true' && github.event_name == 'pull_request')
+        run: |
+          cd aries-agent-test-harness
+          NO_TTY=1 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -t @AcceptanceTest -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound
 

--- a/.github/workflows/bdd-interop-tests.yml
+++ b/.github/workflows/bdd-interop-tests.yml
@@ -54,7 +54,7 @@ jobs:
           cd aries-agent-test-harness
           NO_TTY=1 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -t @critical -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound
       - name: Run Release or Nightly Interop Tests
-        if: (steps.check_if_release.outputs.is_release != 'true' && github.event_name == 'pull_request')
+        if: (steps.check_if_release.outputs.is_release == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
           cd aries-agent-test-harness
           NO_TTY=1 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -t @AcceptanceTest -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound

--- a/.github/workflows/scenario-integration-tests.yml
+++ b/.github/workflows/scenario-integration-tests.yml
@@ -1,6 +1,9 @@
 name: Scenario Integration Tests
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aries_cloudagent"
-version = "1.0.1rc1"
+version = "1.0.0"
 description = "Hyperledger Aries Cloud Agent Python (ACA-Py) is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 authors = ["Hyperledger Aries <aries@lists.hyperledger.org>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aries_cloudagent"
-version = "1.0.0"
+version = "1.0.1rc1"
 description = "Hyperledger Aries Cloud Agent Python (ACA-Py) is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 authors = ["Hyperledger Aries <aries@lists.hyperledger.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Adjusts nightly and release integration testing creates re-useable `is_release` action.

Scenario testing:
- on PR's, releases, nightly, manual

BDD Integration tests:
- PR's, Nightly, manual
  - only PR tags (small suite that isn't covered by other tests)
- Releases
  - Release tags (full suite)
  
BDD Interop tests (AATH):
- PR's
  - critical tags (reduced suite)
- Nightly, releases, manual
  - Acceptance tags 