### PR TITLE
fix: enable refreshing did endpoint using mediator info

### DIFF
--- a/aries_cloudagent/wallet/tests/test_routes.py
+++ b/aries_cloudagent/wallet/tests/test_routes.py
@@ -29,11 +29,14 @@ class TestWalletRoutes(IsolatedAsyncioTestCase):
     def setUp(self):
         self.wallet = mock.create_autospec(BaseWallet)
         self.session_inject = {BaseWallet: self.wallet}
+        self.route_mgr = mock.MagicMock()
+        self.route_mgr.mediation_record_if_id = mock.CoroutineMock(return_value=None)
+        self.route_mgr.routing_info = mock.CoroutineMock(return_value=(None, None))
         self.profile = InMemoryProfile.test_profile(
-            settings={"admin.admin_api_key": "secret-key"}
+            settings={"admin.admin_api_key": "secret-key"},
+            bind={KeyTypes: KeyTypes(), RouteManager: self.route_mgr},
         )
         self.context = AdminRequestContext.test_context(self.session_inject, self.profile)
-        self.context.injector.bind_instance(KeyTypes, KeyTypes())
         self.request_dict = {
             "context": self.context,
             "outbound_message_router": mock.CoroutineMock(),


### PR DESCRIPTION
This PR makes it possible to update endpoint info with mediator information after the initial endpoint publish.

The `POST /wallet/public/did` endpoint was capable of setting the endpoint with mediator info (routing keys, mediator endpoint). However, if your mediator changes after the initial publish, there wasn't a (convenient) way for the controller to refresh the endpoint with the new mediator info. This adds this functionality to the `POST /wallet/set-did-endpoint` to do just that.