### PR TITLE
Only change interop testing fork on pull requests

### DIFF
--- a/.github/workflows/bdd-interop-tests.yml
+++ b/.github/workflows/bdd-interop-tests.yml
@@ -42,10 +42,15 @@ jobs:
         run: |
           # Get AATH 
           git clone https://github.com/hyperledger/aries-agent-test-harness.git
-          echo ${{ fromJson(steps.get_pr_data.outputs.data).head.repo.html_url }}
-          echo ${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
-          sed -i 's|@git+https://github.com/hyperledger/aries-cloudagent-python@main|@git+${{ fromJson(steps.get_pr_data.outputs.data).head.repo.html_url }}@${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}|g' ./aries-agent-test-harness/aries-backchannels/acapy/requirements-main.txt
+
+          # Change fork and branch for pull requests
+          if [ ${{ github.event_name }} == 'pull_request' ]; then
+            echo ${{ fromJson(steps.get_pr_data.outputs.data).head.repo.html_url }}
+            echo ${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
+            sed -i 's|@git+https://github.com/hyperledger/aries-cloudagent-python@main|@git+${{ fromJson(steps.get_pr_data.outputs.data).head.repo.html_url }}@${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}|g' ./aries-agent-test-harness/aries-backchannels/acapy/requirements-main.txt
+          fi
           cat aries-agent-test-harness/aries-backchannels/acapy/requirements-main.txt
+
           cd aries-agent-test-harness
           ./manage build -a acapy-main
       - name: Run PR Interop Tests


### PR DESCRIPTION
I made a mistake for the Interop AATH tests when not a pull request. It should only change the location of the fork and branch for pull requests. Otherwise it replaces the location with a blank string and fails.