### PR TITLE
feat: verify creds signed with Ed25519VerificationKey2020

### DIFF
--- a/aries_cloudagent/vc/ld_proofs/crypto/tests/test_wallet_key_pair.py
+++ b/aries_cloudagent/vc/ld_proofs/crypto/tests/test_wallet_key_pair.py
@@ -76,4 +76,4 @@ class TestWalletKeyPair(IsolatedAsyncioTestCase):
 
         with self.assertRaises(LinkedDataProofException) as context:
             key_pair.from_verification_method({})
-        assert "no publicKeyBase58" in str(context.exception)
+        assert "Unrecognized" in str(context.exception)


### PR DESCRIPTION
This PR adds support for verifying JSON-LD Credentials using a verification method of type `Ed25519VerificationKey2020`.

I'm not thrilled about this approach but I think it's the least disruptive change possible right now. Less disruptive seems like a good idea given @PatStLouis work on supporting VC-DI is already underway.

Sidebar, Patrick, hopefully the VC-DI and VCDM 2.0 implementation handles working with verification methods better than the original LDP-VC code does :sweat_smile: Working on a verification method that has been framed does not feel right.