### PR TITLE
:memo Fix typos in PUBLISHING.md

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -68,7 +68,7 @@ Once you have the list of PRs:
 - Organize the list into suitable categories in the [CHANGELOG.md](CHANGELOG.md) file, update (if necessary) the PR title and add notes to clarify the changes. See previous release entries to understand the style -- a format that should help developers.
 - Add a narrative about the release above the PR that highlights what has gone into the release.
 - To cover the `dependabot` PRs without listing them all, add to the end of the
-  categorized list of PRs the lat two lines of the script output. Make sure the dates are right! The text will look like this:
+  categorized list of PRs the last two lines of the script output. Make sure the dates are right! The text will look like this:
 
 ```text
 - Dependabot PRs
@@ -133,7 +133,7 @@ Include a PR for this soon-to-be PR. You can guess at the number of the PR by us
    found in the document [Container Images and Github Actions](docs/deploying/ContainerImagesAndGithubActions.md).
 
    In addition, the published documentation site [https://aca-py.org] should be automatically updated to include the new release via the [publish-docs] GitHub Action.
-   Additional information about that process and some related maintainance activities that are needed from time to time can be found in the [Updating the ACA-Py Documentation Site] document.
+   Additional information about that process and some related maintenance activities that are needed from time to time can be found in the [Updating the ACA-Py Documentation Site] document.
 
 [publish.yml]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/.github/workflows/publish.yml
 [publish-indy.yml]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/.github/workflows/publish-indy.yml


### PR DESCRIPTION
Fix typos in PUBLISHING.md: Corrected 'lat' to 'last' and 'maintainance' to 'maintenance' for improved clarity and accuracy in the documentation.