### PR TITLE
Fix scenario tests

### DIFF
--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -10,7 +10,7 @@ Every test example will have a docker-compose.yml file for all the agents and se
 - From the scenarios directory. 
 - Make sure the local acapy image is up to date. 
  - `cd ..`
- - `docker build -t acapy-test -f ../docker/Dockerfile.run .`
+ - `docker build -t acapy-test -f ./docker/Dockerfile.run .`
  - `cd scenarios`
 - Navigate to the base example. `cd examples/simple`
 - `docker compose up`
@@ -19,7 +19,7 @@ To run all the tests with pytest:
 - From the scenarios directory. 
 - Make sure the local acapy image is up to date. 
  - `cd ..`
- - `docker build -t acapy-test -f ../docker/Dockerfile.run .`
+ - `docker build -t acapy-test -f ./docker/Dockerfile.run .`
  - `cd scenarios`
 - `poetry run pytest -m examples`
 - TODO: easily run individual tests with pytest.

--- a/scenarios/examples/connectionless/example.py
+++ b/scenarios/examples/connectionless/example.py
@@ -59,8 +59,7 @@ async def icv2():
                         "role": "ENDORSER",
                     },
                 ) as resp:
-                    if resp.ok:
-                        return await resp.json()
+                    assert resp.ok
 
             await alice.post("/wallet/did/public", params=params(did=public_did.did))
 

--- a/scenarios/examples/json_ld/example.py
+++ b/scenarios/examples/json_ld/example.py
@@ -77,8 +77,7 @@ async def main():
                                 "role": "ENDORSER",
                             },
                         ) as resp:
-                            if resp.ok:
-                                return await resp.json()
+                            assert resp.ok
 
                     await alice.post(
                         "/wallet/did/public", params=params(did=public_did.did)

--- a/scenarios/examples/multitenancy/example.py
+++ b/scenarios/examples/multitenancy/example.py
@@ -72,8 +72,7 @@ async def main():
                         "role": "ENDORSER",
                     },
                 ) as resp:
-                    if resp.ok:
-                        return await resp.json()
+                    assert resp.ok
 
             await alice.post("/wallet/did/public", params=params(did=public_did.did))
         _, cred_def = await indy_anoncred_credential_artifacts(

--- a/scenarios/examples/presenting_revoked_credential/example.py
+++ b/scenarios/examples/presenting_revoked_credential/example.py
@@ -72,8 +72,7 @@ async def main():
                         "role": "ENDORSER",
                     },
                 ) as resp:
-                    if resp.ok:
-                        return await resp.json()
+                    assert resp.ok
 
             await alice.post("/wallet/did/public", params=params(did=public_did.did))
         schema, cred_def = await indy_anoncred_credential_artifacts(

--- a/scenarios/examples/self_attested/example.py
+++ b/scenarios/examples/self_attested/example.py
@@ -58,8 +58,7 @@ async def main():
                         "role": "ENDORSER",
                     },
                 ) as resp:
-                    if resp.ok:
-                        return await resp.json()
+                    assert resp.ok
 
             await alice.post("/wallet/did/public", params=params(did=public_did.did))
         schema, cred_def = await indy_anoncred_credential_artifacts(


### PR DESCRIPTION
I noticed when I was making a new test that the existing tests weren't running the full scenario. I had made a mistake when pointing the tests to `test.bcovrin.vonx.io`. I had a return statement after `POST /did/create/public` that was causing the scenario to end early. 