### PR TITLE
Only run integration tests on correct file changes

### DIFF
--- a/.github/workflows/bdd-integration-tests.yml
+++ b/.github/workflows/bdd-integration-tests.yml
@@ -28,14 +28,29 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Check changed files
+        id: check-changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            src: "aries_cloudagent/**/*"
+            demo: "demo/**/*"
+      - name: Check if demo or src files changed
+        id: check-if-demo-or-src-changed
+        run: |
+          if [ "${{ steps.check-changed-files.outputs.demo_any_changed }}" != "true" ] && [ "${{ steps.check-changed-files.outputs.src_any_changed }}" != "true" ] && [ '${{ github.event_name }}' == 'pull_request' ]; then
+            echo "No demo or src files changed..."
+            echo run_tests=false >> $GITHUB_OUTPUT
+          fi
       - name: Check if PR is a release
+        if: steps.check-if-demo-or-src-changed.outputs.run_tests != 'false'
         uses: ./.github/actions/is-release
         id: check_if_release
       - name: Run PR or Nightly Integration Tests
+        if: (steps.check_if_release.outputs.is_release != 'true' && steps.check-if-demo-or-src-changed.outputs.run_tests != 'false')
         uses: ./.github/actions/run-integration-tests
-        if: (steps.check_if_release.outputs.is_release != 'true')
       - name: Run Release Integration Tests
-        if: (steps.check_if_release.outputs.is_release == 'true')
+        if: (steps.check_if_release.outputs.is_release == 'true' && steps.check-if-demo-or-src-changed.outputs.run_tests != 'false')
         uses: ./.github/actions/run-integration-tests
         with:
           TEST_SCOPE: "-t @Release -t ~@BBS"

--- a/.github/workflows/bdd-integration-tests.yml
+++ b/.github/workflows/bdd-integration-tests.yml
@@ -33,7 +33,9 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files_yaml: |
-            src: "aries_cloudagent/**/*"
+            src: 
+              - aries_cloudagent/**/*
+              - poetry.lock
             demo: "demo/**/*"
       - name: Check if demo or src files changed
         id: check-if-demo-or-src-changed

--- a/.github/workflows/bdd-interop-tests.yml
+++ b/.github/workflows/bdd-interop-tests.yml
@@ -28,10 +28,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Check changed files
+        id: check-changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            src: "aries_cloudagent/**/*"
+      - name: Check if src files changed
+        id: check-if-src-changed
+        run: |
+          if [ "${{ steps.check-changed-files.outputs.src_any_changed }}" != "true" ] && [ '${{ github.event_name }}' == 'pull_request' ]; then
+            echo "No src files changed..."
+            echo run_tests=false >> $GITHUB_OUTPUT
+          fi
       - name: Check if PR is a release
+        if: steps.check-if-src-changed.outputs.run_tests != 'false'
         uses: ./.github/actions/is-release
         id: check_if_release
       - name: Request GitHub API for PR data
+        if: steps.check-if-src-changed.outputs.run_tests != 'false'
         uses: octokit/request-action@v2.x
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -39,6 +54,7 @@ jobs:
         with:
           route: GET /repos/${{ github.event.repository.full_name }}/pulls/${{ github.event.number }}
       - name: Prepare Interop Tests
+        if: steps.check-if-src-changed.outputs.run_tests != 'false'
         run: |
           # Get AATH 
           git clone https://github.com/hyperledger/aries-agent-test-harness.git
@@ -54,12 +70,12 @@ jobs:
           cd aries-agent-test-harness
           ./manage build -a acapy-main
       - name: Run PR Interop Tests
-        if: (steps.check_if_release.outputs.is_release != 'true' && github.event_name == 'pull_request')
+        if: (steps.check_if_release.outputs.is_release != 'true' && github.event_name == 'pull_request' && steps.check-if-src-changed.outputs.run_tests != 'false')
         run: |
           cd aries-agent-test-harness
           NO_TTY=1 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -t @critical -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound
       - name: Run Release or Nightly Interop Tests
-        if: (steps.check_if_release.outputs.is_release == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        if: (steps.check_if_release.outputs.is_release == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && steps.check-if-src-changed.outputs.run_tests != 'false')
         run: |
           cd aries-agent-test-harness
           NO_TTY=1 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io ./manage run -d acapy-main -t @AcceptanceTest -t ~@wip -t ~@T004-RFC0211 -t ~@DidMethod_orb -t ~@Transport_NoHttpOutbound

--- a/.github/workflows/bdd-interop-tests.yml
+++ b/.github/workflows/bdd-interop-tests.yml
@@ -33,7 +33,9 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files_yaml: |
-            src: "aries_cloudagent/**/*"
+            src: 
+              - aries_cloudagent/**/*
+              - poetry.lock
       - name: Check if src files changed
         id: check-if-src-changed
         run: |

--- a/.github/workflows/scenario-integration-tests.yml
+++ b/.github/workflows/scenario-integration-tests.yml
@@ -26,14 +26,31 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Check changed files
+        id: check-changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            scenarios: "scenarios/**/*"
+            src: "aries_cloudagent/**/*"
+      - name: Check if scenarios or src files changed
+        id: check-if-scenarios-or-src-changed
+        run: |
+          if [ "${{ steps.check-changed-files.outputs.scenarios_any_changed }}" != "true" ] && [ "${{ steps.check-changed-files.outputs.src_any_changed }}" != "true" ] && [ '${{ github.event_name }}' == 'pull_request' ]; then
+            echo "No scenarios or src files changed..."
+            echo run_tests=false >> $GITHUB_OUTPUT
+          fi
       - name: Install poetry
+        if: steps.check-if-scenarios-or-src-changed.outputs.run_tests != 'false'
         run: pipx install poetry
         id: setup-poetry
       - uses: actions/setup-python@v5
+        if: steps.check-if-scenarios-or-src-changed.outputs.run_tests != 'false'
         with:
           python-version: "3.12"
           cache: "poetry"
       - name: Run Scenario Tests
+        if: steps.check-if-scenarios-or-src-changed.outputs.run_tests != 'false'
         run: |
           # Build the docker image for testing
           docker build -t acapy-test -f docker/Dockerfile.run .

--- a/.github/workflows/scenario-integration-tests.yml
+++ b/.github/workflows/scenario-integration-tests.yml
@@ -32,7 +32,9 @@ jobs:
         with:
           files_yaml: |
             scenarios: "scenarios/**/*"
-            src: "aries_cloudagent/**/*"
+            src: 
+              - aries_cloudagent/**/*
+              - poetry.lock 
       - name: Check if scenarios or src files changed
         id: check-if-scenarios-or-src-changed
         run: |


### PR DESCRIPTION
Only runs the integration tests when there is changes that should be tested.

Scenario Tests:
- scenarios or aries-cloudagent or poetry.lock directories change

BDD Integration Tests:
- demo or aries-cloudagent or poetry.lock directories change

BDD Interop Tests:
- aries-cloudagent or poetry.lock directory change

This is to speed things up and not put as much load on the remote test resources. Possibly, we could also stop running the unit tests for non-code changes. Although then the sonarcloud scan wouldn't run on it.