### PR TITLE
[BUG] Handle get key operation when no tag has been set

### DIFF
--- a/aries_cloudagent/wallet/askar.py
+++ b/aries_cloudagent/wallet/askar.py
@@ -97,7 +97,7 @@ class AskarWallet(BaseWallet):
         if kid:
             tags = {"kid": kid}
         else:
-            tags = None
+            tags = {}
 
         try:
             keypair = _create_keypair(key_type, seed)

--- a/aries_cloudagent/wallet/askar.py
+++ b/aries_cloudagent/wallet/askar.py
@@ -192,8 +192,14 @@ class AskarWallet(BaseWallet):
         if not key:
             raise WalletNotFoundError("Unknown key: {}".format(verkey))
         metadata = json.loads(key.metadata or "{}")
-        # FIXME implement key types
-        kid = key.tags["kid"] if "kid" in key.tags else None
+
+        # Provisioned keys don't get tags by default
+        try:
+            kid = key.tags["kid"] if "kid" in key.tags else None
+        except Exception:
+            kid = None
+            
+        # FIXME implement key types 
         return KeyInfo(verkey=verkey, metadata=metadata, key_type=ED25519, kid=kid)
 
     async def replace_signing_key_metadata(self, verkey: str, metadata: dict):

--- a/aries_cloudagent/wallet/askar.py
+++ b/aries_cloudagent/wallet/askar.py
@@ -193,11 +193,7 @@ class AskarWallet(BaseWallet):
             raise WalletNotFoundError("Unknown key: {}".format(verkey))
         metadata = json.loads(key.metadata or "{}")
 
-        # Provisioned keys don't get tags by default
-        try:
-            kid = key.tags["kid"] if "kid" in key.tags else None
-        except Exception:
-            kid = None
+        kid = key.tags.get("kid")
 
         # FIXME implement key types
         return KeyInfo(verkey=verkey, metadata=metadata, key_type=ED25519, kid=kid)

--- a/aries_cloudagent/wallet/askar.py
+++ b/aries_cloudagent/wallet/askar.py
@@ -198,8 +198,8 @@ class AskarWallet(BaseWallet):
             kid = key.tags["kid"] if "kid" in key.tags else None
         except Exception:
             kid = None
-            
-        # FIXME implement key types 
+
+        # FIXME implement key types
         return KeyInfo(verkey=verkey, metadata=metadata, key_type=ED25519, kid=kid)
 
     async def replace_signing_key_metadata(self, verkey: str, metadata: dict):

--- a/aries_cloudagent/wallet/in_memory.py
+++ b/aries_cloudagent/wallet/in_memory.py
@@ -165,7 +165,7 @@ class InMemoryWallet(BaseWallet):
             verkey=key["verkey"],
             metadata=key["metadata"].copy(),
             key_type=key["key_type"],
-            kid=key["kid"] if "kid" in key else None,
+            kid=key["kid"],
         )
 
     async def replace_signing_key_metadata(self, verkey: str, metadata: dict):

--- a/aries_cloudagent/wallet/in_memory.py
+++ b/aries_cloudagent/wallet/in_memory.py
@@ -165,7 +165,7 @@ class InMemoryWallet(BaseWallet):
             verkey=key["verkey"],
             metadata=key["metadata"].copy(),
             key_type=key["key_type"],
-            kid=key["kid"],
+            kid=key["kid"] if "kid" in key else None,
         )
 
     async def replace_signing_key_metadata(self, verkey: str, metadata: dict):


### PR DESCRIPTION
Handle cases where a key doesn't have a tags property.

@dbluhm @jamshale small but critical bug introduced by my last PR, I was under the impression every key had tags by default but it doesn't seem like so, this will handle such cases.