### PR TITLE
Adjust sonarcloud and integration test workflows

### DIFF
--- a/.github/actions/run-unit-tests/action.yml
+++ b/.github/actions/run-unit-tests/action.yml
@@ -30,7 +30,7 @@ runs:
     - name: Tests
       shell: bash
       run: |
-        poetry run pytest --cov=aries_cloudagent --cov-report term-missing --cov-report xml --ignore-glob=/tests/* --ignore-glob=demo/* --ignore-glob=docker/* --ignore-glob=docs/* --ignore-glob=scripts/* 2>&1 | tee pytest.log
+        poetry run pytest --cov=aries_cloudagent --cov-report term-missing --cov-report xml --ignore-glob=/tests/* --ignore-glob=demo/* --ignore-glob=docker/* --ignore-glob=docs/* --ignore-glob=scripts/* --ignore-glob=scenarios/* 2>&1 | tee pytest.log
         PYTEST_EXIT_CODE=${PIPESTATUS[0]}
         if grep -Eq "RuntimeWarning: coroutine .* was never awaited" pytest.log; then
           echo "Failure: Detected unawaited coroutine warning in pytest output."

--- a/.github/workflows/bdd-integration-tests.yml
+++ b/.github/workflows/bdd-integration-tests.yml
@@ -36,6 +36,7 @@ jobs:
             src: 
               - aries_cloudagent/**/*
               - poetry.lock
+              - pyproject.toml
             demo: "demo/**/*"
       - name: Check if demo or src files changed
         id: check-if-demo-or-src-changed

--- a/.github/workflows/bdd-interop-tests.yml
+++ b/.github/workflows/bdd-interop-tests.yml
@@ -36,6 +36,7 @@ jobs:
             src: 
               - aries_cloudagent/**/*
               - poetry.lock
+              - pyproject.toml
       - name: Check if src files changed
         id: check-if-src-changed
         run: |

--- a/.github/workflows/scenario-integration-tests.yml
+++ b/.github/workflows/scenario-integration-tests.yml
@@ -35,6 +35,7 @@ jobs:
             src: 
               - aries_cloudagent/**/*
               - poetry.lock 
+              - pyproject.toml
       - name: Check if scenarios or src files changed
         id: check-if-scenarios-or-src-changed
         run: |

--- a/.github/workflows/sonar-merge-main.yml
+++ b/.github/workflows/sonar-merge-main.yml
@@ -30,5 +30,6 @@ jobs:
         with: 
             args: >
                 -Dsonar.python.coverage.reportPaths=test-reports/coverage.xml
-                -Dsonar.coverage.exclusions=**/tests/*,**/demo/*,**/docs/*,**/docker/*,**/scripts/*
+                -Dsonar.coverage.exclusions=**/tests/**,**/demo/**,**/docs/**,**/docker/**,**/scripts/**,**/scenarios/**
+                -Dsonar.cpd.exclusions=**/tests/**,**/demo/**,**/docs/**,**/docker/**,**/scripts/**,**/scenarios/**
                 -Dsonar.sources=./

--- a/.github/workflows/sonar-merge-main.yml
+++ b/.github/workflows/sonar-merge-main.yml
@@ -8,6 +8,7 @@ jobs:
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
+    if: github.repository == 'hyperledger/aries-cloudagent-python'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -68,6 +68,7 @@ jobs:
             -Dsonar.pullrequest.key=${{ fromJson(steps.get_pr_data.outputs.data).number }} 
             -Dsonar.pullrequest.branch=${{ fromJson(steps.get_pr_data.outputs.data).head.ref }} 
             -Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
-            -Dsonar.coverage.exclusions=**/tests/*,**/demo/*,**/docs/*,**/docker/*,**/scripts/*
+            -Dsonar.coverage.exclusions=**/tests/**,**/demo/**,**/docs/**,**/docker/**,**/scripts/**,**/scenarios/**
+            -Dsonar.cpd.exclusions=**/tests/**,**/demo/**,**/docs/**,**/docker/**,**/scripts/**,**/scenarios/**
             -Dsonar.python.coverage.reportPaths=test-reports/coverage.xml
             -Dsonar.sources=./

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   SonarCloud:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success' && github.repository == 'hyperledger/aries-cloudagent-python'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This adjusts the soanrcloud to ignore coverage and duplication on the entire folders for the existing folders and scenarios.

Also runs integration tests when there is a pyproject.toml file change (during releases).

The security reports still generate for the entire repo. I don't think I can filter these. We could allow users to review or mark them as safe, or only scan the aries_cloudagent source code. I think it's ok to deal with this for now.

Also change to workflow to only run on hyperledger repo.