### PR TITLE
Removing padding from url invitations

### DIFF
--- a/aries_cloudagent/protocols/connections/v1_0/messages/connection_invitation.py
+++ b/aries_cloudagent/protocols/connections/v1_0/messages/connection_invitation.py
@@ -82,7 +82,7 @@ class ConnectionInvitation(AgentMessage):
 
         """
         c_json = self.to_json()
-        c_i = bytes_to_b64(c_json.encode("ascii"), urlsafe=True)
+        c_i = bytes_to_b64(c_json.encode("ascii"), urlsafe=True, pad=False)
         result = urljoin(base_url or self.endpoint or "", "?c_i={}".format(c_i))
         return result
 

--- a/aries_cloudagent/protocols/out_of_band/v1_0/messages/invitation.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/messages/invitation.py
@@ -175,7 +175,7 @@ class InvitationMessage(AgentMessage):
 
         """
         c_json = self.to_json()
-        oob = bytes_to_b64(c_json.encode("ascii"), urlsafe=True)
+        oob = bytes_to_b64(c_json.encode("ascii"), urlsafe=True, pad=False)
         endpoint = None
         if not base_url:
             for service_item in self.services:

--- a/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/out_of_band/v1_0/tests/test_manager.py
@@ -9,6 +9,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import ANY
 
 from aries_cloudagent.tests import mock
+from aries_cloudagent.wallet.util import pad
 
 from .....connections.models.conn_record import ConnRecord
 from .....connections.models.connection_target import ConnectionTarget
@@ -883,7 +884,8 @@ class TestOOBManager(IsolatedAsyncioTestCase, TestConfig):
 
             base64_message = invi_rec.invitation_url.split("=", maxsplit=1)[1]
             base64_bytes = base64_message.encode("ascii")
-            message_bytes = base64.b64decode(base64_bytes)
+            message_bytes = base64.b64decode(base64_bytes + b"==")
+            base64.urlsafe_b64decode(pad(base64_message))
             data = message_bytes.decode("ascii")
             assert data
             invite_json = json.loads(data)


### PR DESCRIPTION
I didn't understand this for a while but looking at the RFC PR, I think this is all that's needed.

Uses the common util in the wallet directory to remove the padding from the url via the `bytes_to_b64` function. Then this same util module is used with `b64_to_bytes` which pads the invitation string when one is received. This was already in place, meaning that aca-py already handled unpadded invitation urls.

This util is used in several other places, mostly for attachment and jws signing. They all remove padding as well. The only place it looks to be used with padding is for bbs_bls_signature proof values. I'm not sure if this is required or not. 

***NOTE:*** I changed it for the old connection invitation endpoint as well even though is depreciated and didn't get update in the RFC.

