### PR TITLE
Ensure that DAP_PORT is always an int

### DIFF
--- a/aries_cloudagent/__main__.py
+++ b/aries_cloudagent/__main__.py
@@ -21,7 +21,7 @@ def init_debug(args):
     # --debug to use microsoft's visual studio remote debugger
     if ENABLE_PTVSD or "--debug" in args:
         DAP_HOST = os.getenv("PTVSD_HOST", None) or os.getenv("DAP_HOST", "localhost")
-        DAP_PORT = os.getenv("PTVSD_PORT", None) or os.getenv("DAP_PORT", 5678)
+        DAP_PORT = int(os.getenv("PTVSD_PORT", None) or os.getenv("DAP_PORT", 5678))
         try:
             import debugpy
 


### PR DESCRIPTION
As of now when the `--debug` flag is used with the set `DAP_PORT` env var will result in an exception since the port number will default to being a string rather than the required int type. The source of this error can be found  [here](https://github.com/microsoft/debugpy/blob/main/src/debugpy/server/api.py#L116)

This PR simply converts the port number from an str into an int